### PR TITLE
refactor(webhook): split the webhook send into its own flow

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -304,12 +304,17 @@ class Webhook(BaseModel):
         await self._prepare_payload(data=data, context=context, client=client)
         self._assign_headers()
 
-    async def send(
-        self, data: dict[str, Any], context: EventContext, http_service: InfrahubHTTP, client: InfrahubClient
-    ) -> Response:
-        await self.prepare(data=data, context=context, client=client)
+    async def compute_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> Any:
+        """Build and return the payload to deliver, running any transform once."""
+        await self._prepare_payload(data=data, context=context, client=client)
+        return self._payload
+
+    async def send_payload(self, payload: Any, http_service: InfrahubHTTP) -> Response:
+        """Assign the headers for the given payload and POST it to the webhook endpoint."""
+        self._payload = payload
+        self._assign_headers()
         return await http_service.post(
-            url=self.url, json=self.get_payload(), headers=self._headers, verify=self.validate_certificates
+            url=self.url, json=payload, headers=self._headers, verify=self.validate_certificates
         )
 
     def get_payload(self) -> dict[str, Any]:

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -246,15 +246,14 @@ class Webhook(BaseModel):
     event_type: str = Field(...)
     validate_certificates: bool | None = Field(...)
     custom_headers: list[WebhookHeader] = Field(default_factory=list)
-    _payload: Any = None
-    _headers: dict[str, Any] | None = None
     shared_key: str | None = Field(default=None, description="Shared key for signing the webhook requests")
 
-    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:  # noqa: ARG002
-        self._payload = {"data": data, **context.model_dump()}
+    async def compute_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> Any:  # noqa: ARG002
+        """Build and return the payload to deliver."""
+        return {"data": data, **context.model_dump()}
 
