### PR TITLE
fix(frontend): stop auto-selecting first parent in relationship create form

### DIFF
--- a/changelog/9634.fixed.md
+++ b/changelog/9634.fixed.md
@@ -1,0 +1,1 @@
+Fixed the object creation form auto-selecting the first available object in the parent filter of a relationship to a hierarchical node (e.g. the **Device** filter when adding an interface's lag). The parent filter now starts empty and is only pre-filled from an existing relationship value or parent context.

--- a/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.test.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+
+import { getSchema } from "@/entities/schema/domain/get-schema";
+
+import { getDefaultParentFromApi } from "./get-default-parent-from-api";
+
+vi.mock("@/shared/api/graphql/graphqlClientApollo", () => ({
+  default: { query: vi.fn() },
+}));
+
+vi.mock("@/entities/schema/domain/get-schema", () => ({
+  getSchema: vi.fn(),
+}));
+
+describe("getDefaultParentFromApi", () => {
+  const parentRelationship = {
+    peer: "TestDevice",
+    direction: "inbound" as const,
+    identifier: "device__interface",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Schema exposing the child relationship used to derive the parent filter attribute.
+    vi.mocked(getSchema).mockReturnValue({
+      schema: {
+        relationships: [
+          { name: "interfaces", direction: "outbound", identifier: "device__interface" },
+        ],
+      },
+    } as any);
+    vi.mocked(graphqlClient.query).mockResolvedValue({ data: {} } as any);
+  });
+
+  it("does not query (no auto-selected parent) when there is no current relationship value", async () => {
+    const result = await getDefaultParentFromApi({
+      parentRelationship,
+      defaultValue: undefined,
+      branchName: "main",
+      atDate: null,
+    });
+
+    expect(graphqlClient.query).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: null, error: null });
+  });
+
+  it("queries filtered by the current value id when a relationship value exists", async () => {
+    await getDefaultParentFromApi({
+      parentRelationship,
+      defaultValue: {
+        source: { type: "user" },
+        value: { id: "interface-1", __typename: "TestInterface", display_label: "eth0" },
+      },
+      branchName: "main",
+      atDate: null,
+    });
+
+    expect(graphqlClient.query).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(graphqlClient.query).mock.calls[0]![0].variables).toEqual({
+      ids: ["interface-1"],
+    });
+  });
+});

--- a/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.ts
@@ -53,7 +53,8 @@ export const getDefaultParentFromApi = ({
       ? defaultValue.value.id
       : undefined;
 
-  if (!parentRelationship?.peer || !parentRelationshipAttribute?.name) {
+  // Without a current value there is no child to resolve a parent from.
+  if (!parentRelationship?.peer || !parentRelationshipAttribute?.name || !id) {
     return { data: null, error: null };
   }
 
@@ -66,7 +67,7 @@ export const getDefaultParentFromApi = ({
 
   return graphqlClient.query({
     query,
-    variables: { ids: id ? [id] : undefined },
+    variables: { ids: [id] },
     context: {
       branch: branchName,
       date: atDate,


### PR DESCRIPTION
## Summary

Fixes #9634. When creating an object with a relationship to a **hierarchical** node, the form renders a parent "pool" filter to narrow the options (e.g. a **Device** filter for an interface's `lag`). On create this filter was auto-populated with the first available object (`atl1-core1` in the report) that the user never set and could not clear.

Root cause: `getDefaultParentFromApi` derives the lookup `id` from `defaultValue`. On create there is no `defaultValue`, so the query ran with `ids: undefined` → no filter → all parents returned, and `getDefaultParent` took `edges[0]`. The query is only meaningful as "find the parent of the currently-selected child", so it should not run when nothing is selected.

## Change

- `get-default-parent-from-api.ts`: bail out (`{ data: null, error: null }`) when there is no current relationship value `id`, so the parent filter starts empty. The legitimate pre-fill paths (editing an existing value, creating a child from a parent's page) are unaffected.
- Added unit tests covering both branches (no value → no query; value present → filtered by id).
- Changelog fragment.

## Test plan

- `vitest` for `relationships/`: 33 passed (7 files). New `does not query when there is no current relationship value` test fails before the change, passes after.

> [!NOTE]
> Branched off `stable`. Run `pnpm biome:fix` once `node_modules` matches this branch — biome couldn't run in my worktree due to an unrelated `ultracite/core` resolution mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-selecting the first available parent in hierarchical relationship create forms. The parent filter now starts empty and only pre-fills when editing or when opened from a parent context (IFC-2769).

- **Bug Fixes**
  - Bail out when no current relationship value id; when present, always query filtered by that id to avoid arbitrary selection.
  - Added tests for both paths and a changelog entry.

<sup>Written for commit 939150cd5a71fc0432bde1b37ad7f02c05eb022f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

