### PR TITLE
Fix add branch button overflowing in some browsers

### DIFF
--- a/frontend/app/src/shared/components/aria/autocomplete.tsx
+++ b/frontend/app/src/shared/components/aria/autocomplete.tsx
@@ -49,7 +49,7 @@ interface SearchInputProps extends AriaSearchFieldProps {
 function AutocompleteSearchField({ className, placeholder, ...props }: SearchInputProps) {
   return (
     <AriaSearchField
-      className={classNames("group flex items-center text-sm", className)}
+      className={classNames("group flex items-center overflow-hidden text-sm", className)}
       aria-label="Search"
       autoFocus
       {...props}


### PR DESCRIPTION
cherry pick:(#9526)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Add branch" button overflowing in some browsers by applying overflow-hidden to the autocomplete search field wrapper. Keeps the button and input within the container and prevents layout breakage.

<sup>Written for commit b8e4eacb3c9038b14c9f5832b5080ef8aabb8ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