-    def _assign_headers(self, uuid: UUID | None = None, at: Timestamp | None = None) -> None:
-        self._headers = {
+    def _build_headers(self, payload: Any, uuid: UUID | None = None, at: Timestamp | None = None) -> dict[str, Any]:
+        headers: dict[str, Any] = {
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
@@ -269,19 +268,21 @@ class Webhook(BaseModel):
                 )
             seen_keys.add(header.key)
             try:
-                self._headers[header.key] = header.resolve()
+                headers[header.key] = header.resolve()
             except WebhookHeaderResolutionError as exc:
                 logger.warning("Webhook '%s': %s, skipping header '%s'", self.name, exc, header.key)
 
         if self.shared_key:
             message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"
             timestamp = str(at.to_timestamp()) if at else str(Timestamp().to_timestamp())
-            payload = json.dumps(self._payload or {}, separators=(",", ":"))
-            unsigned_data = f"{message_id}.{timestamp}.{payload}".encode()
+            signed_payload = json.dumps(payload or {}, separators=(",", ":"))
+            unsigned_data = f"{message_id}.{timestamp}.{signed_payload}".encode()
             signature = self._sign(data=unsigned_data)
-            self._headers["webhook-id"] = message_id
-            self._headers["webhook-timestamp"] = timestamp
-            self._headers["webhook-signature"] = f"v1,{base64.b64encode(signature).decode('utf-8')}"
+            headers["webhook-id"] = message_id
+            headers["webhook-timestamp"] = timestamp
+            headers["webhook-signature"] = f"v1,{base64.b64encode(signature).decode('utf-8')}"
+
+        return headers
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -300,25 +301,10 @@ class Webhook(BaseModel):
             return self.shared_key
         raise ValueError("Shared key is not set for the webhook")
 
-    async def prepare(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:
-        await self._prepare_payload(data=data, context=context, client=client)
-        self._assign_headers()
-
-    async def compute_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> Any:
-        """Build and return the payload to deliver, running any transform once."""
-        await self._prepare_payload(data=data, context=context, client=client)
-        return self._payload
-
     async def send_payload(self, payload: Any, http_service: InfrahubHTTP) -> Response:
         """Assign the headers for the given payload and POST it to the webhook endpoint."""
-        self._payload = payload
-        self._assign_headers()
-        return await http_service.post(
-            url=self.url, json=payload, headers=self._headers, verify=self.validate_certificates
-        )
-
-    def get_payload(self) -> dict[str, Any]:
-        return self._payload
+        headers = self._build_headers(payload=payload)
+        return await http_service.post(url=self.url, json=payload, headers=headers, verify=self.validate_certificates)
 
     def to_cache(self) -> dict[str, Any]:
         return self.model_dump()
@@ -369,7 +355,8 @@ class TransformWebhook(Webhook):
     transform_timeout: int = Field(...)
     convert_query_response: bool = Field(...)
 
-    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:
+    async def compute_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> Any:
+        """Build and return the payload by running the configured Python transform once."""
         repo: InfrahubReadOnlyRepository | InfrahubRepository
         if self.repository_kind == InfrahubKind.READONLYREPOSITORY:
             repo = await InfrahubReadOnlyRepository.init(
@@ -381,7 +368,7 @@ class TransformWebhook(Webhook):
         branch = context.branch or repo.default_branch
         commit = repo.get_commit_value(branch_name=branch)
 
-        self._payload = await repo.execute_python_transform.with_options(timeout_seconds=self.transform_timeout)(
+        return await repo.execute_python_transform.with_options(timeout_seconds=self.transform_timeout)(
             branch_name=branch,
             commit=commit,
             location=f"{self.transform_file}::{self.transform_class}",

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -28,7 +28,7 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-@task(name="webhook-send", task_run_name="Send Standard Webhook {webhook.name}", cache_policy=NONE, retries=3)
+@flow(name="webhook-send", flow_run_name="Send webhook {webhook.name}", retries=3)
 async def webhook_send(webhook: Webhook, context: EventContext, event_data: dict) -> Response:
     """Send an HTTP request to the webhook endpoint. Retries up to 3 times on failure."""
     http_service = get_http()

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import ujson
 from infrahub_sdk import InfrahubClient  # noqa: TC002  needed for prefect flow
@@ -28,13 +28,15 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-@flow(name="webhook-send", flow_run_name="Send webhook {webhook.name}", retries=3)
-async def webhook_send(webhook: Webhook, context: EventContext, event_data: dict) -> Response:
-    """Send an HTTP request to the webhook endpoint. Retries up to 3 times on failure."""
+@flow(name="webhook-send", flow_run_name="Send webhook {webhook_name}", retries=3)
+async def webhook_send(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:  # noqa: ARG001
+    """Resolve the webhook config, assign its headers, and POST the prepared payload. Retries up to 3 times."""
+    log = get_run_logger()
     http_service = get_http()
-    client = get_client()
-    response = await webhook.send(data=event_data, context=context, http_service=http_service, client=client)
+    webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
+    response = await webhook.send_payload(payload=payload, http_service=http_service)
     response.raise_for_status()
+    log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
     return response
 
 
@@ -79,18 +81,8 @@ async def convert_node_to_webhook(webhook_node: CoreWebhook, client: InfrahubCli
     return CustomWebhook.from_object(obj=webhook_node, custom_headers=custom_headers)
 
 
-@flow(name="webhook-process", flow_run_name="Send webhook for {webhook_name}")
-async def webhook_process(
-    webhook_id: str,
-    webhook_name: str,  # noqa: ARG001
-    webhook_kind: str,
-    event_id: str,
-    event_type: str,
-    event_occured_at: str,
-    event_payload: dict,
-    branch_name: str | None = None,
-) -> None:
-    """Resolve a webhook's configuration from cache (or DB on miss) and send the HTTP request.
+async def _resolve_webhook(webhook_id: str, webhook_kind: str) -> Webhook:
+    """Return the webhook config from cache, or fetch it from the database and cache it.
 
     Raises:
         ValueError: When the cached webhook type is not a supported webhook kind.
@@ -100,27 +92,39 @@ async def webhook_process(
     client = get_client()
     cache = await get_cache()
 
-    await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
-
     webhook_data_str = await cache.get(key=f"{CACHE_KEY_PREFIX}:{webhook_id}")
     if not webhook_data_str:
         log.info(f"Webhook {webhook_id} not found in cache")
         webhook_node = await client.get(kind=webhook_kind, id=webhook_id, prefetch_relationships=True)
         webhook = await convert_node_to_webhook(webhook_node=webhook_node, client=client)
-        webhook_data = webhook.to_cache()
         await cache.set(
-            key=f"{CACHE_KEY_PREFIX}:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS
+            key=f"{CACHE_KEY_PREFIX}:{webhook_id}", value=ujson.dumps(webhook.to_cache()), expires=KVTTL.TWO_HOURS
         )
+        return webhook
 
-    else:
-        webhook_data = ujson.loads(webhook_data_str)
+    webhook_data = ujson.loads(webhook_data_str)
+    if webhook_data["webhook_type"] not in WEBHOOK_MAP:
+        raise ValueError(f"Unsupported webhook kind: {webhook_data['webhook_type']}")
+    return WEBHOOK_MAP[webhook_data["webhook_type"]].from_cache(webhook_data)
 
-        if webhook_data["webhook_type"] not in WEBHOOK_MAP:
-            raise ValueError(f"Unsupported webhook kind: {webhook_data['webhook_type']}")
 
-        webhook_class = WEBHOOK_MAP[webhook_data["webhook_type"]]
-        webhook = webhook_class.from_cache(webhook_data)
+@flow(name="webhook-process", flow_run_name="Send webhook for {webhook_name}")
+async def webhook_process(
+    webhook_id: str,
+    webhook_name: str,
+    webhook_kind: str,
+    event_id: str,
+    event_type: str,
+    event_occured_at: str,
+    event_payload: dict,
+    branch_name: str | None = None,
+) -> None:
+    """Resolve the webhook config, compute the payload once, and hand it to the send flow."""
+    client = get_client()
 
+    await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
+
+    webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
     webhook_context = EventContext.from_event(
         event_id=event_id,
         event_type=event_type,
@@ -128,5 +132,5 @@ async def webhook_process(
         event_payload=event_payload,
     )
     event_data = event_payload.get("data", {})
-    response = await webhook_send(webhook=webhook, context=webhook_context, event_data=event_data)
-    log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
+    payload = await webhook.compute_payload(data=event_data, context=webhook_context, client=client)
+    await webhook_send(webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload)

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -528,7 +528,7 @@ REQUEST_ARTIFACT_DEFINITION_CHECK = WorkflowDefinition(
 
 WEBHOOK_PROCESS = WorkflowDefinition(
     name="webhook-process",
-    type=WorkflowType.USER,
+    type=WorkflowType.INTERNAL,
     module="infrahub.webhook.tasks.process",
     function="webhook_process",
 )

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -174,9 +174,9 @@ class TestWebhookProcess(TestInfrahubApp):
             event_payload=BRANCH_CREATED_PAYLOAD,
         )
 
-        await webhook.prepare(data={}, context=context, client=client)
+        payload = await webhook.compute_payload(data={}, context=context, client=client)
 
-        assert webhook.get_payload() == {
+        assert payload == {
             "ACCOUNT_ID": "182853f2-3a43-c7f9-3e84-c5152eff4b17",
             "BRANCH": None,
             "DATA": {},

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -34,9 +34,9 @@ def test_standard_webhook_header() -> None:
     )
     test_id = UUID("217b4ebc-b84f-4736-b1ee-222182aed371")
     time1 = Timestamp("2025-02-27T11:43:49.064807Z")
-    webhook._assign_headers(uuid=test_id, at=time1)
+    headers = webhook._build_headers(payload=None, uuid=test_id, at=time1)
 
-    assert webhook._headers == {
+    assert headers == {
         "Accept": "application/json",
         "Content-Type": "application/json",
         "webhook-id": "msg_217b4ebcb84f4736b1ee222182aed371",
@@ -45,8 +45,8 @@ def test_standard_webhook_header() -> None:
     }
 
 
-def test_assign_headers_with_static_custom_header() -> None:
-    """_assign_headers() with static custom header."""
+def test_build_headers_with_static_custom_header() -> None:
+    """Static custom header is added alongside the default headers."""
     webhook = CustomWebhook(
         name="test",
         url="http://test.com",
@@ -54,12 +54,11 @@ def test_assign_headers_with_static_custom_header() -> None:
         validate_certificates=True,
         custom_headers=[WebhookHeader(key="Authorization", value="Bearer token", kind=HeaderKind.STATIC)],
     )
-    webhook._assign_headers()
+    headers = webhook._build_headers(payload=None)
 
-    assert webhook._headers is not None
-    assert webhook._headers["Authorization"] == "Bearer token"
-    assert webhook._headers["Accept"] == "application/json"
-    assert webhook._headers["Content-Type"] == "application/json"
+    assert headers["Authorization"] == "Bearer token"
+    assert headers["Accept"] == "application/json"
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_custom_header_overrides_default() -> None:
@@ -71,10 +70,9 @@ def test_custom_header_overrides_default() -> None:
         validate_certificates=True,
         custom_headers=[WebhookHeader(key="Content-Type", value="text/plain", kind=HeaderKind.STATIC)],
     )
-    webhook._assign_headers()
+    headers = webhook._build_headers(payload=None)
 
-    assert webhook._headers is not None
-    assert webhook._headers["Content-Type"] == "text/plain"
+    assert headers["Content-Type"] == "text/plain"
 
 
 def test_cache_roundtrip_preserves_custom_headers() -> None:
@@ -101,7 +99,7 @@ def test_cache_roundtrip_preserves_custom_headers() -> None:
     assert restored.custom_headers[0].kind == "static"
 
 
-def test_assign_headers_resolves_environment_variable() -> None:
+def test_build_headers_resolves_environment_variable() -> None:
     """Environment variable header resolves from os.environ at send time."""
     webhook = CustomWebhook(
         name="test",
@@ -112,14 +110,13 @@ def test_assign_headers_resolves_environment_variable() -> None:
     )
 
     with patch.dict("os.environ", {"MY_API_KEY": "secret123"}):
-        webhook._assign_headers()
+        headers = webhook._build_headers(payload=None)
 
-    assert webhook._headers is not None
-    assert webhook._headers["X-API-Key"] == "secret123"
-    assert webhook._headers["Accept"] == "application/json"
+    assert headers["X-API-Key"] == "secret123"
+    assert headers["Accept"] == "application/json"
 
 
-def test_assign_headers_skips_missing_environment_variable(caplog: pytest.LogCaptureFixture) -> None:
+def test_build_headers_skips_missing_environment_variable(caplog: pytest.LogCaptureFixture) -> None:
     """Missing environment variable is skipped with a warning, no exception raised."""
     webhook = CustomWebhook(
         name="test",
@@ -133,17 +130,16 @@ def test_assign_headers_skips_missing_environment_variable(caplog: pytest.LogCap
     )
 
     with patch.dict("os.environ", {}, clear=True), caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
-        webhook._assign_headers()
+        headers = webhook._build_headers(payload=None)
 
-    assert webhook._headers is not None
-    assert "X-API-Key" not in webhook._headers
-    assert webhook._headers["X-Source"] == "infrahub"
+    assert "X-API-Key" not in headers
+    assert headers["X-Source"] == "infrahub"
     assert "MISSING_VAR" in caplog.text
     assert "X-API-Key" in caplog.text
     assert "test" in caplog.text  # webhook name included in warning
 
 
-def test_assign_headers_warns_on_duplicate_keys(caplog: pytest.LogCaptureFixture) -> None:
+def test_build_headers_warns_on_duplicate_keys(caplog: pytest.LogCaptureFixture) -> None:
     """Duplicate header keys produce a warning and the last value wins."""
     webhook = CustomWebhook(
         name="dup-test",
@@ -157,10 +153,9 @@ def test_assign_headers_warns_on_duplicate_keys(caplog: pytest.LogCaptureFixture
     )
 
     with caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
-        webhook._assign_headers()
+        headers = webhook._build_headers(payload=None)
 
-    assert webhook._headers is not None
-    assert webhook._headers["X-Token"] == "second"
+    assert headers["X-Token"] == "second"
     assert "duplicate header key 'X-Token'" in caplog.text
     assert "dup-test" in caplog.text
 
@@ -177,16 +172,16 @@ def test_webhook_signature_with_payload() -> None:
         validate_certificates=True,
         shared_key="my-webhook-secret",
     )
-    webhook._payload = {
+    payload = {
         "data": {"id": "abc123", "kind": "BuiltinTag", "display_label": "my tag"},
         "event_type": "infrahub.node.created",
         "branch": "main",
     }
     test_id = UUID("217b4ebc-b84f-4736-b1ee-222182aed371")
     time1 = Timestamp("2025-02-27T11:43:49.064807Z")
-    webhook._assign_headers(uuid=test_id, at=time1)
+    headers = webhook._build_headers(payload=payload, uuid=test_id, at=time1)
 
-    assert webhook._headers == {
+    assert headers == {
         "Accept": "application/json",
         "Content-Type": "application/json",
         "webhook-id": "msg_217b4ebcb84f4736b1ee222182aed371",

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -50,8 +50,15 @@ Application Event (e.g. node.created) ──► │ Prefect Automation   │
                                           └────────┬────────┘
                                                    │
                                           ┌────────┴────────┐
-                                          │ Prepare payload  │
-                                          │ + HMAC headers   │
+                                          │ Compute payload  │
+                                          └────────┬────────┘
+                                                   │
+                                                   ▼
+                                          webhook_send subflow
+                                                   │
+                                          ┌────────┴────────┐
+                                          │ Build headers    │
+                                          │ + HMAC signing   │
                                           └────────┬────────┘
                                                    │
                                                    ▼
@@ -95,12 +102,12 @@ Pydantic model for a custom HTTP header: `key` (str), `value` (str), `kind` (Lit
 
 The base class handles:
 
-- Payload preparation (`_prepare_payload`)
-- Header assignment with custom headers and optional HMAC signing (`_assign_headers`)
-- HTTP delivery via `send()`
+- Payload computation (`compute_payload`)
+- Header construction with custom headers and optional HMAC signing (`_build_headers`)
+- HTTP delivery of a precomputed payload via `send_payload()`
 - Cache serialization (`to_cache` / `from_cache`)
 
-The `custom_headers: list[WebhookHeader]` field on the base `Webhook` class holds headers loaded from the `CoreWebhook.headers` relationship. During `_assign_headers()`, custom headers are applied after system defaults (Accept, Content-Type) but before HMAC signature headers. Static headers use the value directly; environment headers resolve from `os.environ` at send time (missing vars are skipped with a warning log).
+The `custom_headers: list[WebhookHeader]` field on the base `Webhook` class holds headers loaded from the `CoreWebhook.headers` relationship. During `_build_headers()`, custom headers are applied after system defaults (Accept, Content-Type) but before HMAC signature headers. Static headers use the value directly; environment headers resolve from `os.environ` at send time (missing vars are skipped with a warning log).
 
 ## Schema (GraphQL)
 
@@ -172,9 +179,10 @@ When a matched event fires, Prefect runs the `webhook_process` flow:
 2. On cache miss, fetches the webhook node from the database and caches it
 3. Deserializes the webhook using the `WEBHOOK_MAP` type registry
 4. Builds `EventContext` from the raw event
-5. Calls `webhook.send()` which prepares the payload, assigns headers (with optional HMAC), and POSTs to the target URL
+5. Calls `webhook.compute_payload()` to build the payload
+6. Hands the payload to the `webhook_send` subflow, which resolves the webhook config, builds the headers (with optional HMAC), and POSTs to the target URL
 
-The `webhook_send` task has 3 retries configured and calls `response.raise_for_status()`.
+The `webhook_send` subflow has 3 retries configured and calls `response.raise_for_status()`. It is invoked directly by `webhook_process` rather than registered in the workflow catalogue.
 
 ## Security
 
@@ -209,7 +217,7 @@ Three headers are added to signed requests:
 
 | Workflow | Type | Cron | Purpose |
 |----------|------|------|---------|
-| `WEBHOOK_PROCESS` | USER | — | Delivers webhook payload on event match |
+| `WEBHOOK_PROCESS` | INTERNAL | — | Resolves the webhook, computes the payload, and invokes the `webhook_send` subflow on event match |
 | `WEBHOOK_CONFIGURE` | INTERNAL | daily at 3 AM (random minute) | Unified webhook automation configuration (configure, delete, reconcile) |
 | `WEBHOOK_INVALIDATE_HEADERS` | INTERNAL | — | Invalidates cached webhook data when a referenced KeyValue header changes |
 


### PR DESCRIPTION
[IFC-2785](https://opsmill.atlassian.net/browse/IFC-2785)

Draft, stacked on `pmi-20260618-ifc-2119-resend-webhook`.

## Why make the send its own flow

The webhook send is currently an inline task inside the `webhook-process` flow, so it has no run of its own and cannot be surfaced, inspected, resent, or cancelled on its own. As its own flow, a delivery becomes a Prefect flow run with its own state, parameters, logs, and retries, which is what the resend, cancel, typing, and capture work builds on.

Roles of the two flows:

* `webhook-process` (internal): resolves the config and computes the payload once, then passes that payload to the send flow. Computing it here fixes the payload before the send flow runs, so every retry replays the same payload and a `TransformWebhook` script runs once per delivery instead of once per attempt. An internal flow is not shown in the tasks screen, so the orchestrator stays out of it.
* `webhook-send`: resolves the config and assigns the headers on each run, so the signature is rebuilt on every attempt. This is the run that retries and that gets shown and acted on.

## What changed

* `webhook_send` becomes a subflow called by `webhook_process` (was an inline task).
* `webhook_process` is marked INTERNAL, so it is not shown in the tasks screen.
* The payload is computed in the process flow and the headers in the send flow.
* The payload is passed explicitly; the transient `_payload`/`_headers` state is removed and header building is now pure.

The HTTP send itself is unchanged (same retries, same raise on HTTP error).

## Test plan

* `pytest backend/tests/functional/webhook/test_process.py`

[IFC-2785]: https://opsmill.atlassian.net/browse/IFC-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the webhook HTTP send into its own `webhook-send` subflow and made `webhook-process` internal. Each delivery is now a standalone flow run with its own state, retries, and logs while keeping payloads stable across retries.

- **Refactors**
  - `webhook-send` is now a `@flow` subflow invoked by `webhook-process`; it re-resolves config, builds headers, and posts the provided payload with the same retries/error handling; it is not registered in the workflow catalogue.
  - `webhook-process` (now INTERNAL) resolves config, computes the payload once, then calls the send subflow.
  - Added `_resolve_webhook` to fetch from cache or DB; caches for 2 hours.
  - Model API is now pure: `compute_payload(...)` returns the payload, `_build_headers(payload)` returns headers, `send_payload(payload, http_service)` posts; removed `_payload`/`_headers`, `prepare`, and `get_payload`.
  - Signatures are rebuilt on each send attempt; transforms run once per delivery.
  - Updated unit and functional tests to use the explicit payload/header API and assert on returned dicts.
  - Synced `dev/knowledge/backend/webhooks.md` to reflect the send subflow and INTERNAL workflow.

<sup>Written for commit 48817bf976f11d974ba257ff77d1099e3b86c9d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

