### PR TITLE
fix(computed-attribute): refresh derived values after branch merge [IFC-2758]

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Sequence
 from uuid import uuid4
 
@@ -41,6 +42,7 @@ from infrahub.events.branch_action import (
 )
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
+from infrahub.events.schema_action import SchemaUpdatedEvent
 from infrahub.exceptions import ValidationError
 from infrahub.generators.constants import GeneratorDefinitionRunSource
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
@@ -300,7 +302,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                 log.info(f"Branch '{branch}' is not open (status={obj.status}), skipping merge")
                 return
 
-            node_events = await _do_merge_branch(
+            merge_result = await _do_merge_branch(
                 db=db,
                 log=log,
                 branch=obj,
@@ -309,8 +311,17 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
             )
 
         events: list[InfrahubEvent] = [merge_event]
+        if merge_result.schema_was_updated:
+            # Drives the display label, HFID and computed-attribute backfills for the merged schema changes.
+            events.append(
+                SchemaUpdatedEvent(
+                    branch_name=default_branch.name,
+                    schema_hash=registry.schema.get_schema_branch(name=default_branch.name).get_hash(),
+                    meta=EventMeta.from_parent(parent=merge_event, branch=default_branch),
+                )
+            )
 
-        for action, node_changelog in node_events:
+        for action, node_changelog in merge_result.node_events:
             meta = EventMeta.from_parent(parent=merge_event, branch=default_branch)
             node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
             mutate_event = node_event_class(
@@ -364,13 +375,19 @@ async def _rollback_merge(
     return True
 
 
+@dataclass(frozen=True)
+class MergeBranchResult:
+    node_events: Sequence[tuple[DiffAction, NodeChangelog]]
+    schema_was_updated: bool
+
+
 async def _do_merge_branch(
     db: InfrahubDatabase,
     log: Logger | LoggerAdapter,
     branch: Branch,
     context: InfrahubContext,
     proposed_change_id: str | None = None,
-) -> Sequence[tuple[DiffAction, NodeChangelog]]:
+) -> MergeBranchResult:
     component_registry = get_component_registry()
     workflow = get_workflow()
     merge_at = Timestamp()
@@ -390,6 +407,7 @@ async def _do_merge_branch(
         diff_locker=DiffLocker(),
         workflow=workflow,
     )
+    schema_was_updated = False
     try:
         async with lock.registry.global_graph_lock():
             # Set to MERGING to lock the branch while merge proceeds
@@ -438,6 +456,7 @@ async def _do_merge_branch(
                 manage_rollback=False,
             )
             log.info("Migrations completed")
+            schema_was_updated = True
         # -------------------------------------------------------------
         # Trigger the reconciliation of IPAM data after the merge
         # -------------------------------------------------------------
@@ -505,7 +524,7 @@ async def _do_merge_branch(
         parameters={"source_branch": branch.name, "target_branch": registry.default_branch},
     )
 
-    return node_events
+    return MergeBranchResult(node_events=node_events, schema_was_updated=schema_was_updated)
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")

--- a/backend/tests/component/core/diff/test_merge_task_lock.py
+++ b/backend/tests/component/core/diff/test_merge_task_lock.py
@@ -13,7 +13,7 @@ from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.branch.tasks import merge_branch
+from infrahub.core.branch.tasks import MergeBranchResult, merge_branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -51,11 +51,11 @@ class TestMergeTaskLock:
         branch: Branch,
         context: Any,  # noqa: ARG004
         proposed_change_id: str | None = None,  # noqa: ARG004
-    ) -> list:
+    ) -> MergeBranchResult:
         branch.status = BranchStatus.MERGED
         await branch.save(db=db)
         registry.branch[branch.name] = branch
-        return []
+        return MergeBranchResult(node_events=[], schema_was_updated=False)
 
     @staticmethod
     def _mock_event_service() -> AsyncMock:
@@ -116,7 +116,7 @@ class TestMergeTaskLock:
             branch.status = BranchStatus.MERGED
             await branch.save(db=db)
             registry.branch[branch.name] = branch
-            return []
+            return MergeBranchResult(node_events=[], schema_was_updated=False)
 
         mock_do_merge_fn = AsyncMock(side_effect=tracking_mock_do_merge)
         mock_get_event_svc = AsyncMock(return_value=self._mock_event_service())

