### PR TITLE
Version 1.9.9

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -261,6 +261,7 @@ walkthroughs
 whitespace
 widget's
 Widget's
+worktree
 worktrees
 Yaml
 YAML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.9](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.9) - 2026-06-23
+
+### Security
+
+- Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.
+
+### Added
+
+- Added a link in the Proposed Change "Checks" tab from each Artifact Validator to the originating `CoreArtifactDefinition`, so users can navigate directly to the definition that produced the check.
+
+### Fixed
+
+- Importing a Git repository now succeeds even when one of its branches has a merge conflict against the default branch. The conflicting branch is imported as-is and a warning is logged; the conflict is reported when a user later attempts to merge the branch. ([#2293](https://github.com/opsmill/infrahub/issues/2293))
+- Fixed the unclear error message shown when picking a time earlier than the Infrahub instance was created. ([#4076](https://github.com/opsmill/infrahub/issues/4076))
+- Narrowed the git repository lock so it only guards on-disk git working-copy mutations (clone, fetch, worktree creation) and no longer wraps importing repository objects into the graph. ([#6639](https://github.com/opsmill/infrahub/issues/6639))
+- Added a refresh button to the artifact detail page so regenerated artifact content can be reloaded in place, without requiring a full browser refresh. ([#9335](https://github.com/opsmill/infrahub/issues/9335))
+- Fixed git repository synchronization so that a failure on one branch no longer prevents the other branches from being synchronized. ([#9463](https://github.com/opsmill/infrahub/issues/9463))
+- Fixed the file action reported by the repository diff so a file added on a branch is labelled `added` (and a deleted file `removed`) instead of being inverted in `GET /api/diff/files` and the Proposed Change Files tab. ([#9530](https://github.com/opsmill/infrahub/issues/9530))
+- Rebasing a branch now only requires the `global:rebase_branch:allow_all` permission. Previously the default-branch permission check ran ahead of the rebase check and also demanded `global:edit_default_branch:allow_all`, so users granted only the rebase permission were denied with "You are not allowed to change data in the default branch". ([#9604](https://github.com/opsmill/infrahub/issues/9604))
+- Fixed the repository **Import latest commit** and **Reimport current commit** actions running against `main` instead of the branch currently selected in the UI. ([#9653](https://github.com/opsmill/infrahub/issues/9653))
+- Computed attribute updates no longer raise a `ValueError` when `PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES` is set to `1`. The workflow submission chunk size is now floored at 1.
+- Concurrent imports of the same repository no longer race to create the same object and fail on a name uniqueness constraint, which could leave the repository out of sync. The graph-changing phase of a repository import is now serialized under the repository lock.
+- Repository synchronization now resolves both a new repository's initial import and the pinned worker-pool commit from the repository's Git default branch rather than Infrahub's default branch name, fixing repositories whose Git default branch differs and staging-branch syncs.
+
 ## [Infrahub - v1.9.8](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.8) - 2026-06-09
 
 ### Changed

--- a/changelog/+fix-computed-attribute-chunk-size.fixed.md
+++ b/changelog/+fix-computed-attribute-chunk-size.fixed.md
@@ -1,1 +1,0 @@
-Computed attribute updates no longer raise a `ValueError` when `PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES` is set to `1`. The workflow submission chunk size is now floored at 1.

--- a/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
+++ b/changelog/+gitpython-ghsa-mv93-w799-cj2w.security.md
@@ -1,1 +1,0 @@
-Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.

--- a/changelog/+link-artifact-validator-to-definition.added.md
+++ b/changelog/+link-artifact-validator-to-definition.added.md
@@ -1,1 +1,0 @@
-Added a link in the Proposed Change "Checks" tab from each Artifact Validator to the originating `CoreArtifactDefinition`, so users can navigate directly to the definition that produced the check.

--- a/changelog/+pin-sync-commit-git-default-branch.fixed.md
+++ b/changelog/+pin-sync-commit-git-default-branch.fixed.md
@@ -1,1 +1,0 @@
-Repository synchronization now resolves both a new repository's initial import and the pinned worker-pool commit from the repository's Git default branch rather than Infrahub's default branch name, fixing repositories whose Git default branch differs and staging-branch syncs.

--- a/changelog/+repository-import-uniqueness-race.fixed.md
+++ b/changelog/+repository-import-uniqueness-race.fixed.md
@@ -1,1 +1,0 @@
-Concurrent imports of the same repository no longer race to create the same object and fail on a name uniqueness constraint, which could leave the repository out of sync. The graph-changing phase of a repository import is now serialized under the repository lock.

--- a/changelog/2293.fixed.md
+++ b/changelog/2293.fixed.md
@@ -1,1 +1,0 @@
-Importing a Git repository now succeeds even when one of its branches has a merge conflict against the default branch. The conflicting branch is imported as-is and a warning is logged; the conflict is reported when a user later attempts to merge the branch.

--- a/changelog/4076.fixed.md
+++ b/changelog/4076.fixed.md
@@ -1,1 +1,0 @@
-Fixed the unclear error message shown when picking a time earlier than the Infrahub instance was created.

--- a/changelog/6639.fixed.md
+++ b/changelog/6639.fixed.md
@@ -1,1 +1,0 @@
-Narrowed the git repository lock so it only guards on-disk git working-copy mutations (clone, fetch, worktree creation) and no longer wraps importing repository objects into the graph.

--- a/changelog/9335.fixed.md
+++ b/changelog/9335.fixed.md
@@ -1,1 +1,0 @@
-Added a refresh button to the artifact detail page so regenerated artifact content can be reloaded in place, without requiring a full browser refresh.

--- a/changelog/9463.fixed.md
+++ b/changelog/9463.fixed.md
@@ -1,1 +1,0 @@
-Fixed git repository synchronization so that a failure on one branch no longer prevents the other branches from being synchronized.

--- a/changelog/9530.fixed.md
+++ b/changelog/9530.fixed.md
@@ -1,1 +1,0 @@
-Fixed the file action reported by the repository diff so a file added on a branch is labelled `added` (and a deleted file `removed`) instead of being inverted in `GET /api/diff/files` and the Proposed Change Files tab.

--- a/changelog/9604.fixed.md
+++ b/changelog/9604.fixed.md
@@ -1,1 +1,0 @@
-Rebasing a branch now only requires the `global:rebase_branch:allow_all` permission. Previously the default-branch permission check ran ahead of the rebase check and also demanded `global:edit_default_branch:allow_all`, so users granted only the rebase permission were denied with "You are not allowed to change data in the default branch".

--- a/changelog/9653.fixed.md
+++ b/changelog/9653.fixed.md
@@ -1,1 +1,0 @@
-Fixed the repository **Import latest commit** and **Reimport current commit** actions running against `main` instead of the branch currently selected in the UI.

--- a/docs/docs/release-notes/infrahub/release-1_9_9.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_9.mdx
@@ -9,7 +9,7 @@ title: Release 1.9.9
     </tr>
     <tr>
       <th>Release Date</th>
-      <td>June 23th, 2026</td>
+      <td>June 23rd, 2026</td>
     </tr>
     <tr>
       <th>Tag</th>

--- a/docs/docs/release-notes/infrahub/release-1_9_9.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_9.mdx
@@ -1,0 +1,41 @@
+---
+title: Release 1.9.9
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.9</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 23th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.9](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.9)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Security
+
+- Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.
+
+### Added
+
+- Added a link in the Proposed Change "Checks" tab from each Artifact Validator to the originating `CoreArtifactDefinition`, so users can navigate directly to the definition that produced the check.
+
+### Fixed
+
+- Importing a Git repository now succeeds even when one of its branches has a merge conflict against the default branch. The conflicting branch is imported as-is and a warning is logged; the conflict is reported when a user later attempts to merge the branch. ([#2293](https://github.com/opsmill/infrahub/issues/2293))
+- Fixed the unclear error message shown when picking a time earlier than the Infrahub instance was created. ([#4076](https://github.com/opsmill/infrahub/issues/4076))
+- Narrowed the git repository lock so it only guards on-disk git working-copy mutations (clone, fetch, worktree creation) and no longer wraps importing repository objects into the graph. ([#6639](https://github.com/opsmill/infrahub/issues/6639))
+- Added a refresh button to the artifact detail page so regenerated artifact content can be reloaded in place, without requiring a full browser refresh. ([#9335](https://github.com/opsmill/infrahub/issues/9335))
+- Fixed git repository synchronization so that a failure on one branch no longer prevents the other branches from being synchronized. ([#9463](https://github.com/opsmill/infrahub/issues/9463))
+- Fixed the file action reported by the repository diff so a file added on a branch is labelled `added` (and a deleted file `removed`) instead of being inverted in `GET /api/diff/files` and the Proposed Change Files tab. ([#9530](https://github.com/opsmill/infrahub/issues/9530))
+- Rebasing a branch now only requires the `global:rebase_branch:allow_all` permission. Previously the default-branch permission check ran ahead of the rebase check and also demanded `global:edit_default_branch:allow_all`, so users granted only the rebase permission were denied with "You are not allowed to change data in the default branch". ([#9604](https://github.com/opsmill/infrahub/issues/9604))
+- Fixed the repository **Import latest commit** and **Reimport current commit** actions running against `main` instead of the branch currently selected in the UI. ([#9653](https://github.com/opsmill/infrahub/issues/9653))
+- Computed attribute updates no longer raise a `ValueError` when `PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES` is set to `1`. The workflow submission chunk size is now floored at 1.
+- Concurrent imports of the same repository no longer race to create the same object and fail on a name uniqueness constraint, which could leave the repository out of sync. The graph-changing phase of a repository import is now serialized under the repository lock.
+- Repository synchronization now resolves both a new repository's initial import and the pinned worker-pool commit from the repository's Git default branch rather than Infrahub's default branch name, fixing repositories whose Git default branch differs and staging-branch syncs.

--- a/docs/docs/release-notes/infrahub/release-1_9_9.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_9.mdx
@@ -20,11 +20,11 @@ title: Release 1.9.9
 
 ### Security
 
-- Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted git config section names.
+- Upgraded GitPython to 3.1.50 to address GHSA-mv93-w799-cj2w, a configuration-injection vulnerability that could lead to arbitrary code execution via crafted `git config` section names.
 
 ### Added
 
-- Added a link in the Proposed Change "Checks" tab from each Artifact Validator to the originating `CoreArtifactDefinition`, so users can navigate directly to the definition that produced the check.
+- Added a link in the Proposed Change "Checks" tab from each artifact validator to the originating `CoreArtifactDefinition`, so users can navigate directly to the definition that produced the check.
 
 ### Fixed
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -641,6 +641,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_9',
                 'release-notes/infrahub/release-1_9_8',
                 'release-notes/infrahub/release-1_9_7',
                 'release-notes/infrahub/release-1_9_6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.8"
+version = "1.9.9"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.8"
+version = "1.9.9"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.8"
+version = "1.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.8"
+version = "1.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION

# Why

Prepare for release 1.9.9

## What changed

* Version number in pyproject.toml & uv.lock
* Release notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 1.9.9 release by bumping `infrahub-server` and `infrahub-testcontainers`, updating lockfiles, and publishing release notes. Consolidates towncrier fragments into `CHANGELOG.md`, adds 1.9.9 to the docs sidebar, adds 'worktree' to Vale spelling exceptions, and fixes a date in the release notes.

<sup>Written for commit ef0c2361aa988e5006711663b0061cc5a0d33464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

