### PR TITLE
docs: document schema-level order_by for metadata and direction [INFP-530]

### DIFF
--- a/docs/docs/development-resources/graphql/queries-and-mutations.mdx
+++ b/docs/docs/development-resources/graphql/queries-and-mutations.mdx
@@ -149,9 +149,9 @@ Every list query and every many-cardinality relationship field accepts an `order
 
 The `order` argument has the following fields:
 
-- `order_by: [String!]` — a list of sort entries using the same grammar as the schema `order_by` field: attribute paths (`name__value__desc`), relationship-attribute paths (`author__name__value`), and object metadata (`node_metadata__created_at__desc`). The trailing `__asc` / `__desc` is optional and defaults to ascending.
-- `node_metadata` — order by object-level metadata using the field-per-direction form, for example `{ created_at: DESC }`.
-- `disable: Boolean` — set to `true` to return results without any ordering.
+- `order_by: [String!]` - a list of sort entries using the same grammar as the schema `order_by` field: attribute paths (`name__value__desc`), relationship-attribute paths (`author__name__value`), and object metadata (`node_metadata__created_at__desc`). The trailing `__asc` / `__desc` is optional and defaults to ascending.
+- `node_metadata` - order by object-level metadata using the field-per-direction form, for example `{ created_at: DESC }`.
+- `disable: Boolean` - set to `true` to return results without any ordering.
 
 ```graphql title="Order tags newest-first using order_by"
 query {

--- a/docs/docs/development-resources/graphql/queries-and-mutations.mdx
+++ b/docs/docs/development-resources/graphql/queries-and-mutations.mdx
@@ -149,13 +149,17 @@ Every list query and every many-cardinality relationship field accepts an `order
 
 The `order` argument has the following fields:
 
-- `order_by: [String!]` - a list of sort entries using the same grammar as the schema `order_by` field: attribute paths (`name__value__desc`), relationship-attribute paths (`author__name__value`), and object metadata (`node_metadata__created_at__desc`). The trailing `__asc` / `__desc` is optional and defaults to ascending.
-- `node_metadata` - order by object-level metadata using the field-per-direction form, for example `{ created_at: DESC }`.
-- `disable: Boolean` - set to `true` to return results without any ordering.
+- `by: [OrderByItem!]` - an ordered list of sort entries. Each entry is an object with two fields:
+  - `field: String!` - what to sort on: an attribute path (`name__value`), a relationship-attribute path (`author__name__value`), or object metadata (`node_metadata__created_at` / `node_metadata__updated_at`). The field carries **no** direction suffix.
+  - `direction: OrderDirection` - `ASC` or `DESC`. Defaults to `ASC` when omitted.
 
-```graphql title="Order tags newest-first using order_by"
+  Entries apply in order, so the first is the primary sort, the second the tiebreaker, and so on.
+- `disable: Boolean` - set to `true` to return results without any ordering.
+- `node_metadata` *(deprecated)* - the legacy field-per-direction form, for example `{ created_at: DESC }`. Use `by` with the `node_metadata__created_at` / `node_metadata__updated_at` fields instead.
+
+```graphql title="Order tags newest-first"
 query {
-  BuiltinTag(order: { order_by: ["node_metadata__created_at__desc"] }) {
+  BuiltinTag(order: { by: [{ field: "node_metadata__created_at", direction: DESC }] }) {
     edges {
       node {
         name {
@@ -167,11 +171,11 @@ query {
 }
 ```
 
-The same result using the `node_metadata` form:
+Sort on more than one field - descending name, then ascending serial number as a tiebreaker. The `direction` on the second entry is omitted, so it defaults to `ASC`:
 
-```graphql title="Order tags newest-first using node_metadata"
+```graphql title="Order by multiple fields"
 query {
-  BuiltinTag(order: { node_metadata: { created_at: DESC } }) {
+  InfraDevice(order: { by: [{ field: "name__value", direction: DESC }, { field: "serial_number__value" }] }) {
     edges {
       node {
         name {
@@ -186,7 +190,7 @@ query {
 A few rules govern how `order` interacts with the schema default:
 
 - When `order` is provided, it **fully replaces** the schema's `order_by` for that query. The two are not combined, and the schema default contributes no fallback tiebreaker.
-- `order_by` and `node_metadata` cannot be set in the same `order` argument.
+- `by` cannot be combined with the deprecated `node_metadata` field in the same `order` argument.
 
 ## Mutations format
 

--- a/docs/docs/development-resources/graphql/queries-and-mutations.mdx
+++ b/docs/docs/development-resources/graphql/queries-and-mutations.mdx
@@ -143,6 +143,51 @@ query {
 }
 ```
 
+## Ordering results
+
+Every list query and every many-cardinality relationship field accepts an `order` argument to control the sort order of the objects returned. When `order` is omitted, the results use the schema's [default ordering](../../schema/default-ordering).
+
+The `order` argument has the following fields:
+
+- `order_by: [String!]` — a list of sort entries using the same grammar as the schema `order_by` field: attribute paths (`name__value__desc`), relationship-attribute paths (`author__name__value`), and object metadata (`node_metadata__created_at__desc`). The trailing `__asc` / `__desc` is optional and defaults to ascending.
+- `node_metadata` — order by object-level metadata using the field-per-direction form, for example `{ created_at: DESC }`.
+- `disable: Boolean` — set to `true` to return results without any ordering.
+
+```graphql title="Order tags newest-first using order_by"
+query {
+  BuiltinTag(order: { order_by: ["node_metadata__created_at__desc"] }) {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+The same result using the `node_metadata` form:
+
+```graphql title="Order tags newest-first using node_metadata"
+query {
+  BuiltinTag(order: { node_metadata: { created_at: DESC } }) {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+A few rules govern how `order` interacts with the schema default:
+
+- When `order` is provided, it **fully replaces** the schema's `order_by` for that query. The two are not combined, and the schema default contributes no fallback tiebreaker.
+- `order_by` and `node_metadata` cannot be set in the same `order` argument.
+
 ## Mutations format
 
 The format of the mutation to `Create`, `Update` and `Upsert` an object has some similarities with the query format. The format will be slightly different for:

--- a/docs/docs/objects/metadata.mdx
+++ b/docs/docs/objects/metadata.mdx
@@ -87,7 +87,7 @@ The `created_by` and `updated_by` fields return account objects, which have a `d
 
 Query results can be ordered by object-level metadata timestamps using the `order` parameter with `node_metadata`. The example above demonstrates ordering by `created_at` in descending order to show the most recently created objects first. You can also order by `updated_at` to sort by modification time.
 
-Metadata ordering can also be declared at the schema level via the node or generic `order_by` field. Entries take the form `node_metadata__<field>` or `node_metadata__<field>__<direction>`, where `<field>` is `created_at` or `updated_at` and `<direction>` is `asc` or `desc` (ascending if omitted). Regular `order_by` entries accept the same `__asc` / `__desc` suffix. For example, `name__value__desc`. A query-time `order` argument fully replaces the schema-level default rather than being layered on top, so the two never stack.
+Object metadata can also be the default sort order for a kind, declared in the schema rather than requested on every query. Set the node or generic [`order_by`](../schema/default-ordering) field to an entry like `node_metadata__created_at__desc`. A query-time `order` argument fully replaces that schema-level default rather than being layered on top, so the two never stack.
 
 ### Filtering by metadata
 

--- a/docs/docs/objects/metadata.mdx
+++ b/docs/docs/objects/metadata.mdx
@@ -59,7 +59,7 @@ In GraphQL queries, object-level metadata is accessed via the `node_metadata` fi
 
 ```graphql
 {
-  BuiltinTag(order: {node_metadata: {created_at: DESC}}) {
+  BuiltinTag(order: {by: [{field: "node_metadata__created_at", direction: DESC}]}) {
     edges {
       node {
         name {

--- a/docs/docs/schema/default-ordering.mdx
+++ b/docs/docs/schema/default-ordering.mdx
@@ -111,7 +111,7 @@ A concrete node inherits a generic's `order_by` only when the node does not decl
 
 A query can pass an `order` argument to sort that one request differently. When it does, the `order` argument **fully replaces** the schema's `order_by` for that query - the two are not combined, and the schema default contributes no fallback tiebreaker.
 
-The query-time `order` argument uses the same entry grammar as the schema field. For the GraphQL details, see the ordering section of the queries guide.
+The query-time `order` argument expresses the same sort targets - attributes, relationship attributes, and object metadata - but in a structured form rather than the schema field's suffixed strings: each entry is a `{ field, direction }` object, where `direction` is a separate `ASC`/`DESC` value instead of an `__asc`/`__desc` suffix. For the GraphQL details, see the ordering section of the queries guide.
 
 <ReferenceLink title="Ordering results in GraphQL" url="../development-resources/graphql/queries-and-mutations#ordering-results" />
 

--- a/docs/docs/schema/default-ordering.mdx
+++ b/docs/docs/schema/default-ordering.mdx
@@ -33,7 +33,7 @@ nodes:
         kind: TextArea
 ```
 
-An empty or absent `order_by` applies no schema-level ordering, the same as today.
+An empty or absent `order_by` applies no schema-level ordering.
 
 ## Entry grammar
 
@@ -129,12 +129,6 @@ The query-time `order` argument uses the same entry grammar as the schema field.
 ## `node_metadata` is a reserved name
 
 Because `node_metadata__` distinguishes metadata entries from attribute paths, `node_metadata` is a reserved attribute and relationship name. A schema that defines an attribute or relationship literally named `node_metadata` fails to load.
-
-:::warning Upgrade note
-
-If a schema in use before this release has an attribute or relationship named `node_metadata`, it will fail to load after upgrading. Rename the field to load the schema.
-
-:::
 
 ## Related concepts
 

--- a/docs/docs/schema/default-ordering.mdx
+++ b/docs/docs/schema/default-ordering.mdx
@@ -6,13 +6,13 @@ import ReferenceLink from "../../src/components/Card";
 
 # Default ordering
 
-The `order_by` field on a node or generic sets the default sort order for every list of that kind's objects. Once declared, the order applies everywhere the objects are listed — the web interface, the GraphQL API, and the Python SDK — without each query specifying how to sort.
+The `order_by` field on a node or generic sets the default sort order for every list of that kind's objects. Once declared, the order applies everywhere the objects are listed - the web interface, the GraphQL API, and the Python SDK - without each query specifying how to sort.
 
 `order_by` controls which **objects** come first in a list. This is distinct from [`order_weight`](./order-weight), which controls which **fields** come first within a single object's view.
 
 ## Why this matters
 
-A schema author usually knows the natural order for a kind of object: documentation notes read best newest-first, devices read best alphabetically, invoices read best by largest amount. Without a schema-level default, that order has to be requested on every individual query, and any consumer that forgets — the detail-page tab, an ad-hoc API call — shows the objects in an order nobody chose.
+A schema author usually knows the natural order for a kind of object: documentation notes read best newest-first, devices read best alphabetically, invoices read best by largest amount. Without a schema-level default, that order has to be requested on every individual query, and any consumer that forgets - the object list view, an ad-hoc API call - shows the objects in an order nobody chose.
 
 Declaring `order_by` once moves that decision into the schema. Every consumer inherits it, and a single edit changes the order across all of them.
 
@@ -70,7 +70,7 @@ nodes:
       - node_metadata__created_at__desc
 ```
 
-When notes are attached to a parent object through a many-cardinality relationship, the parent's notes tab and any API read of that relationship return them newest-first — no per-query ordering argument.
+When notes are attached to a parent object through a many-cardinality relationship, the parent's notes tab and any API read of that relationship return them newest-first - no per-query ordering argument.
 
 Order devices by descending name, then by ascending serial number as a tiebreaker:
 
@@ -87,15 +87,15 @@ nodes:
 
 Schema-level `order_by` is honored consistently in the three places a list of objects is returned:
 
-- **Top-level listings** — querying a kind directly.
-- **Relationship listings** — the objects on the far side of a many-cardinality relationship. The **peer** schema's `order_by` is the source of truth; there is no per-relationship override.
-- **Hierarchy listings** — children, ancestors, and descendants of a hierarchical node.
+- **Top-level listings** - querying a kind directly.
+- **Relationship listings** - the objects on the far side of a many-cardinality relationship. The **peer** schema's `order_by` is the source of truth; there is no per-relationship override.
+- **Hierarchy listings** - children, ancestors, and descendants of a hierarchical node.
 
-Whenever `order_by` is in effect, the object UUID is appended as a final ascending tiebreaker. Two objects that compare equal on every declared entry — two notes created in the same millisecond — therefore keep a stable relative order, so pagination does not shuffle between requests.
+Whenever `order_by` is in effect, the object UUID is appended as a final ascending tiebreaker. Two objects that compare equal on every declared entry - two notes created in the same millisecond - therefore keep a stable relative order, so pagination does not shuffle between requests.
 
 ## Ordering by object metadata
 
-`created_at` and `updated_at` are object-level metadata that Infrahub records automatically for every node — there is no need to add a timestamp attribute to the schema to sort on them.
+`created_at` and `updated_at` are object-level metadata that Infrahub records automatically for every node - there is no need to add a timestamp attribute to the schema to sort on them.
 
 <ReferenceLink title="Data lineage and metadata" url="../objects/metadata" />
 
@@ -103,13 +103,13 @@ Only `created_at` and `updated_at` can be used in `order_by`. The `created_by` a
 
 ## Inheritance
 
-A concrete node inherits a generic's `order_by` only when the node does not declare its own. When the node declares `order_by`, its value applies in full and the generic's is not merged in. The metadata and direction syntax inherits the same way. This matches existing `order_by` inheritance — no new rules are introduced.
+A concrete node inherits a generic's `order_by` only when the node does not declare its own. When the node declares `order_by`, its value applies in full and the generic's is not merged in. The metadata and direction syntax inherits the same way. This matches existing `order_by` inheritance - no new rules are introduced.
 
 <ReferenceLink title="Generics & inheritance" url="./generics-and-inheritance" />
 
 ## Overriding at query time
 
-A query can pass an `order` argument to sort that one request differently. When it does, the `order` argument **fully replaces** the schema's `order_by` for that query — the two are not combined, and the schema default contributes no fallback tiebreaker.
+A query can pass an `order` argument to sort that one request differently. When it does, the `order` argument **fully replaces** the schema's `order_by` for that query - the two are not combined, and the schema default contributes no fallback tiebreaker.
 
 The query-time `order` argument uses the same entry grammar as the schema field. For the GraphQL details, see the ordering section of the queries guide.
 
@@ -138,8 +138,8 @@ If a schema in use before this release has an attribute or relationship named `n
 
 ## Related concepts
 
-- [Order weight](./order-weight) — Controls the order of fields within an object's view
-- [Data lineage and metadata](../objects/metadata) — The object-level metadata you can sort on
-- [Generics & inheritance](./generics-and-inheritance) — How a node inherits a generic's `order_by`
-- [Ordering results in GraphQL](../development-resources/graphql/queries-and-mutations#ordering-results) — Overriding the default order at query time
-- [Reference: Node](../reference/schema/node) — Full node property reference
+- [Order weight](./order-weight) - Controls the order of fields within an object's view
+- [Data lineage and metadata](../objects/metadata) - The object-level metadata you can sort on
+- [Generics & inheritance](./generics-and-inheritance) - How a node inherits a generic's `order_by`
+- [Ordering results in GraphQL](../development-resources/graphql/queries-and-mutations#ordering-results) - Overriding the default order at query time
+- [Reference: Node](../reference/schema/node) - Full node property reference

--- a/docs/docs/schema/default-ordering.mdx
+++ b/docs/docs/schema/default-ordering.mdx
@@ -1,0 +1,145 @@
+---
+title: Default ordering
+---
+
+import ReferenceLink from "../../src/components/Card";
+
+# Default ordering
+
+The `order_by` field on a node or generic sets the default sort order for every list of that kind's objects. Once declared, the order applies everywhere the objects are listed — the web interface, the GraphQL API, and the Python SDK — without each query specifying how to sort.
+
+`order_by` controls which **objects** come first in a list. This is distinct from [`order_weight`](./order-weight), which controls which **fields** come first within a single object's view.
+
+## Why this matters
+
+A schema author usually knows the natural order for a kind of object: documentation notes read best newest-first, devices read best alphabetically, invoices read best by largest amount. Without a schema-level default, that order has to be requested on every individual query, and any consumer that forgets — the detail-page tab, an ad-hoc API call — shows the objects in an order nobody chose.
+
+Declaring `order_by` once moves that decision into the schema. Every consumer inherits it, and a single edit changes the order across all of them.
+
+## The `order_by` field
+
+`order_by` is an optional list of strings on nodes and generics. Each entry names something to sort by; entries are applied in order, so the first entry is the primary sort, the second is the tiebreaker, and so on.
+
+```yaml
+nodes:
+  - name: Note
+    namespace: Documentation
+    order_by:
+      - node_metadata__created_at__desc
+    attributes:
+      - name: title
+        kind: Text
+      - name: body
+        kind: TextArea
+```
+
+An empty or absent `order_by` applies no schema-level ordering, the same as today.
+
+## Entry grammar
+
+An entry is a sort target with an optional direction suffix. The target is one of three forms:
+
+| Target | Form | Example |
+| --- | --- | --- |
+| Attribute | `<attribute>__value` | `title__value` |
+| Relationship attribute | `<relationship>__<attribute>__value` | `author__name__value` |
+| Object metadata | `node_metadata__<field>` | `node_metadata__created_at` |
+
+For object metadata, `<field>` is `created_at` or `updated_at`. The `node_metadata__` prefix marks the entry as metadata so it never collides with an attribute name.
+
+Any entry can carry a trailing `__asc` or `__desc` to set the direction. When the suffix is omitted, the direction is **ascending**:
+
+| Entry | Result |
+| --- | --- |
+| `title__value` | Titles A→Z (ascending, the default) |
+| `title__value__desc` | Titles Z→A |
+| `node_metadata__created_at__desc` | Newest first |
+| `node_metadata__updated_at__asc` | Least-recently modified first |
+
+Because the suffix is optional and defaults to ascending, every `order_by` entry written before this syntax existed keeps its original behavior.
+
+## Examples
+
+Order documentation notes newest-first on the object-level `created_at` metadata that Infrahub tracks on every node:
+
+```yaml
+nodes:
+  - name: Note
+    namespace: Documentation
+    order_by:
+      - node_metadata__created_at__desc
+```
+
+When notes are attached to a parent object through a many-cardinality relationship, the parent's notes tab and any API read of that relationship return them newest-first — no per-query ordering argument.
+
+Order devices by descending name, then by ascending serial number as a tiebreaker:
+
+```yaml
+nodes:
+  - name: Device
+    namespace: Infra
+    order_by:
+      - name__value__desc
+      - serial_number__value
+```
+
+## Where ordering applies
+
+Schema-level `order_by` is honored consistently in the three places a list of objects is returned:
+
+- **Top-level listings** — querying a kind directly.
+- **Relationship listings** — the objects on the far side of a many-cardinality relationship. The **peer** schema's `order_by` is the source of truth; there is no per-relationship override.
+- **Hierarchy listings** — children, ancestors, and descendants of a hierarchical node.
+
+Whenever `order_by` is in effect, the object UUID is appended as a final ascending tiebreaker. Two objects that compare equal on every declared entry — two notes created in the same millisecond — therefore keep a stable relative order, so pagination does not shuffle between requests.
+
+## Ordering by object metadata
+
+`created_at` and `updated_at` are object-level metadata that Infrahub records automatically for every node — there is no need to add a timestamp attribute to the schema to sort on them.
+
+<ReferenceLink title="Data lineage and metadata" url="../objects/metadata" />
+
+Only `created_at` and `updated_at` can be used in `order_by`. The `created_by` and `updated_by` metadata reference accounts, whose ordering is not meaningful, and are not supported.
+
+## Inheritance
+
+A concrete node inherits a generic's `order_by` only when the node does not declare its own. When the node declares `order_by`, its value applies in full and the generic's is not merged in. The metadata and direction syntax inherits the same way. This matches existing `order_by` inheritance — no new rules are introduced.
+
+<ReferenceLink title="Generics & inheritance" url="./generics-and-inheritance" />
+
+## Overriding at query time
+
+A query can pass an `order` argument to sort that one request differently. When it does, the `order` argument **fully replaces** the schema's `order_by` for that query — the two are not combined, and the schema default contributes no fallback tiebreaker.
+
+The query-time `order` argument uses the same entry grammar as the schema field. For the GraphQL details, see the ordering section of the queries guide.
+
+<ReferenceLink title="Ordering results in GraphQL" url="../development-resources/graphql/queries-and-mutations#ordering-results" />
+
+## Validation
+
+`order_by` is validated when the schema loads. A malformed entry fails the load with an error naming the node and the offending entry, rather than silently falling back to default ordering. The validator rejects:
+
+| Problem | Example |
+| --- | --- |
+| An unsupported metadata field | `node_metadata__created_by` |
+| A direction token other than `asc` or `desc` | `title__value__descending` |
+| The same field listed twice, or with conflicting directions | `title__value__asc` and `title__value__desc` together |
+| An attribute or relationship literally named `node_metadata` | see below |
+
+## `node_metadata` is a reserved name
+
+Because `node_metadata__` distinguishes metadata entries from attribute paths, `node_metadata` is a reserved attribute and relationship name. A schema that defines an attribute or relationship literally named `node_metadata` fails to load.
+
+:::warning Upgrade note
+
+If a schema in use before this release has an attribute or relationship named `node_metadata`, it will fail to load after upgrading. Rename the field to load the schema.
+
+:::
+
+## Related concepts
+
+- [Order weight](./order-weight) — Controls the order of fields within an object's view
+- [Data lineage and metadata](../objects/metadata) — The object-level metadata you can sort on
+- [Generics & inheritance](./generics-and-inheritance) — How a node inherits a generic's `order_by`
+- [Ordering results in GraphQL](../development-resources/graphql/queries-and-mutations#ordering-results) — Overriding the default order at query time
+- [Reference: Node](../reference/schema/node) — Full node property reference

--- a/docs/docs/schema/nodes-and-attributes.mdx
+++ b/docs/docs/schema/nodes-and-attributes.mdx
@@ -260,11 +260,15 @@ The `order_weight` property controls the position of attributes and relationship
 
 <ReferenceLink title="Full order weight reference" url="./order-weight" />
 
+To control the order of the objects within a list — which object appears first — rather than the order of fields, use the node's `order_by` field.
+
+<ReferenceLink title="Default ordering" url="./default-ordering" />
+
 ## Reserved namespaces and attribute names
 
 Some namespaces like `Core`, `Infrahub`, `Profile`, and `Builtin` are reserved and can't be used by users to define new Nodes and Generics.
 
-In a similar fashion, some attribute names can't be used, like `attribute` or `relationship`.
+In a similar fashion, some attribute names can't be used, like `attribute` or `relationship`. `node_metadata` is also reserved, because it is the prefix used to sort by object metadata in [`order_by`](./default-ordering).
 
 ## Related concepts
 

--- a/docs/docs/schema/order-weight.mdx
+++ b/docs/docs/schema/order-weight.mdx
@@ -318,6 +318,7 @@ relationships:
 
 - [Field visibility](./field-visibility) — Controls whether fields appear in default or extra views
 - [Labels](./display_label) — Controls how fields and nodes are named in the UI
+- [Default ordering](./default-ordering) — Controls the order of objects within a list
 - [Nodes & attributes](./nodes-and-attributes) — Schema properties that control display and ordering
 
 ## Troubleshooting

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -136,6 +136,7 @@ const sidebars: SidebarsConfig = {
             { type: 'doc', id: 'schema/field-visibility', label: 'Field visibility' },
             { type: 'doc', id: 'schema/display_label', label: 'Display labels' },
             { type: 'doc', id: 'schema/order-weight', label: 'Order weight' },
+            { type: 'doc', id: 'schema/default-ordering', label: 'Default ordering' },
             { type: 'doc', id: 'menu/overview', label: 'Menu customization' },
           ],
         },


### PR DESCRIPTION
Adds documentation for the expanded schema `order_by` field ([INFP-530](https://opsmill.atlassian.net/browse/INFP-530)): node-metadata sort targets, explicit `__asc`/`__desc` direction, consistent ordering across top-level / relationship / hierarchy lists, and the query-time precedence change. The feature ships in 1.10, so this targets `release-1.10`.

## What's included

- **New page** — *Schema & Data → Display & presentation → Default ordering* (`docs/docs/schema/default-ordering.mdx`): the `order_by` field, entry grammar (attribute / relationship-attribute / `node_metadata`), where ordering applies, metadata ordering, generic inheritance, query-time override, load-time validation, and the reserved `node_metadata` name.
- **GraphQL guide** — new "Ordering results" section in `queries-and-mutations.mdx` covering the `order` argument (`order_by`, `node_metadata`, `disable`) and the replace-not-stack precedence.
- **Cross-links** — `metadata.mdx`, `nodes-and-attributes.mdx`, and `order-weight.mdx` point to the new page; `node_metadata` reserved-name note added.

## Reviewer attention

1. **Title/placement** — "Default ordering" sits next to "Order weight" in *Display & presentation*. Unlike its siblings (pure UI hints), `order_by` affects API/SDK results too; placed there for discoverability and to disambiguate the two "ordering" knobs.
2. **GraphQL section** — this is the first ordering content in that guide (the `order` argument was previously undocumented).
3. **Generated reference** — `reference/schema/node.mdx` / `generic.mdx` already carry the updated `order_by` description from the feature branch; not re-edited here.

## Verification

- Docusaurus build passes (no broken links/anchors)
- Vale: 0 issues · markdownlint: 0 errors

No new changelog fragment — the feature's `changelog/+order-by-metadata-direction.added.md` already exists on `release-1.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INFP-530]: https://opsmill.atlassian.net/browse/INFP-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for schema-level default ordering via `order_by`, including metadata fields and `__asc`/`__desc`, and updates GraphQL to document the new `order { by: [{ field, direction }], disable }` form and deprecate `node_metadata`. Clarifies that defaults apply across listings and that query-time `order` fully replaces them to satisfy INFP-530 for 1.10.

- **New Features**
  - New “Default ordering” page for `order_by`: entry grammar (attribute `__value`, relationship attributes, `node_metadata__created_at|updated_at`), optional `__asc`/`__desc`, where it applies (top-level, relationships, hierarchy), inheritance, validation, and UUID tiebreaker.
  - GraphQL guide: new “Ordering results” section covering `order` with `by` entries (`field` + `direction` with `ASC` default), `disable`, deprecation of `node_metadata`, and replace-not-stack precedence. Examples updated to the `by` syntax.
  - Cross-links and sidebar updates for discoverability; `nodes-and-attributes`, `metadata`, and `order-weight` now link to the new page.

- **Migration**
  - `node_metadata` is now reserved; rename any attribute or relationship with this name to load schemas on 1.10.

<sup>Written for commit 094c0572a577a5603aebf77972b3e49e31ef167f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

