### PR TITLE
refactor(task-manager): unify Prefect access behind one client adapter

### DIFF
--- a/backend/infrahub/cli/tasks.py
+++ b/backend/infrahub/cli/tasks.py
@@ -7,7 +7,8 @@ from prefect.client.schemas.objects import StateType
 
 from infrahub import config
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
-from infrahub.task_manager.flow_run.retention import FlowRunRetention, PrefectFlowRunRetentionClient
+from infrahub.task_manager.flow_run.prefect_client import PrefectClientAdapter
+from infrahub.task_manager.flow_run.retention import FlowRunRetention
 from infrahub.tasks.dummy import DUMMY_FLOW, DummyInput
 from infrahub.workers.dependencies import build_tls_registry
 from infrahub.workflows.initialization import setup_task_manager
@@ -75,7 +76,7 @@ async def flow_runs(
     config.load_and_exit(config_file_name=config_file)
 
     async with get_client(sync_client=False) as client:
-        await FlowRunRetention(client=PrefectFlowRunRetentionClient(client)).purge(
+        await FlowRunRetention(client=PrefectClientAdapter(client)).purge(
             days_to_keep=days_to_keep,
             batch_size=batch_size,
         )
@@ -96,6 +97,6 @@ async def stale_runs(
     config.load_and_exit(config_file_name=config_file)
 
     async with get_client(sync_client=False) as client:
-        await FlowRunRetention(client=PrefectFlowRunRetentionClient(client)).purge(
+        await FlowRunRetention(client=PrefectClientAdapter(client)).purge(
             states=[StateType.RUNNING], delete=False, days_to_keep=days_to_keep, batch_size=batch_size
         )

--- a/backend/infrahub/task_manager/flow_run/count.py
+++ b/backend/infrahub/task_manager/flow_run/count.py
@@ -1,6 +1,5 @@
 from typing import Protocol
 
-from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.filters import FlowFilter, FlowRunFilter
 
 from infrahub import config
@@ -8,6 +7,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache import InfrahubCache
 
 from .cache_key import FlowRunCountCacheKeyBuilder
+from .prefect_client import FlowRunCounting
 
 
 class FlowRunCounterProtocol(Protocol):
@@ -22,7 +22,7 @@ class FlowRunCounter:
     """Count flow runs matching a filter, caching results above a configurable threshold."""
 
     def __init__(
-        self, client: PrefectClient, cache: InfrahubCache, cache_key_builder: FlowRunCountCacheKeyBuilder
+        self, client: FlowRunCounting, cache: InfrahubCache, cache_key_builder: FlowRunCountCacheKeyBuilder
     ) -> None:
         self.client = client
         self.cache = cache
@@ -46,9 +46,7 @@ class FlowRunCounter:
             except (TypeError, ValueError):
                 await self.cache.delete(key=cache_key)
 
-        response = await self.client._client.post("/flow_runs/count", json=body)
-        response.raise_for_status()
-        count_value = int(response.json())
+        count_value = await self.client.count_flow_runs(body)
 
         if count_value >= config.SETTINGS.workflow.flow_run_count_cache_threshold:
             await self.cache.set(key=cache_key, value=str(count_value), expires=KVTTL.ONE_MINUTE)

--- a/backend/infrahub/task_manager/flow_run/prefect_client.py
+++ b/backend/infrahub/task_manager/flow_run/prefect_client.py
@@ -1,0 +1,86 @@
+from typing import Any, Protocol
+from uuid import UUID
+
+from prefect import State
+from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.filters import ArtifactFilter, FlowFilter, FlowRunFilter, LogFilter
+from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log
+from prefect.client.schemas.sorting import FlowRunSort
+
+
+class FlowRunQuerying(Protocol):
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
+    ) -> list[FlowRun]: ...
+
+
+class FlowRunDataReading(Protocol):
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]: ...
+
+    async def read_artifacts(
+        self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter
+    ) -> list[Artifact]: ...
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]: ...
+
+
+class FlowRunCounting(Protocol):
+    async def count_flow_runs(self, body: dict[str, Any]) -> int: ...
+
+
+class FlowRunMaintenance(Protocol):
+    async def delete_flow_run(self, flow_run_id: UUID) -> None: ...
+
+    async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> None: ...
+
+
+class ReaderPrefectClient(FlowRunQuerying, FlowRunDataReading, Protocol): ...
+
+
+class RetentionPrefectClient(FlowRunQuerying, FlowRunMaintenance, Protocol): ...
+
+
+class PrefectClientAdapter:
+    """Adapt a Prefect client to the operations the flow-run feature relies on."""
+
+    def __init__(self, client: PrefectClient) -> None:
+        self.client = client
+
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
+    ) -> list[FlowRun]:
+        return await self.client.read_flow_runs(
+            flow_filter=flow_filter, flow_run_filter=flow_run_filter, limit=limit, offset=offset, sort=sort
+        )
+
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
+        return await self.client.read_logs(log_filter=log_filter, offset=offset, limit=limit)
+
+    async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
+        return await self.client.read_artifacts(artifact_filter=artifact_filter, flow_run_filter=flow_run_filter)
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
+        if flow_filter is None:
+            return await self.client.read_flows()
+        return await self.client.read_flows(flow_filter=flow_filter)
+
+    async def count_flow_runs(self, body: dict[str, Any]) -> int:
+        response = await self.client._client.post("/flow_runs/count", json=body)
+        response.raise_for_status()
+        return int(response.json())
+
+    async def delete_flow_run(self, flow_run_id: UUID) -> None:
+        await self.client.delete_flow_run(flow_run_id=flow_run_id)
+
+    async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> None:
+        await self.client.set_flow_run_state(flow_run_id=flow_run_id, state=state, force=force)

