### PR TITLE
docs(menu): document the web UI search-anywhere (Cmd+K) bar

### DIFF
--- a/docs/docs/menu/overview.mdx
+++ b/docs/docs/menu/overview.mdx
@@ -195,3 +195,9 @@ nodes:
 ### The IPAM section is built in
 
 If your schema includes nodes that inherit from `BuiltinIPPrefix` or `BuiltinIPAddress`, Infrahub automatically adds an IPAM section to the menu. You do not need to define it in your menu file.
+
+## Search anywhere
+
+Beyond the menu, you can jump directly to any object, schema, or page from a single search dialog.
+
+Press `Cmd+K` (macOS) or `Ctrl+K` (Windows and Linux) anywhere in the web interface to open it, then start typing. The dialog searches across objects, attributes, schemas, menu items, and documentation. You can also open it from the **Search** button at the top of the left menu, which shows the keyboard shortcut.

--- a/docs/docs/overview/quickstart.mdx
+++ b/docs/docs/overview/quickstart.mdx
@@ -141,6 +141,10 @@ uv run infrahubctl object load objects/countries.yml
 Go to [http://localhost:8000](http://localhost:8000) and navigate to the **Country** list in the left-hand menu. You should see **United States** and **France**. Click on **United States** to view its details.
 :::
 
+:::info
+Instead of navigating the menu, press `Cmd+K` (macOS) or `Ctrl+K` (Windows and Linux) and type a name to jump straight to any object, schema, or page. See [Search anywhere](../menu/overview.mdx#search-anywhere).
+:::
+
 ## Explore branching
 
 Branches in Infrahub work like Git branches — they let you stage changes in isolation without affecting the main dataset. This is one of Infrahub's most powerful features: you can propose, review, and test data changes before merging them. [Learn more about branching](../branches/overview).


### PR DESCRIPTION
## Summary

The web UI's global **search-anywhere** dialog (Cmd/Ctrl+K) shipped long ago but was never documented for users — it appeared only in release notes (1.9.0) and a bug report (#4861). This adds it where readers will actually find it.

- **`docs/docs/menu/overview.mdx`** — new "Search anywhere" section: the shortcut, what it searches (objects, attributes, schemas, menu items, documentation), and the sidebar **Search** button fallback.
- **`docs/docs/overview/quickstart.mdx`** — one-line discovery tip at the step where the reader first navigates the menu to find an object, linking to the section above.

## Facts verified against the frontend

Sourced from `frontend/app/src/entities/navigation/ui/search-anywhere/`:

- Handler registers `(metaKey || ctrlKey) + k` and calls `preventDefault()` — works cross-platform.
- Placeholder: `"Search for objects, attributes, schemas, documentations ..."`; four result groups (objects/nodes, schemas, menu items, docs).
- Always-visible **Search** button in the left sidebar showing the `⌘ K` / `⌃ K` hint.

## Deliberately omitted

The OS/browser conflict table from #4861 is **not** included. The current handler calls `preventDefault()` on both `metaKey` and `ctrlKey` — the fix for that collision. Documenting a stale "may not work" caveat would mislead. The sidebar **Search** button is documented as the universal fallback instead.

## Reviewer attention

- Placement: `menu/overview.mdx` is the closest existing home (shared sidebar subject) though its primary topic is menu *customization*. Flagging in case the team prefers a dedicated Web UI page.
- Please confirm #4861 is closed before merge.

## Verification

- `markdownlint-cli2` clean on both files.
- `npm run build` succeeds — the `#search-anywhere` cross-link anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the web UI “Search anywhere” dialog, opened with Cmd+K (macOS) or Ctrl+K (Windows/Linux), which searches objects, attributes, schemas, menu items, and docs. Adds a “Search anywhere” section to Menu > Overview and a Quickstart tip linking to it, with the sidebar Search button as an alternative trigger.

<sup>Written for commit 11e15207395ddb00633a4b55e389939eee989cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

