### PR TITLE
Merge stable into release-1.10 (restore dropped registry import)

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -666,14 +666,24 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         if branch_name in local_branches:
             return False
 
-        # TODO Catch potential exceptions coming from repo.git.branch & repo.git.worktree
-        repo.git.branch(branch_name)
+        remote_branch = None
+        if self.has_origin:
+            remote_branch = next(
+                (br for br in repo.remotes.origin.refs if br.name == f"origin/{branch_name}"),
+                None,
+            )
+
+        # When a matching remote branch exists, point the local branch directly at the
+        # remote tip. Branching from HEAD and then pulling would fail whenever the remote
+        # branch's history diverges from the default branch.
+        if remote_branch is not None:
+            repo.git.branch(branch_name, remote_branch.name)
+        else:
+            repo.git.branch(branch_name)
+
         self.create_branch_worktree(branch_name=branch_name, branch_id=branch_id or branch_name)
 
-        # If there is not remote configured, we are done
-        #  Since the branch is a match for the main branch we don't need to create a commit worktree
-        # If there is a remote, Check if there is an existing remote branch with the same name and if so track it.
-        if not self.has_origin:
+        if remote_branch is None:
             log.debug(
                 f"Branch {branch_name} created in Git without tracking a remote branch.",
                 repository=self.name,
@@ -681,24 +691,14 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             )
             return True
 
-        remote_branch = [br for br in repo.remotes.origin.refs if br.name == f"origin/{branch_name}"]
-
-        if remote_branch:
-            br_repo = self.get_git_repo_worktree(identifier=branch_name)
-            br_repo.head.reference.set_tracking_branch(remote_branch[0])
-            try:
-                br_repo.remotes.origin.pull(branch_name)
-            except GitCommandError as exc:
-                await self._raise_enriched_error(error=exc, branch_name=branch_name)
-            self.create_commit_worktree(str(br_repo.head.reference.commit))
-            log.debug(
-                f"Branch {branch_name} created in Git, tracking remote branch {remote_branch[0]}.",
-                repository=self.name,
-                branch=branch_name,
-            )
-        else:
-            log.debug(f"Branch {branch_name} created in Git without tracking a remote branch.", repository=self.name)
-
+        br_repo = self.get_git_repo_worktree(identifier=branch_name)
+        br_repo.head.reference.set_tracking_branch(remote_branch)
+        self.create_commit_worktree(str(br_repo.head.reference.commit))
+        log.debug(
+            f"Branch {branch_name} created in Git, tracking remote branch {remote_branch.name}.",
+            repository=self.name,
+            branch=branch_name,
+        )
         return True
 
     def create_commit_worktree(self, commit: str) -> bool | Worktree:
@@ -875,8 +875,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Process a remote branch to validate that we can use it safely.
 
         - Make sure that the branch name won't conflict with infrahub's default branch
