### PR TITLE
fix(auth): narrow SSO group create-race handling to uniqueness violations

### DIFF
--- a/backend/infrahub/auth/auth_groups/service.py
+++ b/backend/infrahub/auth/auth_groups/service.py
@@ -27,7 +27,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node.create import create_node
 from infrahub.core.protocols import CoreAccount, CoreAccountGroup
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import UniquenessViolationError
 from infrahub.log import get_logger
 
 if TYPE_CHECKING:
@@ -166,7 +166,8 @@ class AutoCreatedGroupsService:
         group that won.
 
         Raises:
-            ValidationError: when creation fails and no reusable group can be found afterwards.
+            UniquenessViolationError: when the create races and no reusable group can be found afterwards.
+            ValidationError: when creation fails for any other reason; such errors are not treated as a race.
 
         """
         existing = await self._lookup_by_name(name)
@@ -181,7 +182,7 @@ class AutoCreatedGroupsService:
                 branch=branch,
                 schema=CoreAccountGroup,
             )
-        except ValidationError:
+        except UniquenessViolationError:
             existing = await self._lookup_by_name(name)
             if existing is None:
                 raise

--- a/backend/infrahub/core/node/constraints/attribute_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/attribute_uniqueness.py
@@ -5,7 +5,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import UniquenessViolationError
 
 from .interface import NodeConstraintInterface
 
@@ -48,6 +48,6 @@ class NodeAttributeUniquenessConstraint(NodeConstraintInterface):
             )
 
             if any(n for n in nodes if n.get_id() != node.id):
-                raise ValidationError(
+                raise UniquenessViolationError(
                     {unique_attr.name: f"An object already exist with this value: {unique_attr.name}: {attr.value}"}
                 )

--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -14,7 +14,7 @@ from infrahub.core.validators.uniqueness.model import (
     QueryRelationshipPathValued,
 )
 from infrahub.core.validators.uniqueness.query import UniquenessValidationQuery
-from infrahub.exceptions import HFIDViolatedError, ValidationError
+from infrahub.exceptions import HFIDViolatedError, UniquenessViolationError
 
 from .interface import NodeConstraintInterface
 
@@ -218,7 +218,7 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                     continue
 
             error_msg = self._message_builder.build(node_schema=node.get_schema(), fields=violation.fields)
-            raise ValidationError(error_msg)
+            raise UniquenessViolationError(error_msg)
 
         if hfid_violation:
             error_msg = self._message_builder.build(node_schema=node.get_schema(), fields=hfid_violation.fields)

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -373,7 +373,11 @@ class DiffError(Error):
         self.message = message
 
 
-class HFIDViolatedError(ValidationError):
+class UniquenessViolationError(ValidationError):
+    """Raised when a node's uniqueness constraint is violated."""
+
+
+class HFIDViolatedError(UniquenessViolationError):
     matching_nodes_ids: set[str]
 
     def __init__(self, input_value: str | dict | list, matching_nodes_ids: set[str]) -> None:

--- a/backend/tests/component/core/constraint_validators/test_node_uniqueness.py
+++ b/backend/tests/component/core/constraint_validators/test_node_uniqueness.py
@@ -3,11 +3,12 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
+from infrahub.core.node.constraints.attribute_uniqueness import NodeAttributeUniquenessConstraint
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
 from infrahub.core.node.constraints.uniqueness_violation_message import UniquenessViolationMessageBuilder
 from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import UniquenessViolationError
 
 
 async def test_node_validate_constraint_node_uniqueness_failure(
@@ -23,10 +24,23 @@ async def test_node_validate_constraint_node_uniqueness_failure(
     new_john = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await new_john.new(db=db, name="John", height=160)
 
-    with pytest.raises(ValidationError) as exc:
+    with pytest.raises(UniquenessViolationError) as exc:
         await constraint.check(new_john)
 
     assert "Violates uniqueness constraint 'name'" in exc.value.message
+
+
+async def test_node_validate_constraint_attribute_uniqueness_failure(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main: Node
+) -> None:
+    constraint = NodeAttributeUniquenessConstraint(db=db, branch=default_branch)
+    new_john = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await new_john.new(db=db, name="John", height=160)
+
+    with pytest.raises(UniquenessViolationError) as exc:
+        await constraint.check(new_john)
+
+    assert "An object already exist with this value" in exc.value.message
 
 
 async def test_node_validate_constraint_node_uniqueness_success(
@@ -87,5 +101,5 @@ async def test_hierarchical_uniqueness_constraint(
 
     ld62 = await Node.init(db=db, schema="LocationRack", branch=default_branch)
     await ld62.new(db=db, name="ld6-ldn2", parent=uk)
-    with pytest.raises(ValidationError, match=r"Violates uniqueness constraint 'parent-status'"):
+    with pytest.raises(UniquenessViolationError, match=r"Violates uniqueness constraint 'parent-status'"):
         await constraint.check(ld62)


### PR DESCRIPTION
Addresses cubic feedback on #9677 about the SSO auto-create group flow's exception handling.

## Behavior

The auto-create SSO groups flow reuses an existing group when a create loses the find-or-create race against a concurrent creation of the same name. The reuse path triggers on a uniqueness collision only; a creation error for any other reason propagates to the caller.

## Change

- Add `UniquenessViolationError(ValidationError)` in `exceptions.py`, with `HFIDViolatedError` reparented under it (an HFID violation is a uniqueness violation).
- The grouped-uniqueness constraint raises `UniquenessViolationError` on a standard-constraint violation; the HFID path raises the now-subclassed `HFIDViolatedError`.
- The auto-create flow catches `UniquenessViolationError`.

Because `UniquenessViolationError` subclasses `ValidationError`, every existing `except ValidationError` / `pytest.raises(ValidationError)` behaves identically. The uniqueness message is an unstructured string, so the GraphQL mutation error path — which reclassifies only a bare `ValidationError` — re-raises it unchanged, keeping the same 422 and message.

## Tests

Covered by existing component tests run in CI:

- `backend/tests/component/auth/auth_groups/test_autocreate_race_reuse.py` — exercises the create-race reuse path via the typed exception.
- `backend/tests/component/core/constraint_validators/test_node_uniqueness.py` — asserts `pytest.raises(ValidationError)`, satisfied by the subclass.

Not run locally (need a Neo4j stack); validated `ruff`, `ruff format`, and `ty` on the changed files.