### PR TITLE
ci: Run vale checks against ./changelog

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,8 +7,8 @@ mdx = md
 
 [docs/**/*.md]
 BasedOnStyles = Infrahub
-;(import.*?\n) to ignore import statement in .mdx
-;(```.*?```\n) to ignore code block in .mdx
+;(import.*?\n) to ignore import statement in .md
+;(```.*?```\n) to ignore code block in .md
 BlockIgnores = (?s) *((import.*?\n)|(```.*?```\n))
 
 [docs/**/*.mdx]
@@ -16,6 +16,10 @@ BasedOnStyles = Infrahub
 ;(import.*?\n) to ignore import statement in .mdx
 ;(```.*?```\n) to ignore code block in .mdx
 BlockIgnores = (?s) *((import.*?\n)|(```.*?```\n))
+
+[changelog/**/*.md]
+; Apply Infrahub style checks to towncrier newsfragments to catch errors
+BasedOnStyles = Infrahub
 
 ; Ignore content in reference directories
 [docs/docs/reference/**]

--- a/changelog/9675.housekeeping.md
+++ b/changelog/9675.housekeeping.md
@@ -1,0 +1,1 @@
+Added Vale style and spelling checks to Towncrier news fragments in the changelog folder.

--- a/changelog/9675.housekeeping.md
+++ b/changelog/9675.housekeeping.md
@@ -1,1 +1,0 @@
-Added Vale style and spelling checks to Towncrier news fragments in the changelog folder.


### PR DESCRIPTION
# Why

Closes #9675

## What changed

- Added a configuration block in  .vale.ini  to apply  Infrahub  style checks to  `changelog/**/*.md`  files.

## How to test

https://github.com/opsmill/infrahub/blob/b636a87f51972ca0c89dc61e253b5b75dcb0e217/.github/workflows/ci.yml#L1083-L1084

<!-- Expected outputs, screenshots, or links to CI results -->

## Checklist

- [ ] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Infrahub Vale style and spelling checks to Towncrier news fragments in `changelog/**/*.md` via `.vale.ini` so CI enforces style and catches issues early. Also remove a stray changelog file and fix comment typos in the Vale config.

<sup>Written for commit 71d581688e5024b7e36a26d9f004b9a464ed7e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