-        - Make sure that a representation if the branch can be created in the database
-        - Make sure that there are no conflicts that would prevent it from being merged
+        - Make sure that a representation of the branch can be created in the database
+        - Warn (but do not block) when the branch would conflict with the default branch on merge
         """
         if branch_name == registry.default_branch and branch_name != self.default_branch:
             # If the default branch of Infrahub and the git repository differs we map the repository
@@ -894,7 +894,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             )
             return False
 
-        # Make sure the branch won't conflict on merge
+        # Surface a warning when the branch conflicts with the default branch so users
+        # know a future merge will be rejected, but still allow the import to proceed.
         try:
             has_conflicts = self.has_conflicting_changes(target_branch=self.default_branch, source_branch=branch_name)
         except GitCommandError as exc:
@@ -904,17 +905,13 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 repository=self.name,
                 error=str(exc),
             )
-            return False
+            return True
 
         if has_conflicts:
             get_run_logger().warning(
-                f"Remote branch {branch_name} will cause conflicts, they need to be resolved before importing the branch into Infrahub"
+                f"Remote branch {branch_name} conflicts with {self.default_branch}; "
+                "the merge will be rejected until the conflict is resolved upstream"
             )
-            return False
-
-        # Find the commit on the remote branch
-        # Check out the commit in a worktree
-        # Validate
 
         return True
 

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,4 +1,7 @@
+import logging
+from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from git import Repo
@@ -11,16 +14,114 @@ from infrahub.git import InfrahubRepository
 from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
+PREFECT_LOGGER_NAME = "infrahub.git.base"
+
+
+@pytest.fixture
+def patch_prefect_logger() -> Iterator[None]:
+    """Replace Prefect's `get_run_logger` with a stdlib logger so calls outside a flow context succeed."""
+    with patch(
+        "infrahub.git.base.get_run_logger",
+        return_value=logging.getLogger(PREFECT_LOGGER_NAME),
+    ):
+        yield
+
+
+def _build_source_with_conflicting_branches(source_dir: Path) -> None:
+    """Initialize a git source repo with `main` and `change1` whose tips edit the same lines."""
+    source = Repo.init(source_dir, initial_branch="main")
+    with source.config_writer() as cfg:
+        cfg.set_value("user", "name", "Test")
+        cfg.set_value("user", "email", "test@test.local")
+    target = source_dir / "data.txt"
+    target.write_text("line 1\nline 2\nline 3\n", encoding="utf-8")
+    source.index.add(["data.txt"])
+    base_commit = source.index.commit("base")
+
+    source.git.checkout("-b", "change1")
+    target.write_text("change1 version\nline 2\nline 3\n", encoding="utf-8")
+    source.index.add(["data.txt"])
+    source.index.commit("change on change1")
+
+    source.git.checkout("main")
+    source.git.reset("--hard", base_commit.hexsha)
+    target.write_text("main version\nline 2\nline 3\n", encoding="utf-8")
+    source.index.add(["data.txt"])
+    source.index.commit("change on main")
+
+
+async def _build_repository_with_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "conflicting-repo"
+) -> InfrahubRepository:
+    """Build an `InfrahubRepository` whose remote has `main` and a divergent `change1`.
+
+    Raises:
+        RuntimeError: When the constructed source repo no longer produces a conflict between `main` and `change1`.
+
+    """
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    monkeypatch.setattr(config.SETTINGS.git, "repositories_directory", str(repos_dir))
+
+    source_dir = tmp_path / "source-repo"
+    source_dir.mkdir()
+    _build_source_with_conflicting_branches(source_dir)
+
+    repository = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name=name,
+        location=str(source_dir),
+        default_branch_name="main",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+    if not repository.has_conflicting_changes(target_branch="main", source_branch="change1"):
+        raise RuntimeError(
+            "test helper drift: main and change1 must conflict for the conflict-import tests to be meaningful"
+        )
+    return repository
+
+
+async def test_create_branch_in_git_with_conflicting_remote_lands_at_remote_tip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A remote branch that conflicts with the default branch must still be imported locally.
+
+    The local branch should land at the remote tip so that downstream merge attempts can
+    surface the conflict at merge time, rather than aborting the entire import.
+    """
+    repository = await _build_repository_with_conflict(tmp_path, monkeypatch)
+
+    remote_branches = repository.get_branches_from_remote()
+    expected_commit = remote_branches["change1"].commit
+
+    await repository.create_branch_in_git(branch_name="change1", branch_id=str(UUIDT.new()))
+
+    local_branches = repository.get_branches_from_local(include_worktree=False)
+    assert "change1" in local_branches
+    assert local_branches["change1"].commit == expected_commit
+
+
+async def test_validate_remote_branch_allows_conflicting_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patch_prefect_logger: None,
+) -> None:
+    """validate_remote_branch must accept a branch that conflicts with the default branch.
+
+    Skipping the branch would prevent it from being imported. The conflict is surfaced at
+    merge time instead.
+    """
+    repository = await _build_repository_with_conflict(tmp_path, monkeypatch)
+    assert repository.validate_remote_branch(branch_name="change1") is True
+
 
 async def test_has_conflicting_changes_no_false_positive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """has_conflicting_changes() should not report false positives when.
