### PR TITLE
fix(git): serialize repository object import under the repository lock

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -269,16 +269,21 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         commit: str,  # noqa: ARG002
         config_file: InfrahubRepositoryConfig,
     ) -> None:
+        local_transforms = await self._build_jinja2_transform_definitions(
+            branch_name=branch_name, config_file=config_file
+        )
+        await self._apply_jinja2_transform_definitions(branch_name=branch_name, local_transforms=local_transforms)
+
+    async def _build_jinja2_transform_definitions(
+        self, branch_name: str, config_file: InfrahubRepositoryConfig
+    ) -> dict[str, InfrahubRepositoryJinja2]:
+        """Build the desired Jinja2 transform definitions from the repository config.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+        """
         log = get_run_logger()
 
         schema = await self.sdk.schema.get(kind=InfrahubKind.TRANSFORMJINJA2, branch=branch_name)
-
-        transforms_in_graph = {
-            transform.name.value: transform
-            for transform in await self.sdk.filters(
-                kind=CoreTransformJinja2, branch=branch_name, repository__ids=[str(self.id)]
-            )
-        }
 
         local_transforms: dict[str, InfrahubRepositoryJinja2] = {}
 
@@ -308,6 +313,25 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             transform.query = graphql_query.id
 
             local_transforms[transform.name] = transform
