### PR TITLE
Merge stable into release-1.10

### DIFF
--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -20,6 +20,7 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     exempt_operations = [
         "BranchCreate",
         "BranchDelete",
+        "BranchRebase",
         "DiffUpdate",
         "InfrahubAccountSelfUpdate",
         "InfrahubAccountTokenCreate",

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -214,3 +214,42 @@ class TestDefaultBranchPermission:
             branch=permissions_helper.default_branch,
         )
         assert resolution == CheckerResolution.NEXT_CHECKER
+
+    async def test_branch_rebase_exempt_for_user_without_permission(
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+    ) -> None:
+        checker = DefaultBranchPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+        permission_manager = PermissionManager(account_session=session)
+        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+
+        graphql_query = create_autospec(spec=InfrahubGraphQLQueryAnalyzer)
+        graphql_query.branch = None
+        graphql_query.contains_mutation = True
+        graphql_query.operation_names = ["BranchRebase"]
+
+        graphql_context = GraphqlContext(
+            db=MagicMock(),
+            branch=MagicMock(),
+            types=MagicMock(),
+            single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
+            account_metadata_resolver=AccountMetadataResolver(),
+            account_session=session,
+            permissions=permission_manager,
+        )
+        query_parameters = GraphqlParams(schema=MagicMock(), context=graphql_context)
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=graphql_query,
+            query_parameters=query_parameters,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER

--- a/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -238,8 +238,12 @@ class TestDefaultBranchPermission:
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
         )
-        permission_manager = PermissionManager(account_session=session)
-        await permission_manager.load_permissions(db=db, branch=permissions_helper.default_branch)
+        permission_manager = await PermissionManager.load_for_account(
+            db=db,
+            branch=permissions_helper.default_branch,
+            default_branch_name=permissions_helper.default_branch.name,
+            account_session=session,
+        )
 
         graphql_query = create_autospec(spec=InfrahubGraphQLQueryAnalyzer)
         graphql_query.branch = None

--- a/changelog/9604.fixed.md
+++ b/changelog/9604.fixed.md
@@ -1,0 +1,1 @@
+Rebasing a branch now only requires the `global:rebase_branch:allow_all` permission. Previously the default-branch permission check ran ahead of the rebase check and also demanded `global:edit_default_branch:allow_all`, so users granted only the rebase permission were denied with "You are not allowed to change data in the default branch".


### PR DESCRIPTION
Supersedes #9608, which was blocked on a component-test failure after merging stable.

## Summary

Merges `stable` into `release-1.10`. Brings in the `BranchRebase` default-branch exemption (IFC-2765): users with `global:rebase_branch:allow_all` can rebase branches without `global:edit_default_branch:allow_all`.

## Conflicts resolved

Clean auto-merge — no textual conflicts. One semantic incompatibility from the merge:

- `backend/tests/component/graphql/auth/query_permission_checker/test_default_branch_checker.py` — stable's new `test_branch_rebase_exempt_for_user_without_permission` constructed `PermissionManager(account_session=...)` then called `load_permissions(...)`, but `release-1.10` changed `PermissionManager` to require a `resolver` and load via the `load_for_account(...)` classmethod. Adapted the test to `PermissionManager.load_for_account(...)`, matching the sibling tests in the file. (`d95990c70`)

## Conflicts raised for review

None.

## Validation

- All 13 tests in `test_default_branch_checker.py` pass, including the previously failing `test_branch_rebase_exempt_for_user_without_permission`.
- `ty check` clean on `default_branch_checker.py` and `permissions/manager.py`.
- No generated files touched by the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge `stable` into `release-1.10` to bring in the `BranchRebase` default-branch exemption (IFC-2765). Users with `global:rebase_branch:allow_all` can rebase without `global:edit_default_branch:allow_all`.

- **Bug Fixes**
  - Added `BranchRebase` to `DefaultBranchPermissionChecker.exempt_operations` so only the rebase checker enforces permissions.
  - Added regression test `test_branch_rebase_exempt_for_user_without_permission`; adapted to `PermissionManager.load_for_account` for `release-1.10`.
  - Added changelog entry documenting the permission behavior change.

<sup>Written for commit d95990c70a4b53808d77dfdf45d4d639f355a5cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

