### PR TITLE
ci: add libldap2-dev and libsasl2-dev to build bonsai Python package

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -38,6 +38,9 @@ jobs:
         package_dir: ["", "python_testcontainers"]
     needs: prepare-environment
     steps:
+      - name: "Install libldap2-dev and libsasl2-dev"
+        run: "sudo apt-get -y update && sudo apt-get -y install libldap2-dev libsasl2-dev"
+
       - name: "Set up Python"
         id: python
         uses: "actions/setup-python@v6"


### PR DESCRIPTION
Install libldap2-dev and libsasl2-dev to be able to build the bonsai Python package.
There is no wheel provided for Linux of this package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `libldap2-dev` and `libsasl2-dev` in the PyPI publish workflow to build the `bonsai` Python package from source on Linux and unblock publishing. No Linux wheel is available, so these system headers are required.

<sup>Written for commit 79cd129caa80b15f01c33439fba6f0bb024358e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