+
+        return local_transforms
+
+    async def _apply_jinja2_transform_definitions(
+        self, branch_name: str, local_transforms: dict[str, InfrahubRepositoryJinja2]
+    ) -> None:
+        """Reconcile the desired Jinja2 transform definitions against the graph: create, update, delete.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
+
+        transforms_in_graph = {
+            transform.name.value: transform
+            for transform in await self.sdk.filters(
+                kind=CoreTransformJinja2, branch=branch_name, repository__ids=[str(self.id)]
+            )
+        }
 
         present_in_both, only_graph, only_local = compare_lists(
             list1=list(transforms_in_graph.keys()), list2=list(local_transforms.keys())

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -731,6 +731,22 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def import_python_check_definitions(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
     ) -> None:
+        definitions = await self._build_python_check_definitions(
+            branch_name=branch_name, commit=commit, config_file=config_file
+        )
+        await self._apply_python_check_definitions(branch_name=branch_name, definitions=definitions)
+
+    async def _build_python_check_definitions(
+        self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
+    ) -> list[CheckDefinitionInformation]:
+        """Build the desired check definitions by reading the pinned commit worktree.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+
+        Raises:
+            ModuleNotFoundError: When a check module cannot be imported.
+
+        """
         log = get_run_logger()
 
         commit_wt = self.get_worktree(identifier=commit)
@@ -740,7 +756,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if str(self.directory_root) not in sys.path:
             sys.path.append(str(self.directory_root))
 
-        checks = []
+        checks: list[CheckDefinitionInformation] = []
         log.info(f"Found {len(config_file.check_definitions)} check definitions in the repository")
         for check in config_file.check_definitions:
             log.debug(f"{self.name}, file={check.file_path}")
@@ -765,7 +781,19 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 )  # type: ignore[call-overload]
             )
 
-        local_check_definitions = {check.name: check for check in checks}
+        return checks
+
+    async def _apply_python_check_definitions(
+        self, branch_name: str, definitions: list[CheckDefinitionInformation]
+    ) -> None:
+        """Reconcile the desired check definitions against the graph by creating, updating and deleting.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
+
+        local_check_definitions = {check.name: check for check in definitions}
         check_definition_in_graph = {
             check.name.value: check
             for check in await self.sdk.filters(

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -641,6 +641,20 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             Error: When rendering a configured GraphQL query template fails (from infrahub_sdk).
 
         """
+        local_queries = await self._build_graphql_query_definitions(commit=commit, config_file=config_file)
+        await self._apply_graphql_query_definitions(branch_name=branch_name, local_queries=local_queries)
+
+    async def _build_graphql_query_definitions(
+        self, commit: str, config_file: InfrahubRepositoryConfig
+    ) -> dict[str, str]:
+        """Render the desired GraphQL queries from the pinned commit worktree.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+
+        Raises:
+            Error: When rendering a configured GraphQL query template fails (from infrahub_sdk).
+
+        """
         log = get_run_logger()
 
         commit_wt = self.get_worktree(identifier=commit)
@@ -656,6 +670,16 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             except InfrahubSdkError as exc:
                 log.error(f"Query '{query_config.name}': {exc}")
                 raise
+
+        return local_queries
+
+    async def _apply_graphql_query_definitions(self, branch_name: str, local_queries: dict[str, str]) -> None:
+        """Reconcile the desired GraphQL queries against the graph by creating, updating and deleting.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
 
         if not local_queries:
             return

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -144,6 +145,25 @@ class TransformPythonInformation(BaseModel):
     """Description of the Transform"""
 
 
+@dataclass
+class ObjectImportPlan:
+    """The desired state of a branch's objects, built by reading the pinned commit worktree.
+
+    Holds no graph state, only what was read from disk, so it can be built without serialization and
+    then applied to the graph under the repository lock.
+    """
+
+    infrahub_branch_name: str
+    commit: str
+    config_file: InfrahubRepositoryConfig
+    query_strings: dict[str, str]
+    transform_definitions: list[TransformPythonInformation]
+    jinja2_definitions: dict[str, InfrahubRepositoryJinja2]
+    check_definitions: list[CheckDefinitionInformation]
+    generator_definitions: list[InfrahubGeneratorDefinitionConfig]
+    artifact_definitions: dict[str, InfrahubRepositoryArtifactDefinitionConfig]
+
+
 class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     """This class provides interfaces to read and process information from .infrahub.yml files and can perform.
 
@@ -195,6 +215,19 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def import_objects_from_files(
         self, infrahub_branch_name: str, git_branch_name: str | None = None, commit: str | None = None
     ) -> None:
+        plan = await self.build_import_plan(
+            infrahub_branch_name=infrahub_branch_name, git_branch_name=git_branch_name, commit=commit
+        )
+        await self.apply_import_plan(plan)
+
+    async def build_import_plan(
+        self, infrahub_branch_name: str, git_branch_name: str | None = None, commit: str | None = None
+    ) -> ObjectImportPlan:
+        """Build the desired state of a branch's objects by reading the pinned commit worktree.
+
+        Performs no graph mutation other than recording that a sync is in progress, so the expensive
+        worktree reads and module imports do not need to be serialized against concurrent imports.
+        """
         if not commit:
             commit = self.get_commit_value(branch_name=git_branch_name or infrahub_branch_name)
 
@@ -203,47 +236,88 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         self.create_commit_worktree(commit)
         await self._update_sync_status(branch_name=infrahub_branch_name, status=RepositorySyncStatus.SYNCING)
 
+        try:
+            config_file = await self.get_repository_config(branch_name=infrahub_branch_name, commit=commit)  # type: ignore[call-overload]
+            query_strings = await self._build_graphql_query_definitions(commit=commit, config_file=config_file)
+            transform_definitions = await self._build_python_transform_definitions(
+                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
+            )
+            jinja2_definitions = await self._build_jinja2_transform_definitions(
+                branch_name=infrahub_branch_name, config_file=config_file
+            )
+            check_definitions = await self._build_python_check_definitions(
+                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
+            )
+            generator_definitions = await self._build_generator_definitions(
+                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
+            )
+            artifact_definitions = await self._build_artifact_definitions(
+                branch_name=infrahub_branch_name, config_file=config_file
+            )
+        except Exception:
+            await self._update_sync_status(branch_name=infrahub_branch_name, status=RepositorySyncStatus.ERROR_IMPORT)
+            raise
+
+        return ObjectImportPlan(
+            infrahub_branch_name=infrahub_branch_name,
+            commit=commit,
+            config_file=config_file,
+            query_strings=query_strings,
+            transform_definitions=transform_definitions,
+            jinja2_definitions=jinja2_definitions,
+            check_definitions=check_definitions,
+            generator_definitions=generator_definitions,
+            artifact_definitions=artifact_definitions,
+        )
+
+    async def apply_import_plan(self, plan: ObjectImportPlan) -> None:
+        """Apply a previously built plan to the graph: schema, queries, transforms, objects, definitions.
+
+        Performs every graph mutation of the import, so it must run serialized against any concurrent
+        import of the same repository.
+        """
         sync_status = RepositorySyncStatus.IN_SYNC
         error: Exception | None = None
 
         try:
-            config_file = await self.get_repository_config(branch_name=infrahub_branch_name, commit=commit)  # type: ignore[call-overload]
-            await self.import_schema_files(branch_name=infrahub_branch_name, commit=commit, config_file=config_file)  # type: ignore[call-overload]
-            if config_file.schemas:
-                await self.sdk.schema.all(branch=infrahub_branch_name, refresh=True)
-            await self.import_all_graphql_query(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
+            await self.import_schema_files(
+                branch_name=plan.infrahub_branch_name, commit=plan.commit, config_file=plan.config_file
             )  # type: ignore[call-overload]
+            if plan.config_file.schemas:
+                await self.sdk.schema.all(branch=plan.infrahub_branch_name, refresh=True)
+            await self._apply_graphql_query_definitions(
+                branch_name=plan.infrahub_branch_name, local_queries=plan.query_strings
+            )
             # Transforms must be registered before objects so that an object referencing a transform
             # defined in the same repository resolves during import.
-            await self.import_python_transforms(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-            )  # type: ignore[call-overload]
-            await self.import_jinja2_transforms(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-            )  # type: ignore[call-overload]
+            await self._apply_python_transform_definitions(
+                branch_name=plan.infrahub_branch_name, definitions=plan.transform_definitions
+            )
+            await self._apply_jinja2_transform_definitions(
+                branch_name=plan.infrahub_branch_name, local_transforms=plan.jinja2_definitions
+            )
             await self.import_objects(
-                branch_name=infrahub_branch_name,
-                commit=commit,
-                config_file=config_file,
+                branch_name=plan.infrahub_branch_name,
+                commit=plan.commit,
+                config_file=plan.config_file,
             )  # type: ignore[call-overload]
             # Checks, generators and artifact definitions are imported after objects because their
             # targets reference groups that are defined as objects in the repository.
-            await self.import_python_check_definitions(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-            )  # type: ignore[call-overload]
-            await self.import_generator_definitions(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-            )  # type: ignore[call-overload]
-            await self.import_artifact_definitions(
-                branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-            )  # type: ignore[call-overload]
+            await self._apply_python_check_definitions(
+                branch_name=plan.infrahub_branch_name, definitions=plan.check_definitions
+            )
+            await self._apply_generator_definitions(
+                branch_name=plan.infrahub_branch_name, definitions=plan.generator_definitions
+            )
+            await self._apply_artifact_definitions(
+                branch_name=plan.infrahub_branch_name, local_artifact_defs=plan.artifact_definitions
+            )
 
         except Exception as exc:
             sync_status = RepositorySyncStatus.ERROR_IMPORT
             error = exc
 
-        await self._update_sync_status(branch_name=infrahub_branch_name, status=sync_status)
+        await self._update_sync_status(branch_name=plan.infrahub_branch_name, status=sync_status)
 
         if error:
             raise error
@@ -251,11 +325,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if self.reinitialized:
             return
 
-        infrahub_branch = registry.get_branch_from_registry(branch=infrahub_branch_name)
+        infrahub_branch = registry.get_branch_from_registry(branch=plan.infrahub_branch_name)
         event_service = await get_event_service()
         await event_service.send(
             CommitUpdatedEvent(
-                commit=commit,
+                commit=plan.commit,
                 repository_name=self.name,
                 repository_id=str(self.id),
                 meta=EventMeta.with_dummy_context(branch=infrahub_branch),

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -846,6 +846,22 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def import_python_transforms(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
     ) -> None:
+        definitions = await self._build_python_transform_definitions(
+            branch_name=branch_name, commit=commit, config_file=config_file
+        )
+        await self._apply_python_transform_definitions(branch_name=branch_name, definitions=definitions)
+
+    async def _build_python_transform_definitions(
+        self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
+    ) -> list[TransformPythonInformation]:
+        """Build the desired transform definitions by reading the pinned commit worktree.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+
+        Raises:
+            ModuleNotFoundError: When a transform module cannot be imported.
+
+        """
         log = get_run_logger()
         commit_wt = self.get_worktree(identifier=commit)
         branch_wt = self.get_worktree(identifier=commit or branch_name)
@@ -880,7 +896,18 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 )  # type: ignore[call-overload]
             )
 
-        local_transform_definitions = {transform.name: transform for transform in transforms}
+        return transforms
+
+    async def _apply_python_transform_definitions(
+        self, branch_name: str, definitions: list[TransformPythonInformation]
+    ) -> None:
+        """Reconcile the desired transform definitions against the graph by creating, updating and deleting.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
+        local_transform_definitions = {transform.name: transform for transform in definitions}
         transform_definition_in_graph = {
             transform.name.value: transform
             for transform in await self.sdk.filters(

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -398,15 +398,18 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         commit: str,  # noqa: ARG002
         config_file: InfrahubRepositoryConfig,
     ) -> None:
+        local_artifact_defs = await self._build_artifact_definitions(branch_name=branch_name, config_file=config_file)
+        await self._apply_artifact_definitions(branch_name=branch_name, local_artifact_defs=local_artifact_defs)
+
+    async def _build_artifact_definitions(
+        self, branch_name: str, config_file: InfrahubRepositoryConfig
+    ) -> dict[str, InfrahubRepositoryArtifactDefinitionConfig]:
+        """Build the desired artifact definitions from the repository config.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+        """
         log = get_run_logger()
         schema = await self.sdk.schema.get(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch_name)
-
-        artifact_defs_in_graph = {
-            artdef.name.value: artdef
-            for artdef in await self.sdk.filters(
-                kind=CoreArtifactDefinition, branch=branch_name, prefetch_relationships=True, populate_store=True
-            )
-        }
 
         local_artifact_defs: dict[str, InfrahubRepositoryArtifactDefinitionConfig] = {}
 
@@ -426,6 +429,25 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 continue
 
             local_artifact_defs[artdef.name] = artdef
+
+        return local_artifact_defs
+
+    async def _apply_artifact_definitions(
+        self, branch_name: str, local_artifact_defs: dict[str, InfrahubRepositoryArtifactDefinitionConfig]
+    ) -> None:
+        """Reconcile the desired artifact definitions against the graph by creating and updating.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
+
+        artifact_defs_in_graph = {
+            artdef.name.value: artdef
+            for artdef in await self.sdk.filters(
+                kind=CoreArtifactDefinition, branch=branch_name, prefetch_relationships=True, populate_store=True
+            )
+        }
 
         present_in_both, _, only_local = compare_lists(
             list1=list(artifact_defs_in_graph.keys()), list2=list(local_artifact_defs.keys())

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -305,13 +305,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 continue
 
             transform = InfrahubRepositoryJinja2(repository=str(self.id), **config_transform.model_dump())
-
-            # Query the GraphQL query and (eventually) replace the name with the ID
-            graphql_query = await self.sdk.get(
-                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform.query), populate_store=True
-            )
-            transform.query = graphql_query.id
-
             local_transforms[transform.name] = transform
 
         return local_transforms
@@ -325,6 +318,13 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         concurrent import of the same repository.
         """
         log = get_run_logger()
+
+        # Resolve each query reference to its node id now that the queries have been applied.
+        for transform in local_transforms.values():
+            graphql_query = await self.sdk.get(
+                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform.query), populate_store=True
+            )
+            transform.query = graphql_query.id
 
         transforms_in_graph = {
             transform.name.value: transform
@@ -796,7 +796,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
             checks.extend(
                 await self.get_check_definition(
-                    branch_name=branch_name,
                     module=module,
                     file_path=file_info.relative_path_file,
                     check_definition=check,
@@ -816,6 +815,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         log = get_run_logger()
 
         local_check_definitions = {check.name: check for check in definitions}
+
+        # Resolve each query reference to its node id now that the queries have been applied.
+        for check in local_check_definitions.values():
+            graphql_query = await self.sdk.get(
+                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(check.query), populate_store=True
+            )
+            check.query = str(graphql_query.id)
+
         check_definition_in_graph = {
             check.name.value: check
             for check in await self.sdk.filters(
@@ -1011,7 +1018,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
             transforms.extend(
                 await self.get_python_transforms(
-                    branch_name=branch_name,
                     module=module,
                     file_path=file_info.relative_path_file,
                     transform=transform,
@@ -1030,6 +1036,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         """
         log = get_run_logger()
         local_transform_definitions = {transform.name: transform for transform in definitions}
+
+        # Resolve each query reference to its node id now that the queries have been applied.
+        for transform in local_transform_definitions.values():
+            graphql_query = await self.sdk.get(
+                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform.query), populate_store=True
+            )
+            transform.query = str(graphql_query.id)
+
         transform_definition_in_graph = {
             transform.name.value: transform
             for transform in await self.sdk.filters(
@@ -1143,7 +1157,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     @task(name="check-definition-get", task_run_name="Get Check Definition", cache_policy=NONE)
     async def get_check_definition(
         self,
-        branch_name: str,
         module: types.ModuleType,
         file_path: str,
         check_definition: InfrahubCheckDefinitionConfig,
@@ -1156,9 +1169,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         check_class = getattr(module, check_definition.class_name)
 
         try:
-            graphql_query = await self.sdk.get(
-                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(check_class.query), populate_store=True
-            )
             checks.append(
                 CheckDefinitionInformation(
                     name=check_definition.name,
@@ -1166,7 +1176,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                     class_name=check_definition.class_name,
                     check_class=check_class,
                     file_path=file_path,
-                    query=str(graphql_query.id),
+                    query=str(check_class.query),
                     timeout=check_class.timeout,
                     parameters=check_definition.parameters,
                     targets=check_definition.targets,
@@ -1182,7 +1192,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
     @task(name="python-transform-get", task_run_name="Get Python Transform", cache_policy=NONE)
     async def get_python_transforms(
-        self, branch_name: str, module: types.ModuleType, file_path: str, transform: InfrahubPythonTransformConfig
+        self, module: types.ModuleType, file_path: str, transform: InfrahubPythonTransformConfig
     ) -> list[TransformPythonInformation]:
         log = get_run_logger()
         if transform.class_name not in dir(module):
@@ -1190,9 +1200,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         transforms = []
         transform_class = getattr(module, transform.class_name)
-        graphql_query = await self.sdk.get(
-            kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform_class.query), populate_store=True
-        )
         try:
             transforms.append(
                 TransformPythonInformation(
@@ -1201,7 +1208,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                     class_name=transform.class_name,
                     transform_class=transform_class,
                     file_path=file_path,
-                    query=str(graphql_query.id),
+                    query=str(transform_class.query),
                     timeout=transform_class.timeout,
                     convert_query_response=transform.convert_query_response,
                     description=transform.description,

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -830,12 +830,24 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def import_generator_definitions(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
     ) -> None:
+        definitions = await self._build_generator_definitions(
+            branch_name=branch_name, commit=commit, config_file=config_file
+        )
+        await self._apply_generator_definitions(branch_name=branch_name, definitions=definitions)
+
+    async def _build_generator_definitions(
+        self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
+    ) -> list[InfrahubGeneratorDefinitionConfig]:
+        """Build the desired generator definitions by reading the pinned commit worktree.
+
+        Performs no graph mutation, so it does not need to be serialized against concurrent imports.
+        """
         log = get_run_logger()
 
         commit_wt = self.get_worktree(identifier=commit)
         branch_wt = self.get_worktree(identifier=commit or branch_name)
 
-        generators = []
+        generators: list[InfrahubGeneratorDefinitionConfig] = []
         log.info(f"Found {len(config_file.generator_definitions)} generator definitions in the repository")
 
         for generator in config_file.generator_definitions:
@@ -849,7 +861,19 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             generator.load_class(import_root=self.directory_root, relative_path=file_info.relative_repo_path_dir)
             generators.append(generator)
 
-        local_generator_definitions = {generator.name: generator for generator in generators}
+        return generators
+
+    async def _apply_generator_definitions(
+        self, branch_name: str, definitions: list[InfrahubGeneratorDefinitionConfig]
+    ) -> None:
+        """Reconcile the desired generator definitions against the graph by creating, updating and deleting.
+
+        Mutates graph nodes whose names are globally unique, so it must run serialized against any
+        concurrent import of the same repository.
+        """
+        log = get_run_logger()
+
+        local_generator_definitions = {generator.name: generator for generator in definitions}
         generator_definition_in_graph = {
             generator.name.value: generator
             for generator in await self.sdk.filters(

--- a/backend/infrahub/git/sync.py
+++ b/backend/infrahub/git/sync.py
@@ -12,34 +12,52 @@ if TYPE_CHECKING:
 
     from infrahub.lock import InfrahubLockRegistry
 
+    from .integrator import ObjectImportPlan
     from .models import GitRepositoryAdd
 
 
 class RepositoryImporter(ABC):
-    """Imports the objects of a single synced branch into the graph."""
+    """Imports the objects of a single synced branch into the graph.
+
+    The import is split into a build phase, which reads the pinned commit worktree with no graph
+    mutation other than recording that a sync is in progress, and an apply phase, which performs
+    every other graph mutation. Callers run the apply phase under the repository lock so that
+    concurrent imports of the same repository are serialized.
+    """
 
     @abstractmethod
-    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None: ...
+    async def build_branch_import(
+        self, repo: InfrahubRepository, pending_import: PendingObjectImport
+    ) -> ObjectImportPlan: ...
+
+    @abstractmethod
+    async def apply_branch_import(self, repo: InfrahubRepository, plan: ObjectImportPlan) -> None: ...
 
 
 class RepositoryFileImporter(RepositoryImporter):
     """Imports a branch by reading the object files of its pinned commit worktree."""
 
-    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
-        await repo.import_objects_from_files(  # type: ignore[call-overload]
+    async def build_branch_import(
+        self, repo: InfrahubRepository, pending_import: PendingObjectImport
+    ) -> ObjectImportPlan:
+        return await repo.build_import_plan(
             infrahub_branch_name=pending_import.infrahub_branch_name,
             git_branch_name=pending_import.git_branch_name,
             commit=pending_import.commit,
         )
 
+    async def apply_branch_import(self, repo: InfrahubRepository, plan: ObjectImportPlan) -> None:
+        await repo.apply_import_plan(plan)
+
 
 class RepositoryAdder:
-    """Adds a new repository, holding the repository lock across the clone and the recording of its pinned commit.
+    """Adds a new repository, serializing the clone and the object import under the repository lock.
 
-    The locked phase covers the clone, the default-branch worktree creation, and writing the pinned
-    commit back to the graph, which must stay consistent with each other. The default-branch object
-    import runs after the lock is released; it reads from the per-commit worktree pinned during the
-    locked phase, so it does not need the lock.
+    The first locked phase covers the clone, the default-branch worktree creation, and writing the
+    pinned commit back to the graph, which must stay consistent with each other. The default-branch
+    object import is then built outside the lock, reading from the per-commit worktree pinned during
+    the locked phase, and applied to the graph under the lock so that concurrent imports of the same
+    repository are serialized.
     """
 
     def __init__(
@@ -63,23 +81,24 @@ class RepositoryAdder:
             default_commit = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
             repo.create_commit_worktree(commit=default_commit)
 
-        await self._importer.import_branch(
-            repo,
-            PendingObjectImport(
-                infrahub_branch_name=model.infrahub_branch_name,
-                git_branch_name=repo.default_branch,
-                commit=default_commit,
-            ),
+        pending_import = PendingObjectImport(
+            infrahub_branch_name=model.infrahub_branch_name,
+            git_branch_name=repo.default_branch,
+            commit=default_commit,
         )
+        plan = await self._importer.build_branch_import(repo, pending_import)
+        async with self._lock_registry.get(name=model.repository_name, namespace="repository"):
+            await self._importer.apply_branch_import(repo, plan)
         return repo
 
 
 class RepositorySyncer:
-    """Synchronizes a repository, holding the repository lock only for the git working-copy mutations.
+    """Synchronizes a repository, serializing the git mutations and each branch import under the lock.
 
-    The lock serializes mutations of the repository's on-disk git state. The object import for each
-    synced branch runs after the lock is released; it reads from the per-commit worktree pinned during
-    the locked phase, so it does not need the lock.
+    The lock serializes mutations of the repository's on-disk git state. Each synced branch is then
+    built outside the lock, reading from the per-commit worktree pinned during the locked phase, and
+    applied to the graph under the lock so that concurrent imports of the same repository are
+    serialized.
     """
 
     def __init__(self, lock_registry: InfrahubLockRegistry, importer: RepositoryImporter) -> None:
@@ -93,7 +112,9 @@ class RepositorySyncer:
         failed_imports = list(collected.failed_imports)
         for pending_import in collected.imports:
             try:
-                await self._importer.import_branch(repo, pending_import)
+                plan = await self._importer.build_branch_import(repo, pending_import)
+                async with self._lock_registry.get(name=repo.name, namespace="repository"):
+                    await self._importer.apply_branch_import(repo, plan)
             except (RepositoryConnectionError, RepositoryCredentialsError):
                 raise
             except Exception as exc:

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -775,7 +775,9 @@ async def import_objects_from_git_repository(model: GitRepositoryImportObjects) 
         repository_kind=model.repository_kind,
         commit=model.commit,
     )
-    await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)  # type: ignore[call-overload]
+    plan = await repo.build_import_plan(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)
+    async with lock.registry.get(name=model.repository_name, namespace="repository"):
+        await repo.apply_import_plan(plan)
 
 
 @flow(

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -295,16 +295,18 @@ async def bootstrap_local_repository(
 
         if default_import_git_branch is not None:
             # Pin the commit while the lock is held so the import below reads an immutable
-            # worktree even though it runs after the lock is released.
+            # worktree even though it is built after the lock is released.
             pinned_import_commit = repo.get_commit_value(branch_name=default_import_git_branch, remote=False)
 
     if default_import_git_branch is not None:
         try:
-            await repo.import_objects_from_files(  # type: ignore[call-overload]
+            plan = await repo.build_import_plan(
                 git_branch_name=default_import_git_branch,
                 infrahub_branch_name=infrahub_branch,
                 commit=pinned_import_commit,
             )
+            async with lock.registry.get(name=repo_name, namespace="repository"):
+                await repo.apply_import_plan(plan)
         except (RepositoryError, CommitNotFoundError) as exc:
             log.info(exc.message)
             return None

--- a/backend/tests/adapters/lock/mocks/importer.py
+++ b/backend/tests/adapters/lock/mocks/importer.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub_sdk.schema.repository import InfrahubRepositoryConfig
+
+from infrahub.git.integrator import ObjectImportPlan
 from infrahub.git.sync import RepositoryImporter
 
 if TYPE_CHECKING:
@@ -11,10 +14,26 @@ if TYPE_CHECKING:
 
 
 class RecordingImporter(RepositoryImporter):
-    """Records a timeline checkpoint instead of importing, to capture the lock state at the import call."""
+    """Records a timeline checkpoint for each import phase, to capture the lock state at each call."""
 
     def __init__(self, timeline: LockTimeline) -> None:
         self._timeline = timeline
 
-    async def import_branch(self, repo: InfrahubRepository, pending_import: PendingObjectImport) -> None:
-        self._timeline.checkpoint("import")
+    async def build_branch_import(
+        self, repo: InfrahubRepository, pending_import: PendingObjectImport
+    ) -> ObjectImportPlan:
+        self._timeline.checkpoint("build")
+        return ObjectImportPlan(
+            infrahub_branch_name=pending_import.infrahub_branch_name,
+            commit=pending_import.commit or "",
+            config_file=InfrahubRepositoryConfig(),
+            query_strings={},
+            transform_definitions=[],
+            jinja2_definitions={},
+            check_definitions=[],
+            generator_definitions=[],
+            artifact_definitions={},
+        )
+
+    async def apply_branch_import(self, repo: InfrahubRepository, plan: ObjectImportPlan) -> None:
+        self._timeline.checkpoint("apply")

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -573,12 +573,15 @@ async def test_sync_new_branch(
     )
 
     repo.client = client
-    # Mock import_objects_from_files since we're testing git sync, not import functionality
-    with patch(
-        "infrahub.git.integrator.InfrahubRepositoryIntegrator.import_objects_from_files", new_callable=AsyncMock
-    ) as mock_import:
+    # Skip the object import (build + apply phases) since we're testing git sync, not import functionality
+    with (
+        patch("infrahub.git.integrator.InfrahubRepositoryIntegrator.build_import_plan", new_callable=AsyncMock),
+        patch(
+            "infrahub.git.integrator.InfrahubRepositoryIntegrator.apply_import_plan", new_callable=AsyncMock
+        ) as mock_apply,
+    ):
         await _sync(repo)
-        mock_import.assert_awaited()
+        mock_apply.assert_awaited()
     worktrees = repo.get_worktrees()
 
     assert repo.get_commit_value(branch_name=branch.name) == "30e911e25ef9e4fad9f9d00fe05395031f90d460"
@@ -594,12 +597,15 @@ async def test_sync_updated_branch(prefect_test_fixture: None, git_repo_04: Infr
     # Mock update_commit_value query
     commit = repo.get_commit_value(branch_name="branch01", remote=True)
 
-    # Mock import_objects_from_files since we're testing git sync, not import functionality
-    with patch(
-        "infrahub.git.integrator.InfrahubRepositoryIntegrator.import_objects_from_files", new_callable=AsyncMock
-    ) as mock_import:
+    # Skip the object import (build + apply phases) since we're testing git sync, not import functionality
+    with (
+        patch("infrahub.git.integrator.InfrahubRepositoryIntegrator.build_import_plan", new_callable=AsyncMock),
+        patch(
+            "infrahub.git.integrator.InfrahubRepositoryIntegrator.apply_import_plan", new_callable=AsyncMock
+        ) as mock_apply,
+    ):
         await _sync(repo)
-        mock_import.assert_awaited()
+        mock_apply.assert_awaited()
 
     assert repo.get_commit_value(branch_name="branch01") == str(commit)
 

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -99,7 +99,6 @@ class TestAddRepository:
         )
 
         self.mock_repo.name = git_upstream_repo_01["name"]
-        self.mock_repo.import_objects_from_files = AsyncMock()
         self.mock_repo.collect_pending_imports = AsyncMock(return_value=CollectedImports())
 
         with patch("infrahub.git.sync.InfrahubRepository", spec=InfrahubRepository) as mock_repo_class:
@@ -117,11 +116,12 @@ class TestAddRepository:
                 internal_status="active",
                 default_branch_name=self.default_branch_name,
             )
-            self.mock_repo.import_objects_from_files.assert_awaited_once_with(
+            self.mock_repo.build_import_plan.assert_awaited_once_with(
                 infrahub_branch_name=self.default_branch_name,
                 git_branch_name=self.default_branch_name,
                 commit="0123456789abcdef0123456789abcdef01234567",
             )
+            self.mock_repo.apply_import_plan.assert_awaited_once()
 
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)
@@ -386,11 +386,15 @@ class TestPullReadOnly:
 
 
 @pytest.mark.usefixtures("git_repos_dir")
-async def test_add_git_repository_releases_lock_before_import(
+async def test_add_git_repository_scopes_import_build_and_apply(
     prefect_test_fixture: None,
     git_upstream_repo_01: dict[str, str],
 ) -> None:
-    """The default-branch import must run after the repository lock held for the clone is released."""
+    """The default-branch import builds outside the lock and applies under it.
+
+    The lock held for the clone is released before the import is built, and the apply phase
+    re-acquires it so that concurrent imports of the same repository are serialized.
+    """
     timeline = LockTimeline()
     client = InfrahubClient(config=Config(requester=dummy_async_request))
     model = GitRepositoryAdd(
@@ -410,4 +414,5 @@ async def test_add_git_repository_releases_lock_before_import(
     )
     await adder.add(model)
 
-    timeline.assert_not_held_at_checkpoint(f"repository.{git_upstream_repo_01['name']}", "import")
+    timeline.assert_not_held_at_checkpoint(f"repository.{git_upstream_repo_01['name']}", "build")
+    timeline.assert_held_at_checkpoint(f"repository.{git_upstream_repo_01['name']}", "apply")

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -7,14 +7,14 @@ from infrahub.git.sync import RepositorySyncer
 from tests.adapters.lock import LockTimeline, RecordingImporter, RecordingLockRegistry
 
 
-async def test_repository_lock_released_before_import(
+async def test_repository_lock_scopes_import_build_and_apply(
     prefect_test_fixture: None, git_repo_04: InfrahubRepository
 ) -> None:
-    """The object import must not run while the repository lock is held.
+    """The build phase of an import must run outside the lock and the apply phase inside it.
 
-    The lock serializes mutations of the repository's on-disk git state. The import reads file
-    content from the per-commit worktree pinned earlier in the sync, so it stays outside that
-    critical section.
+    The build phase reads file content from the per-commit worktree pinned earlier in the sync, so it
+    stays outside the critical section. The apply phase mutates the graph and must be serialized
+    against concurrent imports of the same repository.
     """
     branch = Branch(name="branch01", uuid=uuid4())
     registry.branch[branch.name] = branch
@@ -26,4 +26,5 @@ async def test_repository_lock_released_before_import(
 
     await syncer.sync(git_repo_04)
 
-    timeline.assert_not_held_at_checkpoint(f"repository.{git_repo_04.name}", "import")
+    timeline.assert_not_held_at_checkpoint(f"repository.{git_repo_04.name}", "build")
+    timeline.assert_held_at_checkpoint(f"repository.{git_repo_04.name}", "apply")

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import ANY, call, patch
 
 import pytest
+from prefect import flow
 
 from infrahub import config
 from infrahub.auth import AccountSession, AuthType
@@ -96,6 +97,14 @@ PROPOSED_CHANGE_QUERY = """
 """
 
 
+@flow(name="sync-repository-for-test")
+async def sync_repository(repo: InfrahubRepository) -> None:
+    """Run a repository sync inside a flow run so the import has a Prefect run context, as in production."""
+    await RepositorySyncer(lock_registry=InfrahubLockRegistry(local_only=True), importer=RepositoryFileImporter()).sync(
+        repo
+    )
+
+
 class TestProposedChange(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def user_account(self, db: InfrahubDatabase) -> Node:
@@ -145,9 +154,7 @@ class TestProposedChange(TestInfrahubApp):
         )
 
         repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
-        await RepositorySyncer(
-            lock_registry=InfrahubLockRegistry(local_only=True), importer=RepositoryFileImporter()
-        ).sync(repo)
+        await sync_repository(repo)
 
         result = await graphql_mutation(
             query=PROPOSED_CHANGE_CREATE,

--- a/changelog/+repository-import-uniqueness-race.fixed.md
+++ b/changelog/+repository-import-uniqueness-race.fixed.md
@@ -1,0 +1,1 @@
+Concurrent imports of the same repository no longer race to create the same object and fail on a name uniqueness constraint, which could leave the repository out of sync. The graph-changing phase of a repository import is now serialized under the repository lock.


### PR DESCRIPTION
## Summary

The graph-mutation phase of a repository import was not serialized, so two concurrent imports of the same repository could both create the same globally-unique-named object (transform, query, check, …). The loser hit the `name` uniqueness constraint, the import failed, and the repository was left out of sync.

This splits the import into a lock-free **build** phase (reads the pinned commit worktree) and an **apply** phase (all graph mutations), and serializes the apply phase under the repository lock at every import entry point.

## Two distinct fixes

| Path | State before this PR | Origin | Changelog |
|---|---|---|---|
| Manual object re-import (`import_objects_from_git_repository`) | racy in **1.9.8 (released)** | shipped without the lock since 1.9.8, independent of #9506 | **yes** — `fixed` fragment |
| Add / sync / bootstrap (`RepositoryAdder`, `RepositorySyncer`, `bootstrap_local_repository`) | unreleased regression | #9506 narrowed the lock to git working-copy mutations and moved the import out, dropping serialization of the graph phase (a TOCTOU race) | **no** — #9506 is in no release tag (after `infrahub-v1.9.8` / `infrahub-v1.10.0b0`), so it never shipped |

## What was done

- Split the import into `build_import_plan` (no graph mutation) and `apply_import_plan` (every graph mutation), with GraphQL query-reference resolution moved into apply so build is graph-free.
- Serialize the apply phase under the repository lock at all four entry points (add, sync, bootstrap, manual re-import); the slow build phase stays lock-free.

## Validation

Each path was validated before and after the fix. "Before the fix" was produced by removing the apply lock and rebuilding/relaunching the same environment.

| Path | How it was validated | Before the fix | After the fix |
|---|---|---|---|
| Add / sync / bootstrap (commit 9) | `test_same_repo_references_resolve_on_import` — integration test on the real multi-worker stack (image built from source), run repeatedly | ❌ flaky — 2 of 9 runs fail with `Violates uniqueness constraint 'name'` | ✅ 12/12 runs green (0 uniqueness failures) |
| Manual re-import (commit 10) | Live multi-worker app (API server + 2 Prefect `infrahubasync` workers), burst of concurrent `InfrahubRepositoryProcess` re-imports | ❌ ~23 collisions (69 log lines) on `CoreTransformPythonCreate`; repository left `error-import` | ✅ 0 collisions across 32 concurrent imports; repository `in-sync` |

The add/sync race is hard to trigger from the application on demand: it needs two imports of the same repository to interleave within a brief check-create window, so it surfaces only intermittently (hence a flaky test rather than a reliably reproducible bug). The manual re-import (commit 89629a2c207f8ac84b65c464a4629f0d058181cc) can instead be fired as a deterministic concurrent burst, which is why it was used for the live before/after demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
