### PR TITLE
Merge stable into release-1.10

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from cachetools import TTLCache
@@ -14,7 +15,12 @@ from pydantic import Field
 
 from infrahub import config
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus, RepositoryOperationalStatus
-from infrahub.exceptions import CommitNotFoundError, RepositoryError
+from infrahub.exceptions import (
+    CommitNotFoundError,
+    RepositoryConnectionError,
+    RepositoryCredentialsError,
+    RepositoryError,
+)
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from infrahub.log import get_logger
 
@@ -31,6 +37,34 @@ class PendingObjectImport:
     infrahub_branch_name: str
     commit: str
     git_branch_name: str | None = None
+
+
+class ImportStep(StrEnum):
+    """The phase of a branch synchronization in which a failure occurred."""
+
+    COLLECTION = "collection"
+    IMPORT = "import"
+
+
+@dataclass
+class FailedImport:
+    """A branch that could not be synchronized, with the phase that failed and why."""
+
+    branch_name: str
+    step: ImportStep
+    reason: str
+
+
+@dataclass
+class CollectedImports:
+    """Outcome of the git/branch-setup phase of a sync.
+
+    ``imports`` are the branches ready to have their objects imported. ``failed_imports`` are the
+    branches whose git or branch setup failed, each carrying the phase that failed and the reason.
+    """
+
+    imports: list[PendingObjectImport] = field(default_factory=list)
+    failed_imports: list[FailedImport] = field(default_factory=list)
 
 
 class InfrahubRepository(InfrahubRepositoryIntegrator):
@@ -70,31 +104,42 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         return response
 
-    async def sync(self, staging_branch: str | None = None) -> None:
-        """Synchronize the repository with its remote origin and with the database.
-
-        By default the sync will focus only on the branches pulled from origin that have some differences with the local one.
+    def raise_if_branches_failed(self, failed_imports: list[FailedImport]) -> None:
+        """Log every branch that failed to synchronize and surface them as a single error.
 
         Raises:
-            GraphQLError: When a branch or commit update against the database fails.
+            RepositoryError: When at least one branch failed to synchronize.
 
         """
-        for pending in await self.collect_pending_imports(staging_branch=staging_branch):
-            await self.import_objects_from_files(
-                infrahub_branch_name=pending.infrahub_branch_name,
-                git_branch_name=pending.git_branch_name,
-                commit=pending.commit,
+        if not failed_imports:
+            return
+
+        for failed in failed_imports:
+            log.warning(
+                "Failed to synchronize branch, skipping it.",
+                repository=self.name,
+                branch=failed.branch_name,
+                step=failed.step.value,
+                reason=failed.reason,
             )
 
-    async def collect_pending_imports(self, staging_branch: str | None = None) -> list[PendingObjectImport]:
+        branches = ", ".join(failed.branch_name for failed in failed_imports)
+        raise RepositoryError(
+            identifier=self.name,
+            message=f"Unable to synchronize the following branches of repository {self.name}: {branches}",
+        )
+
+    async def collect_pending_imports(self, staging_branch: str | None = None) -> CollectedImports:
         """Run the git and branch-setup side of a sync and return the imports it produced.
 
         Brings the local clone in line with the remote and records the affected branches and their
         commits in the database, pinning a per-commit worktree for each. Returns one entry per branch
-        whose objects still need importing into the graph. A per-branch git failure is logged and skipped so the
-        other branches' imports are still returned.
+        whose objects still need importing into the graph, alongside the branches whose git setup
+        failed and the reason each one failed.
 
         Raises:
