### PR TITLE
fix(frontend): surface backend error messages on proposed change actions

### DIFF
--- a/changelog/+pc-action-error-message.fixed.md
+++ b/changelog/+pc-action-error-message.fixed.md
@@ -1,0 +1,1 @@
+Proposed change action buttons (approve, reject, merge, close, draft) now surface the actual backend error message in the toast instead of a generic "An error occurred" message, making failures easier to diagnose.

--- a/frontend/app/src/entities/proposed-changes/api/update-proposed-change-review-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/update-proposed-change-review-from-api.ts
@@ -22,5 +22,8 @@ export function updateProposedChangeReviewFromApi({
       proposedChangeId,
       decision,
     },
+    context: {
+      processErrorMessage: () => {},
+    },
   });
 }

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-approve-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-approve-button.tsx
@@ -35,17 +35,8 @@ export const ApproveButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
         />
       );
     },
-    onError: () => {
-      toast(
-        <Alert
-          type={ALERT_TYPES.ERROR}
-          message={
-            hasApproved
-              ? "An error occurred while canceling the approval"
-              : "An error occurred while approving"
-          }
-        />
-      );
+    onError: (error) => {
+      toast(<Alert type={ALERT_TYPES.ERROR} message={error.message} />);
     },
   });
 

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-close-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-close-button.tsx
@@ -26,13 +26,8 @@ export const CloseButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
       });
       toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Proposed change closed!"} />);
     },
-    onError: () => {
-      toast(
-        <Alert
-          type={ALERT_TYPES.ERROR}
-          message={"An error occurred while closing the propsoed change"}
-        />
-      );
+    onError: (error) => {
+      toast(<Alert type={ALERT_TYPES.ERROR} message={error.message} />);
     },
   });
 

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-draft-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-draft-button.tsx
@@ -32,17 +32,8 @@ export const DraftButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
         />
       );
     },
-    onError: () => {
-      toast(
-        <Alert
-          type={ALERT_TYPES.ERROR}
-          message={
-            isDraft
-              ? "An error occurred while removing draft status"
-              : "An error occurred while moving to draft"
-          }
-        />
-      );
+    onError: (error) => {
+      toast(<Alert type={ALERT_TYPES.ERROR} message={error.message} />);
     },
   });
 

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-merge-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-merge-button.tsx
@@ -42,13 +42,8 @@ export const MergeButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
         clearBranchIfCurrent(sourceBranch);
       }
     },
-    onError: () => {
-      toast(
-        <Alert
-          type={ALERT_TYPES.ERROR}
-          message={"An error occurred while merging proposed change"}
-        />
-      );
+    onError: (error) => {
+      toast(<Alert type={ALERT_TYPES.ERROR} message={error.message} />);
     },
   });
 

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-reject-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-reject-button.tsx
@@ -33,17 +33,8 @@ export const RejectButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
         />
       );
     },
-    onError: () => {
-      toast(
-        <Alert
-          type={ALERT_TYPES.ERROR}
-          message={
-            hasRejected
-              ? "An error occurred while canceling the rejection"
-              : "An error occurred while rejecting proposed change"
-          }
-        />
-      );
+    onError: (error) => {
+      toast(<Alert type={ALERT_TYPES.ERROR} message={error.message} />);
     },
   });
 

--- a/frontend/app/src/entities/proposed-changes/ui/queries/update-review.mutation.ts
+++ b/frontend/app/src/entities/proposed-changes/ui/queries/update-review.mutation.ts
@@ -1,27 +1,20 @@
 import { useMutation } from "@tanstack/react-query";
 
+import type { MutationConfig } from "@/shared/api/types";
+
 import {
   type UpdateProposedChangeReviewParams,
   updateProposedChangeReview,
 } from "@/entities/proposed-changes/domain/update-proposed-change-review";
 
-interface UpdateReviewProps {
-  onSuccess?: () => void;
-  onError?: () => void;
-  onSettled?: () => void;
-}
+interface UseUpdateProposedChangeReviewParams
+  extends MutationConfig<typeof updateProposedChangeReview> {}
 
-export function useUpdateProposedChangeReview({
-  onSuccess,
-  onError,
-  onSettled,
-}: UpdateReviewProps) {
+export function useUpdateProposedChangeReview(params: UseUpdateProposedChangeReviewParams) {
   return useMutation({
     mutationFn: async (params: UpdateProposedChangeReviewParams) => {
       return updateProposedChangeReview(params);
     },
-    onSuccess,
-    onError,
-    onSettled,
+    ...params,
   });
 }

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -122,13 +122,13 @@ export function handleGraphQLAuthError({
         // miss is visible during manual testing. Prod stays silent
         // (just the generic toast) to avoid leaking implementation noise.
         if (import.meta.env.DEV) {
-          console.warn(
+          console.error(
             "[catalogue gap] Unmatched error code surfaced as UNDEFINED_ERROR. " +
               "Register it in backend/infrahub/errors/catalogue.py, regenerate " +
               "the schema, and run `pnpm generate:error-bindings`.",
             { message: graphQLError.message, extensions: graphQLError.extensions }
           );
-          notifyUser(`[catalogue gap] ${graphQLError.message}`, operation);
+          notifyUser(graphQLError.message, operation);
           return;
         }
         notifyUser(graphQLError.message, operation);


### PR DESCRIPTION
revamp of: https://github.com/opsmill/infrahub/pull/9561

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show actual backend error messages in proposed change action toasts (approve, reject, merge, close, draft) instead of generic errors. This makes failures easier to diagnose and aligns UI with GraphQL error handling.

- **Bug Fixes**
  - Action buttons now display `error.message` in the toast on failure.
  - `useUpdateProposedChangeReview` accepts a `MutationConfig` and forwards handlers to surface errors.
  - GraphQL client logs catalogue gaps with `console.error` and shows the raw backend message in dev (no `[catalogue gap]` prefix).

<sup>Written for commit 6f616ed5f32c3624162c8a4f15a973a993138f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