-
-    file content contains conflict marker characters like '======='.
-
-    """
+    """has_conflicting_changes() must not flag a diff that only adds lines containing '======='."""
     repos_dir = tmp_path / "repositories"
     repos_dir.mkdir()
     monkeypatch.setattr(registry, "_default_branch", "main")

--- a/changelog/2293.fixed.md
+++ b/changelog/2293.fixed.md
@@ -1,0 +1,1 @@
+Importing a Git repository now succeeds even when one of its branches has a merge conflict against the default branch. The conflicting branch is imported as-is and a warning is logged; the conflict is reported when a user later attempts to merge the branch.

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -252,6 +252,7 @@ If you find yourself wanting to mock:
 
 - External HTTP APIs with no test mode (use `responses` or `httpx_mock` sparingly)
 - Time-dependent behavior (`freezegun`)
+- Prefect's `get_run_logger` when calling a `.fn` outside a flow context — patch it to return a stdlib `logging.getLogger(...)` so `caplog` can capture output. See [Backend Testing — Logging](../../knowledge/backend/testing.md#logging-use-caplog-instead-of-mocking-get_run_logger) for the pattern.
 
 Even in these cases, prefer adapter patterns when the dependency is used widely.
 

--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "backend/infrahub/**/*.py"
+  - "python_testcontainers/infrahub_testcontainers/**/*.py"
 ---
 
 # Backend Component Design (SOLID / DI)

--- a/dev/rules/backend-component-design.md
+++ b/dev/rules/backend-component-design.md
@@ -11,6 +11,12 @@ Applies when creating a new backend component or making significant changes to a
 
 New logic should live in components that receive their collaborators through constructor injection rather than instantiating them internally. This keeps components composable, swappable, and testable without patching.
 
+## Required dependencies, not optional
+
+Constructor dependencies for new code are required parameters - not `collaborator: Collaborator | None = None` with an internal default. Optional injection hides that the dependency exists and lets a caller silently skip wiring it. Make every collaborator an explicit, required constructor argument - explicit is better than implicit.
+
+The single exception is editing existing code where adding a required parameter would force a large change across many call sites. There, an optional parameter is a transitional compromise to keep the change small - not the target shape for new components.
+
 ## Build components near the application entry point
 
 Construct components as close to the application entry point as possible. Use a builder class or factory function when wiring is non-trivial, and inject each sub-component rather than constructing it inside a parent component's `__init__`.
@@ -39,9 +45,35 @@ A single implementation does not need an interface yet; introduce one when the s
 can be either a no-op version (such as in the case of an enterprise-only feature) or a testing version of a component (such as in the case of an
 in-memory version of a component typically backed by the database).
 
-## Why this matters
+## Dispatching across implementations
 
-Constructor-injected long-lived dependencies plus method-passed transient entities is the boundary that lets components be reused across requests/operations and mocked with adapter implementations instead of `unittest.mock`. The [testing rule](./testing-python.md) requires adapter/protocol patterns for tests — that requirement is only practical when production code follows this design.
+When a component must pick one of several implementations at runtime based on the input, do not branch with `isinstance` (or a `match` on the input's type) inside one class. Give each implementation a predicate on the shared interface (e.g. `supports(request) -> bool`) alongside its entry method, hold the implementations as an injected list in an aggregator component, and let the aggregator delegate to the first that supports the input:
+
+```python
+class CheckerInterface(ABC):
+    @abstractmethod
+    def supports(self, request: Request) -> bool: ...
+    @abstractmethod
+    def check(self, request: Request) -> Result: ...
+
+class AggregatedChecker:
+    def __init__(self, checkers: list[CheckerInterface]) -> None:
+        self.checkers = checkers
+
+    def run(self, request: Request) -> Result:
+        for checker in self.checkers:
+            if checker.supports(request):
+                return checker.check(request)
+        raise NoCheckerError(request)
+```
+
+The aggregator depends only on the interface; the concrete list is assembled by the factory at the wiring layer, so adding an implementation is one new class plus one line in the factory, with no edit to the dispatch logic. `AggregatedConstraintChecker` (`backend/infrahub/core/validators/`) is the canonical example in the codebase.
+
+This is for an open, extensible set of implementations. When the set is closed and fixed (an enum, a sealed union), an exhaustive `match` with `typing.assert_never` is the right tool instead.
+
+## Why this design matters
+
+Stepping back from the individual rules above: constructor-injected long-lived dependencies plus method-passed transient entities is the boundary that lets components be reused across requests/operations and mocked with adapter implementations instead of `unittest.mock`. The [testing rule](./testing-python.md) requires adapter/protocol patterns for tests — that requirement is only practical when production code follows this design.
 
 Use this as a design driver, not just a constraint: the no-mock rule is the forcing function for this structure. When you make a component's decision logic testable without patching — collaborators injected through the constructor, a single entry point that is pure and operates only on its arguments — dependency inversion and single responsibility fall out as the path of least resistance rather than discipline you have to summon. The corollary is a useful smell test: if a component is hard to test without a mock, that is the signal it needs splitting or its dependencies injected, not that it needs a mock.
 

--- a/dev/rules/code-doc-style.md
+++ b/dev/rules/code-doc-style.md
@@ -1,6 +1,7 @@
 ---
 paths:
-  - "backend/infrahub/**/*.py"
+  - "backend/**/*.py"
+  - "python_testcontainers/**/*.py"
 ---
 
 # Code documentation style

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -5,6 +5,8 @@ paths:
   - "backend/tests/functional/**/*.py"
   - "backend/tests/integration/**/*.py"
   - "backend/tests/integration_docker/**/*.py"
+  - "python_testcontainers/tests/**/*.py"
+
 ---
 
 # Python Testing Rules

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -32,6 +32,7 @@ Acceptable exceptions only:
 
 - External HTTP APIs with no test mode: use `httpx_mock` or `responses`
 - Time-dependent behavior: `freezegun`
+- Prefect's `get_run_logger`: when calling a Prefect-decorated function via `.fn` outside a flow context, patch `get_run_logger` to return a stdlib `logging.getLogger(...)` so `caplog` can capture output. See `dev/knowledge/backend/testing.md` for the full pattern.
 
 ## Parametrized tests
 

--- a/dev/rules/testing-python.md
+++ b/dev/rules/testing-python.md
@@ -44,9 +44,11 @@ with pytest.raises(SomeError, match=r"expected message"):
     call_function()
 ```
 
+Make `match` cover the whole stable message (anchor with `^...$` where practical), not a short fragment of it. A fragment passes even when the rest of the wording regresses. Match only a substring when the message has a genuinely variable part (an id, a path, a count) that you cannot pin down.
+
 ## GraphQL error assertions
 
-Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes.
+Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. The full-message-over-fragment preference applies to any exception assertion, not just GraphQL; with `pytest.raises` express it through an anchored `match` (above) rather than `==`.
 
 ## Test file placement
 


### PR DESCRIPTION
GitHub's auto-merge for PR #9572 dropped `from infrahub.core.registry import registry` from `backend/tests/unit/git/test_git_repository.py`, leaving the file with usages of `registry` but no import. The result fails ruff with `F821 Undefined name 'registry'`.

This PR performs the same merge by hand and restores the import. Once merged, PR #9572 can be closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing `from infrahub.core.registry import registry` import and completes the stable → `release-1.10` merge. Improves Git import so conflicting remote branches are imported at the remote tip with a warning and proper tracking/worktrees.

- **Bug Fixes**
  - Test fix: restore `registry` import in `backend/tests/unit/git/test_git_repository.py` (fixes ruff `F821`).
  - Git import: when a matching remote branch exists, create the local branch at the remote tip, set tracking, and create a commit worktree from that commit.
  - Validation: `validate_remote_branch` logs a warning for branches that conflict with the default branch and allows import; the merge path still rejects unresolved conflicts.
  - Tests/docs/rules: add tests for conflict import and validation; patch Prefect `get_run_logger` in tests; widen dev-rule path scopes and document required constructor deps, aggregator dispatch, and stricter exception assertions.

<sup>Written for commit 826597136e3d1fe8c8f302c2de86da967bd34585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

