### PR TITLE
fix(ci): pin SBOM attest to legacy bundle format to match image signing

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -226,14 +226,14 @@ jobs:
 
       - name: Attest SBOM (SPDX)
         run: |
-          cosign attest --yes \
+          cosign attest --yes --new-bundle-format=false --use-signing-config=false \
             --type spdxjson \
             --predicate infrahub-sbom.spdx.json \
             "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
 
       - name: Attest SBOM (CycloneDX)
         run: |
-          cosign attest --yes \
+          cosign attest --yes --new-bundle-format=false --use-signing-config=false \
             --type cyclonedx \
             --predicate infrahub-sbom.cdx.json \
             "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"


### PR DESCRIPTION
## Problem

The `sbom` job's two `cosign attest` steps omit the `--new-bundle-format=false --use-signing-config=false` flags that the `sign` job pins. Under cosign 3.x (installed by `cosign-installer@v4.1.1`) these default to `true`, so attestations are written in the **new Sigstore bundle format via the OCI 1.1 Referrers API** instead of the legacy `sha256-….att` tag the signature uses.

The attest commands still exit 0 — the job is green and the SBOMs are genuinely signed and logged in Rekor — but the attestations land in a different scheme than the signature. As a result:

- `cosign tree <image>` shows only the `.sig`, no `.att`
- `cosign verify-attestation --type spdxjson <image> …` (without `--new-bundle-format`) returns `no matching attestations`

Confirmed against the published `1.9.8` image: the SPDX/CycloneDX attestations exist as `vnd.dev.sigstore.bundle.v0.3+json` referrers and verify cleanly **only** when `--new-bundle-format` is passed.

## Fix

Add `--new-bundle-format=false --use-signing-config=false` to both `attest` steps so all supply-chain artifacts (signature + SBOM attestations) use one consistent legacy tag-based scheme, and the standard verify command works with no extra flags:

```bash
cosign verify-attestation --type spdxjson registry.opsmill.io/opsmill/infrahub:<ver> \
  --certificate-identity-regexp "^https://github.com/opsmill/.*" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
```

## Notes

- Takes effect on the next release that runs this workflow.
- Already-published images (≤ 1.9.8) are **not** retroactively fixed; their attestations remain valid but require `--new-bundle-format` to verify. Re-running the `sbom` job against an older digest would add the legacy-format copies if desired.
- CI-only change → no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins SBOM attestations to the legacy tag-based format to match image signing. This restores `cosign tree` visibility and lets `cosign verify-attestation` work without extra flags.

- **Bug Fixes**
  - Added `--new-bundle-format=false --use-signing-config=false` to both `cosign attest` steps in CI.
  - Affects new releases only; existing images keep bundle-format attestations unless re-attested.

<sup>Written for commit ef08ff23fd63fcfdbe8fa11372415f7275462e5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