--- a/backend/infrahub/task_manager/flow_run/reader.py
+++ b/backend/infrahub/task_manager/flow_run/reader.py
@@ -13,7 +13,7 @@ from prefect.client.schemas.filters import (
     LogFilter,
     LogFilterFlowRunId,
 )
-from prefect.client.schemas.objects import Flow, FlowRun
+from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log
 from prefect.client.schemas.sorting import FlowRunSort
 
 from infrahub.log import get_logger
@@ -24,6 +24,57 @@ log = get_logger()
 
 NB_LOGS_LIMIT = 10_000
 PREFECT_MAX_LOGS_PER_CALL = 200
+
+
+class FlowRunReaderClient(Protocol):
+    """The subset of Prefect client read operations the flow-run reader depends on."""
+
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter,
+        flow_run_filter: FlowRunFilter,
+        limit: int | None,
+        offset: int,
+        sort: FlowRunSort,
+    ) -> list[FlowRun]: ...
+
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]: ...
+
+    async def read_artifacts(
+        self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter
+    ) -> list[Artifact]: ...
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]: ...
+
+
+class PrefectFlowRunReaderClient:
+    """Forward the flow-run read operations to a Prefect client."""
+
+    def __init__(self, client: PrefectClient) -> None:
+        self.client = client
+
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter,
+        flow_run_filter: FlowRunFilter,
+        limit: int | None,
+        offset: int,
+        sort: FlowRunSort,
+    ) -> list[FlowRun]:
+        return await self.client.read_flow_runs(
+            flow_filter=flow_filter, flow_run_filter=flow_run_filter, limit=limit, offset=offset, sort=sort
+        )
+
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
+        return await self.client.read_logs(log_filter=log_filter, offset=offset, limit=limit)
+
+    async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
+        return await self.client.read_artifacts(artifact_filter=artifact_filter, flow_run_filter=flow_run_filter)
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
+        if flow_filter is None:
+            return await self.client.read_flows()
+        return await self.client.read_flows(flow_filter=flow_filter)
 
 
 class FlowRunReaderProtocol(Protocol):
@@ -45,7 +96,7 @@ class FlowRunReaderProtocol(Protocol):
 class FlowRunReader:
     """Thin adapter over the Prefect client read operations used to display flow runs."""
 
