### PR TITLE
Remove all data-cy attributes from the frontend codebase

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -17,7 +17,7 @@ exports[`fix ts error`] = {
     "src/entities/branches/ui/branch-create-form.tsx:2904341468": [
       [34, 33, 13, "tsc: Argument of type \'BranchListItem\' is not assignable to parameter of type \'Branch\'.\\n  Type \'BranchListItem\' is missing 3 properties from type \'Branch\'", "2717214769"]
     ],
-    "src/entities/diff/ui/artifact-diff/artifact-content-diff.tsx:2275808763": [
+    "src/entities/diff/ui/artifact-diff/artifact-content-diff.tsx:3279147963": [
       [7, 39, 9, "tsc: Could not find a declaration file for module \'unidiff\'. \'../../../../../../node_modules/.pnpm/unidiff@1.0.4/node_modules/unidiff/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/unidiff\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'unidiff\';\`", "1870574010"],
       [29, 13, 23, "tsc: No overload matches this call.\\n  Overload 1 of 3, \'(message: Buffer<ArrayBufferLike> | string, options?: Sha1AsStringOptions | undefined): string\', gave the following error.\\n    Argument of type \'number\' is not assignable to parameter of type \'Buffer<ArrayBufferLike> | string\'.\\n  Overload 2 of 3, \'(message: Buffer<ArrayBufferLike> | string, options?: Sha1AsBytesOptions | undefined): Uint8Array<ArrayBufferLike>\', gave the following error.\\n    Argument of type \'number\' is not assignable to parameter of type \'string | Buffer<ArrayBufferLike>\'.\\n  Overload 3 of 3, \'(message: string | Buffer<ArrayBufferLike>, options?: Sha1Options | Uint8Array<ArrayBufferLike> | undefined): string\', gave the following error.\\n    Argument of type \'number\' is not assignable to parameter of type \'string | Buffer<ArrayBufferLike>\'.", "1877915893"],
       [329, 17, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
@@ -364,10 +364,10 @@ exports[`fix ts error`] = {
       [99, 54, 2, "tsc: Property \'id\' does not exist on type \'Node | PoolValue\'.\\n  Property \'id\' does not exist on type \'PoolValue\'.", "5861160"],
       [146, 23, 5, "tsc: Argument of type \'NodeCore\' is not assignable to parameter of type \'Node | PoolValue | null\'.\\n  Type \'NodeCore\' is not assignable to type \'Node\'.\\n    Types of property \'display_label\' are incompatible.\\n      Type \'null | string | undefined\' is not assignable to type \'string\'.\\n        Type \'undefined\' is not assignable to type \'string\'.", "189936718"]
     ],
-    "src/shared/components/table/table.tsx:193878238": [
-      [79, 40, 23, "tsc: Argument of type \'number | string | tRowValue | undefined\' is not assignable to parameter of type \'number | string | tRowValue\'.\\n  Type \'undefined\' is not assignable to type \'number | string | tRowValue\'.", "1426455104"],
-      [85, 40, 23, "tsc: Argument of type \'number | string | tRowValue | undefined\' is not assignable to parameter of type \'number | string | tRowValue\'.\\n  Type \'undefined\' is not assignable to type \'number | string | tRowValue\'.", "1426455104"],
-      [151, 35, 5, "tsc: Property \'value\' does not exist on type \'never\'.", "189936718"]
+    "src/shared/components/table/table.tsx:2375213391": [
+      [78, 40, 23, "tsc: Argument of type \'number | string | tRowValue | undefined\' is not assignable to parameter of type \'number | string | tRowValue\'.\\n  Type \'undefined\' is not assignable to type \'number | string | tRowValue\'.", "1426455104"],
+      [84, 40, 23, "tsc: Argument of type \'number | string | tRowValue | undefined\' is not assignable to parameter of type \'number | string | tRowValue\'.\\n  Type \'undefined\' is not assignable to type \'number | string | tRowValue\'.", "1426455104"],
+      [150, 35, 5, "tsc: Property \'value\' does not exist on type \'never\'.", "189936718"]
     ],
     "src/shared/components/ui/alert.tsx:757342485": [
       [15, 12, 11, "tsc: This syntax is not allowed when \'erasableSyntaxOnly\' is enabled.", "2602525471"]

--- a/frontend/app/src/entities/diff/ui/artifact-diff/artifact-content-diff.tsx
+++ b/frontend/app/src/entities/diff/ui/artifact-diff/artifact-content-diff.tsx
@@ -309,7 +309,7 @@ export const ArtifactContentDiff = ({ itemPrevious, itemNew, id }: ArtifactConte
   });
 
   return (
-    <div className={"pr-2 pb-2"} data-cy="artifact-content-diff">
+    <div className={"pr-2 pb-2"}>
       <div className="flex">
         <div className="flex-1">
           {itemPrevious?.storage_id && (

--- a/frontend/app/src/entities/nodes/object-item-edit/object-item-edit-paginated.tsx
+++ b/frontend/app/src/entities/nodes/object-item-edit/object-item-edit-paginated.tsx
@@ -111,7 +111,6 @@ function ObjectItemEditForm({
       kind={objectname}
       currentObject={objectDetailsData}
       currentProfiles={objectProfiles}
-      data-cy="object-item-edit"
       isUpdate
     />
   );

--- a/frontend/app/src/entities/proposed-changes/ui/conversations/thread.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/conversations/thread.tsx
@@ -160,7 +160,6 @@ export const Thread = (props: tThread) => {
     <Card
       className={classNames("relative gap-2 rounded-md p-2", isResolved && "bg-gray-200")}
       data-testid="thread"
-      data-cy="thread"
     >
       {displayContext && getThreadTitle(thread)}
 

--- a/frontend/app/src/shared/components/display/question-mark.tsx
+++ b/frontend/app/src/shared/components/display/question-mark.tsx
@@ -17,7 +17,6 @@ export const QuestionMark = ({ className, message }: tQuestionMark) => {
         shape="circle"
         variant="outline"
         className={classNames("h-4 w-4 p-2 text-[10px]", className)}
-        data-cy="question-mark"
       >
         ?
       </Button>

--- a/frontend/app/src/shared/components/table/table.tsx
+++ b/frontend/app/src/shared/components/table/table.tsx
@@ -67,7 +67,6 @@ export const Table = ({ columns, rows, onDelete, onUpdate, className, permission
                 "h-[36px] border-gray-200 border-b",
                 row.link ? "cursor-pointer hover:bg-gray-50" : ""
               )}
-              data-cy="object-table-row"
             >
               {columns.map((column, index) => {
                 return (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed all `data-cy` attributes across the frontend to clean up the DOM and standardize on `data-testid` and semantic selectors. Applied lint fixes; no UI or runtime behavior changes.

- **Migration**
  - Update e2e tests to stop using `[data-cy=...]`. Prefer `[data-testid=...]`, role-based queries, or stable text.
  - Example: `thread` remains available via `[data-testid="thread"]`; other elements no longer expose `data-cy`.

<sup>Written for commit 831c2b0d26e80002ae8dffb6121107e272c230ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

