### PR TITLE
fix(git): pin sync commit via the repository git default branch

### DIFF
--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -278,7 +278,7 @@ async def bootstrap_local_repository(
             except RepositoryError as exc:
                 log.info(exc.message)
                 return None
-            default_import_git_branch = registry.default_branch
+            default_import_git_branch = repo.default_branch
 
         if repo.reinitialized:
             default_import_git_branch = repo.default_branch
@@ -326,7 +326,7 @@ async def sync_repository_from_origin(
             infrahub_branch=infrahub_branch,
         )
         try:
-            pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
+            pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
         except (ValueError, InvalidGitRepositoryError) as exc:
             log.debug(
                 f"Could not resolve pinned commit for {repository.name.value}, workers will fall back to pull: {exc}"

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -234,6 +234,19 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
         raise
 
 
+def resolve_initial_import_branch(repo: InfrahubRepository, init_failed: bool) -> str | None:
+    """Return the git branch whose objects must be seeded after a clone, or None when none is needed.
+
+    A freshly created or re-cloned local copy needs its default branch imported into the graph; an
+    already-present clone does not. The branch is taken from the repository's own default branch, which
+    is the git branch the clone checks out, rather than the platform default branch which may differ
+    and would not exist locally.
+    """
+    if init_failed or repo.reinitialized:
+        return repo.default_branch
+    return None
+
+
 async def bootstrap_local_repository(
     repo_name: str,
     repository: CoreRepository,
@@ -248,7 +261,6 @@ async def bootstrap_local_repository(
     skipped.
     """
     log = get_run_logger()
-    default_import_git_branch: str | None = None
     pinned_import_commit: str | None = None
     async with lock.registry.get(name=repo_name, namespace="repository"):
         init_failed = False
@@ -278,10 +290,8 @@ async def bootstrap_local_repository(
             except RepositoryError as exc:
                 log.info(exc.message)
                 return None
-            default_import_git_branch = repo.default_branch
 
-        if repo.reinitialized:
-            default_import_git_branch = repo.default_branch
+        default_import_git_branch = resolve_initial_import_branch(repo, init_failed=init_failed)
 
         if default_import_git_branch is not None:
             # Pin the commit while the lock is held so the import below reads an immutable

--- a/backend/tests/component/api/test_read_only.py
+++ b/backend/tests/component/api/test_read_only.py
@@ -174,7 +174,7 @@ class TestApiReadOnly(TestInfrahubApp):
 
         response = await test_client.post("/graphql", json={"query": query}, headers=admin_headers)
 
-        assert response.status_code
+        assert response.status_code == 200
         assert response.json() == {"data": {"AccountProfile": {"name": {"value": "admin"}}}}
 
     async def test_download_schema(

--- a/backend/tests/component/git/test_sync_repository.py
+++ b/backend/tests/component/git/test_sync_repository.py
@@ -30,30 +30,28 @@ class SyncScenario:
 
 
 SCENARIOS = [
-    # The git default branch matches Infrahub's, no staging: the only case where the buggy
-    # lookup happened to work, since the Infrahub branch name equals the git branch name.
+    # Git default branch matches Infrahub's default; no staging branch.
     SyncScenario(
         name="active_matching_default",
         git_default_branch="main",
         staging_branch=None,
         active_internal_status=RepositoryInternalStatus.ACTIVE.value,
     ),
-    # The git default branch differs from Infrahub's: the broadcast must resolve the git default.
+    # Git default branch differs from Infrahub's default.
     SyncScenario(
         name="active_mismatched_default",
         git_default_branch="production",
         staging_branch=None,
         active_internal_status=RepositoryInternalStatus.ACTIVE.value,
     ),
-    # Staging on an ordinary "main" repo: the Infrahub branch is the staging branch, which has no
-    # local git branch, so the commit must still resolve via the git default.
+    # Staging sync; git default branch matches Infrahub's default.
     SyncScenario(
         name="staging_matching_default",
         git_default_branch="main",
         staging_branch="staging-x",
         active_internal_status=RepositoryInternalStatus.STAGING.value,
     ),
-    # Staging combined with a mismatched git default branch.
+    # Staging sync; git default branch differs from Infrahub's default.
     SyncScenario(
         name="staging_mismatched_default",
         git_default_branch="production",
@@ -76,9 +74,9 @@ def message_bus_recorder(helper: TestHelper) -> Generator[BusRecorder, None, Non
 
 
 async def _build_repository(
-    db: InfrahubDatabase, source_dir: Path, git_default_branch: str
+    db: InfrahubDatabase, source_dir: Path, git_default_branch: str, internal_status: str
 ) -> tuple[Node, InfrahubRepository]:
-    """Seed a repository node and clone it locally, with the given git default branch."""
+    """Seed a repository node and clone it locally, with the given git default branch and status."""
     upstream = Repo.init(source_dir, initial_branch=git_default_branch)
     (source_dir / "file.txt").write_text("content")
     upstream.index.add(["file.txt"])
@@ -90,7 +88,7 @@ async def _build_repository(
         name="test-repository",
         location=str(source_dir),
         default_branch=git_default_branch,
-        internal_status=RepositoryInternalStatus.ACTIVE.value,
+        internal_status=internal_status,
     )
     await node.save(db=db)
 
@@ -99,6 +97,7 @@ async def _build_repository(
         name="test-repository",
         location=str(source_dir),
         default_branch_name=git_default_branch,
+        internal_status=internal_status,
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
         update_commit_value=False,
     )
@@ -115,15 +114,19 @@ async def test_sync_broadcasts_synced_commit(
     prefect_test_fixture: None,
     message_bus_recorder: BusRecorder,
 ) -> None:
-    """The commit broadcast to the worker pool must resolve to the repository's git default branch HEAD.
+    """The commit broadcast to the worker pool resolves to the repository's git default branch HEAD.
 
-    The buggy lookup used the Infrahub branch name, which only ever matches a local git branch when
-    the git default branch matches Infrahub's default and no staging branch is involved. Every other
-    setup dropped the commit to None, leaving the worker pool without a SHA to converge on.
+    Holds across matching and mismatched default branches and staging syncs, so every worker
+    converges on the same pinned commit.
     """
     source_dir = tmp_path / "source-repo"
     source_dir.mkdir()
-    node, repo = await _build_repository(db=db, source_dir=source_dir, git_default_branch=scenario.git_default_branch)
+    node, repo = await _build_repository(
+        db=db,
+        source_dir=source_dir,
+        git_default_branch=scenario.git_default_branch,
+        internal_status=scenario.active_internal_status,
+    )
 
     assert repo.client is not None
     client = repo.client

--- a/backend/tests/component/git/test_sync_repository.py
+++ b/backend/tests/component/git/test_sync_repository.py
@@ -1,0 +1,150 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from git import Repo
+from infrahub_sdk import Config, InfrahubClient
+from prefect import flow
+
+from infrahub import config
+from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.database import InfrahubDatabase
+from infrahub.git import InfrahubRepository
+from infrahub.git.tasks import sync_repository_from_origin
+from infrahub.message_bus.messages import RefreshGitFetch
+from infrahub.workers.dependencies import clear_singletons
+from tests.adapters.message_bus import BusRecorder
+from tests.conftest import TestHelper
+from tests.helpers.test_client import dummy_async_request
+
+
+@dataclass
+class SyncScenario:
+    name: str
+    git_default_branch: str
+    staging_branch: str | None
+    active_internal_status: str
+
+
+SCENARIOS = [
+    # The git default branch matches Infrahub's, no staging: the only case where the buggy
+    # lookup happened to work, since the Infrahub branch name equals the git branch name.
+    SyncScenario(
+        name="active_matching_default",
+        git_default_branch="main",
+        staging_branch=None,
+        active_internal_status=RepositoryInternalStatus.ACTIVE.value,
+    ),
+    # The git default branch differs from Infrahub's: the broadcast must resolve the git default.
+    SyncScenario(
+        name="active_mismatched_default",
+        git_default_branch="production",
+        staging_branch=None,
+        active_internal_status=RepositoryInternalStatus.ACTIVE.value,
+    ),
+    # Staging on an ordinary "main" repo: the Infrahub branch is the staging branch, which has no
+    # local git branch, so the commit must still resolve via the git default.
+    SyncScenario(
+        name="staging_matching_default",
+        git_default_branch="main",
+        staging_branch="staging-x",
+        active_internal_status=RepositoryInternalStatus.STAGING.value,
+    ),
+    # Staging combined with a mismatched git default branch.
+    SyncScenario(
+        name="staging_mismatched_default",
+        git_default_branch="production",
+        staging_branch="staging-x",
+        active_internal_status=RepositoryInternalStatus.STAGING.value,
+    ),
+]
+
+
+@pytest.fixture
+def message_bus_recorder(helper: TestHelper) -> Generator[BusRecorder, None, None]:
+    """Install a recording bus and drop cached singletons so the flow resolves it, restoring on exit."""
+    original = config.OVERRIDE.message_bus
+    recorder = helper.get_message_bus_recorder()
+    config.OVERRIDE.message_bus = recorder
+    clear_singletons()
+    yield recorder
+    config.OVERRIDE.message_bus = original
+    clear_singletons()
+
+
+async def _build_repository(
+    db: InfrahubDatabase, source_dir: Path, git_default_branch: str
+) -> tuple[Node, InfrahubRepository]:
+    """Seed a repository node and clone it locally, with the given git default branch."""
+    upstream = Repo.init(source_dir, initial_branch=git_default_branch)
+    (source_dir / "file.txt").write_text("content")
+    upstream.index.add(["file.txt"])
+    upstream.index.commit("First commit")
+
+    node = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+    await node.new(
+        db=db,
+        name="test-repository",
+        location=str(source_dir),
+        default_branch=git_default_branch,
+        internal_status=RepositoryInternalStatus.ACTIVE.value,
+    )
+    await node.save(db=db)
+
+    repo = await InfrahubRepository.new(
+        id=node.id,
+        name="test-repository",
+        location=str(source_dir),
+        default_branch_name=git_default_branch,
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        update_commit_value=False,
+    )
+    return node, repo
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[scenario.name for scenario in SCENARIOS])
+async def test_sync_broadcasts_synced_commit(
+    scenario: SyncScenario,
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    tmp_path: Path,
+    git_repos_dir: Path,
+    prefect_test_fixture: None,
+    message_bus_recorder: BusRecorder,
+) -> None:
+    """The commit broadcast to the worker pool must resolve to the repository's git default branch HEAD.
+
+    The buggy lookup used the Infrahub branch name, which only ever matches a local git branch when
+    the git default branch matches Infrahub's default and no staging branch is involved. Every other
+    setup dropped the commit to None, leaving the worker pool without a SHA to converge on.
+    """
+    source_dir = tmp_path / "source-repo"
+    source_dir.mkdir()
+    node, repo = await _build_repository(db=db, source_dir=source_dir, git_default_branch=scenario.git_default_branch)
+
+    assert repo.client is not None
+    client = repo.client
+    infrahub_branch = scenario.staging_branch or registry.default_branch
+
+    @flow(name="test-sync-repository-from-origin")
+    async def _run_sync() -> None:
+        await sync_repository_from_origin(
+            repository=node,
+            repo=repo,
+            active_internal_status=scenario.active_internal_status,
+            staging_branch=scenario.staging_branch,
+            infrahub_branch=infrahub_branch,
+            infrahub_branch_id="branch-id",
+            client=client,
+        )
+
+    await _run_sync()
+
+    fetch_messages = [message for message in message_bus_recorder.messages if isinstance(message, RefreshGitFetch)]
+    assert len(fetch_messages) == 1
+
+    expected_commit = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
+    assert fetch_messages[0].commit == expected_commit

--- a/backend/tests/unit/git/test_tasks.py
+++ b/backend/tests/unit/git/test_tasks.py
@@ -1,4 +1,54 @@
-from infrahub.git.tasks import format_check_log_entry
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+
+from infrahub.core.constants import RepositoryInternalStatus
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from infrahub.git.tasks import format_check_log_entry, resolve_initial_import_branch
+
+
+@dataclass
+class ImportBranchCase:
+    name: str
+    init_failed: bool
+    reinitialized: bool
+    expected: str | None
+
+
+IMPORT_BRANCH_CASES = [
+    # A fresh clone (init raised, recreated via new) must seed its git default branch.
+    ImportBranchCase(name="freshly_created", init_failed=True, reinitialized=False, expected="production"),
+    # A re-cloned local copy (local directory was missing) must seed its git default branch.
+    ImportBranchCase(name="reinitialized", init_failed=False, reinitialized=True, expected="production"),
+    # An already-present valid clone needs no initial import.
+    ImportBranchCase(name="existing_clone", init_failed=False, reinitialized=False, expected=None),
+]
+
+
+@pytest.mark.parametrize("case", IMPORT_BRANCH_CASES, ids=[case.name for case in IMPORT_BRANCH_CASES])
+def test_resolve_initial_import_branch_uses_git_default(
+    case: ImportBranchCase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The seeded branch must be the repository's git default branch, never the platform default."""
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    # The repository's git default branch ("production") differs from Infrahub's default ("main").
+    assert registry.default_branch != "production"
+    repo = InfrahubRepository(
+        id=uuid4(),
+        name="test-repository",
+        location="git@github.com:mock/test-repository.git",
+        default_branch_name="production",
+        has_origin=True,
+        cache_repo=None,
+        is_read_only=False,
+        internal_status=RepositoryInternalStatus.ACTIVE.value,
+        infrahub_branch_name=None,
+        reinitialized=case.reinitialized,
+    )
+
+    assert resolve_initial_import_branch(repo, init_failed=case.init_failed) == case.expected
 
 
 def test_format_check_log_entry_message_only() -> None:

--- a/changelog/+pin-sync-commit-git-default-branch.fixed.md
+++ b/changelog/+pin-sync-commit-git-default-branch.fixed.md
@@ -1,0 +1,1 @@
+Repository synchronization now resolves both a new repository's initial import and the pinned worker-pool commit from the repository's Git default branch rather than Infrahub's default branch name, fixing repositories whose Git default branch differs and staging-branch syncs.


### PR DESCRIPTION
## Why

Feedbacks brought up by Cubic in this PR: https://github.com/opsmill/infrahub/pull/9564.

### Git module related problems

`sync_repository_from_origin` and `bootstrap_local_repository` resolved the commit to pin/import using an **Infrahub** branch name (`infrahub_branch` / `registry.default_branch`) where a **git** branch name is required. `get_commit_value` resolves against local git branches, which are named after the repository's git default branch. The Infrahub branch name only coincides with a local git branch in the common case (git default == Infrahub default, no staging). In the other cases the lookup misses:

- **Broadcast** (`sync_repository_from_origin`): `RefreshGitFetch.commit` is dropped to `None`, so the worker pool can't converge on the pinned SHA and falls back to pulling latest.
- **Bootstrap** (`bootstrap_local_repository`): `get_commit_value` raises `ValueError`, crashing the sync for repos created on the init-failed path.

Affected setups: repositories whose git default branch differs from Infrahub's default, and staging-branch syncs (where the Infrahub branch has no local git branch at all).

#### Fix

Resolve both lookups via `repo.default_branch` — the git branch the local clone actually checks out.

### Tests assertions

#### Fix

Assert against a real error code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes commit pinning during repository sync and bootstrap by resolving from each repo’s Git default branch. Workers now converge on the correct SHA; initial imports run only for fresh or re-cloned repos.

- **Bug Fixes**
  - In sync, resolve the pinned commit from `repo.default_branch`; the `RefreshGitFetch` broadcast now carries the correct SHA across mismatched defaults and staging (covered by a component test).
  - In bootstrap, seed graph data from the Git default branch only on fresh or reinitialized clones.

- **Refactors**
  - Extract initial-import branch selection into `resolve_initial_import_branch` with unit tests.
  - Tightened a read-only API test to assert `== 200`.

<sup>Written for commit 0d5733b9a5d9940e2e12c995637f3529d0f69c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



