### PR TITLE
add SortableList and SortableItem to @infrahub/ui

### DIFF
--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.stories.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { XIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "../button/button";
+import { Select, SelectItem, SelectList, SelectTrigger } from "../select/select";
+import { SortableItem, SortableList } from "./sortable-list";
+
+const meta: Meta<typeof SortableList> = {
+  component: SortableList,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+interface Task {
+  id: string;
+  name: string;
+}
+
+const INITIAL_TASKS: Task[] = [
+  { id: "1", name: "Design the schema" },
+  { id: "2", name: "Build the API" },
+  { id: "3", name: "Wire up the UI" },
+  { id: "4", name: "Write the tests" },
+  { id: "5", name: "Ship it" },
+];
+
+/*
+ * SortableList is controlled, so the parent always holds the current order.
+ * Here it is rendered live beside the list to make onReorder's output tangible.
+ */
+function DefaultRender() {
+  const [tasks, setTasks] = useState(INITIAL_TASKS);
+
+  return (
+    <div className="flex items-start gap-6">
+      <SortableList aria-label="Tasks" items={tasks} onReorder={setTasks} className="w-72">
+        {(task) => (
+          <SortableItem id={task.id} textValue={task.name}>
+            <span className="flex-1 truncate">{task.name}</span>
+          </SortableItem>
+        )}
+      </SortableList>
+      <ol className="w-48 rounded-lg border border-stone-200 bg-stone-50 p-2 text-stone-600 text-xs">
+        {tasks.map((task, index) => (
+          <li key={task.id} className="flex gap-2 px-1 py-0.5">
+            <span className="text-stone-400">{index + 1}.</span>
+            <span className="truncate">{task.name}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DefaultRender />,
+};
+
+interface Rule {
+  id: string;
+  name: string;
+  action: string;
+}
+
+const INITIAL_RULES: Rule[] = [
+  { id: "1", name: "Source IP matches", action: "allow" },
+  { id: "2", name: "Port is 443", action: "allow" },
+  { id: "3", name: "Geo is blocked", action: "deny" },
+  { id: "4", name: "Rate limit exceeded", action: "log" },
+];
+
+const ACTIONS = [
+  { key: "allow", label: "Allow" },
+  { key: "deny", label: "Deny" },
+  { key: "log", label: "Log only" },
+];
+
+/*
+ * Each row mixes two independent interactive controls — a Select and a remove
+ * button — next to the drag handle. Opening the Select (which is itself a
+ * popover) and pressing the button register as presses, not drags, so they work
+ * inside a draggable row.
+ */
+function WithControlsRender() {
+  const [rules, setRules] = useState(INITIAL_RULES);
+
+  const setAction = (id: string, action: string) =>
+    setRules((current) => current.map((rule) => (rule.id === id ? { ...rule, action } : rule)));
+
+  const remove = (id: string) => setRules((current) => current.filter((rule) => rule.id !== id));
+
+  return (
+    <SortableList aria-label="Firewall rules" items={rules} onReorder={setRules} className="w-96">
+      {(rule) => (
+        <SortableItem id={rule.id} textValue={rule.name}>
+          <span className="flex-1 truncate">{rule.name}</span>
+          <Select
+            aria-label={`Action for ${rule.name}`}
+            selectedKey={rule.action}
+            onSelectionChange={(key) => setAction(rule.id, String(key))}
+          >
+            <SelectTrigger className="min-h-8 w-32 py-1" />
+            <SelectList items={ACTIONS}>
+              {(action) => (
+                <SelectItem key={action.key} textValue={action.label}>
+                  {action.label}
+                </SelectItem>
+              )}
+            </SelectList>
+          </Select>
+          <Button
+            variant="ghost"
+            size="sm"
+            shape="square"
+            aria-label={`Remove ${rule.name}`}
+            onPress={() => remove(rule.id)}
+          >
+            <XIcon />
+          </Button>
+        </SortableItem>
+      )}
+    </SortableList>
+  );
+}
+
+export const WithControls: Story = {
+  render: () => <WithControlsRender />,
+};

--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
@@ -1,0 +1,122 @@
+import type React from "react";
+
+import { GripVerticalIcon } from "lucide-react";
+import {
+  DropIndicator,
+  GridList as AriaGridList,
+  type DropTarget,
+  type DroppableCollectionReorderEvent,
+  GridListItem as AriaGridListItem,
+  type GridListItemProps as AriaGridListItemProps,
+  type GridListProps as AriaGridListProps,
+  type Key,
+  useDragAndDrop,
+} from "react-aria-components";
+import { cn, tv } from "tailwind-variants";
+
+import { focusVisibleStyle } from "../../styles/focus-visible";
+import { composeAriaClassName } from "../../utils/compose-aria-class-name";
+import { Button } from "../button/button";
+
+function reorderItems<T extends { id: Key }>(
+  items: T[],
+  event: DroppableCollectionReorderEvent,
+): T[] {
+  const { keys, target } = event;
+  const moved = items.filter((item) => keys.has(item.id));
+  const rest = items.filter((item) => !keys.has(item.id));
+
+  const targetItem = rest.find((item) => item.id === target.key);
+  if (!targetItem) {
+    return items;
+  }
+
+  const targetIndex = rest.indexOf(targetItem);
+  const insertIndex = target.dropPosition === "before" ? targetIndex : targetIndex + 1;
+  return [...rest.slice(0, insertIndex), ...moved, ...rest.slice(insertIndex)];
+}
+
+export interface SortableListProps<T extends { id: Key }> extends Omit<
+  AriaGridListProps<T>,
+  "items" | "children" | "dragAndDropHooks"
+> {
+  items: T[];
+  onReorder: (items: T[]) => void;
+  children: (item: T) => React.ReactNode;
+}
+
+function SortableDropIndicator({ target }: { target: DropTarget }) {
+  return (
+    // -mt-px offsets the line's own height so this in-flow row adds no space, keeping siblings put.
+    <DropIndicator
+      target={target}
+      className="-mt-px mx-2 h-px rounded-full bg-cyan-600 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden"
+    />
+  );
+}
+
+export function SortableList<T extends { id: Key }>({
+  items,
+  onReorder,
+  children,
+  ...props
+}: SortableListProps<T>) {
+  const { dragAndDropHooks } = useDragAndDrop({
+    getItems: (keys) => [...keys].map((key) => ({ "text/plain": String(key) })),
+    onReorder: (event) => {
+      onReorder(reorderItems(items, event));
+    },
+    renderDropIndicator: (target) => <SortableDropIndicator target={target} />,
+  });
+
+  return (
+    <AriaGridList items={items} dragAndDropHooks={dragAndDropHooks} {...props}>
+      {children}
+    </AriaGridList>
+  );
+}
+
+const sortableItemStyles = tv({
+  base: [
+    "flex cursor-grab select-none items-center gap-2 rounded-lg border border-transparent p-1 text-sm text-stone-600 outline-hidden",
+    "data-hovered:bg-stone-700/10 data-hovered:text-stone-800",
+    "data-selected:bg-stone-700/10 data-selected:text-stone-800",
+    "data-dragging:cursor-grabbing",
+    "data-disabled:pointer-events-none data-disabled:opacity-50",
+  ],
+  variants: {
+    isDragging: { true: "opacity-50" },
+  },
+});
+
+export interface SortableItemProps extends AriaGridListItemProps {
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+export function SortableItem({ children, className, ref, ...props }: SortableItemProps) {
+  return (
+    <AriaGridListItem
+      ref={ref}
+      className={composeAriaClassName(className, ({ isDragging }) =>
+        cn(focusVisibleStyle, sortableItemStyles({ isDragging })),
+      )}
+      {...props}
+    >
+      {(renderProps) => (
+        <>
+          <Button
+            slot="drag"
+            variant="ghost"
+            shape="square"
+            size="xxs"
+            aria-label="Reorder"
+            className="text-stone-400"
+          >
+            <GripVerticalIcon className="size-4" />
+          </Button>
+          {typeof children === "function" ? children(renderProps) : children}
+        </>
+      )}
+    </AriaGridListItem>
+  );
+}

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -72,6 +72,12 @@ export {
   SelectTrigger,
 } from "./components/select/select";
 export { Sheet, type SheetProps } from "./components/sheet/sheet";
+export {
+  SortableItem,
+  type SortableItemProps,
+  SortableList,
+  type SortableListProps,
+} from "./components/sortable-list/sortable-list";
 export { Spinner, type SpinnerProps } from "./components/spinner/spinner";
 export { Tooltip, type TooltipProps } from "./components/tooltip/tooltip";
 export {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `SortableList` and `SortableItem` to `@infrahub/ui` for accessible, keyboard-friendly drag‑and‑drop reordering. Includes Storybook examples and public exports.

- **New Features**
  - `SortableList<T extends { id: Key }>` and `SortableItem` for reorderable lists.
  - Controlled API: pass `items`, receive new order via `onReorder`.
  - Built on `react-aria-components` GridList with a drag handle (`slot="drag"`), keyboard and SR support.
  - Works with interactive controls inside items (e.g., `Select`, buttons) without breaking drag.
  - Drop indicator and drag/focus styles included.
  - Exported from `@infrahub/ui` index and documented via Default and WithControls stories.

<sup>Written for commit bca7cc5d00e93427ed31cdbe1871f2bac9eec3bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

