### PR TITLE
small frontend updates for dependencies/reachable nodes

### DIFF
--- a/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
+++ b/frontend/app/src/entities/path-traversal/api/get-reachable-nodes-from-api.ts
@@ -31,7 +31,16 @@ const pathFields = {
 };
 
 export async function getReachableNodesFromApi(params: GetReachableNodesParams) {
-  const { sourceId, targetKinds, maxDepth, maxResults, maxPaths, branchName, atDate } = params;
+  const {
+    sourceId,
+    targetKinds,
+    maxDepth,
+    maxResults,
+    maxPaths,
+    shortestPathsOnly,
+    branchName,
+    atDate,
+  } = params;
 
   const dataArgs: Record<string, unknown> = {
     source_id: sourceId,
@@ -40,6 +49,7 @@ export async function getReachableNodesFromApi(params: GetReachableNodesParams) 
   if (maxDepth !== undefined) dataArgs.max_depth = maxDepth;
   if (maxResults !== undefined) dataArgs.max_results = maxResults;
   if (maxPaths !== undefined) dataArgs.max_paths = maxPaths;
+  if (shortestPathsOnly !== undefined) dataArgs.shortest_paths_only = shortestPathsOnly;
 
   const queryString = jsonToGraphQLQuery({
     query: {

--- a/frontend/app/src/entities/path-traversal/domain/path-traversal.types.ts
+++ b/frontend/app/src/entities/path-traversal/domain/path-traversal.types.ts
@@ -64,4 +64,5 @@ export type GetReachableNodesParams = ContextParams & {
   maxDepth?: number;
   maxResults?: number;
   maxPaths?: number;
+  shortestPathsOnly?: boolean;
 };

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.test.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.test.tsx
@@ -12,4 +12,14 @@ describe("DependenciesModeForm validation", () => {
     await expect.element(component.getByText("Source is required")).toBeVisible();
     await expect.element(component.getByText("Select at least one target kind")).toBeVisible();
   });
+
+  test("exposes the shortest paths only option, checked by default", async () => {
+    const component = await render(<DependenciesModeSidebar />);
+
+    await component.getByRole("button", { name: /search options/i }).click();
+
+    const checkbox = component.getByRole("checkbox", { name: /shortest paths only/i });
+    await expect.element(checkbox).toBeVisible();
+    await expect.element(checkbox).toBeChecked();
+  });
 });

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -111,7 +111,7 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
               }}
               render={({ field }) => (
                 <div className="space-y-1">
-                  <FormLabel>Max Results</FormLabel>
+                  <FormLabel>Max Targets</FormLabel>
                   <FormInput>
                     <Input
                       type="number"
@@ -138,7 +138,7 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
               }}
               render={({ field }) => (
                 <div className="space-y-1">
-                  <FormLabel>Max Targets</FormLabel>
+                  <FormLabel>Max Paths</FormLabel>
                   <FormInput>
                     <Input
                       type="number"

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -105,7 +105,7 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
             <FormField
               name="maxResults"
               rules={{
-                required: "Max results is required",
+                required: "Max targets is required",
                 min: { value: 1, message: "Must be ≥ 1" },
                 max: { value: 200, message: "Must be ≤ 200" },
               }}

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-form.tsx
@@ -1,5 +1,6 @@
 import type { UseFormReturn } from "react-hook-form";
 
+import { Checkbox } from "@/shared/components/inputs/checkbox";
 import { KindMultiSelect } from "@/shared/components/inputs/kind-multi-select";
 import {
   Accordion,
@@ -137,7 +138,7 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
               }}
               render={({ field }) => (
                 <div className="space-y-1">
-                  <FormLabel>Max Paths</FormLabel>
+                  <FormLabel>Max Targets</FormLabel>
                   <FormInput>
                     <Input
                       type="number"
@@ -151,6 +152,27 @@ export function DependenciesModeForm({ form, onSubmit, isPending }: Dependencies
                     />
                   </FormInput>
                   <FormMessage />
+                </div>
+              )}
+            />
+
+            <FormField
+              name="shortestPathsOnly"
+              render={({ field }) => (
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <FormInput>
+                      <Checkbox
+                        checked={Boolean(field.value)}
+                        onChange={(e) => field.onChange(e.target.checked)}
+                      />
+                    </FormInput>
+                    <FormLabel className="cursor-pointer">Shortest paths only</FormLabel>
+                  </div>
+                  <p className="text-gray-500 text-xs">
+                    Only return the shortest path(s) to each target. Uncheck to return every path
+                    within the max depth.
+                  </p>
                 </div>
               )}
             />

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-main.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-main.tsx
@@ -21,6 +21,7 @@ export function DependenciesModeMain({
       maxDepth: params.depth,
       maxResults: params.maxResults,
       maxPaths: params.maxPaths,
+      shortestPathsOnly: params.shortestPathsOnly,
     },
     { enabled: !!params.source && params.targetKinds.length > 0 }
   );

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/dependencies-mode-sidebar.tsx
@@ -27,6 +27,7 @@ export function DependenciesModeSidebar() {
       maxDepth: params.depth,
       maxResults: params.maxResults,
       maxPaths: params.maxPaths,
+      shortestPathsOnly: params.shortestPathsOnly,
     },
     { enabled: !!params.source && params.targetKinds.length > 0 }
   );
@@ -45,7 +46,7 @@ export function DependenciesModeSidebar() {
       {data && (
         <PathResultsList
           paths={paths}
-          countLabel={`${data.count} dependenc${data.count === 1 ? "y" : "ies"} found`}
+          countLabel={`${data.count} path${data.count === 1 ? "" : "s"} found`}
           selectedIndex={params.selectedIndex}
           onSelect={(index) => setParams({ selectedIndex: index })}
           variant="amber"

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.test.ts
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.test.ts
@@ -11,6 +11,7 @@ describe("paramsToFormValues", () => {
         depth: 8,
         maxResults: 100,
         maxPaths: 1000,
+        shortestPathsOnly: true,
         selectedIndex: 0,
       })
     ).toEqual({
@@ -19,6 +20,7 @@ describe("paramsToFormValues", () => {
       maxDepth: 8,
       maxResults: 100,
       maxPaths: 1000,
+      shortestPathsOnly: true,
     });
   });
 });
@@ -32,6 +34,7 @@ describe("formValuesToParams", () => {
         maxDepth: 3,
         maxResults: 100,
         maxPaths: 1000,
+        shortestPathsOnly: false,
       })
     ).toEqual({
       source: "src-id",
@@ -39,6 +42,7 @@ describe("formValuesToParams", () => {
       depth: 3,
       maxResults: 100,
       maxPaths: 1000,
+      shortestPathsOnly: false,
       selectedIndex: 0,
     });
   });

--- a/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.ts
+++ b/frontend/app/src/entities/path-traversal/ui/dependencies-mode/use-dependencies-mode-params.ts
@@ -1,4 +1,10 @@
-import { parseAsInteger, parseAsNativeArrayOf, parseAsString, useQueryStates } from "nuqs";
+import {
+  parseAsBoolean,
+  parseAsInteger,
+  parseAsNativeArrayOf,
+  parseAsString,
+  useQueryStates,
+} from "nuqs";
 
 export const DEPENDENCIES_MODE_PARAMS = {
   source: parseAsString.withDefault(""),
@@ -6,6 +12,7 @@ export const DEPENDENCIES_MODE_PARAMS = {
   depth: parseAsInteger.withDefault(5),
   maxResults: parseAsInteger.withDefault(50),
   maxPaths: parseAsInteger.withDefault(500),
+  shortestPathsOnly: parseAsBoolean.withDefault(true),
   selectedIndex: parseAsInteger.withDefault(0),
 } as const;
 
@@ -15,6 +22,7 @@ export type DependenciesModeParams = {
   depth: number;
   maxResults: number;
   maxPaths: number;
+  shortestPathsOnly: boolean;
   selectedIndex: number;
 };
 
@@ -24,6 +32,7 @@ export type DependenciesModeFormValues = {
   maxDepth: number;
   maxResults: number;
   maxPaths: number;
+  shortestPathsOnly: boolean;
 };
 
 export function paramsToFormValues(p: DependenciesModeParams): DependenciesModeFormValues {
@@ -33,6 +42,7 @@ export function paramsToFormValues(p: DependenciesModeParams): DependenciesModeF
     maxDepth: p.depth,
     maxResults: p.maxResults,
     maxPaths: p.maxPaths,
+    shortestPathsOnly: p.shortestPathsOnly,
   };
 }
 
@@ -43,6 +53,7 @@ export function formValuesToParams(v: DependenciesModeFormValues): Partial<Depen
     depth: v.maxDepth,
     maxResults: v.maxResults,
     maxPaths: v.maxPaths,
+    shortestPathsOnly: v.shortestPathsOnly,
     selectedIndex: 0,
   };
 }

