### PR TITLE
fix(git): import non-main default_branch commits in periodic sync

### DIFF
--- a/backend/infrahub/git/utils.py
+++ b/backend/infrahub/git/utils.py
@@ -40,7 +40,15 @@ async def get_repositories_commit_per_branch(
         repos: list[CoreRepository | CoreReadOnlyRepository] = await NodeManager.query(
             db=db,
             branch=branch,
-            fields={"id": None, "name": None, "commit": None, "internal_status": None, "location": None, "ref": None},
+            fields={
+                "id": None,
+                "name": None,
+                "commit": None,
+                "internal_status": None,
+                "location": None,
+                "ref": None,
+                "default_branch": None,
+            },
             schema=kind,
             order=OrderModel(disable=True),
         )

--- a/backend/tests/component/git/test_utils.py
+++ b/backend/tests/component/git/test_utils.py
@@ -52,6 +52,18 @@ async def test_get_repositories_commit_per_branch_main(
     }
 
 
+async def test_get_repositories_commit_per_branch_non_main_default_branch(
+    db: InfrahubDatabase, register_core_models_schema: SchemaBranch, default_branch: Branch
+) -> None:
+    repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY, branch=default_branch)
+    await repo.new(db=db, name="repo01", default_branch="staging", commit="commit01", location="location01")
+    await repo.save(db=db)
+
+    repositories = await get_repositories_commit_per_branch(db=db)
+
+    assert repositories["repo01"].repository.default_branch.value == "staging"
+
+
 async def test_get_repositories_commit_per_branch_branches(
     db: InfrahubDatabase, register_core_models_schema: SchemaBranch, repository_01: Node, repository_02: Node
 ) -> None:

--- a/changelog/9600.fixed.md
+++ b/changelog/9600.fixed.md
@@ -1,0 +1,1 @@
+Periodic Git synchronization now imports new commits on a repository's configured default branch when that branch is not `main`. Previously the sync loaded repositories without their `default_branch` attribute, fell back to the schema default of `main`, and failed to locate the worktree, leaving such repositories pinned to a stale commit while still reporting `in-sync`.


### PR DESCRIPTION
## Summary

Read-write `CoreRepository` whose `default_branch` is **not `main`** (e.g. `staging`) never imported new commits on its default branch via the periodic sync. The instance stayed pinned to its last-imported commit while reporting `sync_status: in-sync`, and `git_repositories_sync` failed every cycle with `Unable to identify the worktree : staging`.

## Root cause

`get_repositories_commit_per_branch` (`backend/infrahub/git/utils.py`) did not request the `default_branch` attribute when loading repositories for the sync flow. The attribute fell back to the schema default `"main"`, so `sync_remote_repositories` looked up a worktree keyed by the actual git branch name (`staging`) — which does not exist — and the flow raised. Repositories with `default_branch=main` were unaffected because the accidental default happened to be correct.

## Fix

Add `default_branch` to the fetched fields so the configured value reaches the pull path:

```python
fields={
    "id": None, "name": None, "commit": None, "internal_status": None,
    "location": None, "ref": None, "default_branch": None,
},
```

## Verification

Verified live on 1.9.6: with this change, a previously-stuck instance imported a fresh commit on its non-`main` default branch within ~30s, the `git_repositories_sync` flow returned `Completed`, and the worktree error disappeared. `default_branch=main` behavior is unchanged.

## Scope

Distinct mechanism from the related non-`main` `default_branch` issues #8749 (artifact generation) and #9568 (multi-worker write-back/push) — this is the import/pull path.

Fixes #9600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes periodic Git sync for repositories whose `default_branch` is not `main`. We now load `default_branch` during sync so pulls target the configured branch and import new commits (IFC-2757).

- **Bug Fixes**
  - Request `default_branch` in `get_repositories_commit_per_branch` to prevent fallback to `"main"` and worktree errors; enables importing commits on non-`main` default branches.
  - Add a regression test to ensure non-`main` `default_branch` is loaded; verified on 1.9.6, `main` behavior unchanged.

<sup>Written for commit fb8772d54db0c68bfe65bbd1a3ea07f3ecf81880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