--- a/backend/tests/integration_docker/test_merge_derived_value_refresh.py
+++ b/backend/tests/integration_docker/test_merge_derived_value_refresh.py
@@ -1,0 +1,99 @@
+"""A branch merge that applies a computed-attribute schema change refreshes derived values on main-only nodes."""
+
+from __future__ import annotations
+
+from asyncio import sleep
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+from infrahub.core.constants import ComputedAttributeKind
+from infrahub.core.schema import AttributeSchema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
+from tests.helpers.schema import WIDGET
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+KIND = WIDGET.kind
+
+
+def _schema(template: str) -> dict:
+    widget = deepcopy(WIDGET)
+    widget.attributes.append(
+        AttributeSchema(
+            name="label",
+            kind="Text",
+            read_only=True,
+            optional=True,
+            computed_attribute=ComputedAttribute(kind=ComputedAttributeKind.JINJA2, jinja2_template=template),
+        )
+    )
+    return {"version": "1.0", "nodes": [widget.model_dump()]}
+
+
+async def _poll_label(client: InfrahubClient, node_id: str, expected: str, max_wait: int = 120) -> str:
+    """Poll up to ``max_wait`` seconds for the node's stored label to reach ``expected``.
+
+    The backfill is dispatched asynchronously (SchemaUpdatedEvent -> automation -> computed-attribute
+    setup -> per-node update); under Redis-backed scaleout messaging that chain has non-trivial latency,
+    so the budget is generous. Returns the last observed value so the caller can assert with a diagnostic.
+    """
+    last = ""
+    for _ in range(max_wait):
+        node = await client.get(kind=KIND, id=node_id)
+        last = node.label.value
+        if last == expected:
+            return last
+        await sleep(1)
+    return last
+
+
+class TestMergeDerivedValueRefresh(TestInfrahubDockerClient):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    async def test_merge_refreshes_main_only_computed_attribute(self, client: InfrahubClient) -> None:
+        # baseline: the v1 template renders the bare name
+        r1 = await client.schema.load(schemas=[_schema("{{ name__value }}")], wait_until_converged=True)
+        assert r1.schema_updated
+        assert await client.schema.in_sync()
+
+        alpha = await client.create(kind=KIND, data={"name": "alpha"})
+        await alpha.save()
+        alpha_initial = await client.get(kind=KIND, id=alpha.id)
+        assert alpha_initial.label.value == "alpha"
+
+        # sanity check: a schema-load applied directly to main (not via merge) refreshes the stored value
+        rc = await client.schema.load(schemas=[_schema("v2-{{ name__value }}")], wait_until_converged=True)
+        assert rc.schema_updated
+        alpha_v2 = await _poll_label(client, alpha.id, expected="v2-alpha")
+        assert alpha_v2 == "v2-alpha", (
+            f"direct schema-load on main did not refresh the value (got {alpha_v2!r}); "
+            f"without observable backfill the assertion below is inconclusive."
+        )
+
+        # load the v3 template on a branch, to be merged into main
+        branch = await client.branch.create(branch_name="tmpl-v3")
+        loaded = await client.schema.load(
+            schemas=[_schema("v3-{{ name__value }}")], branch=branch.name, wait_until_converged=True
+        )
+        assert loaded.schema_updated
+
+        # beta exists only on main (created after the branch forked), so the merge brings no data diff for it
+        beta = await client.create(kind=KIND, data={"name": "beta"})
+        await beta.save()
+        beta_initial = await client.get(kind=KIND, id=beta.id)
+        assert beta_initial.label.value == "v2-beta", f"expected main still at v2 (got {beta_initial.label.value!r})"
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+
+        # after the merge, main is on v3; the main-only node should refresh to "v3-beta"
+        beta_after = await _poll_label(client, beta.id, expected="v3-beta")
+        assert beta_after == "v3-beta", (
+            f"main-only node was not refreshed after the merge (got {beta_after!r}, expected 'v3-beta')."
+        )

--- a/changelog/+merge-refresh-derived-values.fixed.md
+++ b/changelog/+merge-refresh-derived-values.fixed.md
@@ -1,0 +1,1 @@
+Merging a branch that changes a computed attribute, display label, or human-friendly ID template now refreshes those derived values on nodes that exist only on the target branch. Previously the merge applied the new schema without emitting a schema-update event, so the backfill never ran and the affected nodes kept stale values.


### PR DESCRIPTION
## Summary

A branch merge that applies schema changes updates the registry but emits no `SchemaUpdatedEvent`, so the display label, HFID, and computed-attribute backfills never run on the target branch. Stored derived values on destination nodes that were absent from the merge diff (for example nodes created on the target branch after the source branch forked) stay stale until the node is next mutated.

This emits a `SchemaUpdatedEvent` for the destination branch after a merge that applied schema changes, mirroring the interactive schema-load path, so the existing backfill recomputes the affected values. The event is sent after the merge fully succeeds so an event-send failure cannot trigger a rollback.

## Testing

Adds an integration_docker repro (`test_merge_derived_value_staleness.py`): a node created on the target branch after the source branch forked keeps its old computed value after a template change is merged, while an interactive-path control refreshes correctly. The test was red before the change and green after, verified against a locally built image.

## Out of scope

- The rebase path has the same gap but needs a deeper fix: emitting the event is not sufficient because the backfill deduplicates the rebased branch against the default branch and skips recompute when their schemas match. Tracked for follow-up.
- On large datasets the triggered backfill is currently a full per-kind sweep; scoping it to the changed elements is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits a SchemaUpdatedEvent after schema-changing branch merges so the target branch recomputes display labels, HFIDs, and computed attributes. Addresses the merge half of IFC-2758; the rebase gap remains open.

- **Bug Fixes**
  - Emit SchemaUpdatedEvent on the destination branch only when schema changes were applied; queued with post-merge events after the merge commits, and send failures never abort the merge.
  - Add integration test backend/tests/integration_docker/test_merge_derived_value_refresh.py that verifies a main-only node refreshes after merging a template change.

- **Refactors**
  - _do_merge_branch now returns MergeBranchResult exposing schema_was_updated; component tests updated to use it.

<sup>Written for commit c3cab135e424f8e7cfa4b573a7fb32b4b449263e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

