### PR TITLE
fix(webhook): surface webhook task runs in the related tasks panel

### DIFF
--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -100,8 +100,7 @@ async def webhook_process(
     client = get_client()
     cache = await get_cache()
 
-    if branch_name:
-        await add_tags(branches=[branch_name])
+    await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
 
     webhook_data_str = await cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook_id}")
     if not webhook_data_str:

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -8,6 +8,7 @@ import pytest
 from infrahub.core.constants import InfrahubKind
 from infrahub.webhook.models import EventContext
 from infrahub.webhook.tasks import convert_node_to_webhook, webhook_process
+from infrahub.workflows.constants import WorkflowTag
 from tests.adapters.http import MemoryHTTP
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -122,6 +123,11 @@ class TestWebhookProcess(TestInfrahubApp):
                 event_occured_at="2025-02-28T08:37:09.969Z",
                 event_payload=BRANCH_CREATED_PAYLOAD,
             )
+
+        related_node_tag = WorkflowTag.RELATED_NODE.render(identifier=webhook1.id)
+        flow_runs = await prefect_client.read_flow_runs()
+        applied_tags = {tag for flow_run in flow_runs for tag in flow_run.tags}
+        assert related_node_tag in applied_tags
 
     async def test_process_standard_webhook_failure(
         self,

--- a/changelog/+webhook-related-tasks.fixed.md
+++ b/changelog/+webhook-related-tasks.fixed.md
@@ -1,0 +1,1 @@
+Webhook task runs are now discoverable from the webhook's related tasks panel.


### PR DESCRIPTION
## Why

Task runs for a webhook were not discoverable from the webhook's **Related tasks** panel.

### Goal

Webhook task runs show up under the webhook's Related tasks.

Closes https://opsmill.atlassian.net/browse/IFC-2752

## What changed

- Webhook send runs are now tagged with the webhook node id, so they are discoverable from the webhook's Related tasks panel. The tag is applied before the HTTP send, so runs appear regardless of send success/failure.
- The standard-webhook process test now asserts the run carries the related-node tag.

Implementation: `webhook_process` calls `add_tags(nodes=[webhook_id], branches=...)` instead of tagging the branch alone.

## How to test

```bash
uv run pytest backend/tests/functional/webhook/test_process.py -k test_process_standard_webhook_success
```

Manual: with a webhook configured, trigger a matching event, then open the webhook's **Tasks** tab — the "Send webhook" run is listed. Verified locally end to end (querying `InfrahubTask(related_node__ids: [<webhook id>])` returned the runs after triggering an event).

<img width="3432" height="1816" alt="image" src="https://github.com/user-attachments/assets/c707c2bb-ffba-4ae5-8103-d92d9287fea7" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags webhook flow runs with the webhook node id so their task runs show in the webhook’s Related tasks panel. The tag is applied before sending, so runs appear even if the send fails.

- **Bug Fixes**
  - Apply related-node tag using the webhook id (before HTTP send); branch tag is retained.
  - Add a functional test to assert the tag on the run.
  - No schema or UI changes.

<sup>Written for commit f1a3e9fd41cffd8e2acdd6c6b278a36005976340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

