### PR TITLE
docs(hardware): document PostgreSQL task-manager database sizing

### DIFF
--- a/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
+++ b/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
@@ -4,7 +4,7 @@ title: Hardware requirements
 
 import EnterpriseBadge from '@site/src/components/EnterpriseBadge';
 
-This page outlines the hardware requirements for running Infrahub, including minimum and recommended specifications, enterprise sizing, cloud provider machine types, and a utility for benchmarking your system's performance.
+This page outlines the hardware requirements for running Infrahub, including minimum and recommended specifications, enterprise sizing, cloud provider machine types, task manager database storage, and a utility for benchmarking your system's performance.
 
 If you only want to try Infrahub, follow the [Quick Start](../../overview/quickstart.mdx).
 
@@ -26,6 +26,24 @@ For cloud deployments, use at least the following machine types:
 | Microsoft Azure             | Standard_D4as_v7   |
 | Oracle Cloud Infrastructure | VM.Standard.E6     |
 | Alibaba Cloud               | ecs.g9a.xlarge     |
+
+## Task manager database (PostgreSQL) storage
+
+The storage figures in the tables above size the Neo4j graph database. The task manager (Prefect) keeps its own [PostgreSQL database](../../overview/architecture.mdx#task-manager), which you size separately.
+
+PostgreSQL storage grows with **activity, not with the amount of data stored in Infrahub**. It is driven by how busy the instance is — the number of open proposed changes, the volume of changes per day, task execution history, and events — not by how many objects (IP addresses, devices, services) you manage. An instance with a small dataset but heavy automation can use more PostgreSQL storage than a large but mostly static one.
+
+Use the following as starting points:
+
+| Instance type               | PostgreSQL storage |
+|-----------------------------|--------------------|
+| Local or one-off            | 8 GB               |
+| Long-running or development | 20 GB              |
+| Production                  | 100 GB             |
+
+Infrahub periodically prunes old activity logs, so storage usage tends to plateau rather than grow without bound. Monitor disk utilization over time and resize the volume as activity increases.
+
+For what the task manager database contains and how to back it up, see the [database backup overview](../maintain-upgrade/database-backup/overview.mdx). For the signals to watch in production, see the [FAQ](../../faq/faq.mdx).
 
 ## Enterprise sizing <EnterpriseBadge />
 


### PR DESCRIPTION
## What

Adds a **Task manager database (PostgreSQL) storage** section to the hardware requirements page.

The existing sizing tables only cover the Neo4j volume. There was no guidance anywhere on how to size the PostgreSQL database the task manager (Prefect) depends on — and users were running out of disk because they sized it for data volume.

## Why

PostgreSQL storage is driven by **activity, not data volume**: open proposed changes, changes per day, task execution history, and events. A small dataset with heavy automation can need more PostgreSQL storage than a large but mostly static one. The new section states this directly and gives starting points:

| Instance type | PostgreSQL storage |
|---|---|
| Local or one-off | 8 GB |
| Long-running or development | 20 GB |
| Production | 100 GB |

Source: internal sizing discussion (Fatih Acar).

## Notes for reviewers

- **Retention is stated qualitatively** ("Infrahub periodically prunes old activity logs, so storage usage tends to plateau") rather than citing a hard day count, since that mechanism is being reworked. Revisit when it lands.
- **Enterprise tiers not touched.** The Medium/Large *Data* vs *Action* tiers map onto the activity-vs-data distinction, but there are no per-tier PostgreSQL numbers to publish, so that table keeps its Neo4j-only storage column.
- Placement chosen as a standalone section because PostgreSQL sizing is keyed on deployment activity, a different axis than the capacity tiers (Min/Recommended, Small→Large) the other tables use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PostgreSQL task manager database sizing section to the hardware requirements to help users provision disk correctly. Clarifies storage scales with activity (not data volume) and provides starting sizes: 8 GB (local/one-off), 20 GB (long-running/dev), 100 GB (production), plus a retention note and links to backup and FAQ.

<sup>Written for commit 3dfc7f7a1624fad3720f5ab51cd0c27d008fbe04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

