### PR TITLE
Migrate autocomplete to @infrahub/ui

### DIFF
--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import {
+  Autocomplete,
   Button,
   LinkButton,
   ListBox,
@@ -17,7 +18,6 @@ import React from "react";
 import { type ButtonProps as AriaButtonProps, Collection } from "react-aria-components";
 
 import { constructPath } from "@/shared/api/rest/fetch";
-import { Autocomplete } from "@/shared/components/aria/autocomplete";
 import { Separator } from "@/shared/components/aria/separator";
 import { Row } from "@/shared/components/container";
 import { QSP } from "@/shared/config/qsp";

--- a/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-branches.tsx
+++ b/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-branches.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import {
+  Autocomplete,
   Breadcrumb,
   BreadcrumbItem,
   Breadcrumbs,
@@ -11,7 +12,6 @@ import {
 import { useParams } from "react-router";
 
 import { constructPath } from "@/shared/api/rest/fetch";
-import { Autocomplete } from "@/shared/components/aria/autocomplete";
 import { MenuTrigger } from "@/shared/components/aria/menu";
 
 import { useGetBranches } from "@/entities/branches/ui/queries/get-branches.query";

--- a/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-resource-manager.tsx
+++ b/frontend/app/src/entities/navigation/ui/breadcrumbs/breadcrumb-resource-manager.tsx
@@ -1,4 +1,5 @@
 import {
+  Autocomplete,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbItemError,
@@ -15,7 +16,6 @@ import { ChevronsUpDownIcon } from "lucide-react";
 import { Link, useParams } from "react-router";
 
 import { constructPath } from "@/shared/api/rest/fetch";
-import { Autocomplete } from "@/shared/components/aria/autocomplete";
 import { MenuTrigger } from "@/shared/components/aria/menu";
 import { Col, Row } from "@/shared/components/container";
 

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
@@ -1,11 +1,10 @@
 import { Icon } from "@iconify-icon/react";
-import { Button, ListBox, ListBoxItem, Popover, PopoverTrigger } from "@infrahub/ui";
+import { Autocomplete, Button, ListBox, ListBoxItem, Popover, PopoverTrigger } from "@infrahub/ui";
 import { ChevronRightIcon } from "lucide-react";
 import type React from "react";
 import { useRef, useState } from "react";
 import type { Key } from "react-aria-components";
 
-import { Autocomplete } from "@/shared/components/aria/autocomplete";
 import { isFieldFiltered } from "@/shared/hooks/is-field-filtered";
 import type { Filter } from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";

--- a/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-autocomplete.tsx
@@ -1,9 +1,14 @@
 import { Icon } from "@iconify-icon/react";
-import { ListBox, ListBoxItem, ListBoxLoadMoreItem, ListBoxVirtualizer } from "@infrahub/ui";
+import {
+  Autocomplete,
+  ListBox,
+  ListBoxItem,
+  ListBoxLoadMoreItem,
+  ListBoxVirtualizer,
+} from "@infrahub/ui";
 import React from "react";
 import { Collection } from "react-aria-components";
 
-import { Autocomplete } from "@/shared/components/aria/autocomplete";
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import { debounce } from "@/shared/utils/common";
 

--- a/frontend/packages/ui/oxlint.config.ts
+++ b/frontend/packages/ui/oxlint.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     "eslint/no-undefined": "off",
     "eslint/sort-imports": "off",
     "eslint/sort-keys": "off",
+    "jsx-a11y/no-autofocus": "off",
     "oxc/no-optional-chaining": "off",
     "oxc/no-rest-spread-properties": "off",
     "react-perf/jsx-no-new-object-as-prop": "off",

--- a/frontend/packages/ui/oxlint.config.ts
+++ b/frontend/packages/ui/oxlint.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
     "react/no-multi-comp": "off",
     "react/only-export-components": "off",
     "react/react-in-jsx-scope": "off",
+    "react-perf/jsx-no-jsx-as-prop": "off",
     "react_perf/jsx-no-new-array-as-prop": "off",
     "react_perf/jsx-no-new-function-as-prop": "off",
     "typescript/explicit-function-return-type": "off",

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
@@ -9,6 +9,9 @@ import { Autocomplete } from "./autocomplete";
 const meta: Meta<typeof Autocomplete> = {
   title: "Components/Autocomplete",
   component: Autocomplete,
+  parameters: {
+    layout: "centered",
+  },
 };
 export default meta;
 
@@ -16,24 +19,38 @@ type Story = StoryObj<typeof Autocomplete>;
 
 const fruits = ["Apple", "Banana", "Cherry", "Date", "Elderberry", "Fig", "Grape"];
 
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="w-64 overflow-hidden rounded-lg border border-neutral-300">{children}</div>
+);
+
+const fruitList = () => (
+  <ListBox aria-label="Fruits" className="max-h-60 p-1" emptyMessage="No result found">
+    {fruits.map((fruit) => (
+      <ListBoxItem key={fruit} textValue={fruit}>
+        {fruit}
+      </ListBoxItem>
+    ))}
+  </ListBox>
+);
+
 export const Default: Story = {
   render: () => (
-    <div className="w-64 rounded-lg border border-neutral-300">
-      <Autocomplete
-        suffix={
-          <Button variant="ghost" shape="square" size="xxs">
-            <PlusIcon />
-          </Button>
-        }
-      >
-        <ListBox aria-label="Fruits" className="max-h-60 p-1" emptyMessage="No result found">
-          {fruits.map((fruit) => (
-            <ListBoxItem key={fruit} textValue={fruit}>
-              {fruit}
-            </ListBoxItem>
-          ))}
-        </ListBox>
-      </Autocomplete>
+    <div className="flex gap-8">
+      <Frame>
+        <Autocomplete>{fruitList()}</Autocomplete>
+      </Frame>
+
+      <Frame>
+        <Autocomplete
+          suffix={
+            <Button variant="ghost" shape="square" size="xxs">
+              <PlusIcon />
+            </Button>
+          }
+        >
+          {fruitList()}
+        </Autocomplete>
+      </Frame>
     </div>
   ),
 };

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { PlusIcon } from "lucide-react";
 
 import { Button } from "../button/button";

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "../button/button";
+import { ListBox, ListBoxItem } from "../list-box/list-box";
+import { Autocomplete } from "./autocomplete";
+
+const meta: Meta<typeof Autocomplete> = {
+  title: "Components/Autocomplete",
+  component: Autocomplete,
+};
+export default meta;
+
+type Story = StoryObj<typeof Autocomplete>;
+
+const fruits = ["Apple", "Banana", "Cherry", "Date", "Elderberry", "Fig", "Grape"];
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-64 rounded-lg border border-neutral-300">
+      <Autocomplete
+        suffix={
+          <Button variant="ghost" shape="square" size="xxs">
+            <PlusIcon />
+          </Button>
+        }
+      >
+        <ListBox aria-label="Fruits" className="max-h-60 p-1" emptyMessage="No result found">
+          {fruits.map((fruit) => (
+            <ListBoxItem key={fruit} textValue={fruit}>
+              {fruit}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Autocomplete>
+    </div>
+  ),
+};

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
@@ -1,5 +1,6 @@
-import { SearchIcon, XIcon } from "lucide-react";
 import type React from "react";
+
+import { SearchIcon, XIcon } from "lucide-react";
 import {
   Autocomplete as AriaAutocomplete,
   type AutocompleteProps as AriaAutocompleteProps,
@@ -12,6 +13,39 @@ import {
 import { cn } from "tailwind-variants";
 
 import { Button } from "../button/button";
+
+interface AutocompleteSearchFieldProps extends AriaSearchFieldProps {
+  placeholder?: AriaInputProps["placeholder"];
+}
+
+function AutocompleteSearchField({
+  className,
+  placeholder,
+  ...props
+}: AutocompleteSearchFieldProps) {
+  return (
+    <AriaSearchField
+      className={cn("group flex items-center overflow-hidden text-sm", className)}
+      aria-label="Search"
+      {...props}
+    >
+      <SearchIcon aria-hidden className="m-2 size-3.5 text-neutral-400" />
+      <AriaInput
+        className="min-w-0 flex-1 border-none outline-hidden placeholder:text-neutral-400 [&::-webkit-search-cancel-button]:hidden"
+        placeholder={placeholder}
+      />
+      <Button
+        slot="remove"
+        variant="ghost"
+        shape="square"
+        size="xxs"
+        className="opacity-50 hover:opacity-100 group-data-empty:invisible"
+      >
+        <XIcon />
+      </Button>
+    </AriaSearchField>
+  );
+}
 
 export interface AutocompleteProps extends AriaAutocompleteProps {
   suffix?: React.ReactNode;
@@ -38,35 +72,5 @@ export function Autocomplete({
         {children}
       </div>
     </AriaAutocomplete>
-  );
-}
-
-interface SearchInputProps extends AriaSearchFieldProps {
-  placeholder?: AriaInputProps["placeholder"];
-}
-
-function AutocompleteSearchField({ className, placeholder, ...props }: SearchInputProps) {
-  return (
-    <AriaSearchField
-      className={cn("group flex items-center overflow-hidden text-sm", className)}
-      aria-label="Search"
-      autoFocus
-      {...props}
-    >
-      <SearchIcon aria-hidden className="m-2 size-3.5 text-neutral-400" />
-      <AriaInput
-        className="min-w-0 flex-1 border-none outline-hidden placeholder:text-neutral-400 [&::-webkit-search-cancel-button]:hidden"
-        placeholder={placeholder}
-      />
-      <Button
-        slot="remove"
-        variant="ghost"
-        shape="square"
-        size="xxs"
-        className="opacity-50 hover:opacity-100 group-data-empty:invisible"
-      >
-        <XIcon />
-      </Button>
-    </AriaSearchField>
   );
 }

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
@@ -27,6 +27,7 @@ function AutocompleteSearchField({
     <AriaSearchField
       className={cn("group flex items-center overflow-hidden text-sm", className)}
       aria-label="Search"
+      autoFocus
       {...props}
     >
       <SearchIcon aria-hidden className="m-2 size-3.5 text-neutral-400" />

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@infrahub/ui";
 import { SearchIcon, XIcon } from "lucide-react";
 import type React from "react";
 import {
@@ -10,11 +9,11 @@ import {
   type SearchFieldProps as AriaSearchFieldProps,
   useFilter,
 } from "react-aria-components";
+import { cn } from "tailwind-variants";
 
-import { Row } from "@/shared/components/container";
-import { classNames } from "@/shared/utils/common";
+import { Button } from "../button/button";
 
-interface AutocompleteProps extends AriaAutocompleteProps {
+export interface AutocompleteProps extends AriaAutocompleteProps {
   suffix?: React.ReactNode;
 }
 
@@ -32,10 +31,10 @@ export function Autocomplete({
   return (
     <AriaAutocomplete filter={resolvedFilter} onInputChange={onInputChange} {...props}>
       <div className="max-h-[inherit] overflow-hidden">
-        <Row className="sticky w-full gap-0 overflow-hidden border-neutral-300 border-b pr-1">
+        <div className="sticky flex w-full items-center gap-0 overflow-hidden border-neutral-300 border-b pr-1">
           <AutocompleteSearchField placeholder="Search..." className="grow" />
           {suffix}
-        </Row>
+        </div>
         {children}
       </div>
     </AriaAutocomplete>
@@ -49,7 +48,7 @@ interface SearchInputProps extends AriaSearchFieldProps {
 function AutocompleteSearchField({ className, placeholder, ...props }: SearchInputProps) {
   return (
     <AriaSearchField
-      className={classNames("group flex items-center overflow-hidden text-sm", className)}
+      className={cn("group flex items-center overflow-hidden text-sm", className)}
       aria-label="Search"
       autoFocus
       {...props}

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
+export { Autocomplete, type AutocompleteProps } from "./components/autocomplete/autocomplete";
 export {
   Breadcrumb,
   type BreadcrumbProps,

--- a/tests/e2e/branches/test_branch_selector.py
+++ b/tests/e2e/branches/test_branch_selector.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 class TestBranchSelectorNotLoggedIn:
     async def test_cannot_create_a_branch_if_not_logged_in(self, page: Page) -> None:
         await page.goto("/")
-        await page.get_by_role("button", name="main").click()
+        await page.get_by_test_id("branch-selector-trigger").click()
         await expect(page.get_by_role("button", name="Create branch")).to_be_disabled()
 
         # to go branch list view
@@ -32,7 +32,7 @@ class TestBranchSelectorNotLoggedIn:
 
     async def test_no_quick_create_for_non_existent_branch(self, page: Page) -> None:
         await page.goto("/")
-        await page.get_by_role("button", name="main").click()
+        await page.get_by_test_id("branch-selector-trigger").click()
 
         non_existent_branch_name = "non-existent-branch-123"
         await page.get_by_placeholder("Search...").fill(non_existent_branch_name)
@@ -41,7 +41,7 @@ class TestBranchSelectorNotLoggedIn:
 
     async def test_search_and_switch_branch(self, page: Page, data_scenario_branches: ScenarioBranchesHandle) -> None:
         await page.goto("/")
-        await page.get_by_role("button", name="main").click()
+        await page.get_by_test_id("branch-selector-trigger").click()
 
         branch_list = page.get_by_label("branch list")
         await expect(branch_list.get_by_role("option", name="main default")).to_be_visible()
@@ -57,7 +57,7 @@ class TestBranchSelectorNotLoggedIn:
 class TestBranchSelectorLoggedInAsAdmin:
     async def test_create_a_branch_with_a_name_that_does_not_exist(self, admin_page: Page) -> None:
         await admin_page.goto("/")
-        await admin_page.get_by_role("button", name="main").click()
+        await admin_page.get_by_test_id("branch-selector-trigger").click()
         await admin_page.get_by_placeholder("Search...").fill("quick-branch-form")
         await admin_page.get_by_role("option", name="Create branch quick-branch-form").click()
         await expect(admin_page.get_by_label("New branch name *")).to_have_value("quick-branch-form")

--- a/tests/e2e/branches/test_branches.py
+++ b/tests/e2e/branches/test_branches.py
@@ -48,7 +48,7 @@ class TestBranchesCreationDeletion:
 
     async def test_should_create_a_new_branch(self, admin_page: Page, new_branch_name: str) -> None:
         await admin_page.goto("/")
-        await admin_page.get_by_role("button", name="main").click()
+        await admin_page.get_by_test_id("branch-selector-trigger").click()
         await admin_page.get_by_test_id("create-branch-button").click()
 
         # Form
@@ -63,7 +63,7 @@ class TestBranchesCreationDeletion:
 
     async def test_should_display_the_new_branch(self, admin_page: Page, existing_branch: str) -> None:
         await admin_page.goto("/")
-        await admin_page.get_by_role("button", name="main").click()
+        await admin_page.get_by_test_id("branch-selector-trigger").click()
         await expect(admin_page.get_by_label("branch list")).to_contain_text(existing_branch)
 
         await admin_page.get_by_role("link", name="View all branches").click()
@@ -123,7 +123,7 @@ class TestBranchesCreationDeletion:
 
             await expect(admin_page.get_by_role("heading", name="Branches")).to_be_visible()
             assert "/branches" in admin_page.url
-            await admin_page.get_by_role("button", name="main").click()
+            await admin_page.get_by_test_id("branch-selector-trigger").click()
             await expect(admin_page.get_by_label("branch list")).not_to_contain_text(branch)
         finally:
             with contextlib.suppress(Exception):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated Autocomplete to `@infrahub/ui` and updated app views to use it. Added Storybook coverage and updated branch selector tests.

- **New Features**
  - Added `Autocomplete` to `@infrahub/ui` (built on `react-aria-components`) with optional suffix and client/server filtering.
  - Exported `Autocomplete` and `AutocompleteProps`.
  - Added Storybook story with suffix button and empty state.

- **Refactors**
  - Replaced app imports with `@infrahub/ui` `Autocomplete` in branch selector, breadcrumbs, filter picker, and object autocomplete.
  - Switched to `cn` utility and simplified sticky header markup.
  - Updated `oxlint` to disable `jsx-a11y/no-autofocus` and `react-perf/jsx-no-jsx-as-prop`.
  - Updated e2e tests to use `data-testid="branch-selector-trigger"` for the branch selector.

<sup>Written for commit bbb08fbe796a59edfc31f6c6f846f13310b501fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

