### PR TITLE
feat(webhook): automatic retry policy for the webhook send

### DIFF
--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -28,8 +28,8 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-# 0s, 1m, 30m, 6h
-WEBHOOK_SEND_RETRY_DELAYS: list[float] = [0, 60, 1800, 21600]
+WEBHOOK_SEND_RETRIES: int = 3
+WEBHOOK_SEND_RETRY_DELAY_SECONDS: float = 120  # fixed 2m delay between attempts
 
 
 @task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
@@ -42,14 +42,18 @@ async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, pa
     return response
 
 
-@flow(name="webhook-send", flow_run_name="Send webhook {webhook_name}")
+@flow(
+    name="webhook-send",
+    flow_run_name="Send webhook {webhook_name}",
+    retries=WEBHOOK_SEND_RETRIES,
+    retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS,
+)
 async def webhook_send(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:
-    """Send the webhook delivery, retrying the POST on failure."""
+    """Send the webhook delivery, retrying the whole send on failure."""
     log = get_run_logger()
-    send = webhook_post.with_options(
-        retries=len(WEBHOOK_SEND_RETRY_DELAYS), retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAYS
+    response = await webhook_post(
+        webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload
     )
-    response = await send(webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload)
     log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
     return response
 

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -32,13 +32,7 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 WEBHOOK_SEND_RETRY_DELAYS: list[float] = [0, 60, 1800, 21600]
 
 
-@task(
-    name="webhook-post",
-    task_run_name="Send webhook {webhook_name}",
-    cache_policy=NONE,
-    retries=len(WEBHOOK_SEND_RETRY_DELAYS),
-    retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAYS,
-)
+@task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
 async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:  # noqa: ARG001
     """Resolve the webhook config, assign its headers, and POST the prepared payload."""
     http_service = get_http()
@@ -52,9 +46,10 @@ async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, pa
 async def webhook_send(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:
     """Send the webhook delivery, retrying the POST on failure."""
     log = get_run_logger()
-    response = await webhook_post(
-        webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload
+    send = webhook_post.with_options(
+        retries=len(WEBHOOK_SEND_RETRY_DELAYS), retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAYS
     )
+    response = await send(webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload)
     log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
     return response
 

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -28,14 +28,33 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-@flow(name="webhook-send", flow_run_name="Send webhook {webhook_name}", retries=3)
-async def webhook_send(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:  # noqa: ARG001
-    """Resolve the webhook config, assign its headers, and POST the prepared payload. Retries up to 3 times."""
-    log = get_run_logger()
+# 0s, 1m, 30m, 6h
+WEBHOOK_SEND_RETRY_DELAYS: list[float] = [0, 60, 1800, 21600]
+
+
+@task(
+    name="webhook-post",
+    task_run_name="Send webhook {webhook_name}",
+    cache_policy=NONE,
+    retries=len(WEBHOOK_SEND_RETRY_DELAYS),
+    retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAYS,
+)
+async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:  # noqa: ARG001
+    """Resolve the webhook config, assign its headers, and POST the prepared payload."""
     http_service = get_http()
     webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
     response = await webhook.send_payload(payload=payload, http_service=http_service)
     response.raise_for_status()
+    return response
+
+
+@flow(name="webhook-send", flow_run_name="Send webhook {webhook_name}")
+async def webhook_send(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:
+    """Send the webhook delivery, retrying the POST on failure."""
+    log = get_run_logger()
+    response = await webhook_post(
+        webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload
+    )
     log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
     return response
 

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -41,6 +41,16 @@ BRANCH_CREATED_PAYLOAD: dict[str, Any] = {
 }
 
 
+@pytest.fixture
+def immediate_webhook_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the webhook send retries without their production back-off.
+
+    A failing delivery exhausts its retries promptly instead of sleeping through the real
+    multi-hour schedule, keeping retry-path tests within the suite timeout.
+    """
+    monkeypatch.setattr("infrahub.webhook.tasks.process.WEBHOOK_SEND_RETRY_DELAYS", [0, 0, 0, 0])
+
+
 @pytest.fixture(scope="class")
 async def initial_dataset(
     db: InfrahubDatabase,

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -7,6 +7,7 @@ from prefect.client.orchestration import PrefectClient, get_client
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
+from infrahub.webhook.tasks import process
 from infrahub.workflows.catalogue import WEBHOOK_CONFIGURE, WEBHOOK_INVALIDATE_HEADERS, WEBHOOK_PROCESS, WORKER_POOLS
 from infrahub.workflows.initialization import setup_worker_pools
 from tests.constants import TestKind
@@ -46,9 +47,9 @@ def immediate_webhook_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the webhook send retries without their production back-off.
 
     A failing delivery exhausts its retries promptly instead of sleeping through the real
-    multi-hour schedule, keeping retry-path tests within the suite timeout.
+    schedule, keeping retry-path tests within the suite timeout.
     """
-    monkeypatch.setattr("infrahub.webhook.tasks.process.WEBHOOK_SEND_RETRY_DELAYS", [0, 0, 0, 0])
+    monkeypatch.setattr(process, "webhook_send", process.webhook_send.with_options(retry_delay_seconds=0))
 
 
 @pytest.fixture(scope="class")

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -137,6 +137,7 @@ class TestWebhookProcess(TestInfrahubApp):
         webhook2: Node,
         webhook_deployment: None,
         dependency_provider: Provider,
+        immediate_webhook_retries: None,
     ) -> None:
         from infrahub.workers.dependencies import build_http_service
 


### PR DESCRIPTION
Closes [IFC-2779].

Draft, stacked on the webhook send/subflow split (#9672).

## What this adds

#9672 already makes `webhook-send` a flow that retries 3 times. On top of that, this PR adds a fixed back-off between those attempts: `retry_delay_seconds=120` (2 minutes), so retries are spaced 2 minutes apart instead of immediate. Each retry re-runs the flow body, which re-resolves the webhook config and re-signs the headers.

A fixed delay is used because Prefect flow retries take a single `retry_delay_seconds` value; a per-attempt schedule is only honoured for task retries.

The send itself is wrapped in a `webhook-post` task that the flow calls.

## Tests

The `immediate_webhook_retries` fixture overrides the flow delay to 0 so the failing-delivery test exhausts its retries within the suite timeout while still exercising the real retry path.

* `pytest backend/tests/functional/webhook/test_process.py`

[IFC-2779]: https://opsmill.atlassian.net/browse/IFC-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automatic retry policy for webhook deliveries by splitting the HTTP POST into a `webhook-post` task and retrying the `webhook-send` flow with a fixed 2-minute backoff (3 retries). Implements IFC-2779; each attempt re-resolves config and re-signs headers.

- **New Features**
  - Adds `webhook-post`; `webhook-send` now handles retries natively (retries=3, `retry_delay_seconds=120`).
  - Each retry re-invokes `webhook-post` to refresh config and signing.
  - Test fixture `immediate_webhook_retries` overrides the flow delay to 0 so failing-delivery tests exhaust retries quickly.

<sup>Written for commit 11bf64a5010f8c5652deb5a248aee2a2c93ca362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
