### PR TITLE
fix(backend): omit task related nodes with unresolvable kind

### DIFF
--- a/backend/infrahub/task_manager/models.py
+++ b/backend/infrahub/task_manager/models.py
@@ -49,12 +49,10 @@ class RelatedNodesInfo(BaseModel):
     def get_related_nodes(self, flow_id: UUID) -> list[RelatedNodeInfo]:
         if flow_id not in self.flows or len(self.flows[flow_id].keys()) == 0:
             return []
-        return list(self.flows[flow_id].values())
+        return [item for item in self.flows[flow_id].values() if item.kind is not None]
 
     def get_related_nodes_as_dict(self, flow_id: UUID) -> list[dict[str, str | None]]:
-        if flow_id not in self.flows or len(self.flows[flow_id].keys()) == 0:
-            return []
-        return [item.model_dump() for item in list(self.flows[flow_id].values())]
+        return [item.model_dump() for item in self.get_related_nodes(flow_id=flow_id)]
 
     def get_first_related_node(self, flow_id: UUID) -> RelatedNodeInfo | None:
         if nodes := self.get_related_nodes(flow_id=flow_id):

--- a/backend/tests/component/graphql/queries/test_task.py
+++ b/backend/tests/component/graphql/queries/test_task.py
@@ -803,14 +803,19 @@ async def test_task_query_unresolvable_related_node(
     default_branch: Branch,
     prefect_client: PrefectClient,
     register_core_models_schema: None,
+    tag_blue: Node,
 ) -> None:
-    """A related-node tag whose kind cannot be resolved is omitted instead of crashing the resolver."""
+    """A related-node tag whose kind cannot be resolved is omitted while resolvable ones are still returned."""
     unresolvable_id = "0177c800-0000-0000-0000-0000000000ff"
     flow = await prefect_client.create_flow_run(
         flow=dummy_flow,
         name="dummy-unresolvable-related-node",
         parameters={"firstname": "xxxx", "lastname": "yyy"},
-        tags=[TAG_NAMESPACE, WorkflowTag.RELATED_NODE.render(identifier=unresolvable_id)],
+        tags=[
+            TAG_NAMESPACE,
+            WorkflowTag.RELATED_NODE.render(identifier=tag_blue.get_id()),
+            WorkflowTag.RELATED_NODE.render(identifier=unresolvable_id),
+        ],
         state=State(type="RUNNING"),
     )
 
@@ -828,9 +833,9 @@ async def test_task_query_unresolvable_related_node(
     assert len(edges) == 1
     node = edges[0]["node"]
     assert node["id"] == str(flow.id)
-    assert node["related_nodes"] == []
-    assert node["related_node"] is None
-    assert node["related_node_kind"] is None
+    assert node["related_nodes"] == [{"id": tag_blue.get_id(), "kind": "BuiltinTag"}]
+    assert node["related_node"] == tag_blue.get_id()
+    assert node["related_node_kind"] == "BuiltinTag"
 
 
 async def test_task_no_count(

--- a/backend/tests/component/graphql/queries/test_task.py
+++ b/backend/tests/component/graphql/queries/test_task.py
@@ -798,6 +798,41 @@ async def test_task_query_progress(
     }
 
 
+async def test_task_query_unresolvable_related_node(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    prefect_client: PrefectClient,
+    register_core_models_schema: None,
+) -> None:
+    """A related-node tag whose kind cannot be resolved is omitted instead of crashing the resolver."""
+    unresolvable_id = "0177c800-0000-0000-0000-0000000000ff"
+    flow = await prefect_client.create_flow_run(
+        flow=dummy_flow,
+        name="dummy-unresolvable-related-node",
+        parameters={"firstname": "xxxx", "lastname": "yyy"},
+        tags=[TAG_NAMESPACE, WorkflowTag.RELATED_NODE.render(identifier=unresolvable_id)],
+        state=State(type="RUNNING"),
+    )
+
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_TASK,
+        variables={"related_nodes": [unresolvable_id]},
+    )
+
+    assert result.errors is None
+    assert result.data
+
+    edges = result.data["InfrahubTask"]["edges"]
+    assert len(edges) == 1
+    node = edges[0]["node"]
+    assert node["id"] == str(flow.id)
+    assert node["related_nodes"] == []
+    assert node["related_node"] is None
+    assert node["related_node_kind"] is None
+
+
 async def test_task_no_count(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/changelog/9662.fixed.md
+++ b/changelog/9662.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash when loading the Tasks page where a task was tagged with a related node whose kind could no longer be resolved (for example a deleted definition or a stale tag). Such unresolvable related nodes are now omitted from the task instead of causing a GraphQL resolver error.


### PR DESCRIPTION
## Problem

Closes #9662.

Opening the **Tasks** page crashes the GraphQL resolver with:

```
TypeError: Cannot return null for non-nullable field TaskRelatedNode.kind.
```

A Prefect flow run can be tagged with `infrahub.app/node/<id>` where `<id>` no longer resolves to an active node (deleted definition, stale tag). `RelatedNodeInfo.kind` then stays `None`, and the non-nullable `TaskRelatedNode.kind` field rejects it — one critical log entry per unresolvable task, and the page fails to load.

## Correction to the issue's root-cause analysis

The issue's suggested fix #1 ("branch-scoped lookup → fall back to `main`") does **not** apply to the current code. `NodeGetKindQuery` only filters by branch when a branch is passed, and `_get_related_nodes` passes none, so the query is already branch-agnostic (verified identical in `stable` and the `infrahub-v1.9.8` tag). A node living only on `main` resolves fine from a feature branch — so a fallback would be dead code. The real trigger is an ID that resolves to **no active node at all**.

## Fix

Backend-only, no GraphQL contract change. Filter related-node entries whose `kind` could not be resolved out of the model's list accessors, so the task is returned without the unrenderable node instead of erroring. The deprecated singular `related_node`/`related_node_kind` fields stay consistent since they share the same accessor.

## Testing

- New component test `test_task_query_unresolvable_related_node` reproduces the crash (confirmed RED → GREEN).
- `backend/tests/component/graphql/queries/test_task.py` + `backend/tests/unit/task_manager/` — 18 passed.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Tasks page crash by omitting task-related nodes whose kind cannot be resolved so tasks load without GraphQL errors; backend-only with no schema changes. Fixes #9662.

- **Bug Fixes**
  - Filter out related nodes with unresolved kind in `get_related_nodes`; `get_related_nodes_as_dict` now delegates to it to keep deprecated singular fields consistent.
  - Added component tests for an unresolvable ID and a mixed case to ensure resolvable nodes and singular fields are returned correctly.

<sup>Written for commit b138ab99361a02228574d32c4200496ac4cb51e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

