### PR TITLE
fix(deps): upgrade gitpython to 3.1.50 for GHSA-mv93-w799-cj2w

### DIFF
--- a/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
+++ b/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
@@ -1,0 +1,1 @@
+Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "prefect-redis==0.2.8",
     "ujson>=5,<6",
     "Jinja2>=3,<4",
-    "gitpython>=3,<4",
+    "gitpython>=3.1.50,<4",
     "pyyaml>=6,<7",
     "tomli>=1.1.0; python_version<='3.11'",
     "deepdiff==8.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1011,14 +1011,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -1481,7 +1481,7 @@ requires-dist = [
     { name = "fast-depends", specifier = "==3.0.5" },
     { name = "fastapi", specifier = "==0.131.0" },
     { name = "fastapi-storages", specifier = ">=0.3,<0.4" },
-    { name = "gitpython", specifier = ">=3,<4" },
+    { name = "gitpython", specifier = ">=3.1.50,<4" },
     { name = "graphene", specifier = ">=3.4,<3.5" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3,<4" },


### PR DESCRIPTION
## What

Upgrades `gitpython` from `3.1.45` to `3.1.50` and raises the floor pin to `>=3.1.50,<4`.

## Why

`GHSA-mv93-w799-cj2w` shows up when running **grype against the 1.9.8 SBOM**. It affects GitPython `<= 3.1.49` and is a bypass of the earlier CVE-2026-42215 patch: that fix validated newlines in the `value` argument of `set_value()` but left `section`/`option` unvalidated. An attacker controlling a section name can inject a newline to forge a `[core]` header with a malicious `hooksPath`, leading to arbitrary code execution when git hooks fire. Fixed in `3.1.50` (the latest 3.1.x release).

## Changes

- `pyproject.toml` — `gitpython>=3,<4` → `gitpython>=3.1.50,<4`
- `uv.lock` — `gitpython 3.1.45 → 3.1.50` (gitpython-only; no other packages touched)
- `changelog/` — `security` fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `gitpython` to 3.1.50 and raise the pin to `>=3.1.50,<4` to address GHSA-mv93-w799-cj2w. This fixes a config-injection bug where crafted section/option names could forge a `[core]` hooksPath and trigger arbitrary code execution.

<sup>Written for commit dc07706377167407e04b68b758766ff83234131a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