+            RepositoryConnectionError: When the remote repository is unreachable.
+            RepositoryCredentialsError: When the credentials for the remote repository are invalid.
             GraphQLError: When a branch or commit update against the database fails.
 
         """
@@ -104,11 +149,13 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         new_branches, updated_branches = await self.compare_local_remote()
 
-        pending_imports: list[PendingObjectImport] = []
         if not new_branches and not updated_branches:
-            return pending_imports
+            return CollectedImports()
 
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
+
+        imports: list[PendingObjectImport] = []
+        failed_imports: list[FailedImport] = []
 
         # TODO need to handle properly the situation when a branch is not valid.
         if self.internal_status == RepositoryInternalStatus.ACTIVE.value:
@@ -131,18 +178,19 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                     commit = self.get_commit_value(branch_name=branch_name, remote=False)
                     self.create_commit_worktree(commit=commit)
                     await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
+                except (RepositoryConnectionError, RepositoryCredentialsError):
+                    # The remote itself is unreachable or unauthorized; iterating the remaining
+                    # branches is pointless, so let it abort the whole sync.
+                    raise
                 except (RepositoryError, CommitNotFoundError, GitCommandError, ValueError) as exc:
-                    # Isolate per-branch git failures so imports already collected for the other
-                    # branches are still returned and applied.
-                    log.warning(
-                        "Failed to prepare branch for import, skipping it.",
-                        repository=self.name,
-                        branch=branch_name,
-                        exc_info=exc,
+                    # Isolate per-branch git failures so the other branches are still collected;
+                    # graph errors are left to propagate.
+                    failed_imports.append(
+                        FailedImport(branch_name=branch_name, step=ImportStep.COLLECTION, reason=str(exc))
                     )
                     continue
 
-                pending_imports.append(PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit))
+                imports.append(PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit))
 
             for branch_name in updated_branches:
                 is_valid = self.validate_remote_branch(branch_name=branch_name)
@@ -153,21 +201,18 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 try:
                     commit_after = await self.pull(branch_name=branch_name)
+                except (RepositoryConnectionError, RepositoryCredentialsError):
+                    raise
                 except (RepositoryError, CommitNotFoundError, GitCommandError, ValueError) as exc:
-                    # Isolate per-branch git failures so imports already collected for the other
-                    # branches are still returned and applied; graph errors are left to propagate.
-                    log.warning(
-                        "Failed to pull branch for import, skipping it.",
-                        repository=self.name,
-                        branch=branch_name,
-                        exc_info=exc,
+                    # Isolate per-branch git failures so the other branches are still collected;
+                    # graph errors are left to propagate.
+                    failed_imports.append(
+                        FailedImport(branch_name=branch_name, step=ImportStep.COLLECTION, reason=str(exc))
                     )
                     continue
 
                 if isinstance(commit_after, str):
-                    pending_imports.append(
-                        PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit_after)
-                    )
+                    imports.append(PendingObjectImport(infrahub_branch_name=infrahub_branch, commit=commit_after))
 
                 elif commit_after is True:
                     log.warning(
@@ -176,10 +221,10 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                         branch=branch_name,
                     )
 
-        pending_imports.extend(
+        imports.extend(
             await self._collect_staging_imports(staging_branch=staging_branch, updated_branches=updated_branches)
         )
-        return pending_imports
+        return CollectedImports(imports=imports, failed_imports=failed_imports)
 
     async def _collect_staging_imports(
         self, staging_branch: str | None, updated_branches: list[str]

--- a/backend/infrahub/git/sync.py
+++ b/backend/infrahub/git/sync.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from .repository import InfrahubRepository, PendingObjectImport
+from infrahub.exceptions import RepositoryConnectionError, RepositoryCredentialsError
+
+from .repository import FailedImport, ImportStep, InfrahubRepository, PendingObjectImport
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
@@ -86,6 +88,21 @@ class RepositorySyncer:
 
     async def sync(self, repo: InfrahubRepository, staging_branch: str | None = None) -> None:
         async with self._lock_registry.get(name=repo.name, namespace="repository"):
-            pending_imports = await repo.collect_pending_imports(staging_branch=staging_branch)
-        for pending_import in pending_imports:
-            await self._importer.import_branch(repo, pending_import)
+            collected = await repo.collect_pending_imports(staging_branch=staging_branch)
+
+        failed_imports = list(collected.failed_imports)
+        for pending_import in collected.imports:
+            try:
+                await self._importer.import_branch(repo, pending_import)
+            except (RepositoryConnectionError, RepositoryCredentialsError):
+                raise
+            except Exception as exc:
+                # The import already records its own per-branch error status before re-raising, so
+                # isolate the failure here to keep importing the remaining branches.
+                failed_imports.append(
+                    FailedImport(
+                        branch_name=pending_import.infrahub_branch_name, step=ImportStep.IMPORT, reason=str(exc)
+                    )
+                )
+
+        repo.raise_if_branches_failed(failed_imports)

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -305,6 +305,74 @@ async def git_repo_06(
 
 
 @pytest.fixture
+async def git_repo_07(
+    client: InfrahubClient,
+    git_upstream_repo_03: dict[str, str | Path],
+    git_repos_dir: Path,
+    branch01: BranchData,
+    branch02: BranchData,
+) -> InfrahubRepository:
+    """Git Repository with git_upstream_repo_03 as remote.
+
+    The repo has 3 local branches: main, branch01 and branch02.
+    After the repo has been initialized:
+    - branch01 has been updated both locally and in the remote with different changes to the
+      same file, so pulling branch01 fails with a conflict.
+    - branch02 has been updated in the remote only, so pulling branch02 is a clean fast-forward.
+    """
+    upstream = Repo(git_upstream_repo_03["path"])
+
+    # Create branch02 in the remote with a dedicated file so it cannot conflict with main
+    upstream.git.checkout("-b", "branch02", "main")
+    branch02_file = Path(git_upstream_repo_03["path"]) / "branch02-file.txt"
+    branch02_file.write_text("initial content\n", encoding="utf-8")
+    upstream.index.add([str(branch02_file)])
+    upstream.index.commit("Add branch02 file")
+    upstream.git.checkout("main")
+
+    repo = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name=git_upstream_repo_03["name"],
+        location=str(git_upstream_repo_03["path"]),
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+    await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
+    await repo.create_branch_in_git(branch_name=branch02.name, branch_id=branch02.id)
+
+    # Update the first file of branch01 in the remote
+    upstream.git.checkout(branch01.name)
+    first_file = find_first_file_in_directory(Path(git_upstream_repo_03["path"]))
+    assert first_file
+    async with await anyio.open_file(first_file, mode="a", encoding="utf-8") as file:
+        await file.write("remote line\n")
+    upstream.index.add([first_file])
+    upstream.index.commit("Change first file in the remote")
+    upstream.git.checkout("main")
+
+    # Update the same file of branch01 locally with a different change to create a conflict on pull
+    branch_wt = repo.get_worktree(identifier=branch01.name)
+    branch_repo = Repo(branch_wt.directory)
+    local_first_file = find_first_file_in_directory(branch_wt.directory)
+    assert local_first_file
+    async with await anyio.open_file(local_first_file, mode="a", encoding="utf-8") as file:
+        await file.write("local line\n")
+    branch_repo.index.add([local_first_file])
+    branch_repo.index.commit("Change first file locally")
+
+    # Advance branch02 in the remote with a fast-forward commit
+    upstream.git.checkout("branch02")
+    async with await anyio.open_file(branch02_file, mode="a", encoding="utf-8") as file:
+        await file.write("new line\n")
+    upstream.index.add([str(branch02_file)])
+    upstream.index.commit("Change branch02 file")
+    upstream.git.checkout("main")
+
+    await repo.fetch()
+
+    return repo
+
+
+@pytest.fixture
 async def git_repo_jinja(
     client: InfrahubClient, git_upstream_repo_02: dict[str, str | Path], git_repos_dir: Path, branch01: BranchData
 ) -> InfrahubRepository:

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -34,7 +35,9 @@ from infrahub.git.integrator import (
     ArtifactGenerateResult,
     CheckDefinitionInformation,
 )
+from infrahub.git.sync import RepositoryFileImporter, RepositorySyncer
 from infrahub.git.worktree import Worktree
+from infrahub.lock import InfrahubLockRegistry
 from infrahub.services import InfrahubServices
 from infrahub.utils import find_first_file_in_directory
 from tests.conftest import TestHelper
@@ -528,9 +531,14 @@ async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData) -> 
     assert str(response) == str(commit_after)
 
 
+async def _sync(repo: InfrahubRepository, staging_branch: str | None = None) -> None:
+    syncer = RepositorySyncer(lock_registry=InfrahubLockRegistry(local_only=True), importer=RepositoryFileImporter())
+    await syncer.sync(repo, staging_branch=staging_branch)
+
+
 async def test_sync_no_update(git_repo_02: InfrahubRepository) -> None:
     repo = git_repo_02
-    await repo.sync()
+    await _sync(repo)
 
     assert True
 
@@ -569,7 +577,7 @@ async def test_sync_new_branch(
     with patch(
         "infrahub.git.integrator.InfrahubRepositoryIntegrator.import_objects_from_files", new_callable=AsyncMock
     ) as mock_import:
-        await repo.sync()
+        await _sync(repo)
         mock_import.assert_awaited()
     worktrees = repo.get_worktrees()
 
@@ -590,10 +598,31 @@ async def test_sync_updated_branch(prefect_test_fixture: None, git_repo_04: Infr
     with patch(
         "infrahub.git.integrator.InfrahubRepositoryIntegrator.import_objects_from_files", new_callable=AsyncMock
     ) as mock_import:
-        await repo.sync()
+        await _sync(repo)
         mock_import.assert_awaited()
 
     assert repo.get_commit_value(branch_name="branch01") == str(commit)
+
+
+async def test_sync_continues_after_branch_pull_failure(
+    prefect_test_fixture: None, git_repo_07: InfrahubRepository
+) -> None:
+    """A branch whose pull fails must not prevent the synchronization of the remaining branches."""
+    repo = git_repo_07
+
+    for branch_name in ["branch01", "branch02"]:
+        branch = Branch(name=branch_name, uuid=uuid4())
+        registry.branch[branch.name] = branch
+
+    remote_commit_branch02 = repo.get_commit_value(branch_name="branch02", remote=True)
+    assert repo.get_commit_value(branch_name="branch02", remote=False) != str(remote_commit_branch02)
+
+    # A branch failure surfaces as an error once all branches have been processed.
+    expected_message = f"Unable to synchronize the following branches of repository {repo.name}: branch01"
+    with pytest.raises(RepositoryError, match=re.escape(expected_message)):
+        await _sync(repo)
+
+    assert repo.get_commit_value(branch_name="branch02", remote=False) == str(remote_commit_branch02)
 
 
 async def test_render_jinja2_template_success(prefect_test_fixture: None, git_repo_jinja: InfrahubRepository) -> None:

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -23,7 +23,7 @@ from infrahub.git.models import (
     GitRepositoryMerge,
     GitRepositoryPullReadOnly,
 )
-from infrahub.git.repository import InfrahubReadOnlyRepository
+from infrahub.git.repository import CollectedImports, InfrahubReadOnlyRepository
 from infrahub.git.sync import RepositoryAdder
 from infrahub.git.tasks import add_git_repository, add_git_repository_read_only, pull_read_only
 from infrahub.lock import InfrahubLockRegistry
@@ -100,7 +100,7 @@ class TestAddRepository:
 
         self.mock_repo.name = git_upstream_repo_01["name"]
         self.mock_repo.import_objects_from_files = AsyncMock()
-        self.mock_repo.collect_pending_imports = AsyncMock(return_value=[])
+        self.mock_repo.collect_pending_imports = AsyncMock(return_value=CollectedImports())
 
         with patch("infrahub.git.sync.InfrahubRepository", spec=InfrahubRepository) as mock_repo_class:
             mock_repo_class.new.return_value = self.mock_repo

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -12,6 +12,8 @@ from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.git import InfrahubRepository
+from infrahub.git.sync import RepositoryFileImporter, RepositorySyncer
+from infrahub.lock import InfrahubLockRegistry
 from infrahub.message_bus.types import ProposedChangeBranchDiff
 from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import (
@@ -143,7 +145,9 @@ class TestProposedChange(TestInfrahubApp):
         )
 
         repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
-        await repo.sync()
+        await RepositorySyncer(
+            lock_registry=InfrahubLockRegistry(local_only=True), importer=RepositoryFileImporter()
+        ).sync(repo)
 
         result = await graphql_mutation(
             query=PROPOSED_CHANGE_CREATE,

--- a/changelog/9463.fixed.md
+++ b/changelog/9463.fixed.md
@@ -1,0 +1,1 @@
+Fixed git repository synchronization so that a failure on one branch no longer prevents the other branches from being synchronized.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Git repository sync now continues when a single branch fails. Failures are collected and reported together after all branches are processed; connection/credential errors still abort immediately.

- **Bug Fixes**
  - Continue syncing other branches when a branch pull/import fails; record per-branch failures with step (`collection` or `import`) and reason, then raise one `RepositoryError` at the end.
  - Add structured failure tracking via `FailedImport` and `ImportStep`.
  - Keep immediate abort on `RepositoryConnectionError` and `RepositoryCredentialsError`.

- **Migration**
  - Replace `InfrahubRepository.sync` calls with `RepositorySyncer(...).sync(repo)` using `InfrahubLockRegistry` and `RepositoryFileImporter`.
  - `collect_pending_imports` now returns `CollectedImports` with `imports` and `failed_imports`; call `repo.raise_if_branches_failed()` after processing imports.

<sup>Written for commit 01ca0f5f4797f7107db938a1236eeb7669000c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

