### PR TITLE
Merge stable into release-1.10

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -7,13 +7,9 @@ from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBea
 from pydantic import BaseModel, ConfigDict
 
 from infrahub import config
-<<<<<<< HEAD
 from infrahub.auth.auth import authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
 from infrahub.auth.session import AccountSession  # noqa: TC001
-=======
-from infrahub.auth import AccountSession, authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
 from infrahub.branch.query_time_validator import BranchQueryTimeValidator
->>>>>>> origin/stable
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.registry import registry

--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from infrahub import config
 from infrahub.auth import AccountSession, authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
+from infrahub.branch.query_time_validator import BranchQueryTimeValidator
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.registry import registry
@@ -81,7 +82,11 @@ async def get_branch_params(
     branch = await registry.get_branch(db=db, branch=branch_name)
     request.state.branch_name = branch.name
 
-    return BranchParams(branch=branch, at=Timestamp(at))
+    at_ts = Timestamp(at)
+    if at is not None:
+        BranchQueryTimeValidator(registry=registry).validate(branch=branch, at=at_ts)
+
+    return BranchParams(branch=branch, at=at_ts)
 
 
 async def get_branch_dep(

--- a/backend/infrahub/branch/query_time_validator.py
+++ b/backend/infrahub/branch/query_time_validator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.registry import Registry
+
+
+class BranchQueryTimeValidator:
+    def __init__(self, registry: Registry) -> None:
+        self._registry = registry
+
+    def validate(self, branch: Branch, at: Timestamp) -> None:
+        """Validate that `at` falls within the branch's effective lifetime.
+
+        Raises:
+            ValidationError: When `at` is earlier than the branch's effective creation time.
+
+        """
+        if branch.is_default or branch.is_global or branch.origin_branch == branch.name:
+            boundary_branch_name = branch.name
+            boundary_created_at = branch.get_created_at()
+        else:
+            origin = self._registry.get_branch_from_registry(branch=branch.origin_branch)
+            boundary_branch_name = origin.name
+            boundary_created_at = origin.get_created_at()
+
+        if at < Timestamp(boundary_created_at):
+            raise ValidationError(
+                f"Requested time '{at.to_string()}' is before "
+                f"branch '{boundary_branch_name}' was created at '{boundary_created_at}'."
+            )

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -234,6 +234,19 @@ async def sync_git_repo_with_origin_and_tag_on_failure(
         raise
 
 
+def resolve_initial_import_branch(repo: InfrahubRepository, init_failed: bool) -> str | None:
+    """Return the git branch whose objects must be seeded after a clone, or None when none is needed.
+
+    A freshly created or re-cloned local copy needs its default branch imported into the graph; an
+    already-present clone does not. The branch is taken from the repository's own default branch, which
+    is the git branch the clone checks out, rather than the platform default branch which may differ
+    and would not exist locally.
+    """
+    if init_failed or repo.reinitialized:
+        return repo.default_branch
+    return None
+
+
 async def bootstrap_local_repository(
     repo_name: str,
     repository: CoreRepository,
@@ -248,7 +261,6 @@ async def bootstrap_local_repository(
     skipped.
     """
     log = get_run_logger()
-    default_import_git_branch: str | None = None
     pinned_import_commit: str | None = None
     async with lock.registry.get(name=repo_name, namespace="repository"):
         init_failed = False
@@ -278,10 +290,8 @@ async def bootstrap_local_repository(
             except RepositoryError as exc:
                 log.info(exc.message)
                 return None
-            default_import_git_branch = registry.default_branch
 
-        if repo.reinitialized:
-            default_import_git_branch = repo.default_branch
+        default_import_git_branch = resolve_initial_import_branch(repo, init_failed=init_failed)
 
         if default_import_git_branch is not None:
             # Pin the commit while the lock is held so the import below reads an immutable
@@ -326,7 +336,7 @@ async def sync_repository_from_origin(
             infrahub_branch=infrahub_branch,
         )
         try:
-            pinned_commit: str | None = repo.get_commit_value(branch_name=infrahub_branch, remote=False)
+            pinned_commit: str | None = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
         except (ValueError, InvalidGitRepositoryError) as exc:
             log.debug(
                 f"Could not resolve pinned commit for {repository.name.value}, workers will fall back to pull: {exc}"

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -36,6 +36,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_scheme
 from infrahub.auth import AccountSession, authentication_token
+from infrahub.branch.query_time_validator import BranchQueryTimeValidator
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError
@@ -216,18 +217,21 @@ class InfrahubGraphQLApp:
         # if the query contains some mutation, it's not currently supported to set AT manually
         if analyzed_query.contains_mutation:
             graphql_params.context.at = Timestamp()
-        elif at and branch.schema_changed_at and Timestamp(branch.schema_changed_at) > Timestamp(at):
-            schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=Timestamp(at))
-            db.add_schema(name=branch.name, schema=schema_branch)
-            analyzed_query = InfrahubGraphQLQueryAnalyzer(
-                query=query,
-                schema_branch=schema_branch,
-                query_variables=variable_values,
-                schema=graphql_params.schema,
-                operation_name=operation_name,
-                branch=branch,
-                document=cached_parse(query),
-            )
+        elif at:
+            at_ts = Timestamp(at)
+            BranchQueryTimeValidator(registry=registry).validate(branch=branch, at=at_ts)
+            if branch.schema_changed_at and Timestamp(branch.schema_changed_at) > at_ts:
+                schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=at_ts)
+                db.add_schema(name=branch.name, schema=schema_branch)
+                analyzed_query = InfrahubGraphQLQueryAnalyzer(
+                    query=query,
+                    schema_branch=schema_branch,
+                    query_variables=variable_values,
+                    schema=graphql_params.schema,
+                    operation_name=operation_name,
+                    branch=branch,
+                    document=cached_parse(query),
+                )
         impacted_models = analyzed_query.query_report.impacted_models
 
         try:

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -35,13 +35,9 @@ from starlette.responses import JSONResponse, Response
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_scheme
-<<<<<<< HEAD
 from infrahub.auth.auth import authentication_token
 from infrahub.auth.session import AccountSession  # noqa: TC001
-=======
-from infrahub.auth import AccountSession, authentication_token
 from infrahub.branch.query_time_validator import BranchQueryTimeValidator
->>>>>>> origin/stable
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, Error, PermissionDeniedError

--- a/backend/tests/component/api/test_10_query.py
+++ b/backend/tests/component/api/test_10_query.py
@@ -9,6 +9,7 @@ from infrahub import config
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.initialization import create_branch
+from infrahub.core.timestamp import Timestamp
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.workflows.catalogue import GRAPHQL_QUERY_GROUP_UPDATE
 
@@ -265,6 +266,33 @@ async def test_query_endpoint_wrong_branch(
         )
 
     assert response.status_code == 400
+
+
+async def test_query_endpoint_at_before_branch_creation(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    create_test_admin: Node,
+    car_person_data: dict[str, Node],
+) -> None:
+    at_before_creation = Timestamp("2000-01-01T00:00:00Z")
+    assert at_before_creation < Timestamp(default_branch.get_created_at()), (
+        "Test precondition: the chosen `at` must be earlier than the branch's created_at"
+    )
+
+    with client:
+        response = client.get(
+            f"/api/query/query01?at={at_before_creation.to_string()}",
+            headers=admin_headers,
+        )
+
+    expected_message = (
+        f"Requested time '{at_before_creation.to_string()}' is before "
+        f"branch '{default_branch.name}' was created at '{default_branch.get_created_at()}'."
+    )
+    assert response.status_code == 422
+    assert response.json()["errors"][0]["message"] == expected_message
 
 
 async def test_query_endpoint_missing_privs(

--- a/backend/tests/component/api/test_20_graphql.py
+++ b/backend/tests/component/api/test_20_graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
@@ -14,6 +15,12 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class AtBeforeCreationCase:
+    name: str
+    query_branch_name: str | None
 
 
 async def test_graphql_endpoint_with_timestamp(
@@ -68,6 +75,72 @@ async def test_graphql_endpoint_with_timestamp(
     names = [result["node"]["name"]["value"] for result in result["TestPerson"]["edges"]]
 
     assert sorted(names) == ["Jane", "John"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(c, id=c.name)
+        for c in [
+            AtBeforeCreationCase(name="default_branch", query_branch_name=None),
+            AtBeforeCreationCase(name="user_branch_origin_main", query_branch_name="user-branch"),
+        ]
+    ],
+)
+async def test_graphql_endpoint_at_before_branch_creation(
+    case: AtBeforeCreationCase,
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    create_test_admin: Node,
+    car_person_data: dict[str, Node],
+) -> None:
+    """Querying with an `at` earlier than the default branch's creation must produce a clear, user-facing error.
+
+    Since every user branch is currently rooted on the default branch, the error always references the default
+    branch — directly for default-branch queries and indirectly (via the origin) for user-branch queries.
+    """
+    if case.query_branch_name is not None:
+        user_branch = await create_branch(branch_name=case.query_branch_name, db=db)
+        assert user_branch.get_created_at() != default_branch.get_created_at(), (
+            "Test precondition: the user branch must be created at a distinct time from its origin "
+            "so the boundary lookup picks a different value in each parametrized case"
+        )
+
+    at_before_creation = Timestamp("2000-01-01T00:00:00Z")
+    assert at_before_creation < Timestamp(default_branch.get_created_at()), (
+        "Test precondition: the chosen `at` must be earlier than the (origin) branch's created_at"
+    )
+
+    query = """
+    query {
+        TestPerson {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    url_branch_suffix = f"/{case.query_branch_name}" if case.query_branch_name else ""
+    with client:
+        response = client.post(
+            f"/graphql{url_branch_suffix}?at={at_before_creation.to_string()}",
+            json={"query": query},
+            headers=admin_headers,
+        )
+
+    expected_message = (
+        f"Requested time '{at_before_creation.to_string()}' is before "
+        f"branch '{default_branch.name}' was created at '{default_branch.get_created_at()}'."
+    )
+    assert response.status_code == 422
+    assert response.json()["errors"][0]["message"] == expected_message
 
 
 @pytest.mark.xfail(reason="Need to investigate, Currently working alone but failing when it's part of the test suite")

--- a/backend/tests/component/api/test_read_only.py
+++ b/backend/tests/component/api/test_read_only.py
@@ -174,7 +174,7 @@ class TestApiReadOnly(TestInfrahubApp):
 
         response = await test_client.post("/graphql", json={"query": query}, headers=admin_headers)
 
-        assert response.status_code
+        assert response.status_code == 200
         assert response.json() == {"data": {"AccountProfile": {"name": {"value": "admin"}}}}
 
     async def test_download_schema(

--- a/backend/tests/component/git/test_sync_repository.py
+++ b/backend/tests/component/git/test_sync_repository.py
@@ -1,0 +1,153 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from git import Repo
+from infrahub_sdk import Config, InfrahubClient
+from prefect import flow
+
+from infrahub import config
+from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.database import InfrahubDatabase
+from infrahub.git import InfrahubRepository
+from infrahub.git.tasks import sync_repository_from_origin
+from infrahub.message_bus.messages import RefreshGitFetch
+from infrahub.workers.dependencies import clear_singletons
+from tests.adapters.message_bus import BusRecorder
+from tests.conftest import TestHelper
+from tests.helpers.test_client import dummy_async_request
+
+
+@dataclass
+class SyncScenario:
+    name: str
+    git_default_branch: str
+    staging_branch: str | None
+    active_internal_status: str
+
+
+SCENARIOS = [
+    # Git default branch matches Infrahub's default; no staging branch.
+    SyncScenario(
+        name="active_matching_default",
+        git_default_branch="main",
+        staging_branch=None,
+        active_internal_status=RepositoryInternalStatus.ACTIVE.value,
+    ),
+    # Git default branch differs from Infrahub's default.
+    SyncScenario(
+        name="active_mismatched_default",
+        git_default_branch="production",
+        staging_branch=None,
+        active_internal_status=RepositoryInternalStatus.ACTIVE.value,
+    ),
+    # Staging sync; git default branch matches Infrahub's default.
+    SyncScenario(
+        name="staging_matching_default",
+        git_default_branch="main",
+        staging_branch="staging-x",
+        active_internal_status=RepositoryInternalStatus.STAGING.value,
+    ),
+    # Staging sync; git default branch differs from Infrahub's default.
+    SyncScenario(
+        name="staging_mismatched_default",
+        git_default_branch="production",
+        staging_branch="staging-x",
+        active_internal_status=RepositoryInternalStatus.STAGING.value,
+    ),
+]
+
+
+@pytest.fixture
+def message_bus_recorder(helper: TestHelper) -> Generator[BusRecorder, None, None]:
+    """Install a recording bus and drop cached singletons so the flow resolves it, restoring on exit."""
+    original = config.OVERRIDE.message_bus
+    recorder = helper.get_message_bus_recorder()
+    config.OVERRIDE.message_bus = recorder
+    clear_singletons()
+    yield recorder
+    config.OVERRIDE.message_bus = original
+    clear_singletons()
+
+
+async def _build_repository(
+    db: InfrahubDatabase, source_dir: Path, git_default_branch: str, internal_status: str
+) -> tuple[Node, InfrahubRepository]:
+    """Seed a repository node and clone it locally, with the given git default branch and status."""
+    upstream = Repo.init(source_dir, initial_branch=git_default_branch)
+    (source_dir / "file.txt").write_text("content")
+    upstream.index.add(["file.txt"])
+    upstream.index.commit("First commit")
+
+    node = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+    await node.new(
+        db=db,
+        name="test-repository",
+        location=str(source_dir),
+        default_branch=git_default_branch,
+        internal_status=internal_status,
+    )
+    await node.save(db=db)
+
+    repo = await InfrahubRepository.new(
+        id=node.id,
+        name="test-repository",
+        location=str(source_dir),
+        default_branch_name=git_default_branch,
+        internal_status=internal_status,
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        update_commit_value=False,
+    )
+    return node, repo
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[scenario.name for scenario in SCENARIOS])
+async def test_sync_broadcasts_synced_commit(
+    scenario: SyncScenario,
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    tmp_path: Path,
+    git_repos_dir: Path,
+    prefect_test_fixture: None,
+    message_bus_recorder: BusRecorder,
+) -> None:
+    """The commit broadcast to the worker pool resolves to the repository's git default branch HEAD.
+
+    Holds across matching and mismatched default branches and staging syncs, so every worker
+    converges on the same pinned commit.
+    """
+    source_dir = tmp_path / "source-repo"
+    source_dir.mkdir()
+    node, repo = await _build_repository(
+        db=db,
+        source_dir=source_dir,
+        git_default_branch=scenario.git_default_branch,
+        internal_status=scenario.active_internal_status,
+    )
+
+    assert repo.client is not None
+    client = repo.client
+    infrahub_branch = scenario.staging_branch or registry.default_branch
+
+    @flow(name="test-sync-repository-from-origin")
+    async def _run_sync() -> None:
+        await sync_repository_from_origin(
+            repository=node,
+            repo=repo,
+            active_internal_status=scenario.active_internal_status,
+            staging_branch=scenario.staging_branch,
+            infrahub_branch=infrahub_branch,
+            infrahub_branch_id="branch-id",
+            client=client,
+        )
+
+    await _run_sync()
+
+    fetch_messages = [message for message in message_bus_recorder.messages if isinstance(message, RefreshGitFetch)]
+    assert len(fetch_messages) == 1
+
+    expected_commit = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
+    assert fetch_messages[0].commit == expected_commit

--- a/backend/tests/unit/git/test_tasks.py
+++ b/backend/tests/unit/git/test_tasks.py
@@ -1,4 +1,54 @@
-from infrahub.git.tasks import format_check_log_entry
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+
+from infrahub.core.constants import RepositoryInternalStatus
+from infrahub.core.registry import registry
+from infrahub.git import InfrahubRepository
+from infrahub.git.tasks import format_check_log_entry, resolve_initial_import_branch
+
+
+@dataclass
+class ImportBranchCase:
+    name: str
+    init_failed: bool
+    reinitialized: bool
+    expected: str | None
+
+
+IMPORT_BRANCH_CASES = [
+    # A fresh clone (init raised, recreated via new) must seed its git default branch.
+    ImportBranchCase(name="freshly_created", init_failed=True, reinitialized=False, expected="production"),
+    # A re-cloned local copy (local directory was missing) must seed its git default branch.
+    ImportBranchCase(name="reinitialized", init_failed=False, reinitialized=True, expected="production"),
+    # An already-present valid clone needs no initial import.
+    ImportBranchCase(name="existing_clone", init_failed=False, reinitialized=False, expected=None),
+]
+
+
+@pytest.mark.parametrize("case", IMPORT_BRANCH_CASES, ids=[case.name for case in IMPORT_BRANCH_CASES])
+def test_resolve_initial_import_branch_uses_git_default(
+    case: ImportBranchCase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The seeded branch must be the repository's git default branch, never the platform default."""
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    # The repository's git default branch ("production") differs from Infrahub's default ("main").
+    assert registry.default_branch != "production"
+    repo = InfrahubRepository(
+        id=uuid4(),
+        name="test-repository",
+        location="git@github.com:mock/test-repository.git",
+        default_branch_name="production",
+        has_origin=True,
+        cache_repo=None,
+        is_read_only=False,
+        internal_status=RepositoryInternalStatus.ACTIVE.value,
+        infrahub_branch_name=None,
+        reinitialized=case.reinitialized,
+    )
+
+    assert resolve_initial_import_branch(repo, init_failed=case.init_failed) == case.expected
 
 
 def test_format_check_log_entry_message_only() -> None:

--- a/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
+++ b/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
@@ -1,0 +1,1 @@
+Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.

--- a/changelog/+pin-sync-commit-git-default-branch.fixed.md
+++ b/changelog/+pin-sync-commit-git-default-branch.fixed.md
@@ -1,0 +1,1 @@
+Repository synchronization now resolves both a new repository's initial import and the pinned worker-pool commit from the repository's Git default branch rather than Infrahub's default branch name, fixing repositories whose Git default branch differs and staging-branch syncs.

--- a/changelog/4076.fixed.md
+++ b/changelog/4076.fixed.md
@@ -1,0 +1,1 @@
+Fixed the unclear error message shown when picking a time earlier than the Infrahub instance was created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "prefect-redis==0.2.8",
     "ujson>=5,<6",
     "Jinja2>=3,<4",
-    "gitpython>=3,<4",
+    "gitpython>=3.1.50,<4",
     "pyyaml>=6,<7",
     "tomli>=1.1.0; python_version<='3.11'",
     "deepdiff==8.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -723,6 +723,13 @@ allow-dunder-method-names = [
     "PLR0915", # Too many statements
 ]
 
+"backend/infrahub/graphql/app.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
 "backend/infrahub/graphql/manager.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule

--- a/uv.lock
+++ b/uv.lock
@@ -1011,14 +1011,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -1481,7 +1481,7 @@ requires-dist = [
     { name = "fast-depends", specifier = "==3.0.5" },
     { name = "fastapi", specifier = "==0.131.0" },
     { name = "fastapi-storages", specifier = ">=0.3,<0.4" },
-    { name = "gitpython", specifier = ">=3,<4" },
+    { name = "gitpython", specifier = ">=3.1.50,<4" },
     { name = "graphene", specifier = ">=3.4,<3.5" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3,<4" },


### PR DESCRIPTION
Supersedes #9580, which was blocked on merge conflicts.

## Summary

Merges `stable` into `release-1.10`, bringing in the gitpython 3.1.50 security upgrade (GHSA-mv93-w799-cj2w), git sync commit pinning via the repository default branch, and the query-time `at` validation that returns 422 for times before branch creation.

## Conflicts resolved

- `backend/infrahub/api/dependencies.py` — `release-1.10` split the auth package (`infrahub.auth.auth`, `infrahub.auth.session`) while `stable` still imported from `infrahub.auth` and added a `BranchQueryTimeValidator` import. Kept the destination's refactored import paths and added the new import; the `infrahub.auth` package no longer re-exports these symbols. (`81d072321`)
- `backend/infrahub/graphql/app.py` — same auth-import divergence plus the new `BranchQueryTimeValidator` import; resolved the same way. (`81d072321`)

## Conflicts raised for review

None — both conflicts were import-path reconciliations from a pure auth-module refactor. Verified the moved symbols (`authentication_token`, `validate_jwt_access_token`, `validate_jwt_refresh_token`, `AccountSession`) resolve to their new modules and that no other call site still imports them from `infrahub.auth`.

## Generated files regenerated

None — the merge touched no schema, OpenAPI, protocol, GraphQL-type, or reference-doc inputs.

## Validation

- ruff lint + format: pass
- `ty` type-check: pass on both resolved files; module imports resolve
- `uv.lock` consistent with `pyproject.toml`
- `backend/tests/unit/git/test_tasks.py`: 8 passed
- Not run locally (need a running stack; CI covers): `test_10_query.py`, `test_20_graphql.py`, `test_sync_repository.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges `stable` into `release-1.10` to upgrade `gitpython` to 3.1.50, fix git sync commit pinning using the repository’s Git default branch, and validate query-time `at` to return 422 when before branch creation.

- **Bug Fixes**
  - Pin the synced commit and initial import from the repository’s Git default branch (works with mismatched defaults and staging).
  - Validate `at` in REST/GraphQL; return 422 with a clear message if earlier than the branch (or its origin) creation via `BranchQueryTimeValidator`.

- **Dependencies**
  - Upgrade `gitpython` to 3.1.50 to address GHSA-mv93-w799-cj2w.

<sup>Written for commit 81d07232145e63a2beba10bf6f6fbe3f9efddfc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

