### PR TITLE
fix(graphql): allow branch rebase with only rebase_branch permission

### DIFF
--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -20,6 +20,7 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     exempt_operations = [
         "BranchCreate",
         "BranchDelete",
+        "BranchRebase",
         "DiffUpdate",
         "InfrahubAccountSelfUpdate",
         "InfrahubAccountTokenCreate",

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -214,3 +214,42 @@ class TestDefaultBranchPermission:
             branch=permissions_helper.default_branch,
         )
         assert resolution == CheckerResolution.NEXT_CHECKER
+
+    async def test_branch_rebase_exempt_for_user_without_permission(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = DefaultBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        permission_manager = PermissionManager(account_session=session)
+        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+
+        graphql_query = create_autospec(spec=InfrahubGraphQLQueryAnalyzer)
+        graphql_query.branch = None
+        graphql_query.contains_mutation = True
+        graphql_query.operation_names = ["BranchRebase"]
+
+        graphql_context = GraphqlContext(
+            db=MagicMock(),
+            branch=MagicMock(),
+            types=MagicMock(),
+            single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
+            account_metadata_resolver=AccountMetadataResolver(),
+            account_session=session,
+            permissions=permission_manager,
+        )
+        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=graphql_query,
+            query_parameters=query_parameters,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER

--- a/changelog/9604.fixed.md
+++ b/changelog/9604.fixed.md
@@ -1,0 +1,1 @@
+Rebasing a branch now only requires the `global:rebase_branch:allow_all` permission. Previously the default-branch permission check ran ahead of the rebase check and also demanded `global:edit_default_branch:allow_all`, so users granted only the rebase permission were denied with "You are not allowed to change data in the default branch".


### PR DESCRIPTION
## What

Rebasing a branch now requires only `global:rebase_branch:allow_all`, not also `global:edit_default_branch:allow_all`.

Fixes #9604 — IFC-2765

## Why

`BranchRebase` is evaluated against the default-branch GraphQL context (the UI sends it to `/graphql/main`). In the permission-checker chain, `DefaultBranchPermissionChecker` runs *before* `RebaseBranchPermissionChecker` and raises whenever a mutation touches the default branch and isn't exempt. Its `exempt_operations` listed `BranchCreate` and `BranchDelete` but not `BranchRebase`, so a user granted only the rebase permission was denied with *"You are not allowed to change data in the default branch"* before the dedicated rebase checker ever ran.

Reproduced on a local instance: a user holding exactly `global:rebase_branch:allow_all` was denied when rebasing via `/graphql/main`, but the same mutation against the branch's own context (`/graphql/<branch>`) succeeded — confirming only the default-branch checker was blocking.

## Change

Add `"BranchRebase"` to `DefaultBranchPermissionChecker.exempt_operations`, leaving `RebaseBranchPermissionChecker` as the sole authority for rebase operations (mirroring how `BranchCreate`/`BranchDelete` are handled).

Note: `BranchMerge` is intentionally left non-exempt — merging legitimately writes to the default branch.

## Testing

- Existing checker component tests pass (`test_default_branch_checker.py`, `test_rebase_operation_checker.py` — 18 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow rebasing with only `global:rebase_branch:allow_all` by exempting `BranchRebase` in `DefaultBranchPermissionChecker`. This removes the unintended need for `global:edit_default_branch:allow_all` when rebasing via `/graphql/main` and satisfies IFC-2765.

- **Bug Fixes**
  - Added a regression test to ensure `BranchRebase` is exempt from the default-branch checker and defers to `RebaseBranchPermissionChecker`.

<sup>Written for commit 532eeca4732c7995d95e90066413dd5b8c58ca8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

