### PR TITLE
remove extraneous <Tabs>

### DIFF
--- a/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
+++ b/docs/docs/deploy-manage/user-management/ldap/advanced-ldap.mdx
@@ -84,7 +84,7 @@ group_bfs_max_depth = 16
 
 By default, only directory groups that already exist as local groups take effect. Infrahub can instead create local groups on demand from the directory group names a user belongs to, so administrators do not have to mirror every directory group manually. The feature is opt-in and scoped by a regular-expression filter.
 
-The same mechanism handles SSO claims and LDAP group names. For configuration — the filter syntax, the per-login cap, the `origin` provenance attribute, and the audit events — see [Auto-create groups from identity provider claims](../sso/advanced-sso.mdx#auto-create-groups-from-identity-provider-claims).
+The same mechanism handles SSO claims and LDAP group names. For configuration — the filter syntax, the per-login cap, the `origin` provenance attribute, and the audit events — see [Auto-create groups from claims](../sso/advanced-sso.mdx#auto-create-groups-from-claims).
 
 ## Multiple servers and failover
 

--- a/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
@@ -110,9 +110,6 @@ The default group is assigned only on a user's **first** login, when their accou
 
 On every SSO login, each provider-supplied claim is matched against the configured filter. The first matching pattern derives an **effective name** — either from a `(?P<name>...)` named capture group or, when the pattern has no named capture, from the full matched claim. Infrahub then finds-or-creates a `CoreAccountGroup` with that name and adds the logging-in account as a member. A claim that does not match the filter is ignored.
 
-<Tabs groupId="config-method" queryString>
-<TabItem value="environment-variables" default>
-
 #### Configure the filter
 
 <Tabs groupId="config-method" queryString>

--- a/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
+++ b/docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx
@@ -58,7 +58,7 @@ When a user signs in through SSO, Infrahub maps the group claims your identity p
 Group memberships derived from provider claims are evaluated on **every** login and are **additive**: each login adds the user to the groups their claims map to. Infrahub never removes a user from a group based on claims — if a group is dropped from the provider, that removal is **not** synced automatically. If an administrator removes a user from a group that still appears in provider claims, the user is added back on the next login. Revoking group membership permanently requires updating provider claims and removing membership in Infrahub.
 All three rely on your identity provider sending group information in the first place. Configure that first, then pick an approach. [How Infrahub resolves membership](#how-infrahub-resolves-membership) explains how the approaches interact on each login.
 
-The [default group](#step-3-configure-default-group-assignment-optional) is the one exception: it is applied only on a user's first login, not on every login.
+The [default group](#set-a-default-group) is the one exception: it is applied only on a user's first login, not on every login.
 :::
 
 ### Send group claims from your identity provider


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed an extraneous `Tabs`/`TabItem` wrapper in `docs/docs/deploy-manage/user-management/sso/advanced-sso.mdx` around “Configure the filter” to fix nested Tabs and clean up the rendered docs. Also corrected links: updated the default-group anchor to `#set-a-default-group` in SSO docs and aligned the LDAP page link to “Auto-create groups from claims” (`../sso/advanced-sso.mdx#auto-create-groups-from-claims`).

<sup>Written for commit e2708d7ab9aaad42ede74e3920cb89e65a96b007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