-    def __init__(self, client: PrefectClient) -> None:
+    def __init__(self, client: FlowRunReaderClient) -> None:
         self.client = client
 
     async def read_flow_runs(

--- a/backend/infrahub/task_manager/flow_run/reader.py
+++ b/backend/infrahub/task_manager/flow_run/reader.py
@@ -1,7 +1,6 @@
 from typing import Protocol
 from uuid import UUID
 
-from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.filters import (
     ArtifactFilter,
     ArtifactFilterType,
@@ -13,68 +12,18 @@ from prefect.client.schemas.filters import (
     LogFilter,
     LogFilterFlowRunId,
 )
-from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log
+from prefect.client.schemas.objects import Flow, FlowRun
 from prefect.client.schemas.sorting import FlowRunSort
 
 from infrahub.log import get_logger
 
 from .models import FlowLogs, FlowProgress
+from .prefect_client import ReaderPrefectClient
 
 log = get_logger()
 
 NB_LOGS_LIMIT = 10_000
 PREFECT_MAX_LOGS_PER_CALL = 200
-
-
-class FlowRunReaderClient(Protocol):
-    """The subset of Prefect client read operations the flow-run reader depends on."""
-
-    async def read_flow_runs(
-        self,
-        flow_filter: FlowFilter,
-        flow_run_filter: FlowRunFilter,
-        limit: int | None,
-        offset: int,
-        sort: FlowRunSort,
-    ) -> list[FlowRun]: ...
-
-    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]: ...
-
-    async def read_artifacts(
-        self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter
-    ) -> list[Artifact]: ...
-
-    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]: ...
-
-
-class PrefectFlowRunReaderClient:
-    """Forward the flow-run read operations to a Prefect client."""
-
-    def __init__(self, client: PrefectClient) -> None:
-        self.client = client
-
-    async def read_flow_runs(
-        self,
-        flow_filter: FlowFilter,
-        flow_run_filter: FlowRunFilter,
-        limit: int | None,
-        offset: int,
-        sort: FlowRunSort,
-    ) -> list[FlowRun]:
-        return await self.client.read_flow_runs(
-            flow_filter=flow_filter, flow_run_filter=flow_run_filter, limit=limit, offset=offset, sort=sort
-        )
-
-    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
-        return await self.client.read_logs(log_filter=log_filter, offset=offset, limit=limit)
-
-    async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
-        return await self.client.read_artifacts(artifact_filter=artifact_filter, flow_run_filter=flow_run_filter)
-
-    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
-        if flow_filter is None:
-            return await self.client.read_flows()
-        return await self.client.read_flows(flow_filter=flow_filter)
 
 
 class FlowRunReaderProtocol(Protocol):
@@ -94,9 +43,9 @@ class FlowRunReaderProtocol(Protocol):
 
 
 class FlowRunReader:
-    """Thin adapter over the Prefect client read operations used to display flow runs."""
+    """Read and shape the flow-run data needed to display tasks."""
 
