### PR TITLE
Always prevent query deduplication in appollo so tanstack query owns it

### DIFF
--- a/frontend/app/src/entities/nodes/object/api/get-objects-count-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-count-from-api.ts
@@ -43,7 +43,6 @@ export const getObjectsCountFromApi = async ({
     context: {
       branch: branchName,
       date: atDate,
-      queryDeduplication: false,
       processErrorMessage: () => {},
     },
   });

--- a/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.ts
+++ b/frontend/app/src/entities/nodes/relationships/api/get-default-parent-from-api.ts
@@ -70,7 +70,6 @@ export const getDefaultParentFromApi = ({
     context: {
       branch: branchName,
       date: atDate,
-      queryDeduplication: false,
       processErrorMessage: () => {},
     },
   });

--- a/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/shared/api/graphql/graphqlClientApollo.tsx
@@ -232,6 +232,11 @@ const graphqlClient = new ApolloClient({
   link: from([errorLink, authLink, httpLink]),
   cache: new InMemoryCache(),
   defaultOptions,
+  // Apollo is a transport-only layer here: queries run imperatively via
+  // graphqlClient.query (no Apollo hooks/cache) and are fronted by TanStack
+  // Query, which owns caching and request deduplication by queryKey. Disable
+  // Apollo's own in-flight dedup so TanStack is the single dedup authority.
+  queryDeduplication: false,
 });
 
 export default graphqlClient;

--- a/frontend/app/tests/e2e/branches/branches.spec.ts
+++ b/frontend/app/tests/e2e/branches/branches.spec.ts
@@ -5,6 +5,8 @@ import { generateRandomBranchName } from "../../utils";
 import { createBranchAPI } from "../utils/graphql";
 
 test.describe("Branches creation and deletion", () => {
+  test.slow();
+
   test.describe("when logged in as Admin", () => {
     test.describe.configure({ mode: "serial" });
     test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });

--- a/frontend/app/tests/e2e/role-management/roles-management.spec.ts
+++ b/frontend/app/tests/e2e/role-management/roles-management.spec.ts
@@ -8,7 +8,7 @@ test.describe("/role-management/roles - Roles CRUD", () => {
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
   test.describe.configure({ mode: "serial" });
 
-  const BRANCH_NAME = generateRandomBranchName("role-crud");
+  const BRANCH_NAME = generateRandomBranchName("role-management");
 
   test.beforeAll(async ({ request }) => {
     await createBranchAPI(request, BRANCH_NAME);

--- a/tests/e2e/role-management/test_roles_management.py
+++ b/tests/e2e/role-management/test_roles_management.py
@@ -114,22 +114,12 @@ class TestRolesCrud:
         await admin_page.get_by_role("menuitem", name="Delete").click()
         await admin_page.get_by_test_id("modal-delete-confirm").click()
         await expect(admin_page.get_by_text("Object test role updated deleted")).to_be_visible()
-        # Reload so the list is fetched fresh. The post-delete cache invalidation can
-        # race with a stale read behind the server load balancer, leaving the deleted
-        # row in the table for the entire assertion window.
-        await admin_page.reload()
         await expect(admin_page.get_by_role("link", name="test role 2")).to_be_visible()
         await expect(admin_page.get_by_role("link", name="test role updated")).not_to_be_visible()
 
-        # bulk delete the remaining role (reselect it: the reload cleared the selection)
-        await (
-            admin_page.get_by_role("link", name="test role 2")
-            .locator("..")
-            .get_by_test_id("identifier-checkbox-cell")
-            .click()
-        )
+        # bulk delete the remaining role
+        await expect(admin_page.get_by_role("link", name="test role 2")).to_be_visible()
         await admin_page.get_by_role("button", name="Delete").click()
         await admin_page.get_by_test_id("modal-delete-confirm").click()
         await expect(admin_page.get_by_text("Objects deleted!")).to_be_visible()
-        await admin_page.reload()
         await expect(admin_page.get_by_role("link", name="test role 2")).not_to_be_visible()


### PR DESCRIPTION
based on: #https://github.com/opsmill/infrahub/pull/9658
An attempt at reducing e2e test flakiness in very slow environment

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Apollo global query de-dup (`queryDeduplication: false`) and remove per-request flags so `@tanstack/react-query` solely handles caching/dedup. Stabilize E2E: use `role-management` branch prefix, mark branches suite as slow, and remove reload/reselect steps in roles tests to reduce flakiness.

<sup>Written for commit 976bc159fcda660a33e85de7c676d5db0216a637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

