### PR TITLE
fix(proposed-change): match diff action case-insensitively for artifact regeneration

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1272,6 +1272,17 @@ def _run_generator(instance_id: str | None, managed_branch: bool, impacted_insta
 _TRIGGERING_DIFF_ACTIONS = {DiffAction.ADDED.value, DiffAction.UPDATED.value}
 
 
+def _is_triggering_action(action: str) -> bool:
+    """Return True for diff actions that should trigger artifact regeneration.
+
+    ``get_diff_summary`` serialises a node/element action as the GraphQL enum *name*
+    (uppercase, e.g. ``"UPDATED"``/``"ADDED"``), whereas ``DiffAction.*.value`` is
+    lowercase. The comparison must therefore be case-insensitive: a literal
+    ``action in _TRIGGERING_DIFF_ACTIONS`` silently never matches real diff data.
+    """
+    return action.lower() in _TRIGGERING_DIFF_ACTIONS
+
+
 @dataclass(frozen=True, kw_only=True, slots=True)
 class PredicateOutcome:
     """The verdict of a regeneration predicate plus the diagnostic explaining it.
@@ -1304,7 +1315,7 @@ def _query_changed(
     leaves the definition broken and there is nothing to regenerate against.
     """
     matched = any(
-        entry["id"] == definition.query_id and entry["action"] in _TRIGGERING_DIFF_ACTIONS for entry in diff_summary
+        entry["id"] == definition.query_id and _is_triggering_action(entry["action"]) for entry in diff_summary
     )
     if not matched:
         return PredicateOutcome(matched=False)
@@ -1340,7 +1351,7 @@ def _definition_changed(
         (
             entry
             for entry in diff_summary
-            if entry["id"] == definition.definition_id and entry["action"] in _TRIGGERING_DIFF_ACTIONS
+            if entry["id"] == definition.definition_id and _is_triggering_action(entry["action"])
         ),
         None,
     )
@@ -1348,7 +1359,7 @@ def _definition_changed(
         return PredicateOutcome(matched=False)
 
     changed_fields = ", ".join(
-        element["name"] for element in matched_entry["elements"] if element["action"] in _TRIGGERING_DIFF_ACTIONS
+        element["name"] for element in matched_entry["elements"] if _is_triggering_action(element["action"])
     )
     detail = f"definition node was modified ({changed_fields})" if changed_fields else "definition node was modified"
     return PredicateOutcome(

--- a/backend/tests/component/proposed_change/conftest.py
+++ b/backend/tests/component/proposed_change/conftest.py
@@ -72,13 +72,16 @@ def make_node_diff(
     kind: str,
     branch: str,
     field_names: list[str],
-    action: str = "updated",
+    action: str = "UPDATED",
     element_type: str = DiffElementType.ATTRIBUTE.value,
 ) -> NodeDiff:
     """Build a NodeDiff for use in diff summary cache.
 
     `element_type` accepts the raw diff value (e.g. "RELATIONSHIP_ONE") so tests can reproduce a
     relationship endpoint flip exactly as the diff summary emits it.
+
+    `action` is the uppercase GraphQL enum name as emitted by `get_diff_summary`
+    ("UPDATED"/"ADDED"/...), not the lowercase `DiffAction.*.value`.
     """
     return NodeDiff(
         branch=branch,
@@ -90,7 +93,7 @@ def make_node_diff(
             NodeDiffElement(
                 name=field_name,
                 element_type=element_type,
-                action="updated",
+                action="UPDATED",
                 summary=NodeDiffSummary(added=0, updated=1, removed=0),
             )
             for field_name in field_names

--- a/backend/tests/component/proposed_change/test_artifact_regen_edge_cases.py
+++ b/backend/tests/component/proposed_change/test_artifact_regen_edge_cases.py
@@ -264,7 +264,7 @@ class TestArtifactRegenEdgeCases(ArtifactRegenTestBase):
             workflow_recorder=workflow_recorder,
             diff_summary=[
                 make_node_diff(
-                    dataset["artdef_new_id"], "CoreArtifactDefinition", SOURCE_BRANCH, ["name"], action="added"
+                    dataset["artdef_new_id"], "CoreArtifactDefinition", SOURCE_BRANCH, ["name"], action="ADDED"
                 )
             ],
         )

--- a/backend/tests/unit/proposed_change/test_predicates.py
+++ b/backend/tests/unit/proposed_change/test_predicates.py
@@ -62,9 +62,12 @@ def _node_diff(
     *,
     node_id: str,
     kind: str = "CoreGraphQLQuery",
-    action: str = "updated",
+    action: str = "UPDATED",
     elements: list[NodeDiffElement] | None = None,
 ) -> NodeDiff:
+    # ``action`` is the uppercase GraphQL enum name as emitted by ``get_diff_summary``
+    # (e.g. "UPDATED"/"ADDED"), NOT the lowercase ``DiffAction.*.value``. Fixtures must
+    # mirror production casing or the predicates' case-insensitive match goes untested.
     return NodeDiff(
         branch="main",
         kind=kind,
@@ -90,22 +93,22 @@ QUERY_CHANGED_CASES: list[QueryChangedCase] = [
     ),
     QueryChangedCase(
         name="updated_query_is_true",
-        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="updated")],
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="UPDATED")],
         expected=True,
     ),
     QueryChangedCase(
         name="added_query_is_true",
-        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="added")],
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="ADDED")],
         expected=True,
     ),
     QueryChangedCase(
         name="unchanged_action_is_false",
-        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="unchanged")],
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="UNCHANGED")],
         expected=False,
     ),
     QueryChangedCase(
         name="removed_action_is_false",
-        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="removed")],
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery", action="REMOVED")],
         expected=False,
     ),
     QueryChangedCase(
@@ -174,22 +177,22 @@ DEFINITION_CHANGED_CASES: list[DefinitionChangedCase] = [
     ),
     DefinitionChangedCase(
         name="updated_definition_is_true",
-        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="updated")],
+        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="UPDATED")],
         expected=True,
     ),
     DefinitionChangedCase(
         name="added_definition_is_true",
-        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="added")],
+        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="ADDED")],
         expected=True,
     ),
     DefinitionChangedCase(
         name="unchanged_action_is_false",
-        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="unchanged")],
+        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="UNCHANGED")],
         expected=False,
     ),
     DefinitionChangedCase(
         name="removed_action_is_false",
-        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="removed")],
+        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreArtifactDefinition", action="REMOVED")],
         expected=False,
     ),
     DefinitionChangedCase(


### PR DESCRIPTION
## What

Fixes a correctness bug in the INFP-409 scoped artifact-regeneration feature (#9641): a proposed change that only modified a **GraphQL query** or an **artifact definition node** never regenerated the affected artifacts, so they could merge stale.

Closes #9641.

## Root cause

`_TRIGGERING_DIFF_ACTIONS = {DiffAction.ADDED.value, DiffAction.UPDATED.value}` is `{"added", "updated"}` (lowercase), but `client.get_diff_summary()` emits each entry's `action` as the uppercase GraphQL enum name (`"UPDATED"`/`"ADDED"`). So `entry["action"] in _TRIGGERING_DIFF_ACTIONS` is always `False`, and both `_query_changed` and `_definition_changed` silently never match.

`_transform_changed` (file-path intersection) and the data-change path (`_relevant_node_changes`, keyed on kind/fields) never inspect `action`, so they're unaffected — the blast radius is exactly these two predicates.

## Change

- Add a case-insensitive `_is_triggering_action()` helper and use it at all three comparison sites in `tasks.py`.
- Correct the unit (`test_predicates.py`) and component (`conftest.py make_node_diff`, `test_artifact_regen_edge_cases.py`) fixtures to emit the real **uppercase** action. These fixtures previously hardcoded lowercase, matching the buggy constant — which is why CI stayed green.

## Test evidence

With the fixtures corrected to production casing, the predicate unit tests **fail before** the fix and **pass after**:

```
# fixtures uppercased, fix reverted:
6 failed, 21 passed
  test_query_changed[updated_query_is_true] / [added_query_is_true] / [query_match_among_other_entries]
  test_definition_changed[updated_definition_is_true] / [added_definition_is_true] / [definition_match_among_other_entries]
# with the fix:
27 passed
```

Also reproduced and confirmed fixed end-to-end during QA: editing a Jinja2 transform's query file (`templates/device_startup_info.gql`, outside the template closure) on a proposed change produced 0 artifact validators before the fix.

## Notes for review

- Found during QA of IFC-2541; the epic is being bounced back from "Ready for Testing".
- Two related **over-regeneration** behaviors surfaced in the same QA (whole-file `.infrahub.yml` trigger; Python directory-level closure). They are safe (no missed regen) and documented, and are filed separately as enhancements — out of scope for this correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed artifact regeneration when a proposed change updates a GraphQL query or an artifact definition. Diff actions are now matched case-insensitively (handles uppercase "UPDATED"/"ADDED") so affected artifacts regenerate and don’t merge stale, aligning with INFP-409.

- **Bug Fixes**
  - Added `_is_triggering_action()` and used it in `_query_changed`, `_definition_changed`, and element-level comparisons.
  - Updated unit/component fixtures to emit uppercase actions from `get_diff_summary` so tests catch the regression.

<sup>Written for commit dfa94bcc026d7c1688859620a58578085723c97f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

