### PR TITLE
fix(recompute): scope display label and HFID recompute to changed schema elements

### DIFF
--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/checklists/requirements.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Scope display label and HFID recompute on schema updates
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- The spec deliberately keeps internal mechanism names (scoper, deriver, module paths) out of scope; those decisions are recorded for the planning phase: shared scoping core extracted under `core/schema/`, display labels and HFIDs delivered together.
+- One assumption (FR-004 / change-set records node-level definition properties) is flagged for verification during planning before the design relies on it.

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/contracts/recompute-scoping.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/contracts/recompute-scoping.md
@@ -1,0 +1,111 @@
+# Contract: Display-label & HFID recompute scoping (internal backend interfaces)
+
+**Date**: 2026-06-19 · **Spec**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md)
+
+This feature exposes no new external (REST/GraphQL) surface. The contracts below are **internal** Python interfaces, expressed as signatures + behavioral guarantees so implementation and tests can be written against them. Per `dev/rules/code-doc-style.md`, shipped source carries no spec IDs — they appear here only.
+
+## 1. Shared scoping core — relocation
+
+**From**: `backend/infrahub/computed_attribute/scoping.py`
+**To**: `backend/infrahub/core/schema/recompute_scoping.py`
+
+Moved (shape-preserving, generalized where noted in `data-model.md`): `ChangedElementSet`, `DependencySet`, `RecomputeCandidate` (new generic), `DependencyDeriver` (protocol, generalized), `RecomputeScoper`, `RecomputeScopingReport`, `SkippedCandidate`, `_resolve_changed_elements`, and `IMPRECISE_READ_FIELDS`.
+
+**Guarantees**:
+- `computed_attribute`, `display_labels`, `hfid` import these from `core.schema.recompute_scoping`. No feature package imports another feature package for scoping.
+- The move is behavior-preserving: existing `backend/tests/unit/computed_attribute/test_scoping.py` and `backend/tests/component/computed_attribute/test_scoped_recompute_*.py` pass unchanged (adapting only import paths / `ComputedAttributeRef` shape, not assertions).
+
+## 2. `RecomputeScoper` (single entry point) — generalized
+
+**File**: `backend/infrahub/core/schema/recompute_scoping.py`
+
+```python
+class RecomputeScoper:
+    def __init__(self, *, derivers: Mapping[str, DependencyDeriver]) -> None: ...
+
+    def scope(
+        self,
+        *,
+        candidates: Sequence[RecomputeCandidate],
+        changed_elements: ChangedElementSet | None,
+    ) -> RecomputeScopingReport: ...
+```
+
+**Behavioral contract** (`scope`) — unchanged decision logic, generalized over candidate type:
+
+| Input condition | Required output | Requirement |
+|-----------------|-----------------|-------------|
+| `changed_elements is None` | `selected = all candidates`, `skipped = []`, `fallback_full_recompute = True` | FR-006, SC-005 |
+| candidate's `DependencySet.depends_on_everything` | candidate in `selected`; `fallback_full_recompute` stays `False`; others still evaluated | FR-005 |
+| `read_kinds ∩ (added_kinds ∪ removed_kinds) ≠ ∅` | candidate in `selected` | FR-003 |
+| `∃ kind: read_fields[kind] ∩ changed_fields[kind] ≠ ∅` | candidate in `selected` | FR-001, FR-002, FR-004 |
+| none of the above | candidate in `skipped` with reason | FR-001, FR-002, SC-001 |
+
+**Invariants**: `selected ∪ skipped == candidates`; `selected ∩ skipped == ∅`; per-candidate `depends_on_everything` does not set `fallback_full_recompute`; deterministic; no DB/network in `scope()`.
+
+## 3. `DependencyDeriver` implementations — new
+
+**Files**: `backend/infrahub/display_labels/scoping.py`, `backend/infrahub/hfid/scoping.py`
+
+```python
+class DisplayLabelDependencyDeriver:        # backed by DisplayLabels registry + DerivedFieldLookup
+    def __init__(self, *, template_nodes: Mapping[str, TemplateLabel],
+                 peer_kinds: Mapping[tuple[str, str], str],
+                 derived_fields: DerivedFieldLookup) -> None: ...
+    def derive(self, *, candidate: RecomputeCandidate) -> DependencySet: ...
+
+class HFIDDependencyDeriver:                 # backed by HFIDs registry + DerivedFieldLookup
+    def __init__(self, *, definitions: Mapping[str, HFIDDefinition],
+                 peer_kinds: Mapping[tuple[str, str], str],
+                 derived_fields: DerivedFieldLookup) -> None: ...
+    def derive(self, *, candidate: RecomputeCandidate) -> DependencySet: ...
+```
+
+**Guarantees** (both):
+- `derive()` is side-effect-free; reads only the injected metadata (no DB/network).
+- The returned `DependencySet.read_fields[owner_kind]` MUST include the owner's own definition token (`"display_labels"` / `"human_friendly_id"`) so a definition edit recomputes the kind (FR-004).
+- `read_fields` / `read_kinds` MUST cover owner attributes, traversed relationships, and peer fields reached through them (FR-003).
+- `depends_on_everything=True` MUST be set (never raise) when any read field satisfies `DerivedFieldLookup.is_derived(...)` — a peer's `display_label`/`hfid`, or a computed attribute on the read kind (FR-005).
+- Construction inputs are required (no optional collaborators) per `dev/rules/backend-component-design.md`.
+
+## 4. Setup-flow integration
+
+**Files**: `backend/infrahub/display_labels/tasks.py` (`display_labels_setup_jinja2`), `backend/infrahub/hfid/tasks.py` (`hfid_setup`)
+
+Each flow MUST:
+
+1. Accept `changed_elements: ChangedElementsPayload | None = None` and normalize via the shared `_resolve_changed_elements`.
+2. Build the candidate list for the branch (one candidate per kind that defines a display label / HFID).
+3. Construct the deriver (with the per-branch `DerivedFieldLookup`) and call `RecomputeScoper.scope(...)`.
+4. Proceed with the existing per-kind hash check + node sweep **only** for `report.selected` kinds.
+5. Log at info: selected count, total candidate count, and `fallback_full_recompute` (distinguish precise scoping from fallback — FR-009). Log skipped candidates + reasons at debug.
+
+**Guarantees**:
+- `changed_elements is None` ⇒ every kind that would recompute today still does; the per-kind hash check and per-node sweep are byte-for-byte unchanged (FR-006, FR-010, SC-005).
+- Branch scoping is applied before and independently of changed-element scoping; no cross-branch broadening (a test asserts this — Constitution II).
+- The per-node job flows (`process_display_label`, `process_hfid`, `trigger_update_display_labels`, `trigger_update_hfid`) are unchanged.
+- `BranchDeletedEvent` continues to flow with `changed_elements is None` ⇒ full recompute.
+
+## 5. Trigger wiring
+
+**Files**: `backend/infrahub/display_labels/triggers.py` (`TRIGGER_DISPLAY_LABELS_ALL_SCHEMA`), `backend/infrahub/hfid/triggers.py` (`TRIGGER_HFID_ALL_SCHEMA`)
+
+Add the `changed_elements` Prefect parameter to each `ExecuteWorkflow`, mirroring `TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA`:
+
+```jinja
+"changed_elements": {
+  "__prefect_kind": "json",
+  "value": {"__prefect_kind": "jinja",
+            "template": "{{ event.payload['data']['changed_elements'] | default(none, true) | tojson }}"}
+}
+```
+
+**Guarantees**: the payload round-trips through Prefect workflow parameters and is deserialized to `ChangedElementsPayload | None` at the flow boundary; absence yields `None`.
+
+## Out of scope (sibling tickets)
+
+- Merge/rebase paths emitting `changed_elements` — IFC-2758 / IFC-2761.
+- Per-node short-circuit before render/transform — IFC-2762.
+- Performance benchmarks for scoping — IFC-2746.
+- Transform computed attributes on Git import — IFC-2760.
+- Precise transitive resolution of derived reads (this feature is conservative: derived read ⇒ recompute always).

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/data-model.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/data-model.md
@@ -1,0 +1,131 @@
+# Phase 1 Data Model: Scope display label and HFID recompute on schema updates
+
+**Date**: 2026-06-19 · **Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+
+No persisted (Neo4j) data model changes. All entities are in-memory, derived per-branch from the active `SchemaBranch`, and transported via existing event/workflow payloads. Types are frozen dataclasses (internal) or Pydantic (transport), per Constitution III.
+
+## Existing types reused (from PR #9467)
+
+These move to `backend/infrahub/core/schema/recompute_scoping.py` unchanged in shape:
+
+### `ChangedElementsPayload` (Pydantic, transport — stays in `events/schema_action.py`)
+
+```python
+class ChangedElementsPayload(BaseModel):
+    added_kinds: list[str]
+    removed_kinds: list[str]
+    changed_fields: dict[str, list[str]]   # kind -> changed attribute/relationship/property names
+```
+
+Already populated on `SchemaUpdatedEvent`. `None` ⇒ full recompute. Node-level definition properties (`display_labels`, `human_friendly_id`) appear in `changed_fields[kind]` under their own name (see research R1).
+
+### `ChangedElementSet` (frozen dataclass, internal)
+
+```python
+@dataclass(frozen=True)
+class ChangedElementSet:
+    added_kinds: frozenset[str]
+    removed_kinds: frozenset[str]
+    changed_fields: Mapping[str, frozenset[str]]
+
+    @classmethod
+    def from_payload(cls, payload: ChangedElementsPayload) -> ChangedElementSet: ...
+```
+
+### `DependencySet` (frozen dataclass, internal)
+
+```python
+@dataclass(frozen=True)
+class DependencySet:
+    owner_kind: str
+    name: str                                   # derived value identity (attribute name / "display_labels" / "human_friendly_id")
+    read_kinds: frozenset[str] = frozenset()
+    read_fields: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    depends_on_everything: bool = False
+```
+
+> Generalized from the computed-attribute version: `attribute_name` → `name`, `kind` (enum) dropped from the set itself (moved to the candidate). The own field (`owner_kind`, `name`) is always present in `read_fields[owner_kind]`.
+
+### `RecomputeScopingReport` / `SkippedAttribute` (frozen dataclasses, internal)
+
+```python
+@dataclass(frozen=True)
+class SkippedCandidate:           # renamed from SkippedAttribute (generalized)
+    candidate: RecomputeCandidate
+    reason: str
+
+@dataclass(frozen=True)
+class RecomputeScopingReport:
+    selected: list[RecomputeCandidate]
+    skipped: list[SkippedCandidate]
+    fallback_full_recompute: bool
+```
+
+## New / generalized types
+
+### `RecomputeCandidate` (frozen dataclass, internal) — NEW
+
+```python
+@dataclass(frozen=True)
+class RecomputeCandidate:
+    branch: str
+    kind: str            # owner kind
+    name: str            # derived-value identity: attribute name, or "display_labels" / "human_friendly_id"
+    deriver_key: str     # selects the deriver in RecomputeScoper.derivers
+```
+
+`ComputedAttributeRef` is retained for the computed-attribute call sites and adapts to this shape (keeps `branch`, `kind`, `attribute_name`, `computed_kind`; exposes `name`/`deriver_key` so existing tests and code keep working).
+
+**Deriver keys** (string constants):
+
+| Subsystem | `deriver_key` | `name` value |
+|-----------|---------------|--------------|
+| Computed attr (Jinja2) | `computed_attribute.jinja2` | attribute name |
+| Computed attr (Python) | `computed_attribute.python` | attribute name |
+| Display label | `display_label` | `"display_labels"` |
+| HFID | `hfid` | `"human_friendly_id"` |
+
+### `DependencyDeriver` (Protocol, internal) — generalized
+
+```python
+class DependencyDeriver(Protocol):
+    def derive(self, *, candidate: RecomputeCandidate) -> DependencySet: ...
+```
+
+Implementations: `Jinja2DependencyDeriver`, `PythonTransformDependencyDeriver` (existing, signature adapted), `DisplayLabelDependencyDeriver` (new), `HFIDDependencyDeriver` (new).
+
+### `DerivedFieldLookup` (frozen dataclass, internal) — NEW
+
+Injected into the display-label and HFID derivers so they can flag reads of derived values (research R5).
+
+```python
+@dataclass(frozen=True)
+class DerivedFieldLookup:
+    computed_attributes: frozenset[tuple[str, str]]   # (kind, attribute_name) pairs that are computed
+    imprecise_read_fields: frozenset[str] = IMPRECISE_READ_FIELDS   # {"display_label", "hfid"}
+
+    def is_derived(self, *, kind: str, field: str) -> bool:
+        return field in self.imprecise_read_fields or (kind, field) in self.computed_attributes
+```
+
+## Entity relationships
+
+```text
+SchemaUpdatedEvent ──carries──> ChangedElementsPayload ──from_payload──> ChangedElementSet
+                                                                              │
+RecomputeCandidate ──deriver_key selects──> DependencyDeriver ──derive──> DependencySet
+                                                   │ (display/hfid)             │
+                                          DerivedFieldLookup ─────────────────┘ (sets depends_on_everything)
+                                                                              │
+RecomputeScoper.scope(candidates, ChangedElementSet) ──intersect──> RecomputeScopingReport
+                                                                       ├─ selected ─> submit recompute (existing per-kind sweep)
+                                                                       └─ skipped  ─> info/debug log
+```
+
+## Validation / invariants
+
+- `selected ∪ skipped == candidates`; `selected ∩ skipped == ∅`.
+- A per-candidate `depends_on_everything` selects that candidate but MUST NOT set `fallback_full_recompute` (one opaque candidate does not disable scoping for the branch).
+- `changed_elements is None` ⇒ `selected == candidates`, `fallback_full_recompute == True`.
+- `derive()` is pure: reads only injected data (registries / lookups), no DB or network.
+- Display-label and HFID candidates for the same kind are independent rows; a change touching one does not select the other (FR-007).

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/plan.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Scope display label and HFID recompute on schema updates
+
+**Branch**: `scope-label-hfid-recompute-ifc-2759` | **Date**: 2026-06-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/ifc-2759-scope-label-hfid-recompute/spec.md`
+
+## Summary
+
+On a schema update, display label and HFID backfill re-sweep every node of every kind whose definition differs from the default branch, with no dependency check. The computed-attribute work (PR #9467, now on `develop`) already solved this: it carries the changed-element set on `SchemaUpdatedEvent`, derives each computed attribute's dependency set, and intersects the two to recompute only impacted attributes. Display labels and HFIDs were left out and still sweep on any schema change.
+
+This feature brings display labels and HFIDs to parity. Technical approach:
+
+1. **Extract the scoping core to a shared module.** Move `DependencySet`, `ChangedElementSet`, `RecomputeScoper`, `RecomputeScopingReport`, `SkippedAttribute`, and a generalized candidate/deriver protocol out of `backend/infrahub/computed_attribute/scoping.py` into `backend/infrahub/core/schema/recompute_scoping.py`. `computed_attribute`, `display_labels`, and `hfid` all import from `core`. This is a behavior-preserving refactor; the existing computed-attribute unit + component scoping tests are the regression guard and must pass unchanged.
+2. **Add a display-label deriver and an HFID deriver.** Each maps its existing dependency metadata (`TemplateLabel` / `HFIDDefinition`: `attributes`, `relationships`, `relationship_fields`, inverse relationship triggers) into a `DependencySet`. The set includes the owner kind's own definition property (`display_labels` / `human_friendly_id`) so an edit to the definition itself recomputes the kind. When a read resolves to a derived value (a peer's `display_label`/`hfid`, or a computed attribute on the read kind), the deriver sets `depends_on_everything=True` (conservative; never skips a needed recompute).
+3. **Thread `changed_elements` into the setup flows.** Add the `changed_elements` Jinja parameter to `TRIGGER_DISPLAY_LABELS_ALL_SCHEMA` and `TRIGGER_HFID_ALL_SCHEMA` (mirroring `TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA`); add `changed_elements: ChangedElementsPayload | None = None` to `display_labels_setup_jinja2` and `hfid_setup`; resolve it via the shared helper.
+4. **Scope before the existing sweep.** In each setup flow, build candidates for the branch, call `RecomputeScoper.scope(...)`, and proceed with the existing per-kind hash check + node sweep only for selected kinds. When `changed_elements is None`, fall back to today's full behavior.
+5. **Observability.** Log, at info level, the scoping decision: selected count, total candidate count, and whether the run was a full-recompute fallback — matching the computed-attribute log line.
+
+Recompute remains asynchronous and branch-aware; the per-node sweep within a selected kind is unchanged (per-node short-circuiting is IFC-2762, out of scope).
+
+## Technical Context
+
+**Language/Version**: Python 3.14
+**Primary Dependencies**: FastAPI, Prefect (workflows/triggers), Neo4j 2026.05 (driver 6.2), Pydantic 2.12
+**Storage**: Neo4j (graph) — no new persisted data model; dependency sets are derived in-memory from the active `SchemaBranch`
+**Testing**: pytest 9.0 — unit (`backend/tests/unit/display_labels/`, `backend/tests/unit/hfid/`, `backend/tests/unit/computed_attribute/`), component (`backend/tests/component/display_labels/`, `backend/tests/component/hfid/`), functional (`backend/tests/functional/display_labels/`, `backend/tests/functional/hfid/`), integration_docker
+**Target Platform**: Linux server (backend task workers / Prefect)
+**Project Type**: Web service backend (single backend project; no frontend change)
+**Observability**: Recompute task logs — info-level summary distinguishing precise scoping from full-recompute fallback (selected count / total candidates / `fallback_full_recompute`). No new metric/event channel.
+**Performance Goals**: Display-label/HFID recompute after a scoped schema update scales with the number of impacted kinds, not the total number of kinds defining a display label or HFID (SC-002). A change touching unrelated elements produces zero recompute for unaffected kinds (SC-001).
+**Constraints**: Asynchronous / eventually consistent. Correctness over optimization — never skip a needed recompute; mark imprecise and recompute when a dependency cannot be determined (FR-005). Branch isolation preserved. Behavior-preserving on the `changed_elements is None` fallback path (SC-005).
+**Scale/Scope**: Branches may hold thousands of nodes across many kinds; the defect is most visible on large datasets. Change is confined to a new shared scoping module under `core/schema/`, the `display_labels` and `hfid` packages, and their triggers — plus a behavior-preserving move of the existing scoping core out of `computed_attribute`.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Gates derived from `.specify/memory/constitution.md` (v1.0.0). Frontend principles are **N/A** (backend-only feature, no UI surface).
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. Schema-Driven Integrity | Dependency sets derived read-only from the active `SchemaBranch`; no manual edits to generated files; derived values still flow through the schema layer. | PASS — read-only schema use; no generated-file edits. |
+| II. Branch-Safe by Default | Scoping must remain branch-aware; the no-change-set fallback (merge/rebase/git paths) must preserve today's behavior; no cross-branch broadening. | PASS *with required coverage* — fallback path preserved (FR-006); a test MUST assert the `changed_elements is None` path is unchanged and that scoping does not broaden across branches. Merge/rebase emitting a change set is explicitly out of scope (IFC-2758/IFC-2761). |
+| III. Type Safety & Explicit Contracts | Type hints on all new code; frozen dataclasses for internal data (candidate, dependency set, report); `str \| None` style; no untyped dicts for structured data. | PASS — contracts defined as frozen dataclasses (see `contracts/`). |
+| IV. Test Discipline | Display-label/HFID + triggered-action work requires component coverage; integration_docker is required for triggered-action/computed paths. Reuse existing fixtures; tests mirror source. | PASS — unit (derivers + generic scoper), component (setup-flow scoping for both subsystems mirroring `test_scoped_recompute_jinja2.py`), and an integration_docker assertion that a scoped schema change refreshes only affected kinds. Existing full-sweep optimization tests retained as the fallback guard. |
+| V. Query Performance & Efficiency | The feature reduces submitted jobs/queries; no new N+1; derivation is in-memory over already-loaded schema. | PASS — fewer recompute submissions; deriver work is in-memory lookups. |
+| VI. Security & Input Boundaries | No new external input surface; the schema and template/path text consulted is operator-authored and already in the system. | PASS — no new injection surface; no auth change. |
+| VII. Simplicity & Maintainability | Reuse the existing scoper rather than building a parallel one (the extraction is justified because a third + fourth caller now exist — clears the "two callers" bar). Follow DI / single-entry-point component design. Keep the per-node sweep untouched. | PASS — extraction now serves ≥2 callers; new derivers are the minimal additions; no premature abstraction. |
+
+No violations. **Required-coverage note (Principle II):** the `changed_elements is None` fallback-equivalence test and a no-cross-branch-broadening assertion are mandatory for completion; `tasks.md` must carry them. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/ifc-2759-scope-label-hfid-recompute/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── recompute-scoping.md
+├── checklists/
+│   └── requirements.md  # /speckit-specify output
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+backend/infrahub/
+├── core/schema/
+│   ├── recompute_scoping.py            # NEW — shared scoping core (moved from computed_attribute/scoping.py)
+│   ├── schema_branch_display.py        # existing — TemplateLabel / DisplayLabels dependency metadata (read)
+│   ├── schema_branch_hfid.py           # existing — HFIDDefinition / HFIDs dependency metadata (read)
+│   └── schema_branch_computed/
+│       └── python_transform.py         # existing — IMPRECISE_READ_FIELDS (may relocate to core)
+├── computed_attribute/
+│   ├── scoping.py                      # CHANGED — keeps Jinja2/Python derivers; imports core for moved types
+│   ├── tasks.py                        # unchanged behavior (imports follow the move)
+│   └── triggers.py                     # unchanged
+├── display_labels/
+│   ├── scoping.py                      # NEW — DisplayLabelDependencyDeriver + candidate builder
+│   ├── tasks.py                        # CHANGED — display_labels_setup_jinja2 gains changed_elements + scoper call
+│   └── triggers.py                     # CHANGED — TRIGGER_DISPLAY_LABELS_ALL_SCHEMA threads changed_elements
+└── hfid/
+    ├── scoping.py                      # NEW — HFIDDependencyDeriver + candidate builder
+    ├── tasks.py                        # CHANGED — hfid_setup gains changed_elements + scoper call
+    └── triggers.py                     # CHANGED — TRIGGER_HFID_ALL_SCHEMA threads changed_elements
+
+backend/tests/
+├── unit/
+│   ├── computed_attribute/test_scoping.py        # existing — regression guard for the move
+│   ├── display_labels/test_scoping.py            # NEW — DisplayLabelDependencyDeriver + scoper cases
+│   └── hfid/test_scoping.py                       # NEW — HFIDDependencyDeriver + scoper cases
+├── component/
+│   ├── computed_attribute/test_scoped_recompute_*.py   # existing — template to mirror
+│   ├── display_labels/test_scoped_recompute.py   # NEW — setup-flow scoping via WorkflowRecorder
+│   └── hfid/test_scoped_recompute.py             # NEW — setup-flow scoping via WorkflowRecorder
+├── functional/
+│   ├── display_labels/test_display_label_task_optimization.py  # existing — fallback guard
+│   └── hfid/test_hfid_task_optimization.py                     # existing — fallback guard
+└── integration_docker/                            # scoped-refresh assertion (affected kinds only)
+```
+
+**Structure Decision**: Single backend project. The scoping core moves to `core/schema/recompute_scoping.py` so all three feature packages depend inward on `core` rather than on each other. Each feature package gets its own `scoping.py` holding only its deriver + candidate construction, mirroring how `computed_attribute` is organized after the move.
+
+## Complexity Tracking
+
+> No constitution violations. Section intentionally empty.

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/quickstart.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart & Validation Scenarios: Scope display label and HFID recompute
+
+**Date**: 2026-06-19 · **Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+
+Acceptance scenarios mapped to concrete validations. Each maps to a spec requirement and a test level. "DL" = display label, "HFID" = human-friendly ID.
+
+## Developer setup
+
+```bash
+uv sync --all-groups
+# Unit (fast, no DB)
+uv run pytest backend/tests/unit/display_labels/test_scoping.py backend/tests/unit/hfid/test_scoping.py -q
+# Component (TestContainers)
+uv run pytest backend/tests/component/display_labels/test_scoped_recompute.py backend/tests/component/hfid/test_scoped_recompute.py -q
+# Regression guard (the move must not change computed-attribute behavior)
+uv run pytest backend/tests/unit/computed_attribute/test_scoping.py backend/tests/component/computed_attribute -q
+# Fallback guard (existing full-sweep behavior unchanged)
+uv run pytest backend/tests/functional/display_labels/test_display_label_task_optimization.py backend/tests/functional/hfid/test_hfid_task_optimization.py -q
+uv run invoke backend.test-unit
+```
+
+## Validation scenarios
+
+### A. Unrelated change → zero recompute (P1, FR-001/FR-002, SC-001)
+- **Given** kinds with DLs/HFIDs, **when** a schema update changes an attribute no DL/HFID reads,
+- **Then** `RecomputeScoper.scope` returns those candidates in `skipped`, and the setup flow submits **no** `TRIGGER_UPDATE_DISPLAY_LABELS` / `TRIGGER_UPDATE_HFID` for them.
+- **Test**: component (`WorkflowRecorder` — assert empty submission set), unit (scoper case).
+
+### B. Owner attribute read change → recompute (P1, FR-003)
+- **Given** a kind whose DL reads `name`, **when** `name` changes,
+- **Then** that kind's DL candidate is `selected` and its update workflow is submitted.
+- **Test**: component + unit (both subsystems).
+
+### C. Relationship peer-field change → recompute (P1, FR-003)
+- **Given** a kind whose HFID reads `owner__name`, **when** the peer `name` changes,
+- **Then** the HFID candidate is `selected`.
+- **Test**: component (relationship dataset) + unit.
+
+### D. Definition's own edit → recompute (P1, FR-004)
+- **Given** a kind, **when** the schema update changes only its `display_labels` / `human_friendly_id` property,
+- **Then** `changed_fields[kind]` contains `"display_labels"` / `"human_friendly_id"`, the deriver's own-field dependency intersects it, and the candidate is `selected`.
+- **Test**: unit asserting both the payload token (guards research R1) and selection.
+
+### E. Reads a derived value → always recompute (P1, FR-005)
+- **Given** a DL reading `site__display_label`, or an HFID path resolving to a computed attribute, **when** any schema element changes,
+- **Then** the deriver returns `depends_on_everything=True` and the candidate is `selected`; `fallback_full_recompute` stays `False`.
+- **Test**: unit (`DerivedFieldLookup.is_derived` true) for both the `IMPRECISE_READ_FIELDS` case and the computed-attribute-read case.
+
+### F. No change set → full fallback, unchanged behavior (P2, FR-006, SC-005)
+- **Given** a setup invoked with `changed_elements=None` (e.g. branch deletion), **when** it runs,
+- **Then** every candidate is `selected`, `fallback_full_recompute=True`, and the existing per-kind hash check + node sweep behave exactly as today.
+- **Test**: existing `test_*_task_optimization.py` pass unchanged + a scoper unit case.
+
+### G. DL and HFID scoped independently (FR-007)
+- **Given** a kind with both a DL and an HFID with different dependency sets, **when** a change touches only the HFID's dependency,
+- **Then** the HFID candidate is `selected` and the DL candidate is `skipped` (and vice versa).
+- **Test**: unit + component.
+
+### H. Branch isolation (Constitution II — mandatory)
+- **Given** a schema change on branch X, **when** scoping runs,
+- **Then** no recompute is submitted for kinds on other branches; changed-element scoping does not broaden branch scope.
+- **Test**: component assertion.
+
+### I. End-to-end scoped refresh (Constitution IV — integration_docker)
+- **Given** a running stack with nodes across several kinds, **when** a schema update changes one read field,
+- **Then** only the affected kinds' stored DL/HFID values change; unaffected kinds' values and recompute activity are untouched.
+- **Test**: integration_docker.
+
+### J. Empty / no-op change set (edge)
+- **Given** a present-but-empty `ChangedElementSet`, **when** scoping runs,
+- **Then** every candidate is `skipped` (no own-field, no read overlap) — zero submissions.
+- **Test**: unit.
+
+## Definition of done
+
+- Scenarios A–J covered at the stated levels; all green.
+- Regression guard (computed-attribute scoping) and fallback guard (task-optimization) pass unchanged.
+- `uv run invoke format lint` and `uv run pytest backend/tests/unit` clean; `mypy` clean on changed files.
+- No edits to generated files. No new external dependencies.
+- A changelog fragment added under `changelog/` (issue-linked naming per project convention).

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/research.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/research.md
@@ -1,0 +1,95 @@
+# Phase 0 Research: Scope display label and HFID recompute on schema updates
+
+**Date**: 2026-06-19 · **Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+
+All findings are grounded in the current `develop` tree (PR #9467 already merged). File:line references are anchors, not contracts.
+
+## R1. Does the change-set payload capture display-label / HFID definition edits? (resolves the load-bearing assumption)
+
+**Decision**: Yes. The deriver's own-definition dependency uses the NodeSchema property tokens `display_labels` (display labels) and `human_friendly_id` (HFIDs).
+
+**Evidence**:
+- `build_changed_elements_payload` (`backend/infrahub/events/schema_action.py:30-59`) flattens attribute/relationship element buckets but keeps **node-level scalar fields under their own name** (`else: names.add(field_name)`, line 51-52).
+- NodeSchema defines these node-level properties: `human_friendly_id: list[str] | None` (`backend/infrahub/core/schema/generated/base_node_schema.py:56`) and `display_labels: list[str] | None` (line 66).
+- Therefore an edit to a kind's display-label or HFID definition surfaces in `changed_fields[kind]` as `"display_labels"` / `"human_friendly_id"`.
+
+**Consequence**: `DisplayLabelDependencyDeriver` must include `"display_labels"` in `read_fields[owner_kind]`; `HFIDDependencyDeriver` must include `"human_friendly_id"`. This satisfies FR-004.
+
+**Verification task**: a unit test asserts that editing only the definition yields a `changed_fields` entry containing the exact token, and that the deriver's set intersects it. Do not hardcode the token in two places without that test — if the diff ever keys these differently, the test fails loudly rather than silently skipping recompute.
+
+## R2. How to generalize the scoper without breaking the computed-attribute path
+
+**Decision**: Extract the candidate-generic core to `backend/infrahub/core/schema/recompute_scoping.py`; keep the Jinja2/Python derivers in `computed_attribute/scoping.py` importing from core. Make the scoper accept a generic `RecomputeCandidate` and select derivers by a string `deriver_key`.
+
+**Rationale**:
+- The current `RecomputeScoper.scope()` keys derivers by `ComputedAttributeKind` and reads `candidate.kind` / `candidate.attribute_name` for the own-definition check (`computed_attribute/scoping.py:112-184`). Generalizing the key to a string and the candidate to `{branch, kind, name, deriver_key}` removes the computed-attribute coupling while preserving the decision logic verbatim.
+- `ComputedAttributeRef` is retained (its existing fields) and adapted to the generic candidate so the existing unit tests (`backend/tests/unit/computed_attribute/test_scoping.py`) and component tests (`test_scoped_recompute_jinja2.py`, `test_scoped_recompute_python.py`) keep compiling and passing — this is the behavior-preserving guard.
+- Module direction: `core/schema` is imported by feature packages, never the reverse. Putting the core in `computed_attribute` would force `display_labels`/`hfid` to depend on an unrelated feature.
+
+**Alternatives considered**:
+- *Import the core from `computed_attribute`*: rejected — backwards dependency, violates the layering the rest of the codebase follows.
+- *Reuse `ComputedAttributeRef` with synthetic attribute names (`"display_label"`)*: rejected — overloads a computed-attribute type for non-attributes; confusing in reports and logs.
+- *A second, parallel scoper*: rejected by Constitution VII (no parallel implementation of the same decision) and the ticket's own "generalize the scoper" instruction.
+
+**IMPRECISE_READ_FIELDS placement**: currently `frozenset({"display_label", "hfid"})` in `schema_branch_computed/python_transform.py:19`, imported by `computed_attribute/scoping.py:20`. Since three deriver families now consult it, relocate it to `core/schema/recompute_scoping.py` and re-import where used. Behavior-preserving.
+
+## R3. Display-label dependency derivation
+
+**Decision**: `DisplayLabelDependencyDeriver.derive(candidate)` maps `TemplateLabel` → `DependencySet`:
+- `read_fields[owner_kind]` = `attributes ∪ {"display_labels"}` (own definition).
+- For each relationship in `relationships`, add the relationship name to `read_fields[owner_kind]` and the peer fields from `relationship_fields[rel]` to `read_fields[peer_kind]`, with `peer_kind` resolved from the schema.
+- `read_kinds` = owner kind ∪ peer kinds reached.
+- `depends_on_everything=True` when any read field is a derived value (see R5).
+
+**Evidence**: `TemplateLabel{template, attributes, relationships, relationship_fields, get_hash}` and the `DisplayLabels` registry accessors (`get_template_nodes()`, `get_related_trigger_nodes()`, `get_related_template()`) in `backend/infrahub/core/schema/schema_branch_display.py:12-135`. The inverse relationship triggers (`RelationshipTriggers`) already encode "peer kind change → owner recompute", which is the same edge the dependency intersection needs.
+
+**Candidate source**: the kinds with a display label come from `DisplayLabels.get_template_nodes()`; the setup flow already enumerates these.
+
+## R4. HFID dependency derivation
+
+**Decision**: `HFIDDependencyDeriver.derive(candidate)` maps `HFIDDefinition` → `DependencySet` identically to R3, with `"human_friendly_id"` as the own-definition token and `relationship_fields` for peer reads.
+
+**Evidence**: `HFIDDefinition{hfid, attributes, relationships, relationship_fields, filter_key, fields, has_related_components, get_hash}` and the `HFIDs` registry (`get_node_definition()`, `get_template_nodes()`, `get_related_trigger_nodes()`, `get_related_definition()`) in `backend/infrahub/core/schema/schema_branch_hfid.py:12-120`. HFID composition is a list of schema paths (`["name__value", "owner__name__value"]`) decomposed into `attributes` / `relationships` / `relationship_fields` at registration (`register_hfid_schema_path`, lines 63-91) — the same shape the display-label path uses, which is why one deriver implementation pattern serves both.
+
+**Divergence from display labels (R5)**: HFID path components are plain attribute names with no marker for "this attribute is itself computed", so the derived-value check must consult the schema's computed-attribute set, not just `IMPRECISE_READ_FIELDS`.
+
+## R5. Transitive / derived-value hazard
+
+**Decision**: A deriver marks `depends_on_everything=True` when any read field resolves to a derived value on its kind. "Derived value" = the pseudo-fields `display_label` / `hfid` (a peer's computed identity, matched against `IMPRECISE_READ_FIELDS`) **or** a computed attribute defined on the read kind. Inject a `derived_fields` lookup — `set[tuple[str, str]]` of `(kind, field_name)` for computed attributes, plus the `IMPRECISE_READ_FIELDS` tokens — built once per branch from the schema and passed to the deriver at construction.
+
+**Rationale**: Correctness over precision (FR-005, Constitution IV/V tie-break toward correctness). The existing computed-attribute Jinja2 deriver already uses the `IMPRECISE_READ_FIELDS` shortcut (`computed_attribute/scoping.py:271`); this generalizes the same posture and additionally covers an HFID/display-label that reads a computed attribute — which the spec explicitly calls out.
+
+**Alternatives considered**:
+- *Precise transitive resolution (recurse into the derived value's own dependencies)*: rejected for this ticket — higher complexity and risk; the conservative "always recompute" is correct and matches #9467's posture. A future precision pass can replace it without changing the contract.
+- *Ignore the computed-attribute-read case (only check `IMPRECISE_READ_FIELDS`)*: rejected — leaves a real staleness hole for HFIDs/labels reading a computed attribute, which FR-005 forbids.
+
+**Scope note**: this is the only genuinely new logic versus the computed-attribute path and the documented divergence point if HFID detection proves harder than display-label detection (the ticket allows a split; the plan keeps them together because the `derived_fields` lookup serves both).
+
+## R6. Threading `changed_elements` into the setup flows
+
+**Decision**: Mirror `TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA` exactly.
+
+**Evidence / pattern**: `computed_attribute/triggers.py:29-70` passes `changed_elements` via a Prefect Jinja parameter (`{{ event.payload['data']['changed_elements'] | default(none, true) | tojson }}`), and `computed_attribute_setup_jinja2/python` accept `changed_elements: ChangedElementsPayload | None = None` and normalize via `_resolve_changed_elements` (`computed_attribute/tasks.py:85-97`). The display-label and HFID triggers (`display_labels/triggers.py:6-22`, `hfid/triggers.py:6-22`) currently omit this parameter; the setup flows (`display_labels/tasks.py:136`, `hfid/tasks.py:131`) omit the argument.
+
+**Decision detail**: move `_resolve_changed_elements` to the shared `core/schema/recompute_scoping.py` so all three flows use one normalizer.
+
+## R7. Interaction with the existing hash-vs-default check
+
+**Decision**: Scoping is an additional filter applied **before** the existing per-kind hash check and node sweep. A kind is processed only if (a) its dependency set intersects the change set (or it depends on everything / the change set is `None`), and then (b) the existing hash check still applies as today.
+
+**Evidence**: display labels skip a kind unless its `template_hash` differs from default (`display_labels/tasks.py:162-178`); HFID compares `hfid_hash` (`hfid/tasks.py:154-171`). These are orthogonal to dependency scoping and stay in place. The new scoping only narrows the candidate set fed into that existing logic; on the `None` fallback path the candidate set is unchanged, so behavior is identical (SC-005).
+
+## R8. Test strategy
+
+**Decision**:
+- **Unit** (`tests/unit/display_labels/test_scoping.py`, `tests/unit/hfid/test_scoping.py`): exercise each deriver and the generic scoper with a `CannedDeriver`-style fixture (the pattern in `tests/unit/computed_attribute/test_scoping.py`). Cases: hit via own definition, via owner attribute, via relationship peer field, via added/removed kind; skip on no overlap; `depends_on_everything` always selected; `changed_elements is None` → fallback.
+- **Component** (`tests/component/display_labels/test_scoped_recompute.py`, `tests/component/hfid/test_scoped_recompute.py`): mirror `tests/component/computed_attribute/test_scoped_recompute_jinja2.py` using `ScopedRecomputeTestBase` + `WorkflowRecorder`; assert submitted kinds for an unrelated change (zero) vs. a read-field change (recomputed), including across a relationship.
+- **Fallback guard**: the existing `tests/functional/display_labels/test_display_label_task_optimization.py` and `tests/functional/hfid/test_hfid_task_optimization.py` (which assert the full sweep) must pass unchanged on the `changed_elements is None` path.
+- **integration_docker**: one assertion that a scoped schema change refreshes only the affected kinds' labels/HFIDs end-to-end (Constitution IV requires integration_docker for triggered-action paths).
+
+**Rationale**: reuses established adapters (`WorkflowRecorder`, `ScopedRecomputeTestBase`) per Constitution IV (no mocks; adapter pattern). No new test infrastructure.
+
+## Open items carried into tasks
+
+- Confirm the exact peer-kind resolution from a relationship name in both registries (whether the deriver reads peer kind from `RelationshipIdentifier`/`relationship_fields` or must look it up on the schema). Cheap to resolve at implementation; does not change the contract.
+- Confirm `BranchDeletedEvent` continues to flow as `changed_elements is None` for both subsystems (it shares the trigger event set) — full recompute on branch deletion is the intended fallback.

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/spec.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Scope display label and HFID recompute on schema updates
+
+**Feature Branch**: `scope-label-hfid-recompute-ifc-2759`
+**Created**: 2026-06-19
+**Status**: Draft
+**Jira**: [IFC-2759](https://opsmill.atlassian.net/browse/IFC-2759) (epic [IFC-2705](https://opsmill.atlassian.net/browse/IFC-2705))
+**Input**: Scope display label and HFID recompute on schema updates to only the changed schema elements, mirroring the computed-attribute scoping landed in PR #9467.
+
+## Overview
+
+When a schema update is applied to a branch, Infrahub refreshes the stored derived values of affected nodes. For computed attributes this refresh is now *scoped*: only attributes whose declared dependencies intersect the elements that actually changed are recomputed (PR #9467). Display labels and human-friendly IDs (HFIDs) were left out of that work. Today, on any schema change, they re-sweep every node of every kind whose definition differs from the default branch, with no dependency check. On large instances this produces the same over-recompute the computed-attribute work eliminated: a one-field schema edit can trigger a recompute pass across unrelated kinds, costing minutes of degraded instance time.
+
+This feature brings display labels and HFIDs to parity with computed attributes: a schema update recomputes a kind's display label or HFID only when the change touches something that label or HFID actually reads.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Unrelated schema change does not trigger label/HFID recompute (Priority: P1)
+
+An operator updates the schema on an instance that defines display labels and HFIDs across many kinds. The change touches one attribute on one kind that no other kind's display label or HFID reads. After the update, the system must not recompute display labels or HFIDs for the unrelated kinds.
+
+**Why this priority**: This is the performance win the epic exists for. Without it, every schema edit pays a full label/HFID sweep proportional to the total number of kinds, regardless of relevance.
+
+**Independent Test**: Apply a schema update that changes only an element no display label or HFID depends on, and confirm that zero label/HFID recompute work is submitted for the kinds whose dependency sets do not intersect the change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a schema with display labels and HFIDs on multiple kinds, **When** a schema update changes an attribute that no kind's display label or HFID reads, **Then** no display-label or HFID recompute is submitted for any kind.
+2. **Given** a schema update touching only kind A's internal field, **When** kind B's display label and HFID read nothing from kind A, **Then** kind B's display label and HFID are not recomputed.
+
+---
+
+### User Story 2 - A change to a read element still refreshes the affected label/HFID (Priority: P1)
+
+An operator changes an element that a display label or HFID does read — either directly on the owning kind, or on a related kind reachable through a relationship the label/HFID traverses. The affected derived values must still be recomputed. Correctness must not regress in the name of scoping.
+
+**Why this priority**: Scoping that skips a value it should have refreshed produces silent stale data, which is worse than over-recompute. This is the correctness guardrail that makes Story 1 safe to ship.
+
+**Independent Test**: For each dependency kind (direct attribute, relationship, peer field across a relationship, the definition itself), apply a schema change to that element and confirm the affected kind's display label / HFID is recomputed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a kind whose display label reads attribute `name`, **When** a schema update changes `name`, **Then** that kind's display label is recomputed.
+2. **Given** a kind whose HFID reads a peer attribute across a relationship, **When** a schema update changes that peer attribute, **Then** the kind's HFID is recomputed.
+3. **Given** a kind whose display-label template or HFID path list is itself edited in the schema update, **When** the update is applied, **Then** that kind's display label / HFID is recomputed (the definition's own change counts as a dependency).
+4. **Given** a kind whose display label or HFID reads another derived value (a peer's display label/HFID, or a computed attribute), **When** any schema element changes, **Then** that kind's display label / HFID is recomputed (conservative, because the dependency cannot be mapped precisely).
+
+---
+
+### User Story 3 - Recompute falls back to full behavior when the change set is unavailable (Priority: P2)
+
+Some paths apply schema changes without producing a precise set of changed elements (for example branch merge and rebase, which are addressed by separate tickets). When the change set is unavailable, the system must fall back to the existing full recompute behavior rather than skipping work and risking stale data.
+
+**Why this priority**: Preserves correctness on paths not yet emitting a change set, and keeps this feature's blast radius limited to the scoped, change-set-bearing path.
+
+**Independent Test**: Drive a label/HFID setup with no change set provided and confirm every candidate kind is recomputed exactly as today.
+
+**Acceptance Scenarios**:
+
+1. **Given** a schema-update flow invoked without a change set, **When** the label/HFID setup runs, **Then** every kind that would recompute today still recomputes (no behavior change on the fallback path).
+
+---
+
+### Edge Cases
+
+- A schema element is read by more than one kind's display label/HFID (directly and via relationship): all readers must be recomputed.
+- A relationship a display label/HFID traverses is itself changed (added, removed, renamed): the traversing kinds must be recomputed.
+- The change set is present but empty (a no-op schema update): no label/HFID recompute is submitted.
+- A kind defines both a display label and an HFID with different dependency sets: each is scoped independently; a change touching only the HFID's dependencies must not force a display-label recompute and vice versa.
+- A display label/HFID definition is newly added on the branch (not present on the default branch): the change set includes the definition property, so the kind recomputes via its own-definition dependency.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On a schema update that carries a set of changed elements, the system MUST recompute a kind's display label only if the changed elements intersect that display label's declared dependency set.
+- **FR-002**: On a schema update that carries a set of changed elements, the system MUST recompute a kind's HFID only if the changed elements intersect that HFID's declared dependency set.
+- **FR-003**: A display label's / HFID's dependency set MUST include every schema element it reads: attributes on the owning kind, relationships it traverses, and peer fields reached through those relationships.
+- **FR-004**: A display label's / HFID's dependency set MUST include the owning kind's own definition property, so an edit to the display-label template or HFID path list itself triggers recompute of that kind.
+- **FR-005**: When a display label or HFID reads a value that cannot be mapped to a precise set of backing schema elements (a peer's display label or HFID, or a computed attribute's value), the system MUST treat it as depending on everything and recompute it on any schema change.
+- **FR-006**: When a schema update does not carry a set of changed elements, the system MUST fall back to the existing full recompute behavior for display labels and HFIDs.
+- **FR-007**: The system MUST scope each kind's display label and HFID independently, so a change touching only one of them does not force recompute of the other.
+- **FR-008**: The scoping decision for display labels and HFIDs MUST reuse the same dependency-intersection logic used for computed attributes, so the three cannot diverge in how a change set is interpreted.
+- **FR-009**: The system MUST record an observability signal for each scoped label/HFID setup that distinguishes a precise scoping decision from a full-recompute fallback, including how many candidates were selected out of the total.
+- **FR-010**: Existing display-label and HFID recompute behavior on the fallback (no change set) path MUST remain unchanged, verified by the current optimization tests continuing to pass.
+
+### Key Entities *(include if feature involves data)*
+
+- **Display label definition**: A per-kind Jinja2 template producing a node's human-readable label. Declares the attributes, relationships, and peer fields it reads.
+- **HFID definition**: A per-kind ordered list of schema paths producing a node's human-friendly identifier. Declares the attributes, relationships, and peer fields it reads.
+- **Changed-element set**: The added kinds, removed kinds, and per-kind changed field names carried by a schema-update event, describing exactly what the update altered.
+- **Dependency set**: The schema elements a single derived value reads, used to decide whether a change is relevant to it; may be marked imprecise ("depends on everything") when it cannot be determined exactly.
+- **Recompute candidate**: A derived value eligible for recompute on a given branch (here, a kind's display label or HFID), evaluated against the changed-element set.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A schema update that changes only elements unrelated to a kind's display label and HFID submits zero recompute work for that kind (today it submits a full node sweep).
+- **SC-002**: The number of kinds whose display labels/HFIDs are recomputed after a scoped schema update scales with the number of kinds whose dependency sets intersect the change, not with the total number of kinds defining a display label or HFID.
+- **SC-003**: Every node whose display label or HFID value would change as a result of the schema update is still refreshed; no value that should change is left stale (correctness preserved across direct, relationship, and definition-change cases).
+- **SC-004**: A single-field schema change on a large instance no longer scales display-label/HFID recompute with the total kind count, removing that contribution to the post-update degraded-instance window.
+- **SC-005**: Behavior on the no-change-set fallback path is byte-for-byte equivalent to today, demonstrated by the existing optimization tests passing unchanged.
+
+## Assumptions
+
+- The scoping mechanism, change-set payload, and dependency-intersection logic introduced by PR #9467 for computed attributes are present on the base branch and are the foundation this feature generalizes.
+- Display-label and HFID dependency metadata (attributes, relationships, relationship_fields, inverse relationship triggers) is already populated by the schema layer and is sufficient to derive precise dependency sets except where a derived value is read.
+- The change-set payload already records a kind's node-level definition properties (display-label template, HFID path list) when they change, so an edit to a definition is visible as a changed element. This is verified during planning before relying on it.
+- Per-node short-circuiting within a selected kind (skipping nodes whose inputs did not change) is out of scope and tracked separately (IFC-2762); this feature scopes which kinds recompute, not which nodes within a kind.
+- Branch merge and rebase paths emitting a change set (IFC-2758/IFC-2761), performance benchmarks (IFC-2746), and transform computed attributes on Git import (IFC-2760) are out of scope and handled by sibling tickets; this feature operates on the schema-update path that already carries a change set, and falls back to full behavior elsewhere.
+- Display labels and HFIDs are delivered together in a single change because they share structure; the only expected divergence is detecting an HFID path that resolves to a derived value, which is handled conservatively.

--- a/dev/specs/ifc-2759-scope-label-hfid-recompute/tasks.md
+++ b/dev/specs/ifc-2759-scope-label-hfid-recompute/tasks.md
@@ -1,0 +1,183 @@
+---
+description: "Task list for: Scope display label and HFID recompute on schema updates"
+---
+
+# Tasks: Scope display label and HFID recompute on schema updates
+
+**Input**: Design documents from `specs/ifc-2759-scope-label-hfid-recompute/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/recompute-scoping.md, quickstart.md
+
+**Tests**: Included — the spec and the project constitution (Principle IV) require unit + component + integration coverage.
+
+**Branch**: `scope-label-hfid-recompute-ifc-2759`
+
+## Story → delivery mapping
+
+The spec's user stories are behavioral (US1 skip-unrelated, US2 recompute-related, US3 fallback). They are **not** independently shippable: shipping US1 without US2 would skip needed recomputes (unsafe). The safe, independently-shippable increments are by subsystem — display-label scoping, then HFID scoping — each delivering US1 + US2 + US3 together. Phases below follow those increments; tasks carry the `[US#]` they primarily serve.
+
+- **US1** (P1) — unrelated change → zero recompute (FR-001/002, SC-001)
+- **US2** (P1) — read element / definition change → still recompute (FR-003/004/005, SC-003)
+- **US3** (P2) — no change set → full fallback unchanged (FR-006, SC-005)
+
+## Conventions
+
+- Per `dev/rules/code-doc-style.md`: **no spec IDs (IFC-2759, FR-xxx) in source or test names or docstrings.** They live here and in the commit/PR only. (Changelog filename may use the bare issue number per project convention.)
+- All Python calls use keyword arguments; type hints on all new code; frozen dataclasses for internal data (Constitution III). New components use required constructor injection (`dev/rules/backend-component-design.md`).
+- `[P]` = parallelizable (different files, no incomplete dependency).
+
+---
+
+## Phase 1: Setup (baseline guard)
+
+**Purpose**: Capture the green baseline that the Phase 2 refactor must preserve.
+
+- [ ] T001 Run and record green baseline for the regression + fallback guards: `uv run pytest backend/tests/unit/computed_attribute/test_scoping.py backend/tests/component/computed_attribute backend/tests/functional/display_labels/test_display_label_task_optimization.py backend/tests/functional/hfid/test_hfid_task_optimization.py -q`. These must stay green through Phase 2.
+
+---
+
+## Phase 2: Foundational — extract & generalize the shared scoping core (BLOCKING)
+
+**Purpose**: Move the scoping core to `core/schema/` and generalize it over a candidate type, behavior-preserving. **Blocks all subsystem work.**
+
+**⚠️ CRITICAL**: No display-label or HFID task may begin until this phase is complete and the Phase 1 guards are still green.
+
+- [ ] T002 Create `backend/infrahub/core/schema/recompute_scoping.py` and move `ChangedElementSet`, `DependencySet`, `RecomputeScopingReport`, `SkippedCandidate` (renamed from `SkippedAttribute`), `RecomputeScoper`, and `_resolve_changed_elements` from `backend/infrahub/computed_attribute/scoping.py`; relocate `IMPRECISE_READ_FIELDS` from `backend/infrahub/core/schema/schema_branch_computed/python_transform.py` into this module.
+- [ ] T003 In `recompute_scoping.py`, add the generic `RecomputeCandidate` frozen dataclass (`branch`, `kind`, `name`, `deriver_key`) and the generalized `DependencyDeriver` Protocol (`derive(*, candidate) -> DependencySet`); generalize `DependencySet` (`attribute_name` → `name`; drop the computed-attribute `kind` enum field) per `data-model.md`.
+- [ ] T004 In `recompute_scoping.py`, generalize `RecomputeScoper.__init__(*, derivers: Mapping[str, DependencyDeriver])` and `scope(*, candidates: Sequence[RecomputeCandidate], changed_elements: ChangedElementSet | None)`, preserving the decision logic (own-field, read_fields∩changed_fields, read_kinds∩added/removed, depends_on_everything, None→fallback) exactly per `contracts/recompute-scoping.md` §2.
+- [ ] T005 Add `DerivedFieldLookup` frozen dataclass (`computed_attributes: frozenset[tuple[str,str]]`, `imprecise_read_fields=IMPRECISE_READ_FIELDS`, `is_derived(*, kind, field)`) in `recompute_scoping.py`.
+- [ ] T006 Update `backend/infrahub/computed_attribute/scoping.py`: keep `Jinja2DependencyDeriver` and `PythonTransformDependencyDeriver`, import moved types from `core.schema.recompute_scoping`, adapt `ComputedAttributeRef` to satisfy the `RecomputeCandidate` shape (expose `name` and `deriver_key`), and key its derivers by the `computed_attribute.jinja2` / `computed_attribute.python` strings.
+- [ ] T007 [P] Update `backend/infrahub/computed_attribute/tasks.py` and `backend/infrahub/computed_attribute/triggers.py` to the generalized scoper API and import paths (behavior-preserving; no change to submitted workflows).
+- [ ] T008 [P] Update `backend/infrahub/core/schema/schema_branch_computed/python_transform.py` to import `IMPRECISE_READ_FIELDS` from `core.schema.recompute_scoping` (re-export there if any other module imports it from the old location).
+- [ ] T009 Update `backend/tests/unit/computed_attribute/test_scoping.py` to the new import paths and candidate shape; assertions unchanged. Confirm it passes (regression guard).
+- [ ] T010 Relocate `ScopedRecomputeTestBase` from `backend/tests/component/computed_attribute/_base.py` to a shared location (e.g. `backend/tests/component/recompute/_base.py`), generalize its submission helper to take the workflow + parameter key (today it hard-codes `computed_attribute_name`; display labels and HFID submit on `kind`), update the computed-attribute component tests' import, and confirm they stay green — so the display-label and HFID component tests reuse it without a cross-test-package import.
+- [ ] T011 Run the Phase 1 guard command again; confirm computed-attribute unit + component scoping tests and the task-optimization tests are still green (behavior-preserving checkpoint).
+
+**Checkpoint**: Shared scoping core lives in `core/schema/`, generalized, with all pre-existing computed-attribute behavior intact, and a shared component test base ready for both subsystems.
+
+---
+
+## Phase 3: Display-label scoping (Priority: P1) 🎯 MVP
+
+**Goal**: A schema update recomputes a kind's display label only when the change touches an element that display label reads (or its own definition, or a derived read).
+
+**Independent Test**: Apply an unrelated schema change → zero `TRIGGER_UPDATE_DISPLAY_LABELS` submissions; change a read field (incl. across a relationship) or the `display_labels` definition → the affected kind is submitted; invoke with no change set → every candidate submitted (fallback).
+
+**Covers**: US1, US2, US3 for display labels.
+
+### Tests (write first, ensure they fail)
+
+- [ ] T012 [P] [US2] Unit tests in `backend/tests/unit/display_labels/test_scoping.py` for the display-label deriver + scoper: select via own definition (`display_labels` token present in `changed_fields`), via owner attribute, via relationship peer field, via added/removed peer kind; skip on no overlap; `depends_on_everything` when a read resolves to a derived value (peer `display_label`/`hfid` or a computed attribute); empty change set → skip; **independence — for a kind with both a display label and an HFID, a change touching only the HFID's dependency does not select the display-label candidate.**
+- [ ] T013 [P] [US1] Component test in `backend/tests/component/display_labels/test_scoped_recompute.py` reusing the shared `ScopedRecomputeTestBase` + `WorkflowRecorder` (`WORKFLOW = TRIGGER_UPDATE_DISPLAY_LABELS`): assert the set of submitted kinds for unrelated-change (empty), owner-field change, relationship-peer change, and `changed_elements=None` (all candidates).
+
+### Implementation
+
+- [ ] T014 [US2] Build the per-branch `DerivedFieldLookup` + relationship peer-kind resolution helper from the active `SchemaBranch` (computed-attribute `(kind, attr)` set + peer-kind map), as a factory in `core/schema/recompute_scoping.py`. Serves both subsystems.
+- [ ] T015 [US1] Create `backend/infrahub/display_labels/scoping.py`: `DisplayLabelDependencyDeriver` mapping `TemplateLabel` → `DependencySet` (own `display_labels` token in `read_fields[owner_kind]`; attributes; relationships + `relationship_fields` peer reads with peer-kind resolution; `depends_on_everything` via `DerivedFieldLookup`), plus a candidate builder from `DisplayLabels.get_template_nodes()`.
+- [ ] T016 [US2] Add the `changed_elements` Prefect parameter to `TRIGGER_DISPLAY_LABELS_ALL_SCHEMA` in `backend/infrahub/display_labels/triggers.py`, mirroring `TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA` (contracts §5).
+- [ ] T017 [US2] In `backend/infrahub/display_labels/tasks.py`, add `changed_elements: ChangedElementsPayload | None = None` to `display_labels_setup_jinja2`, normalize via `_resolve_changed_elements`, build candidates + deriver, call `RecomputeScoper.scope(...)`, and gate the existing per-kind hash check + node sweep on `report.selected`.
+- [ ] T018 [US1] Add the scoping observability log to `display_labels_setup_jinja2` (info: selected count, total candidate count, `fallback_full_recompute`; debug: skipped + reasons).
+- [ ] T019 [US1] Run T012 + T013 green; run the display-label task-optimization fallback test to confirm the `None` path is unchanged.
+
+**Checkpoint**: Display-label scoping works end-to-end — MVP shippable on its own.
+
+---
+
+## Phase 4: HFID scoping (Priority: P1)
+
+**Goal**: Same scoping for HFIDs, including the divergence case where an HFID path component resolves to a computed attribute.
+
+**Independent Test**: As Phase 3 but for `TRIGGER_UPDATE_HFID` and the `human_friendly_id` definition token; plus an HFID reading a computed attribute → always recomputes.
+
+**Covers**: US1, US2, US3 for HFIDs.
+
+### Tests (write first, ensure they fail)
+
+- [ ] T020 [P] [US2] Unit tests in `backend/tests/unit/hfid/test_scoping.py` for the HFID deriver + scoper: select via own definition (`human_friendly_id` token), owner attribute, relationship peer field, added/removed kind; skip on no overlap; **`depends_on_everything` when an HFID path component resolves to a computed attribute or a peer `display_label`/`hfid`** (the documented divergence); empty change set → skip; **independence — for a kind with both an HFID and a display label, a change touching only the display label's dependency does not select the HFID candidate.**
+- [ ] T021 [P] [US1] Component test in `backend/tests/component/hfid/test_scoped_recompute.py` reusing the shared `ScopedRecomputeTestBase` (`WORKFLOW = TRIGGER_UPDATE_HFID`): submitted-kind assertions for unrelated, owner-field, relationship-peer, and `None` (fallback) cases.
+
+### Implementation
+
+- [ ] T022 [US1] Create `backend/infrahub/hfid/scoping.py`: `HFIDDependencyDeriver` mapping `HFIDDefinition` → `DependencySet` (own `human_friendly_id` token; attributes; `relationship_fields` peer reads; `depends_on_everything` via `DerivedFieldLookup`, which here must catch reads of computed attributes, not just `display_label`/`hfid`), plus a candidate builder from `HFIDs.get_template_nodes()`.
+- [ ] T023 [US2] Add the `changed_elements` Prefect parameter to `TRIGGER_HFID_ALL_SCHEMA` in `backend/infrahub/hfid/triggers.py`.
+- [ ] T024 [US2] In `backend/infrahub/hfid/tasks.py`, add `changed_elements: ChangedElementsPayload | None = None` to `hfid_setup`, normalize, build candidates + deriver, call `RecomputeScoper.scope(...)`, and gate the existing per-kind hash check + node sweep on `report.selected`.
+- [ ] T025 [US1] Add the scoping observability log to `hfid_setup` (same shape as T018).
+- [ ] T026 [US1] Run T020 + T021 green; run the HFID task-optimization fallback test to confirm the `None` path is unchanged.
+
+**Checkpoint**: Both display-label and HFID scoping work independently.
+
+---
+
+## Phase 5: Polish & cross-cutting concerns
+
+- [ ] T027 [P] [US3] Confirm fallback equivalence: `backend/tests/functional/display_labels/test_display_label_task_optimization.py` and `backend/tests/functional/hfid/test_hfid_task_optimization.py` pass unchanged (no edits) — the mandatory fallback guard (Constitution II).
+- [ ] T028 Add a no-cross-branch-broadening assertion (component) for both subsystems: a schema change on one branch submits no recompute for kinds on other branches (mandatory, Constitution II).
+- [ ] T029 Add an `integration_docker` test asserting end-to-end that a scoped schema change refreshes only the affected kinds' display labels/HFIDs and leaves unaffected kinds untouched (mandatory for triggered-action paths, Constitution IV).
+- [ ] T030 Update `dev/knowledge/backend/display-labels-and-hfid.md` to document that display-label and HFID recompute on schema updates is now scoped to changed elements (same dependency-intersection mechanism as computed attributes, with the conservative derived-read fallback) — Constitution Documentation Requirements (backend architecture change).
+- [ ] T031 [P] Add a Towncrier changelog fragment for the change. Use the GitHub issue/PR number as the filename per project convention (e.g. `changelog/<gh-issue>.fixed.md`); if no GitHub issue exists, use a slug (`changelog/+scope-label-hfid-recompute.fixed.md`). Do **not** use the Jira `2759` number. No em dashes / code-overquoting in the text.
+- [ ] T032 [P] Run `uv run invoke format` and `uv run invoke lint`; resolve `mypy` on all changed/new files.
+- [ ] T033 Run `/pre-ci` (`dev/commands/pre-ci.md`) — the locally-executable CI gates including generated-file/doc validation (`docs.validate`).
+- [ ] T034 Execute the `quickstart.md` validation scenarios A–J and confirm each passes.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)**: immediate.
+- **Phase 2 (Foundational)**: after Phase 1; **blocks Phases 3 & 4**.
+- **Phase 3 (Display label)**: after Phase 2. Independently shippable (MVP).
+- **Phase 4 (HFID)**: after Phase 2. Independent of Phase 3 (different packages/files) — can run in parallel with Phase 3 once foundation lands.
+- **Phase 5 (Polish)**: after Phases 3 & 4.
+
+### Within a subsystem phase
+
+- Tests (T012/T013, T020/T021) written first and failing → implementation → green.
+- The deriver (T015/T022) depends on the shared `DerivedFieldLookup` + peer-kind helper (T014). The trigger param (T016/T023) and the setup-flow wiring (T017/T024) are paired.
+
+### Parallel opportunities
+
+- T007, T008 in Phase 2 are `[P]` (different files) once T002–T006 land.
+- Once Phase 2 completes, **Phase 3 and Phase 4 can be developed in parallel** (display_labels/* vs hfid/* are disjoint), except both depend on T014.
+- Test-authoring tasks within a phase (`[P]`) can be written together.
+- Polish tasks T031, T032 are `[P]`.
+
+---
+
+## Parallel Example: after foundation lands
+
+```bash
+# Developer A — display-label increment (Phase 3)
+Task: "Unit tests for display-label deriver in backend/tests/unit/display_labels/test_scoping.py"
+Task: "Component scoped-recompute test in backend/tests/component/display_labels/test_scoped_recompute.py"
+
+# Developer B — HFID increment (Phase 4)
+Task: "Unit tests for HFID deriver in backend/tests/unit/hfid/test_scoping.py"
+Task: "Component scoped-recompute test in backend/tests/component/hfid/test_scoped_recompute.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first
+
+1. Phase 1 (baseline) → Phase 2 (foundation, behavior-preserving) → **STOP & VALIDATE**: all existing computed-attribute tests green.
+2. Phase 3 (display-label scoping) → validate independently → shippable MVP.
+3. Phase 4 (HFID scoping) → validate independently.
+4. Phase 5 (cross-cutting tests, docs, changelog, pre-ci) → ship.
+
+### Risk notes
+
+- **Phase 2 is the riskiest mechanical step** — keep it a single behavior-preserving commit; the Phase 1 guard is the safety net.
+- **T022 (HFID derived-read detection)** is the only genuinely new logic vs. the computed-attribute path and the documented split point if it proves harder than display labels.
+- Confirm (research open item) how each registry resolves a relationship name → peer kind during T014/T015/T022.
+
+---
+
+## Notes
+
+- `[Story]` labels map tasks to spec user stories for traceability only; the shippable increments are the subsystem phases.
+- Commit after each task or logical group; do not force-push the branch.
+- Verify each test fails before implementing it.
+- No edits to generated files; no new external dependencies.


### PR DESCRIPTION
## Summary

Brings display labels and HFIDs to parity with the computed-attribute recompute
scoping (#9415). On a schema update they now recompute only for kinds whose
display-label / HFID dependencies the change actually touches, instead of
re-sweeping every node of every kind whose definition differs from the default
branch.

## Problem

Every schema update re-runs display-label and HFID backfill across all kinds
regardless of relevance. On large instances a one-field schema edit triggers a
recompute pass over unrelated kinds, costing minutes of degraded instance time
and growing with dataset size. Computed attributes already avoid this; display
labels and HFIDs were left out.

## Planned changes

- Extract the recompute scoping core (scoper, dependency set, changed-element
  set, report types, the changed-elements resolver, and the imprecise-read
  constant) out of the computed-attribute package into `core/schema`, generalized
  over a candidate type. Behavior-preserving move; the computed-attribute path is
  unchanged.
- Add a dependency deriver for display labels and one for HFIDs. Each maps the
  dependency metadata the schema layer already exposes (attributes, relationships,
  relationship fields, inverse relationship triggers) into a dependency set, and
  includes the kind's own definition property so editing the template or path list
  recomputes that kind.
- Thread the changed-element set carried by the schema-update event into the
  display-label and HFID setup flows, then scope the existing per-kind sweep to
  the selected kinds.
- Stay conservative for correctness: when a display label or HFID reads a value
  that cannot be mapped to precise backing elements (a peer display label or HFID,
  or a computed attribute), recompute it on any schema change. When the event
  carries no change set, fall back to the current full recompute.
- Log the scoping decision (selected count, total candidates, whether the run was
  a full-recompute fallback).

## Validation

- [ ] `uv run invoke format` and `uv run invoke lint` clean (ruff + mypy)
- [ ] Backend unit, component, and integration tests pass
- [ ] Changelog fragment added
- [ ] `dev/knowledge/backend/display-labels-and-hfid.md` updated
- [ ] `/pre-ci` green (includes generated-doc validation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the spec and implementation plan to scope display‑label and HFID recompute to only kinds affected by schema updates, matching computed‑attribute scoping and targeting better performance on large instances (IFC‑2759).
Plans to extract the shared scoper into `core/schema`, add derivers for `display_labels` and `hfid`, thread `changed_elements` through triggers, and cover with tests; documentation only, no runtime changes in this PR.

<sup>Written for commit 5462627193c66732863d31c16c406a5d21b97f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

