### PR TITLE
docs(transformations): document artifact regeneration dependency tracking

### DIFF
--- a/docs/docs/artifacts/overview.mdx
+++ b/docs/docs/artifacts/overview.mdx
@@ -82,6 +82,16 @@ A Transformation can reference and include the rendered content of other artifac
 
 For step-by-step instructions, see [Composing artifact content](./content-composition.mdx).
 
+## When artifacts regenerate
+
+An artifact is the cached output of a Transformation, so Infrahub regenerates it when its inputs change. Three kinds of change trigger regeneration:
+
+- **The target's data changes** — a node read by the artifact's GraphQL query is modified, so that target's artifact is regenerated.
+- **A new target joins the group** — an artifact is generated for the new member; existing artifacts are left untouched.
+- **The definition's code or configuration changes** — when a proposed change commits to a linked repository, Infrahub regenerates an artifact only if the change touches that definition's GraphQL query, its Transformation's [dependency closure](../transformations/overview#dependency-tracking-and-regeneration), or the artifact definition itself. An unrelated commit — a README edit, or a helper no Transformation uses — regenerates nothing.
+
+Every regeneration decision during a proposed change is recorded in the pipeline's task log, naming the file, query, or field that triggered it. See [Understanding artifact regeneration](../proposed-changes/overview#understanding-artifact-regeneration).
+
 ## How artifacts relate to other features
 
 - **[Transformations](../transformations/overview)** define the logic that produces an artifact's content; an artifact is the cached output of a Transformation for a specific target.

