### PR TITLE
docs(agentic): read dev/knowledge before diagnosis, not just modifying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ CI validates that all generated files are committed — the `validate-generated-
 
 ### Always Do
 
-- Before modifying code in any domain, read the relevant docs in `dev/knowledge/` for that domain
+- Before diagnosing _or_ modifying code in any domain, read the relevant docs in `dev/knowledge/` for that domain. The architectural intent (which layer owns a concern) is often the answer to the bug — don't reason from code alone
 - Run formatters before committing (`uv run invoke format`, `pnpm biome:fix`)
 - Write tests for new functionality
 - Use type hints for Python (backend) and TypeScript types (frontend)


### PR DESCRIPTION
The architectural intent (which layer owns a concern) is often the answer to a bug; reasoning from code alone misses it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated AGENTS.md to require reading `dev/knowledge/` before diagnosing or modifying code. This emphasizes architectural intent (which layer owns a concern) to avoid misdirected bug fixes.

<sup>Written for commit 301f904e37b73ce41e97baf728280c57b5c5d77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