--- a/frontend/app/src/shared/api/graphql/generated/types.ts
+++ b/frontend/app/src/shared/api/graphql/generated/types.ts
@@ -37247,6 +37247,8 @@ export type ReachableNodesInput = {
   max_paths?: InputMaybe<Scalars['Int']['input']>;
   /** Maximum number of distinct terminal nodes to discover (default: 50, max: 200) */
   max_results?: InputMaybe<Scalars['Int']['input']>;
+  /** When true (default), return only the shortest path(s) to each reachable target. When false, return every path to each target within max_depth that meets the filters. */
+  shortest_paths_only?: InputMaybe<Scalars['Boolean']['input']>;
   /** UUID of the source node */
   source_id: Scalars['String']['input'];
   /** Node kinds to search for */


### PR DESCRIPTION
3 small changes all on the `/path-traversal?mode=dependencies` page. depends on #9584 

- renames `Max Results` to `Max Targets` because that is more accurate for reachable nodes
- updates the display on reachable nodes to show "44 paths found" instead of "44 dependencies found" b/c the count returned by graphql is the number of paths and not targets. if necessary, the backend could be changed to return the number of targets instead
- adds new "shortest paths only" parameter to the UI for the reachable nodes that is added in the base branch. it's a checkbox with some help text. it looks like this

<img width="422" height="649" alt="image" src="https://github.com/user-attachments/assets/f6d887c9-139b-43fa-aefa-4c2bbfc9fd7c" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Shortest paths only” to Dependencies mode (on by default), threads it through URL params and the GraphQL input, and refines copy and validation.

- **New Features**
  - New “Shortest paths only” checkbox in Search options (checked by default). Uncheck to return all paths within max depth.
  - New URL param `shortestPathsOnly` (default true); mapped to the form and sent to the API as `shortest_paths_only`.
  - Copy tweaks: “Max Results” → “Max Targets”; validation message updated to match; sidebar count now shows “paths found.”

<sup>Written for commit 3b49440daf83b98e4d72f55c080aaaa072c6bcbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



