### PR TITLE
fix(graphql): reject non-positive max_paths in traversal queries

### DIFF
--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -248,8 +248,8 @@ async def path_traversal_resolver(
     max_depth = data.max_depth or 5
     max_paths = data.max_paths or 10
 
-    if max_paths > MAX_PATHS:
-        raise GraphQLError(f"max_paths must be <= {MAX_PATHS}, got {max_paths}")
+    if not 1 <= max_paths <= MAX_PATHS:
+        raise GraphQLError(f"max_paths must be in [1, {MAX_PATHS}], got {max_paths}")
 
     if source_id == destination_id:
         raise GraphQLError("Source and destination nodes must be different")

--- a/backend/infrahub/graphql/queries/reachable.py
+++ b/backend/infrahub/graphql/queries/reachable.py
@@ -86,6 +86,9 @@ async def reachable_nodes_resolver(
     if not target_kinds:
         raise GraphQLError("At least one target kind is required")
 
+    if max_paths < 1:
+        raise GraphQLError(f"max_paths must be >= 1, got {max_paths}")
+
     source_node: Node | None = await NodeManager.get_one(
         db=graphql_context.db,
         branch=graphql_context.branch,

--- a/backend/tests/component/graphql/queries/test_path_traversal.py
+++ b/backend/tests/component/graphql/queries/test_path_traversal.py
@@ -177,7 +177,34 @@ class TestPathTraversalResolver:
         )
 
         assert errors is not None
-        assert errors[0].message == "max_paths must be <= 100, got 101"
+        assert errors[0].message == "max_paths must be in [1, 100], got 101"
+
+    async def test_resolver_rejects_max_paths_below_minimum(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        default_permission_backend_scope_class: None,
+        session_admin_scope_class: AccountSession,
+        two_cars_one_owner_scope_class: tuple[Node, Node, Node],
+    ) -> None:
+        car_a, car_b, _person = two_cars_one_owner_scope_class
+        default_branch_scope_class.update_schema_hash()
+
+        variables = {
+            "data": {
+                "source_id": car_a.id,
+                "destination_id": car_b.id,
+                "max_depth": 5,
+                "max_paths": -1,
+            }
+        }
+
+        _, errors = await _run_resolver(
+            db=db, branch=default_branch_scope_class, session=session_admin_scope_class, variables=variables
+        )
+
+        assert errors is not None
+        assert errors[0].message == "max_paths must be in [1, 100], got -1"
 
     async def test_resolver_kind_filter_admits_intermediate_kind(
         self,

--- a/backend/tests/component/graphql/queries/test_reachable_nodes.py
+++ b/backend/tests/component/graphql/queries/test_reachable_nodes.py
@@ -202,6 +202,23 @@ async def test_resolver_raises_for_unknown_target_kind(
     assert errors[0].message == f"Unknown target kind: {bogus_kind}"
 
 
+async def test_resolver_rejects_max_paths_below_minimum(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_permission_backend: None,
+    session_admin: AccountSession,
+    car_with_owner_and_driver: tuple[Node, Node, Node],
+) -> None:
+    car, _owner, _driver = car_with_owner_and_driver
+    default_branch.update_schema_hash()
+
+    variables = {"data": {"source_id": car.id, "target_kinds": ["TestPerson"], "max_paths": 0}}
+
+    _data, errors = await _run_resolver(db=db, branch=default_branch, session=session_admin, variables=variables)
+    assert errors is not None
+    assert errors[0].message == "max_paths must be >= 1, got 0"
+
+
 async def test_resolver_respects_session_permissions(
     db: InfrahubDatabase,
     default_branch: Branch,


### PR DESCRIPTION
Raised by a cubic review comment on #9614.

`max_paths < 1` can never produce a path, but the reachable-nodes loop broke before issuing any query and returned an empty result instead of an error. Validate the lower bound at the query resolvers, alongside the other parameter checks:

- `path.py`: `max_paths > MAX_PATHS` → `1 <= max_paths <= MAX_PATHS`.
- `reachable.py`: add a `max_paths >= 1` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)