--- a/docs/docs/proposed-changes/overview.mdx
+++ b/docs/docs/proposed-changes/overview.mdx
@@ -74,6 +74,11 @@ Learn more about [Transformations](../transformations/overview) and [Artifacts](
 
 When a proposed change includes commits to a linked Git repository, Infrahub regenerates only the artifacts whose Transformation actually depends on a changed file. Each Transformation's dependency closure - the templates it includes for a Jinja2 Transformation, or the files in its package directory for a Python Transformation - is computed when the repository is imported and stored on the Transformation. A file change regenerates a definition's artifacts only when the changed file is in that definition's closure. A change to a GraphQL query the definition uses, or to the artifact definition itself, also triggers regeneration.
 
+Two repository-level rules also apply:
+
+- Editing a repository's `.infrahub.yml` regenerates the artifacts of every Transformation in that repository, because the manifest can change how any of them is built.
+- Read-only repositories follow the same rules as regular ones. Bumping a `CoreReadOnlyRepository` to a new pinned commit on the source branch regenerates the artifacts affected by that commit, even on branches where `sync_with_git` is disabled.
+
 #### Where to find the why trail
 
 Every regeneration decision is recorded in the proposed change pipeline's task log. This is the canonical place to see which file, query, or relationship change caused an artifact to regenerate: each entry names the affected definition and the precise cause. For example:

--- a/docs/docs/transformations/jinja2.mdx
+++ b/docs/docs/transformations/jinja2.mdx
@@ -88,6 +88,17 @@ The endpoint is branch-aware. Pass query variables as URL parameters.
 
 To cache rendered output and tie it to a specific target object, define an artifact that uses this Transformation. See [Use artifacts](../artifacts/use).
 
+## Dependency tracking
+
+When a Jinja2 Transformation feeds an artifact, Infrahub regenerates that artifact only when a file the template depends on changes. On import, Infrahub walks the template and records every other template it reaches through static `{% include %}`, `{% import %}`, and `{% extends %}` directives, following them transitively. A change to any template in that set regenerates the artifacts of definitions that use this Transformation.
+
+Static directives resolve automatically. A dynamic reference — where the template name comes from a variable, as in `{% include partial_name %}` — can't be followed at import time. Infrahub then marks the Transformation's dependency closure incomplete and falls back to regenerating its artifacts on **any** file change in the repository. To keep regeneration precise, either:
+
+- Replace the variable with a literal name, for example `{% include "partials/header.j2" %}`, or
+- Declare the templates the dynamic reference can resolve to with the [`watch` key](../git-integration/infrahub-yml#declaring-extra-dependencies-with-watch) in `.infrahub.yml`.
+
+See [Understanding artifact regeneration](../proposed-changes/overview#understanding-artifact-regeneration) for how to read which change triggered a regeneration.
+
 ## Related
 
 - [Transformations](./overview) — concept and architecture

--- a/docs/docs/transformations/overview.mdx
+++ b/docs/docs/transformations/overview.mdx
@@ -106,6 +106,19 @@ This design enables powerful patterns:
 
 The Transformation logic remains group-agnostic, while artifact definitions and Generators provide the targeting mechanism. See [Groups](../groups/overview) for details on creating target groups.
 
+## Dependency tracking and regeneration
+
+When a Transformation feeds an [artifact](../artifacts/overview), Infrahub regenerates that artifact only when something it actually depends on changes. Each Transformation has a **dependency closure** — the set of files whose contents affect its output — computed when the repository is imported and stored on the Transformation.
+
+Infrahub builds the closure differently per language:
+
+- **Jinja2**: the template itself, plus every template it reaches through static `{% include %}`, `{% import %}`, or `{% extends %}`, resolved transitively. See [Write a Jinja2 Transformation](./jinja2#dependency-tracking).
+- **Python**: every Git-tracked file in the directory that contains the transform's `file_path`. See [Write a Python Transformation](./python#dependency-tracking).
+
+A change to a file outside a Transformation's closure no longer regenerates its artifacts. When automatic detection can't follow a dependency — a template name resolved at runtime, or a module imported from another package — declare the extra files with the [`watch` key](../git-integration/infrahub-yml#declaring-extra-dependencies-with-watch) in `.infrahub.yml`.
+
+For how these decisions surface during a proposed change, see [Understanding artifact regeneration](../proposed-changes/overview#understanding-artifact-regeneration).
+
 ## Unit testing for Transformations
 
 Infrahub provides a framework to create unit tests for your Transformations with very minimal code/configuration.

--- a/docs/docs/transformations/python.mdx
+++ b/docs/docs/transformations/python.mdx
@@ -111,6 +111,17 @@ The endpoint is branch-aware. Pass query variables as URL parameters.
 
 To cache transform output and tie it to a specific target object, define an artifact that uses this Transformation. See [Use artifacts](../artifacts/use).
 
+## Dependency tracking
+
+When a Python Transformation feeds an artifact, Infrahub regenerates that artifact only when a file the transform depends on changes. On import, Infrahub records the transform's dependency closure as every Git-tracked file in the directory that contains its `file_path`, including subdirectories — so a transform in `transforms/` picks up its sibling modules and any package nested under that directory. `.pyc` files, `__pycache__/`, and Git-ignored files are excluded. A change to any file in that directory regenerates the artifacts of definitions that use this Transformation.
+
+This is a directory-level heuristic, not import analysis, so two cases need attention:
+
+- **A transform at the repository root** has no containing directory to scope to, so its closure collapses to the single file. Keep the transform in a subdirectory to get directory-level tracking.
+- **Imports from another top-level package** — a helper in `shared/` that a transform under `transforms/` imports — fall outside the directory and aren't detected. A change to such a helper won't regenerate the artifacts unless you declare it with the [`watch` key](../git-integration/infrahub-yml#declaring-extra-dependencies-with-watch) in `.infrahub.yml`.
+
+See [Understanding artifact regeneration](../proposed-changes/overview#understanding-artifact-regeneration) for how to read which change triggered a regeneration.
+
 ## Related
 
 - [Transformations](./overview) — concept and architecture


### PR DESCRIPTION
## What

Fills the documentation gaps for "Smarter artifact regeneration on repository changes" (INFP-409 / JPD409), the feature shipped in 1.10. The primary deliverables (the `watch:` key in `infrahub-yml.mdx` and the "why trail" in `proposed-changes/overview.mdx`) already landed with #9414; this adds the coverage that was missing on adjacent pages.

## Changes (docs-only, all additions — +50 lines)

- **transformations/overview.mdx** — new "Dependency tracking and regeneration" concept section.
- **transformations/jinja2.mdx** — static `{% include/import/extends %}` are auto-detected; a dynamic include marks the closure incomplete → use a literal name or `watch`.
- **transformations/python.mdx** — package-directory heuristic; a root-level transform collapses to its own file; cross-package imports need `watch`.
- **artifacts/overview.mdx** — "When artifacts regenerate" (the three trigger categories).
- **proposed-changes/overview.mdx** — `.infrahub.yml` whole-file rule + read-only repo participation.

## Reviewer attention

- Claims are grounded in `backend/infrahub/git/closure_builder/` and the INFP-409 spec, not the changelog.
- **Known gap, out of scope:** generated `reference/dotinfrahub.mdx` shows `watch | InfrahubWatchConfig` without expanding the `files` field — needs the SDK doc generator, tracked separately.

## Verification

Docusaurus build passes (no broken links/anchors), markdownlint 0, vale 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document smarter artifact regeneration (INFP-409) by explaining how dependency closures are detected for Jinja2 and Python, and exactly when artifacts re-run. Adds guidance for dynamic includes, the Python directory heuristic, repo-wide rules for `.infrahub.yml` edits and read-only repos, and when to use `watch` to declare extra dependencies.

<sup>Written for commit a44aad4bfe9eaff2953ee13517ef09abf56d1b99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