-    def __init__(self, client: FlowRunReaderClient) -> None:
+    def __init__(self, client: ReaderPrefectClient) -> None:
         self.client = client
 
     async def read_flow_runs(

--- a/backend/infrahub/task_manager/flow_run/retention.py
+++ b/backend/infrahub/task_manager/flow_run/retention.py
@@ -1,52 +1,25 @@
 import asyncio
 from datetime import UTC, timedelta
-from typing import Protocol
-from uuid import UUID
 
 from prefect import State
-from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.filters import (
     FlowRunFilter,
     FlowRunFilterStartTime,
     FlowRunFilterState,
     FlowRunFilterStateType,
 )
-from prefect.client.schemas.objects import FlowRun, StateType
+from prefect.client.schemas.objects import StateType
 from prefect.types import DateTime
 
 from infrahub.log import get_logger
 
-
-class FlowRunRetentionClient(Protocol):
-    """The subset of Prefect client operations the retention purge depends on."""
-
-    async def read_flow_runs(self, flow_run_filter: FlowRunFilter, limit: int) -> list[FlowRun]: ...
-
-    async def delete_flow_run(self, flow_run_id: UUID) -> None: ...
-
-    async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> None: ...
-
-
-class PrefectFlowRunRetentionClient:
-    """Forward the retention operations to a Prefect client."""
-
-    def __init__(self, client: PrefectClient) -> None:
-        self.client = client
-
-    async def read_flow_runs(self, flow_run_filter: FlowRunFilter, limit: int) -> list[FlowRun]:
-        return await self.client.read_flow_runs(flow_run_filter=flow_run_filter, limit=limit)
-
-    async def delete_flow_run(self, flow_run_id: UUID) -> None:
-        await self.client.delete_flow_run(flow_run_id=flow_run_id)
-
-    async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> None:
-        await self.client.set_flow_run_state(flow_run_id=flow_run_id, state=state, force=force)
+from .prefect_client import RetentionPrefectClient
 
 
 class FlowRunRetention:
     """Purge old flow runs, either deleting them or forcing them into a terminal state."""
 
-    def __init__(self, client: FlowRunRetentionClient) -> None:
+    def __init__(self, client: RetentionPrefectClient) -> None:
         self.client = client
 
     async def purge(

--- a/backend/infrahub/task_manager/flow_run/service.py
+++ b/backend/infrahub/task_manager/flow_run/service.py
@@ -16,7 +16,8 @@ from .models import (
     FlowRunQueryResult,
     RelatedNodesInfo,
 )
-from .reader import FlowRunReader, FlowRunReaderProtocol, PrefectFlowRunReaderClient
+from .prefect_client import PrefectClientAdapter
+from .reader import FlowRunReader, FlowRunReaderProtocol
 from .tags import WorkflowTagDecoder
 
 
@@ -94,10 +95,11 @@ class PrefectTaskService:
 async def build_prefect_task_service(db: InfrahubDatabase, client: PrefectClient) -> PrefectTaskService:
     tag_decoder = WorkflowTagDecoder()
     cache = await get_cache()
+    prefect = PrefectClientAdapter(client)
     return PrefectTaskService(
         filter_builder=FlowRunFilterBuilder(),
-        reader=FlowRunReader(client=PrefectFlowRunReaderClient(client)),
-        counter=FlowRunCounter(client=client, cache=cache, cache_key_builder=FlowRunCountCacheKeyBuilder()),
+        reader=FlowRunReader(client=prefect),
+        counter=FlowRunCounter(client=prefect, cache=cache, cache_key_builder=FlowRunCountCacheKeyBuilder()),
         enricher=RelatedNodeEnricher(db=db, tag_decoder=tag_decoder),
         tag_decoder=tag_decoder,
     )

--- a/backend/infrahub/task_manager/flow_run/service.py
+++ b/backend/infrahub/task_manager/flow_run/service.py
@@ -16,7 +16,7 @@ from .models import (
     FlowRunQueryResult,
     RelatedNodesInfo,
 )
-from .reader import FlowRunReader, FlowRunReaderProtocol
+from .reader import FlowRunReader, FlowRunReaderProtocol, PrefectFlowRunReaderClient
 from .tags import WorkflowTagDecoder
 
 
@@ -96,7 +96,7 @@ async def build_prefect_task_service(db: InfrahubDatabase, client: PrefectClient
     cache = await get_cache()
     return PrefectTaskService(
         filter_builder=FlowRunFilterBuilder(),
-        reader=FlowRunReader(client=client),
+        reader=FlowRunReader(client=PrefectFlowRunReaderClient(client)),
         counter=FlowRunCounter(client=client, cache=cache, cache_key_builder=FlowRunCountCacheKeyBuilder()),
         enricher=RelatedNodeEnricher(db=db, tag_decoder=tag_decoder),
         tag_decoder=tag_decoder,

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC
 from uuid import UUID, uuid4
 
@@ -21,7 +22,7 @@ class FakeReaderClient:
         self._artifacts = artifacts or []
         self._flows = flows or []
         self._log_fetches: list[tuple[int, int]] = []
-        self.read_flows_calls: list[FlowFilter | None] = []
+        self._flows_filters: list[FlowFilter | None] = []
 
     async def read_flow_runs(
         self,
@@ -45,8 +46,32 @@ class FakeReaderClient:
         return self._artifacts
 
     async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
-        self.read_flows_calls.append(flow_filter)
+        self._flows_filters.append(flow_filter)
         return self._flows
+
+    def _single_flows_filter(self) -> FlowFilter:
+        assert len(self._flows_filters) == 1, "expected exactly one read_flows call"
+        flow_filter = self._flows_filters[0]
+        assert flow_filter is not None, "expected a filtered read_flows call"
+        return flow_filter
+
+    def assert_read_all_flows(self) -> None:
+        """Assert read_flows was called once with no filter (every flow requested)."""
+        assert self._flows_filters == [None]
+
+    def assert_flows_filtered_by_names(self, names: list[str]) -> None:
+        """Assert read_flows was filtered by exactly these workflow names."""
+        flow_filter = self._single_flows_filter()
+        assert flow_filter.name is not None
+        assert flow_filter.name.any_ == names
+        assert flow_filter.id is None
+
+    def assert_flows_filtered_by_ids(self, ids: list[UUID]) -> None:
+        """Assert read_flows was filtered by exactly these flow ids."""
+        flow_filter = self._single_flows_filter()
+        assert flow_filter.id is not None
+        assert flow_filter.id.any_ == ids
+        assert flow_filter.name is None
 
 
 def make_log(flow_run_id: UUID | None, message: str = "log line") -> Log:
@@ -84,15 +109,20 @@ class TestReadLogs:
     async def test_excludes_completed_finished_message(self) -> None:
         flow_id = uuid4()
         client = FakeReaderClient(
-            logs=[make_log(flow_id, message="real work"), make_log(flow_id, message="Finished in state Completed()")]
+            logs=[
+                make_log(flow_id, message="before"),
+                make_log(flow_id, message="Finished in state Completed()"),
+                make_log(flow_id, message="after"),
+            ]
         )
 
         result = await FlowRunReader(client=client).read_logs(flow_ids=[flow_id], log_limit=None, log_offset=None)
 
-        assert [entry.message for entry in result.logs[flow_id]] == ["real work"]
+        assert [entry.message for entry in result.logs[flow_id]] == ["before", "after"]
 
     async def test_rejects_log_limit_above_max(self) -> None:
-        with pytest.raises(ValueError, match=rf"^log_limit cannot be greater than {NB_LOGS_LIMIT}$"):
+        message = f"log_limit cannot be greater than {NB_LOGS_LIMIT}"
+        with pytest.raises(ValueError, match=rf"^{re.escape(message)}$"):
             await FlowRunReader(client=FakeReaderClient()).read_logs(
                 flow_ids=[uuid4()], log_limit=NB_LOGS_LIMIT + 1, log_offset=None
             )
@@ -132,18 +162,14 @@ class TestReadFlows:
         result = await FlowRunReader(client=client).read_flows()
 
         assert result == flows
-        assert client.read_flows_calls == [None]
+        client.assert_read_all_flows()
 
     async def test_filters_by_names(self) -> None:
         client = FakeReaderClient()
 
         await FlowRunReader(client=client).read_flows(names=["wf_a", "wf_b"])
 
-        flow_filter = client.read_flows_calls[0]
-        assert flow_filter is not None
-        assert flow_filter.name is not None
-        assert flow_filter.name.any_ == ["wf_a", "wf_b"]
-        assert flow_filter.id is None
+        client.assert_flows_filtered_by_names(["wf_a", "wf_b"])
 
     async def test_filters_by_ids(self) -> None:
         ids = [uuid4()]
@@ -151,7 +177,4 @@ class TestReadFlows:
 
         await FlowRunReader(client=client).read_flows(ids=ids)
 
-        flow_filter = client.read_flows_calls[0]
-        assert flow_filter is not None
-        assert flow_filter.id is not None
-        assert flow_filter.id.any_ == ids
+        client.assert_flows_filtered_by_ids(ids)

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -1,5 +1,4 @@
 from datetime import UTC
-from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
@@ -21,7 +20,7 @@ class FakeReaderClient:
         self._logs = logs or []
         self._artifacts = artifacts or []
         self._flows = flows or []
-        self.read_logs_calls: list[dict[str, Any]] = []
+        self._log_fetches: list[tuple[int, int]] = []
         self.read_flows_calls: list[FlowFilter | None] = []
 
     async def read_flow_runs(
@@ -35,8 +34,12 @@ class FakeReaderClient:
         return []
 
     async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
-        self.read_logs_calls.append({"offset": offset, "limit": limit})
+        self._log_fetches.append((offset, limit))
         return self._logs[offset : offset + limit]
+
+    def assert_log_pages_fetched(self, pages: list[tuple[int, int]]) -> None:
+        """Assert read_logs was invoked once per (offset, limit) page, in order."""
+        assert self._log_fetches == pages
 
     async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
         return self._artifacts
@@ -74,10 +77,9 @@ class TestReadLogs:
         result = await FlowRunReader(client=client).read_logs(flow_ids=[flow_id], log_limit=None, log_offset=None)
 
         assert len(result.logs[flow_id]) == total
-        assert client.read_logs_calls == [
-            {"offset": 0, "limit": PREFECT_MAX_LOGS_PER_CALL},
-            {"offset": PREFECT_MAX_LOGS_PER_CALL, "limit": PREFECT_MAX_LOGS_PER_CALL},
-        ]
+        client.assert_log_pages_fetched(
+            [(0, PREFECT_MAX_LOGS_PER_CALL), (PREFECT_MAX_LOGS_PER_CALL, PREFECT_MAX_LOGS_PER_CALL)]
+        )
 
     async def test_excludes_completed_finished_message(self) -> None:
         flow_id = uuid4()

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -1,0 +1,155 @@
+from datetime import UTC
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from prefect.client.schemas.filters import ArtifactFilter, FlowFilter, FlowRunFilter, LogFilter
+from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log
+from prefect.client.schemas.sorting import FlowRunSort
+from prefect.types import DateTime
+
+from infrahub.task_manager.flow_run.reader import NB_LOGS_LIMIT, PREFECT_MAX_LOGS_PER_CALL, FlowRunReader
+
+
+class FakeReaderClient:
+    def __init__(
+        self,
+        logs: list[Log] | None = None,
+        artifacts: list[Artifact] | None = None,
+        flows: list[Flow] | None = None,
+    ) -> None:
+        self._logs = logs or []
+        self._artifacts = artifacts or []
+        self._flows = flows or []
+        self.read_logs_calls: list[dict[str, Any]] = []
+        self.read_flows_calls: list[FlowFilter | None] = []
+
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter,
+        flow_run_filter: FlowRunFilter,
+        limit: int | None,
+        offset: int,
+        sort: FlowRunSort,
+    ) -> list[FlowRun]:
+        return []
+
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
+        self.read_logs_calls.append({"offset": offset, "limit": limit})
+        return self._logs[offset : offset + limit]
+
+    async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
+        return self._artifacts
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
+        self.read_flows_calls.append(flow_filter)
+        return self._flows
+
+
+def make_log(flow_run_id: UUID | None, message: str = "log line") -> Log:
+    return Log(name="task", level=20, message=message, timestamp=DateTime.now(tz=UTC), flow_run_id=flow_run_id)
+
+
+def make_artifact(flow_run_id: UUID, data: object) -> Artifact:
+    return Artifact(type="progress", flow_run_id=flow_run_id, data=data)
+
+
+class TestReadLogs:
+    async def test_groups_logs_by_flow_run(self) -> None:
+        flow_a, flow_b = uuid4(), uuid4()
+        client = FakeReaderClient(logs=[make_log(flow_a), make_log(flow_a), make_log(flow_b)])
+
+        result = await FlowRunReader(client=client).read_logs(
+            flow_ids=[flow_a, flow_b], log_limit=None, log_offset=None
+        )
+
+        assert len(result.logs[flow_a]) == 2
+        assert len(result.logs[flow_b]) == 1
+
+    async def test_paginates_beyond_a_single_batch(self) -> None:
+        flow_id = uuid4()
+        total = PREFECT_MAX_LOGS_PER_CALL + 50
+        client = FakeReaderClient(logs=[make_log(flow_id) for _ in range(total)])
+
+        result = await FlowRunReader(client=client).read_logs(flow_ids=[flow_id], log_limit=None, log_offset=None)
+
+        assert len(result.logs[flow_id]) == total
+        assert client.read_logs_calls == [
+            {"offset": 0, "limit": PREFECT_MAX_LOGS_PER_CALL},
+            {"offset": PREFECT_MAX_LOGS_PER_CALL, "limit": PREFECT_MAX_LOGS_PER_CALL},
+        ]
+
+    async def test_excludes_completed_finished_message(self) -> None:
+        flow_id = uuid4()
+        client = FakeReaderClient(
+            logs=[make_log(flow_id, message="real work"), make_log(flow_id, message="Finished in state Completed()")]
+        )
+
+        result = await FlowRunReader(client=client).read_logs(flow_ids=[flow_id], log_limit=None, log_offset=None)
+
+        assert [entry.message for entry in result.logs[flow_id]] == ["real work"]
+
+    async def test_rejects_log_limit_above_max(self) -> None:
+        with pytest.raises(ValueError, match=rf"^log_limit cannot be greater than {NB_LOGS_LIMIT}$"):
+            await FlowRunReader(client=FakeReaderClient()).read_logs(
+                flow_ids=[uuid4()], log_limit=NB_LOGS_LIMIT + 1, log_offset=None
+            )
+
+
+class TestReadProgress:
+    async def test_maps_flow_run_to_progress(self) -> None:
+        flow_a, flow_b = uuid4(), uuid4()
+        client = FakeReaderClient(artifacts=[make_artifact(flow_a, 0.25), make_artifact(flow_b, 1.0)])
+
+        result = await FlowRunReader(client=client).read_progress(flow_ids=[flow_a, flow_b])
+
+        assert result.data == {flow_a: 0.25, flow_b: 1.0}
+
+    async def test_keeps_first_artifact_on_duplicate(self) -> None:
+        flow_id = uuid4()
+        client = FakeReaderClient(artifacts=[make_artifact(flow_id, 0.1), make_artifact(flow_id, 0.9)])
+
+        result = await FlowRunReader(client=client).read_progress(flow_ids=[flow_id])
+
+        assert result.data == {flow_id: 0.1}
+
+    async def test_ignores_non_float_data(self) -> None:
+        flow_id = uuid4()
+        client = FakeReaderClient(artifacts=[make_artifact(flow_id, "not-a-number")])
+
+        result = await FlowRunReader(client=client).read_progress(flow_ids=[flow_id])
+
+        assert result.data == {}
+
+
+class TestReadFlows:
+    async def test_reads_all_when_no_ids_or_names(self) -> None:
+        flows = [Flow(id=uuid4(), name="wf", labels={})]
+        client = FakeReaderClient(flows=flows)
+
+        result = await FlowRunReader(client=client).read_flows()
+
+        assert result == flows
+        assert client.read_flows_calls == [None]
+
+    async def test_filters_by_names(self) -> None:
+        client = FakeReaderClient()
+
+        await FlowRunReader(client=client).read_flows(names=["wf_a", "wf_b"])
+
+        flow_filter = client.read_flows_calls[0]
+        assert flow_filter is not None
+        assert flow_filter.name is not None
+        assert flow_filter.name.any_ == ["wf_a", "wf_b"]
+        assert flow_filter.id is None
+
+    async def test_filters_by_ids(self) -> None:
+        ids = [uuid4()]
+        client = FakeReaderClient()
+
+        await FlowRunReader(client=client).read_flows(ids=ids)
+
+        flow_filter = client.read_flows_calls[0]
+        assert flow_filter is not None
+        assert flow_filter.id is not None
+        assert flow_filter.id.any_ == ids

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -26,11 +26,11 @@ class FakeReaderClient:
 
     async def read_flow_runs(
         self,
-        flow_filter: FlowFilter,
-        flow_run_filter: FlowRunFilter,
-        limit: int | None,
-        offset: int,
-        sort: FlowRunSort,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
     ) -> list[FlowRun]:
         return []
 

--- a/backend/tests/unit/task_manager/flow_run/test_retention.py
+++ b/backend/tests/unit/task_manager/flow_run/test_retention.py
@@ -1,8 +1,9 @@
 from uuid import UUID, uuid4
 
 from prefect import State
-from prefect.client.schemas.filters import FlowRunFilter
+from prefect.client.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.client.schemas.objects import FlowRun, StateType
+from prefect.client.schemas.sorting import FlowRunSort
 
 from infrahub.task_manager.flow_run.retention import FlowRunRetention
 
@@ -20,11 +21,18 @@ class InMemoryRetentionClient:
 
     def __init__(self, flow_runs: list[FlowRun] | None = None) -> None:
         self.runs: list[FlowRun] = list(flow_runs or [])
-        self.read_calls: list[int] = []
+        self.read_calls: list[int | None] = []
         self.deleted: list[UUID] = []
         self.state_changes: list[tuple[UUID, State, bool]] = []
 
-    async def read_flow_runs(self, flow_run_filter: FlowRunFilter, limit: int) -> list[FlowRun]:
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
+    ) -> list[FlowRun]:
         self.read_calls.append(limit)
         return self.runs[:limit]
 
@@ -44,7 +52,14 @@ class StuckRetentionClient:
         self.runs = list(flow_runs)
         self.deleted: list[UUID] = []
 
-    async def read_flow_runs(self, flow_run_filter: FlowRunFilter, limit: int) -> list[FlowRun]:
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
+    ) -> list[FlowRun]:
         return self.runs[:limit]
 
     async def delete_flow_run(self, flow_run_id: UUID) -> None:


### PR DESCRIPTION
## Why

The flow-run feature had grown one Prefect client adapter per consumer (`PrefectFlowRunReaderClient`, `PrefectFlowRunRetentionClient`) plus a counter reaching into Prefect's private `_client`. `read_flow_runs` had two implementations, adapter names didn't match their scope (the "reader" client also read logs/artifacts/flows), and "talk to Prefect" lived in three inconsistent places.

**Goal:** one boundary for Prefect access, with each consumer depending only on the capabilities it uses.

**Non-goals:** no behavior change; the similar `_client` pattern in other task-manager features (event querying, telemetry) is left for a separate pass.

Refs IFC-2711

## What changed

New `flow_run/prefect_client.py`:
- Capability-role protocols: `FlowRunQuerying`, `FlowRunDataReading`, `FlowRunCounting`, `FlowRunMaintenance`.
- Composed views per consumer: `ReaderPrefectClient`, `RetentionPrefectClient`.
- One `PrefectClientAdapter` implementing every role.

- **Reader / counter / retention** now depend on the roles they use; the adapter is built once in the factory and injected into all three.
- `read_flow_runs` has a single implementation; the counter no longer touches `PrefectClient._client`.
- The type checker now prevents misuse (e.g. the counter cannot call `delete_flow_run`).
- Test fakes are narrowed to each consumer's roles.

## How to test

```bash
uv run pytest tests/unit/task_manager tests/unit/graphql/queries/test_task.py
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Prefect access in the task manager behind a single adapter and role-based interfaces. Removes direct `_client` calls, keeps behavior the same, and aligns with IFC-2711.

- **Refactors**
  - Added `backend/infrahub/task_manager/flow_run/prefect_client.py` with role protocols (`FlowRunQuerying`, `FlowRunDataReading`, `FlowRunCounting`, `FlowRunMaintenance`) and a `PrefectClientAdapter`.
  - Reader, counter, and retention now depend only on needed roles; removed the retention-specific client; the adapter is built once and injected via the service factory and CLI.
  - Consolidated `read_flow_runs`; the counter now uses `count_flow_runs` through the adapter (no private `_client` access).
  - Tests: added focused reader tests for pagination and filtering; fakes now expose assertion helpers and stronger checks; retention test clients updated to the unified `read_flow_runs` signature.

<sup>Written for commit 6f1029924f8f81085d71881f21fc4a2c730e6c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



