### PR TITLE
docs: add graph traversal documentation

### DIFF
--- a/dev/specs/infp-1991-graph-traversal-docs/checklists/requirements.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Graph Traversal Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a documentation feature; "no implementation details" is interpreted as: the spec
+  states *what documentation must exist and what it must convey*, not the exact files, MDX
+  structure, or tooling commands used to author it. The Diátaxis framework and the Docusaurus
+  `docs/` site are named only as scope/assumption context, consistent with the repo's own
+  documentation conventions.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/dev/specs/infp-1991-graph-traversal-docs/contracts/graph-traversal-reference.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/contracts/graph-traversal-reference.md
@@ -1,0 +1,99 @@
+# Contract: Graph Traversal Reference Content
+
+For a documentation feature, the "contract" is the **API the reference page must describe
+exactly**. These values were read from the shipped 1.10.0 backend
+(`backend/infrahub/graphql/queries/path.py` and `.../reachable.py`). The reference page
+(`docs/docs/graph-traversal/reference.mdx`) MUST match this; re-verify against
+`schema/schema.graphql` and the source at authoring time, as defaults/limits may shift between
+releases.
+
+> ⚠️ **Spec correction**: the feature spec assumed `max_depth` max = **20** and a single
+> `max_paths` default of 10. The shipped code differs (see below). The docs MUST follow the
+> code, not the spec's assumed numbers. (SC-002: zero contradictory values.)
+
+> Argument casing is **snake_case** (`source_id`, `destination_id`, `max_depth`, …), confirming
+> the release-notes prose over the earlier camelCase example.
+
+> **Authoring constraint**: per `.agents/rules/code-doc-style.md`, the published MDX must NOT
+> contain spec-kit FR IDs, ticket IDs (`infp-1991`), or internal class names beyond the public
+> GraphQL type/field names. Describe the public contract only.
+
+## Query 1 — `InfrahubPathTraversal`
+
+Paths between two specific objects, shortest first. Only the shortest path through each
+intermediate node is returned (longer routes through the same intermediate are omitted).
+
+### Input (`data: PathTraversalInput!`)
+
+| Field | Type | Required | Default | Limit / Notes |
+|---|---|---|---|---|
+| `source_id` | `String` | yes | — | UUID of the start node |
+| `destination_id` | `String` | yes | — | UUID of the end node |
+| `max_depth` | `Int` | no | `5` | max **30**; number of node hops |
+| `max_paths` | `Int` | no | `10` | max **100**; max paths returned |
+| `kind_filter` | `[String!]` | no | — | only traverse through nodes of these kinds |
+| `relationship_filter` | `[String!]` | no | — | relationship **schema identifiers** (e.g. `device__interface`), NOT relationship names (e.g. `interfaces`) |
+| `excluded_namespaces` | `[String!]` | no | — | unioned with always-excluded set; defaults cannot be opted out |
+| `excluded_kinds` | `[String!]` | no | — | unioned with default excluded kinds (`BuiltinIPNamespace` + inheritors) |
+| `included_kinds` | `[String!]` | no | — | re-include default-excluded kinds (`BuiltinIPNamespace` + inheritors); no effect on kinds also in `excluded_kinds` |
+
+**Always-excluded namespaces** (cannot be re-included): `Core`, `Internal`, `Builtin`,
+`Lineage`, `Profile`, `Template`.
+
+### Result (`PathTraversalResultType`)
+
+- `paths: [PathResultType!]!` — shortest first.
+  - `PathResultType.hops: [PathHopType!]!`, `PathResultType.depth: Int!` (edges in this path).
+  - `PathHopType.node: PathNodeType!`, `PathHopType.relationship: PathRelationshipType` (null on first hop).
+- `source: PathNodeType!`, `destination: PathNodeType!`
+- `count: Int!` — total paths discovered.
+- `excluded_kinds: [String!]!` — effective exclusions (defaults + requested − included).
+
+`PathNodeType`: `id`, `kind`, `label`, `display_label`, `hfid: [String!]`.
+`PathRelationshipType`: `from_rel`, `from_label`, `to_rel`, `to_label`, `kind`.
+
+## Query 2 — `InfrahubReachableNodes`
+
+"What depends on this?" — reachable objects of given kinds from one source, with the path to each.
+Used for blast-radius / impact analysis.
+
+### Input (`data: ReachableNodesInput!`)
+
+| Field | Type | Required | Default | Limit / Notes |
+|---|---|---|---|---|
+| `source_id` | `String` | yes | — | UUID of the source node |
+| `target_kinds` | `[String!]` | yes | — | node kinds to search for |
+| `max_depth` | `Int` | no | `5` | max **30** |
+| `max_results` | `Int` | no | `50` | max **200**; distinct terminal nodes discovered |
+| `max_paths` | `Int` | no | `500` | max **5000**; total paths across all terminals |
+| `shortest_paths_only` | `Boolean` | no | `true` | true = shortest path(s) per target; false = every path within `max_depth` matching filters |
+
+### Result (`ReachableNodesResultType`)
+
+- `source: PathNodeType!`
+- `dependencies: [ReachableNodeType!]!` — one entry per (node, path) pair.
+  - `ReachableNodeType.node: PathNodeType!`, `.depth: Int!` (hops from source), `.path: PathResultType!`.
+- `count: Int!` — number of dependency entries returned.
+
+## Cross-cutting facts the docs MUST state
+
+- Both queries are **read-only**, **branch- and time-aware**.
+- **Permission-safe**: a path crossing an object the user cannot read is dropped entirely, not leaked.
+- Available to AI agents over the **MCP server** (same GraphQL queries).
+
+## Worked example (FR-007) — verify field names compile before publishing
+
+```graphql
+query {
+  InfrahubPathTraversal(data: { source_id: "<uuid-A>", destination_id: "<uuid-B>", max_depth: 5 }) {
+    count
+    paths {
+      depth
+      hops {
+        node { kind display_label }
+        relationship { kind from_rel to_rel }
+      }
+    }
+  }
+}
+```

--- a/dev/specs/infp-1991-graph-traversal-docs/data-model.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/data-model.md
@@ -1,0 +1,88 @@
+# Phase 1 Content Inventory: Graph Traversal Documentation
+
+For a documentation feature, the "data model" is the **content inventory**: each deliverable
+page, the sections it must contain, which functional requirements it satisfies, and the
+authoritative source for its facts. This is what `/speckit-tasks` turns into authoring tasks.
+
+## Page 1 — Topic: `docs/docs/graph-traversal/overview.mdx`
+
+**Type**: Explanation (understanding-oriented). **Title**: `Graph traversal`.
+**Satisfies**: FR-001, FR-005, FR-010, FR-011. Anchors links for SC-003.
+
+| Section | Content | Source of truth |
+|---|---|---|
+| Intro (1–2 sentences) | What graph traversal is and the problem it solves | release notes 1.10.0 |
+| Introduced in | "Available since Infrahub 1.10.0" | research R3 |
+| Path discovery vs dependency discovery | The two modes and when to use each | release notes; spec US1/US4 |
+| Core concepts | path, hop, depth, path limit, shortest-first ordering | feature spec; `path.py` |
+| Branch & time awareness | Only edges active on the current branch/time are followed | FR-005; constitution II |
+| Permission safety | A path crossing an unreadable object is dropped entirely | release notes |
+| Always-excluded namespaces | Core, Internal, Builtin, Lineage, Profile, Template | release notes |
+| Where to go next | Links to the guide and reference; links from/to relationships, objects, branches | FR-008 |
+
+**Validation rules**: Must not describe traversal as writing data (read-only). Must state the
+version. Must link to the guide and reference. Terminology per research R6.
+
+## Page 2 — Guide: `docs/docs/graph-traversal/topology-explorer.mdx`
+
+**Type**: How-to (task-oriented). **Title**: verb-led, e.g. `Explore topology and trace paths`.
+**Satisfies**: FR-002, FR-003, FR-006, FR-010.
+
+| Section | Content | Source of truth |
+|---|---|---|
+| Opening | What you will accomplish; prerequisite (a running instance with data) | spec US2 |
+| Open the Topology Explorer | Menu "Path Traversal" / route `/path-traversal` | `menu.py`; release notes |
+| Path mode | Pick source & destination, read the path graph (hops, highlight a path, keyboard-step) | release notes; frontend |
+| Dependency mode | Pick a source + target kinds; read reachable objects ("what depends on this?") | FR-003; release notes |
+| Filtering & bounds | Filter by kind & namespace; adjust depth & path limits; note always-excluded namespaces | FR-004 (brief, links to reference) |
+| Trace from an object | The "Trace from this object" action on object detail pages | release notes |
+| What you'll see in edge cases | No path found; same source/destination; missing object; results hit the limit | FR-006; spec Edge Cases |
+| Related | Links to overview (topic) and reference | FR-008 |
+
+**Validation rules**: Reference values appear here only by **link** to the reference page, not
+restated (FR-012). Keep UI-step coupling light (research R4).
+
+## Page 3 — Reference: `docs/docs/graph-traversal/reference.mdx`
+
+**Type**: Reference (information-oriented). **Title**: `Graph traversal reference`.
+**Satisfies**: FR-004, FR-007, FR-012. Single authoritative location for values (SC-002).
+
+| Section | Content | Source of truth |
+|---|---|---|
+| `InfrahubPathTraversal` | Purpose; every input param with type, default, allowed range; result shape (paths → hops → node+relationship); shortest-first | `contracts/graph-traversal-reference.md`; `path.py`; `schema/schema.graphql` |
+| `InfrahubReachableNodes` | Purpose; inputs (`source_id`, `target_kinds`); result (reachable objects + shortest path each) | same |
+| Defaults & limits table | max depth (default 5 / max 20), max paths (default 10), namespace exclusions | feature spec + **verify in code** |
+| Programmatic example | A runnable GraphQL query (FR-007) | quickstart example, casing verified |
+| Availability | Same queries usable over the MCP server | release notes |
+
+**Validation rules**: Field names, casing, and defaults MUST match `schema/schema.graphql` /
+`path.py` exactly — verify before publishing (research R7). This page is the only place values
+are stated (FR-012).
+
+## Navigation & cross-links (not a page; an integration)
+
+**Satisfies**: FR-008, SC-003.
+
+| Change | File | Detail |
+|---|---|---|
+| Register section | `docs/sidebars.ts` | Add a `graph-traversal` category (overview, topology-explorer, reference) in a logical position |
+| Cross-link (API) | `docs/docs/development-resources/graphql/queries-and-mutations.mdx` | Link to the graph-traversal reference |
+| Cross-link (concept) | `docs/docs/schema/relationships.mdx` | Link to the graph-traversal overview where relationships-as-traversable is relevant |
+| Cross-link (concept) | `docs/docs/objects/overview.mdx` | Link to the overview / "Trace from this object" |
+
+## Traceability: every FR maps to a deliverable
+
+| FR | Deliverable |
+|---|---|
+| FR-001 | Topic: concepts + mode distinction |
+| FR-002 | Guide: end-to-end Topology Explorer walkthrough |
+| FR-003 | Guide: dependency mode |
+| FR-004 | Reference: defaults & limits table |
+| FR-005 | Topic: branch/time awareness |
+| FR-006 | Guide: edge-case behaviors |
+| FR-007 | Reference: programmatic GraphQL example |
+| FR-008 | Sidebar entry + ≥2 cross-links |
+| FR-009 | All pages pass `docs.lint` + `docs.build`; Diátaxis split |
+| FR-010 | Terminology per research R6 across all pages |
+| FR-011 | Topic states "since 1.10.0" |
+| FR-012 | Reference is the single source of values; others link to it |

--- a/dev/specs/infp-1991-graph-traversal-docs/plan.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Graph Traversal Documentation
+
+**Branch**: `docs-graph-traversal-infp-1991` | **Date**: 2026-06-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/infp-1991-graph-traversal-docs/spec.md`
+
+## Summary
+
+Author end-user documentation for the Graph Traversal feature shipped in Infrahub
+**1.10.0** (JPD `infp-1991`). The feature exposes two top-level GraphQL queries —
+`InfrahubPathTraversal` (paths between two objects) and `InfrahubReachableNodes`
+(reachable objects of given kinds from one source) — and a **Topology Explorer** UI
+(menu "Path Traversal", route `/path-traversal`, plus a "Trace from this object" action
+on object detail pages). It is read-only, branch- and time-aware, permission-safe, and
+also reachable by AI agents over the MCP server.
+
+The deliverable is Diátaxis-structured MDX content in the existing Docusaurus site
+(`docs/`): one **Topic** (explanation), one or more **Guides** (how-to for the Topology
+Explorer, including dependency discovery), and **Reference** material for the two GraphQL
+queries (parameters, defaults, limits). Plus sidebar registration and contextual
+cross-links from related existing pages. No product code changes.
+
+## Technical Context
+
+**Language/Version**: MDX (Markdown + JSX) on Docusaurus; content authored against Infrahub 1.10.0 behavior
+**Primary Dependencies**: Docusaurus docs site under `docs/`; Diátaxis framework (Tutorials/Guides/Topics/Reference); `@theme/Tabs`/`TabItem` for tabbed examples
+**Storage**: N/A (static documentation files committed to the repo)
+**Testing**: `uv run invoke docs.lint` (Vale + markdownlint), `uv run invoke docs.build` (link/build validation), `uv run invoke docs.validate` (generated-doc staleness, run in CI)
+**Target Platform**: Published docs site (docs.infrahub.app)
+**Project Type**: Documentation (content within the existing web application repo)
+**Performance Goals**: N/A — measured by reader task-completion and discoverability (see spec Success Criteria), not runtime
+**Constraints**: Must match shipped 1.10.0 behavior exactly; pass docs linters with zero errors; no duplication of reference values across pages; minimal fragile UI-step/screenshot coupling
+**Scale/Scope**: ~3–4 new MDX pages (1 topic, 1–2 guides, 1 reference), 1 sidebar entry/category, ≥2 cross-links from existing pages, optional screenshots
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+This is a documentation-only feature. The code-oriented principles are satisfied vacuously
+(no code is written) but constrain what the docs must *accurately describe*:
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Schema-Driven Integrity | N/A | No code/schema change. Docs must not imply traversal writes data — it is read-only. |
+| II. Branch-Safe by Default | PASS (described) | Docs MUST explain traversal is branch- and time-aware (only edges active on the current branch/time are followed) per FR-005. |
+| III. Type Safety & Explicit Contracts | PASS (described) | Reference page MUST match the GraphQL contract exactly (param names, types, defaults). Source of truth: `backend/infrahub/graphql/queries/path.py` + `schema/schema.graphql`. |
+| IV. Test Discipline | PASS | "Tests" for docs = linters + build + link checks. `docs.lint` and `docs.build` MUST pass (FR-009, SC-004). |
+| V. Query Performance & Efficiency | N/A | No queries authored. Docs accurately state the depth/path bounds that protect performance. |
+| VI. Security & Input Boundaries | PASS (described) | Docs MUST state traversal is permission-safe: a path crossing an unreadable object is dropped entirely, not leaked. |
+| VII. Simplicity & Maintainability | PASS | Reuse existing docs sections, components, and patterns. Single authoritative location for reference values (FR-012). No new docs tooling. |
+
+**Code Quality Gate — Changelog**: Per the constitution, every user-facing change includes a
+Towncrier fragment in `changelog/`. The graph traversal *feature* already shipped in 1.10.0;
+this docs work is not a new user-facing product change, so a changelog fragment is likely
+**not** required — flagged for confirmation in research.md (Decision R5).
+
+### Frontend principles (apply when feature includes UI)
+
+**Not applicable** — no UI code is created. The documentation *describes* the existing
+Topology Explorer UI but adds no React components, hooks, or pages. The Shared Components
+Inventory is therefore omitted.
+
+## Project Structure
+
+### Documentation (this feature — the spec-kit artifacts)
+
+```text
+specs/infp-1991-graph-traversal-docs/
+├── plan.md              # This file (/speckit-plan output)
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output: placement, page split, version, screenshots, changelog
+├── data-model.md        # Phase 1 output: page content inventory (page → FRs → source of truth)
+├── quickstart.md        # Phase 1 output: how to author/preview/lint docs locally
+├── contracts/           # Phase 1 output: the GraphQL-reference contract the docs MUST match
+│   └── graph-traversal-reference.md
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Deliverable Content (repository `docs/`)
+
+The deliverable is a new dedicated docs section plus navigation and cross-links. Exact
+filenames confirmed in research.md (Decision R1/R2):
+
+```text
+docs/
+├── docs/
+│   ├── graph-traversal/                 # NEW dedicated section
+│   │   ├── overview.mdx                 # TOPIC: what graph traversal is, concepts, limits (FR-001, FR-005)
+│   │   ├── topology-explorer.mdx        # GUIDE: use the Topology Explorer UI end-to-end (FR-002, FR-006)
+│   │   └── reference.mdx                # REFERENCE: the two queries, params, defaults (FR-003, FR-004, FR-007, FR-012)
+│   ├── development-resources/
+│   │   └── graphql/
+│   │       └── queries-and-mutations.mdx   # EDIT: cross-link to graph-traversal reference (FR-008)
+│   ├── schema/
+│   │   └── relationships.mdx               # EDIT: contextual cross-link (FR-008)
+│   ├── objects/
+│   │   └── overview.mdx                     # EDIT: contextual cross-link (FR-008)
+│   └── media/
+│       └── graph-traversal/                 # OPTIONAL screenshots (research.md R4)
+└── sidebars.ts                              # EDIT: register the new section (FR-008)
+```
+
+**Structure Decision**: A **dedicated `docs/docs/graph-traversal/` section** is chosen over
+burying the content under `development-resources/graphql/`. Rationale: the feature spans a
+headline UI (Topology Explorer) *and* an API, mirroring how other cross-cutting features get
+their own section (`branches/`, `objects/`, `groups/`, `ipam/`). A single section keeps the
+topic, guide, and reference together so reference values live in one authoritative place
+(FR-012, SC-002), while a cross-link from the existing GraphQL queries page preserves
+discoverability for API users (FR-008). The alternative (all under `graphql/`) is recorded in
+research.md and rejected for under-serving the UI and scattering the concept.
+
+## Complexity Tracking
+
+> No constitution violations. No new dependencies, abstractions, or docs tooling introduced.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |

--- a/dev/specs/infp-1991-graph-traversal-docs/quickstart.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Authoring the Graph Traversal Docs
+
+How to create, preview, and validate the documentation pages for this feature.
+
+## Prerequisites
+
+- Repo set up (`uv sync --all-groups`).
+- Familiarity with the Diátaxis split (Topic / Guide / Reference) and the docs style guide:
+  - `docs/docs/development/docs.mdx` (doc types, MDX, screenshots)
+  - `docs/docs/development/style-guide.mdx` (terminology, headings, capitalization)
+  - `docs/docs/guides/AGENTS.md`, `docs/docs/topics/AGENTS.md`
+
+## Files to create / edit
+
+Create the section:
+
+```text
+docs/docs/graph-traversal/overview.mdx           # Topic
+docs/docs/graph-traversal/topology-explorer.mdx  # Guide
+docs/docs/graph-traversal/reference.mdx          # Reference
+```
+
+Edit for navigation + cross-links:
+
+```text
+docs/sidebars.ts                                            # register the section
+docs/docs/development-resources/graphql/queries-and-mutations.mdx  # link to reference
+docs/docs/schema/relationships.mdx                          # contextual link
+docs/docs/objects/overview.mdx                              # contextual link
+```
+
+## Page skeleton (frontmatter)
+
+Each MDX page starts with an h1-equivalent title in frontmatter, then an h1:
+
+```mdx
+---
+title: Graph traversal
+---
+
+# Graph traversal
+
+...
+```
+
+Tabbed examples (e.g. UI vs GraphQL) use the standard theme components:
+
+```mdx
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
+## Authoring rules (must follow)
+
+- **Terminology** (research R6): "graph traversal" (concept), "path traversal" (two-node;
+  UI menu label "Path Traversal"), "dependency discovery", "Topology Explorer";
+  `InfrahubPathTraversal` / `InfrahubReachableNodes` in code font.
+- **Reference values live only in `reference.mdx`** (FR-012); other pages link to it.
+- **Match the shipped API exactly** — use `contracts/graph-traversal-reference.md`
+  (defaults: depth 5/max 30, path-traversal paths 10/max 100, snake_case args, etc.).
+- **No internal IDs in published content** — per `.agents/rules/code-doc-style.md`, do not put
+  FR-IDs, `infp-1991`, or internal class names in the MDX (public GraphQL type names are fine).
+- State the introducing version: **Infrahub 1.10.0** (FR-011).
+- Keep screenshots minimal; reuse `docs/docs/media/release_notes/infrahub_1_10_0/path_traversal.png`
+  where it fits (research R4).
+
+## Preview locally
+
+```bash
+uv run invoke docs.serve     # serve the docs site for live preview
+```
+
+## Validate before pushing (gates — SC-004, FR-009)
+
+```bash
+uv run invoke docs.format    # auto-format markdown
+uv run invoke docs.lint      # Vale + markdownlint — must be zero errors
+uv run invoke docs.build     # build + link validation
+```
+
+CI also runs `uv run invoke docs.validate` (generated-doc staleness). The new pages are
+hand-authored (not generated), but run it to be safe before pushing.
+
+## Definition of done (maps to spec Success Criteria)
+
+- A reader can run a path traversal and a dependency discovery using only these pages (SC-001).
+- Every parameter/default/limit is documented and matches code; no contradictions (SC-002).
+- Pages reachable from the sidebar and ≥1 related page within three clicks (SC-003).
+- `docs.lint` + `docs.build` pass with zero errors (SC-004).
+- Edge-case behaviors described match actual behavior (SC-005).
+- Pages state they describe Infrahub 1.10.0; no unshipped behavior (SC-006).

--- a/dev/specs/infp-1991-graph-traversal-docs/research.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/research.md
@@ -1,0 +1,117 @@
+# Phase 0 Research: Graph Traversal Documentation
+
+All open decisions from the Technical Context are resolved below. No `NEEDS CLARIFICATION`
+items remain.
+
+## R1 — Where do the docs live? (placement)
+
+**Decision**: Create a dedicated section `docs/docs/graph-traversal/` containing the topic,
+guide, and reference pages.
+
+**Rationale**: The feature is a headline 1.10.0 capability spanning a UI (Topology Explorer)
+and an API (two GraphQL queries). Cross-cutting features in the docs each own a top-level
+section (`branches/`, `objects/`, `groups/`, `ipam/`, `generators/`). A dedicated section is
+the most discoverable home and keeps the reference values in one authoritative place
+(FR-012, SC-002).
+
+**Alternatives considered**:
+- *All under `development-resources/graphql/`* (suggested by initial doc-structure scan):
+  rejected — under-serves the Topology Explorer UI and splits the concept from its task guide.
+- *No new section; extend `objects/` or `schema/`*: rejected — traversal is its own concept,
+  not a property of objects or schema.
+
+## R2 — How to split the pages (Diátaxis)
+
+**Decision**: Three pages.
+1. `overview.mdx` — **Topic** (explanation): what graph traversal is; path discovery vs
+   dependency discovery; concepts (path, hop, depth, path limit); branch/time awareness;
+   permission-safety; always-excluded namespaces. (FR-001, FR-005)
+2. `topology-explorer.mdx` — **Guide** (how-to): open the Topology Explorer (menu "Path
+   Traversal" / `/path-traversal`), use path mode and dependency mode, filter by kind &
+   namespace, highlight a path, keyboard-step between paths, and the "Trace from this object"
+   action on object detail pages; plus the empty/same-node/missing-node behaviors. (FR-002,
+   FR-003, FR-006)
+3. `reference.mdx` — **Reference**: the two GraphQL queries, every parameter, default, and
+   limit, with a working example and a note that the same query is available over MCP.
+   (FR-004, FR-007, FR-012)
+
+**Rationale**: Matches Diátaxis (FR-009) and the repo's topic/guide/reference split. Keeping
+reference values in a single page satisfies FR-012 and SC-002.
+
+**Alternatives considered**: A single combined page — rejected, mixes audiences and violates
+Diátaxis. A separate dependency-discovery guide — folded into the Topology Explorer guide as a
+"dependency mode" section to avoid fragmentation (can be split later if it grows).
+
+## R3 — Which release/version does the doc describe? (FR-011, SC-006)
+
+**Decision**: Infrahub **1.10.0**.
+
+**Rationale**: The feature is announced in `docs/docs/release-notes/infrahub/release-1_10_0.mdx`
+under "Graph path traversal and topology explorer", which is the authoritative description of
+shipped behavior. The topic page states the introducing version; reference content is verified
+against the 1.10.0 implementation.
+
+## R4 — Screenshots / visual walkthrough
+
+**Decision**: Reuse the existing release-notes image where possible
+(`docs/docs/media/release_notes/infrahub_1_10_0/path_traversal.png`) and add at most one or two
+screenshots under `docs/docs/media/graph-traversal/`. Prefer prose + the existing image over a
+dense click-by-click walkthrough.
+
+**Rationale**: Minimizes fragile UI-step coupling (spec Edge Cases; Assumptions). The repo
+supports e2e-generated screenshots (`UPDATE_DOCS_SCREENSHOTS=1 ... tests/e2e/tutorial`); adding
+that pipeline is out of scope for a docs-authoring task and recorded as a follow-up option.
+
+## R5 — Is a Towncrier changelog fragment required?
+
+**Decision**: **No fragment for the feature**; the feature already shipped in 1.10.0. If repo
+policy requires a fragment for any docs PR, add a `documentation`-type fragment in `changelog/`.
+
+**Rationale**: Towncrier fragments track user-facing product changes; documenting an
+already-shipped feature is not a new product change. Confirm against `dev/guidelines/git-workflow.md`
+and recent docs-only PRs during implementation; the cost of adding a `documentation` fragment is
+trivial if required.
+
+## R6 — Terminology (FR-010)
+
+**Decision**: Use these consistently, matching the product and release notes:
+- **Graph traversal** — the overall capability / concept (section + topic title).
+- **Path traversal** — path discovery between two objects; the UI menu label is "Path Traversal".
+- **Dependency discovery** — finding reachable objects of given kinds from one source
+  ("what depends on this?" / blast-radius).
+- **Topology Explorer** — the UI surface that renders results.
+- **`InfrahubPathTraversal`**, **`InfrahubReachableNodes`** — the GraphQL query names, in code font.
+
+**Rationale**: These are the exact names used in the 1.10.0 release notes, menu, and backend.
+Run `docs.lint` (Vale) to catch style/terminology drift.
+
+## R7 — Source of truth for reference values
+
+**Decision**: The reference page's parameters/defaults are verified against, in priority order:
+1. `backend/infrahub/graphql/queries/path.py` (input types, defaults, resolvers)
+2. `schema/schema.graphql` (generated GraphQL schema — exact field names & casing)
+3. `docs/docs/release-notes/infrahub/release-1_10_0.mdx` (narrative confirmation)
+
+**Open item flagged for implementation**: argument **casing**. The release notes prose uses
+`source_id`/`destination_id`/`max_depth`; the feature's own quickstart example used
+`sourceId`/`destinationId`. The reference page MUST use whatever `schema/schema.graphql` /
+`path.py` actually expose — verify before publishing. Captured in `contracts/graph-traversal-reference.md`.
+
+## Confirmed feature facts (from release notes + backend, for content accuracy)
+
+- Two top-level queries: `InfrahubPathTraversal`, `InfrahubReachableNodes`.
+- `InfrahubPathTraversal`: inputs `source_id`, `destination_id`; bounds `max_depth`, `max_paths`;
+  filters `kind_filter`, `relationship_filter`, `excluded_kinds`, `excluded_namespaces`;
+  returns connecting paths shortest-first as ordered hops (node + relationship per hop).
+- `InfrahubReachableNodes`: inputs `source_id`, `target_kinds`; returns each reachable object of
+  those kinds with the shortest path to it; used for blast-radius / impact analysis.
+- Defaults & limits (from feature spec; verify exact values against code): max depth default **5**,
+  max **20**; max paths default **10**.
+- Always-excluded namespaces (cannot be re-included): `Core`, `Internal`, `Builtin`, `Lineage`,
+  `Profile`, `Template`. `excluded_namespaces` only **adds** to this set.
+- Read-only; branch- and time-aware; **permission-safe** (a path crossing an unreadable object is
+  dropped entirely, not leaked).
+- UI: **Topology Explorer**, menu "Path Traversal" at `/path-traversal`; path mode & dependency
+  mode; filter by kind/namespace; highlight a path; keyboard navigation between paths; object
+  detail pages add a **"Trace from this object"** action that pre-seeds the explorer.
+- Available to AI agents over the **MCP server** (same GraphQL queries).

--- a/dev/specs/infp-1991-graph-traversal-docs/spec.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/spec.md
@@ -1,0 +1,216 @@
+# Feature Specification: Graph Traversal Documentation
+
+**Feature Branch**: `docs-graph-traversal-infp-1991`
+**Created**: 2026-06-24
+**Status**: Draft
+**Input**: User description: "I need to add docs for the graph traversal feature"
+
+## User Scenarios & Testing *(mandatory)*
+
+> Context: Graph Path Traversal (JPD `infp-1991`) lets users select infrastructure
+> nodes and discover the nodes and relationships connecting them — path discovery
+> between two points, visual path results, filtering by node/relationship type, and
+> single-node dependency discovery. This specification covers the **documentation**
+> that ships alongside that feature. No graph-traversal code is in scope here; the
+> deliverable is published documentation that lets users understand, use, and
+> reference the feature without reading the source.
+
+### User Story 1 - Understand What Graph Traversal Is and When to Use It (Priority: P1)
+
+As an automation engineer new to the feature, I want a conceptual explanation of graph
+traversal in Infrahub — what it does, the problems it solves, and its key concepts (path,
+hops, depth/path limits, branch awareness, dependency discovery) — so I can decide whether
+and how it fits my use case before I try to use it.
+
+**Why this priority**: Without a conceptual anchor, every other piece of documentation is
+harder to follow. Readers who don't understand *what* a path or traversal depth means cannot
+successfully act on a how-to guide or interpret reference material. This is the foundation
+the rest of the documentation links back to.
+
+**Independent Test**: A reader unfamiliar with the feature can read the explanation page and
+correctly answer what graph traversal produces, what bounds a query (depth and path limits),
+and how branch context affects results — verified by review against the feature's behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** the published documentation, **When** a reader looks for "graph traversal" or
+   "path traversal", **Then** they find a conceptual explanation page that defines the feature,
+   its core terms, and its limits and defaults.
+2. **Given** the explanation page, **When** a reader finishes it, **Then** they understand the
+   difference between path discovery (two nodes) and dependency discovery (one node), and that
+   traversal respects the current branch and point in time.
+3. **Given** the explanation page, **When** a reader wants to act, **Then** the page links them
+   to the relevant task guide(s) and reference material.
+
+---
+
+### User Story 2 - Complete a Path Traversal Task (Priority: P1)
+
+As an infrastructure operator, I want step-by-step instructions for running a path traversal —
+selecting two nodes, applying filters, and reading the results (including the visual view) — so I
+can accomplish the task in the product without trial and error.
+
+**Why this priority**: The feature delivers no value to a user who cannot operate it. A
+task-oriented guide is what turns the conceptual understanding from Story 1 into a completed
+action, and it is the documentation users reach for most often.
+
+**Independent Test**: Following the guide against a running Infrahub instance with sample data, a
+reader who has never used the feature can discover a path between two connected nodes, apply a
+node-kind or relationship-type filter, and interpret the returned result — without consulting any
+other source.
+
+**Acceptance Scenarios**:
+
+1. **Given** the how-to guide, **When** a reader follows it end to end, **Then** they can initiate
+   a path query from an object's detail page (or the dedicated entry point), select start and end
+   nodes, and view results.
+2. **Given** the guide, **When** a reader needs to narrow results, **Then** the guide shows how to
+   filter by node kind and relationship type, exclude kinds/namespaces, and adjust depth and path
+   limits.
+3. **Given** the guide, **When** a query returns no path, the same node twice, or a missing node,
+   **Then** the guide explains the message the user will see and what to do next.
+4. **Given** the guide, **When** a reader wants to discover dependencies of a single node, **Then**
+   the guide covers the dependency-discovery flow (one source node + target kinds).
+
+---
+
+### User Story 3 - Look Up Exact Parameters, Defaults, and Limits (Priority: P2)
+
+As an engineer integrating or scripting against the feature, I want reference documentation that
+lists every traversal parameter, its default, and its allowed range — and how to invoke traversal
+programmatically through the existing query interface — so I can use the feature precisely without
+guessing.
+
+**Why this priority**: Power users and integrators need authoritative, lookup-style facts (default
+depth 5, max 20; default 10 paths; default excluded namespaces) rather than prose. This builds on
+Stories 1–2 but serves a distinct, recurring need.
+
+**Independent Test**: A reader can find each parameter's name, default value, and bounds, and can
+construct a valid programmatic traversal query from the reference page alone — verified against the
+feature's actual parameters and defaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reference documentation, **When** a reader looks up a parameter (e.g. maximum
+   depth, maximum paths, node-kind filter, relationship-type filter, namespace exclusions),
+   **Then** they find its meaning, default, and allowed values.
+2. **Given** the reference, **When** an integrator wants to call traversal programmatically,
+   **Then** they find how it is exposed through the existing query interface with a working example.
+3. **Given** the reference, **When** the feature's defaults or limits change, **Then** the reference
+   is the single place that must be updated (no duplicated values scattered across guides).
+
+---
+
+### User Story 4 - Discover the Documentation (Priority: P2)
+
+As any reader, I want the graph traversal documentation to be findable from the documentation
+navigation and from related existing pages, so I encounter it at the moment I need it rather than
+only when I already know it exists.
+
+**Why this priority**: Documentation that exists but cannot be found is functionally absent.
+Placement in navigation and cross-links from adjacent topics (e.g. objects, schema/relationships,
+branches) determine whether the content from Stories 1–3 is actually reached.
+
+**Independent Test**: Starting from the documentation home/navigation and from at least one related
+existing page, a reader can reach the graph traversal explanation and how-to guide within a few
+clicks, without using site search.
+
+**Acceptance Scenarios**:
+
+1. **Given** the documentation navigation, **When** a reader browses it, **Then** the graph
+   traversal pages appear in a logical, expected location.
+2. **Given** a related existing page (e.g. relationships, objects, branches), **When** a reader is
+   there, **Then** a contextual link points them to the graph traversal documentation where relevant.
+
+---
+
+### Edge Cases
+
+- **Feature still evolving**: If the implementation's defaults or UI entry points are not yet final,
+  the documentation must state the version/release it describes and avoid documenting behavior that
+  is not yet shipped.
+- **Visual/UI references**: Screenshots or UI walkthroughs go stale as the interface changes; the
+  docs should minimize fragile UI-step coupling and note where the UI is the source of truth.
+- **Overlap with existing concepts**: Relationships, branches, and object pages already exist; the
+  new docs must reference rather than duplicate those, to avoid conflicting or drifting explanations.
+- **Programmatic interface**: If parts of the query interface are generated reference (e.g. GraphQL
+  schema), the hand-written docs must link to the generated reference rather than restate it.
+- **Terminology consistency**: "Path traversal", "graph traversal", and "dependency discovery" must
+  be used consistently and match the in-product terminology.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Documentation MUST include a conceptual explanation (Topic) of graph traversal that
+  defines the feature, its core terms (path, hop, depth, path limit, branch/time awareness), and the
+  distinction between path discovery and dependency discovery.
+- **FR-002**: Documentation MUST include at least one task-oriented how-to guide that walks a reader
+  through running a path traversal end to end: selecting start/end nodes, applying filters, adjusting
+  limits, and reading the (visual and listed) results.
+- **FR-003**: Documentation MUST cover the dependency-discovery flow (single source node + target
+  kinds) as a usage path.
+- **FR-004**: Documentation MUST document all traversal parameters with their defaults and allowed
+  ranges: maximum depth (default 5, max 20), maximum paths (default 10), node-kind filters,
+  relationship-type filters, node-kind exclusions, and default namespace exclusions (Core, Internal,
+  Builtin, Lineage, Profile, Template).
+- **FR-005**: Documentation MUST explain how traversal respects branch context and point in time
+  (only relationships active on the current branch are followed).
+- **FR-006**: Documentation MUST describe expected behavior and user-facing messaging for edge cases:
+  no path found, same start/end node, missing node, cycles, and results exceeding limits.
+- **FR-007**: Documentation MUST describe how to invoke traversal programmatically through the
+  existing query interface, including at least one concrete example.
+- **FR-008**: Documentation MUST be placed in the documentation navigation in a discoverable location
+  and cross-linked from at least one related existing page.
+- **FR-009**: Documentation MUST follow the project's Diátaxis structure (separating explanation,
+  how-to, and reference) and pass the project's documentation linters.
+- **FR-010**: Documentation MUST use terminology consistent with the in-product feature and the
+  project style guide.
+- **FR-011**: Documentation MUST state the Infrahub release/version the described behavior applies to.
+- **FR-012**: Reference values (defaults, limits) MUST have a single authoritative location to avoid
+  duplication and drift across pages.
+
+### Key Entities
+
+- **Explanation page (Topic)**: Understanding-oriented content defining graph traversal and its
+  concepts; the conceptual anchor other pages link to.
+- **How-to guide(s)**: Task-oriented, step-by-step content for performing path traversal and
+  dependency discovery in the product.
+- **Reference material**: Lookup-oriented content listing parameters, defaults, limits, and the
+  programmatic interface.
+- **Navigation/cross-links**: Sidebar placement and contextual links from related existing pages that
+  make the documentation discoverable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader unfamiliar with the feature can, using only the published documentation,
+  successfully run a path traversal between two nodes and a dependency discovery on a single node
+  without external help.
+- **SC-002**: 100% of the feature's user-facing parameters, defaults, and limits are documented and
+  match the shipped behavior, with zero contradictory values across pages.
+- **SC-003**: The graph traversal documentation is reachable from the documentation navigation and
+  from at least one related existing page within three clicks, without using search.
+- **SC-004**: All graph traversal documentation passes the project's documentation linters with no
+  errors.
+- **SC-005**: All documented edge-case behaviors (no path, same node, missing node, cycles, limit
+  overflow) match the feature's actual behavior, verified by review.
+- **SC-006**: The documentation explicitly states which Infrahub release it describes, and contains
+  no description of unshipped behavior.
+
+## Assumptions
+
+- The graph traversal feature itself (per `specs/infp-1991-graph-path-traversal/spec.md`) is the
+  subject; this work documents it and does not change its behavior.
+- Documentation is authored in the existing Infrahub Docusaurus site under `docs/`, following the
+  Diátaxis framework (Tutorials / Guides / Topics / Reference) already in use.
+- The target audience is automation engineers, network operators, and infrastructure teams who know
+  Git, CI/CD, and infrastructure-as-code but are not assumed to have prior Infrahub experience.
+- Reference material for any generated interface (e.g. the GraphQL query interface) is produced by the
+  existing code-generation pipeline and is linked to rather than re-authored by hand.
+- The feature's parameters, defaults, and limits documented here are those defined in the feature spec
+  (depth default 5 / max 20, 10 paths, listed namespace exclusions); the reference page is updated if
+  the implementation finalizes different values.
+- Screenshots/visual walkthroughs, if included, are kept minimal to limit maintenance cost as the UI
+  evolves.

--- a/dev/specs/infp-1991-graph-traversal-docs/tasks.md
+++ b/dev/specs/infp-1991-graph-traversal-docs/tasks.md
@@ -1,0 +1,154 @@
+# Tasks: Graph Traversal Documentation
+
+**Input**: Design documents from `/specs/infp-1991-graph-traversal-docs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/graph-traversal-reference.md, quickstart.md
+
+**Tests**: No automated tests apply to a documentation feature. The validation gates are
+`uv run invoke docs.lint` (Vale + markdownlint) and `uv run invoke docs.build` (build + link
+check), per plan.md Constitution Check (FR-009, SC-004).
+
+**Organization**: Tasks are grouped by the four user stories from spec.md so each story can be
+authored and previewed independently. Each story maps to one deliverable page; US4 wires
+navigation and cross-links.
+
+## Path Conventions
+
+Documentation lives in the Docusaurus site under `docs/`. New section:
+`docs/docs/graph-traversal/`. Navigation: `docs/sidebars.ts`. Media: `docs/docs/media/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish the authoring conventions and scaffolding before writing content.
+
+- [x] T001 Review docs conventions and record the concrete rules (frontmatter, heading hierarchy, terminology, capitalization, notification blocks, code-fence languages) from `docs/docs/development/style-guide.mdx`, `docs/docs/development/docs.mdx`, `docs/docs/topics/AGENTS.md`, and `docs/docs/guides/AGENTS.md`
+- [x] T002 [P] Create the section directory `docs/docs/graph-traversal/` and the media directory `docs/docs/media/graph-traversal/`; identify the reusable release-notes image `docs/docs/media/release_notes/infrahub_1_10_0/path_traversal.png` for potential reuse (research.md R4)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Lock down the authoritative facts every page depends on. Content must match the
+shipped 1.10.0 API, not the spec's assumed numbers. **Blocks all content phases.**
+
+- [x] T003 Verify the reference contract against the shipped code: confirm input fields, defaults, and limits in `backend/infrahub/graphql/queries/path.py` and `backend/infrahub/graphql/queries/reachable.py`, and confirm field names/casing in `schema/schema.graphql`; reconcile any drift into `specs/infp-1991-graph-traversal-docs/contracts/graph-traversal-reference.md` (note: `max_depth` max is 30; path-traversal `max_paths` 10/100; reachable `max_results` 50/200 and `max_paths` 500/5000; args are snake_case)
+- [x] T004 Confirm the introducing version and feature narrative against `docs/docs/release-notes/infrahub/release-1_10_0.mdx` (section "Graph path traversal and topology explorer"); record the canonical terminology set (research.md R6) to apply across all pages
+
+**Checkpoint**: Authoritative facts and terminology fixed — content authoring can begin.
+
+---
+
+## Phase 3: User Story 1 - Understand What Graph Traversal Is (Priority: P1) 🎯 MVP
+
+**Goal**: A reader new to the feature can understand what graph traversal is, the two modes, the
+key concepts, and its branch/time/permission semantics — the conceptual anchor other pages link to.
+
+**Independent Test**: Open `docs/docs/graph-traversal/overview.mdx` via `uv run invoke docs.serve`;
+a reader unfamiliar with the feature can state what traversal produces, path vs dependency
+discovery, the depth/path bounds, and how branch context affects results.
+
+- [x] T005 [US1] Author the Topic page `docs/docs/graph-traversal/overview.mdx` with frontmatter `title: Graph traversal`, h1, and the sections from data-model.md Page 1: intro, "Available since Infrahub 1.10.0", path discovery vs dependency discovery, core concepts (path/hop/depth/path limit/shortest-first), branch & time awareness (FR-005), permission safety (path crossing an unreadable object is dropped), always-excluded namespaces (Core, Internal, Builtin, Lineage, Profile, Template), and a "where to go next" section linking to the guide and reference (FR-001, FR-011)
+- [x] T006 [US1] Add forward links from `overview.mdx` to the guide (`topology-explorer.mdx`) and reference (`reference.mdx`) pages, and ensure terminology matches the recorded set (FR-010); confirm the page states it is read-only and does not imply writes
+- [x] T007 [US1] Preview the page and fix any lint findings: `uv run invoke docs.format && uv run invoke docs.lint`
+
+**Checkpoint**: The conceptual page stands alone and is correct — MVP delivered.
+
+---
+
+## Phase 4: User Story 2 - Complete a Path Traversal Task (Priority: P1)
+
+**Goal**: A reader can operate the Topology Explorer end to end — path mode, dependency mode,
+filtering, the "Trace from this object" action — and knows what edge cases look like.
+
+**Independent Test**: Following `topology-explorer.mdx` against a running instance with data, a
+first-time reader can discover a path between two connected objects, run a dependency discovery,
+apply a kind/namespace filter, and interpret the results — without other sources.
+
+- [x] T008 [US2] Author the Guide page `docs/docs/graph-traversal/topology-explorer.mdx` with frontmatter (verb-led title, e.g. `Explore topology and trace paths`), h1, and the sections from data-model.md Page 2: opening + prerequisite, "Open the Topology Explorer" (menu "Path Traversal" / route `/path-traversal`), path mode, dependency mode (FR-003), filtering & bounds (brief — link to reference, do NOT restate values per FR-012), "Trace from this object" action on object detail pages (FR-002)
+- [x] T009 [US2] Add the edge-cases subsection to the guide describing what the user sees for: no path found, same source/destination, missing object, and results hitting the limit (FR-006, spec Edge Cases)
+- [x] T010 [US2] Add a "Related" section linking to `overview.mdx` and `reference.mdx`; optionally embed the reused release-notes image; keep UI-step coupling light (research.md R4)
+- [x] T011 [US2] Preview and fix lint findings: `uv run invoke docs.format && uv run invoke docs.lint`
+
+**Checkpoint**: A reader can complete the core task using the guide.
+
+---
+
+## Phase 5: User Story 3 - Look Up Parameters, Defaults, and Limits (Priority: P2)
+
+**Goal**: The single authoritative reference for both queries — every parameter, default, limit,
+result shape, a working example, and MCP availability.
+
+**Independent Test**: A reader can find each parameter's meaning/default/bounds and construct a
+valid programmatic query from `reference.mdx` alone; values match `schema/schema.graphql`.
+
+- [x] T012 [US3] Author the Reference page `docs/docs/graph-traversal/reference.mdx` (frontmatter `title: Graph traversal reference`, h1) documenting `InfrahubPathTraversal`: every input (`source_id`, `destination_id`, `max_depth` 5/30, `max_paths` 10/100, `kind_filter`, `relationship_filter` = schema identifiers e.g. `device__interface`, `excluded_namespaces`, `excluded_kinds`, `included_kinds`) and the result shape (paths→hops→node+relationship, source, destination, count, excluded_kinds), shortest-first — sourced from `contracts/graph-traversal-reference.md` (FR-004)
+- [x] T013 [US3] In the same page, document `InfrahubReachableNodes`: inputs (`source_id`, `target_kinds`, `max_depth` 5/30, `max_results` 50/200, `max_paths` 500/5000, `shortest_paths_only` default true) and result (`source`, `dependencies[]` of node+depth+path, count); add a defaults & limits table (FR-004, FR-012)
+- [x] T014 [US3] Add a runnable GraphQL example and verify it compiles against the live schema before publishing; add an "Availability" note that the same queries are reachable over the MCP server (FR-007)
+- [x] T015 [US3] Preview and fix lint findings: `uv run invoke docs.format && uv run invoke docs.lint`
+
+**Checkpoint**: Reference is complete and value-accurate; it is the only page stating defaults/limits.
+
+---
+
+## Phase 6: User Story 4 - Discover the Documentation (Priority: P2)
+
+**Goal**: The pages are reachable from the sidebar and from related existing pages.
+
+**Independent Test**: From the sidebar and from at least one related page, a reader reaches the
+overview and guide within three clicks without using search; `docs.build` resolves all links.
+
+- [x] T016 [US4] Register the new section in `docs/sidebars.ts`: add a `graph-traversal` category (items: `graph-traversal/overview`, `graph-traversal/topology-explorer`, `graph-traversal/reference`) in a logical position (FR-008, SC-003)
+- [x] T017 [P] [US4] Add a contextual cross-link to the graph-traversal reference from `docs/docs/development-resources/graphql/queries-and-mutations.mdx`
+- [x] T018 [P] [US4] Add a contextual cross-link to the graph-traversal overview from `docs/docs/schema/relationships.mdx`
+- [x] T019 [P] [US4] Add a contextual cross-link to the overview / "Trace from this object" from `docs/docs/objects/overview.mdx`
+
+**Checkpoint**: Documentation is discoverable and all links resolve.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation against all success criteria.
+
+- [x] T020 Run the full build and link check: `uv run invoke docs.build`; fix any broken links, orphan-doc warnings, or build errors
+- [x] T021 [P] Cross-page consistency pass: confirm reference values appear only in `reference.mdx` (FR-012/SC-002), terminology is consistent (FR-010), and the 1.10.0 version is stated (FR-011/SC-006); confirm no spec-kit FR IDs, ticket IDs, or internal class names leak into the published MDX (per `.agents/rules/code-doc-style.md`)
+- [x] T022 [P] Verify all documented edge-case behaviors match actual behavior in a running instance (SC-005); adjust wording where the UI differs
+- [x] T023 Confirm whether a `changelog/` fragment is required for this docs PR (research.md R5 — likely not, since the feature already shipped); add a `documentation`-type fragment if repo policy requires one
+- [x] T024 Final read-through against spec Success Criteria SC-001…SC-006 and the spec quality checklist
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (Phase 1)** → **Foundational (Phase 2)** must complete before any content phase.
+- **US1 (Phase 3)** is the MVP and has no dependency on US2/US3.
+- **US2 (Phase 4)** and **US3 (Phase 5)** depend only on Foundational; they can be authored in
+  parallel with each other and with US1 (different files), each linking to the others' known paths.
+- **US4 (Phase 6)** depends on US1+US2+US3 existing (sidebar IDs and cross-link targets must
+  resolve, else `docs.build` fails).
+- **Polish (Phase 7)** runs last; T020 (full build) requires US4 complete.
+
+```text
+Setup → Foundational → ┌─ US1 (overview)  ─┐
+                       ├─ US2 (guide)      ─┤→ US4 (sidebar+links) → Polish
+                       └─ US3 (reference)  ─┘
+```
+
+## Parallel Execution Opportunities
+
+- **Phase 1**: T002 [P] runs alongside T001.
+- **Content authoring**: T005 (US1), T008 (US2), T012 (US3) touch three distinct files and can
+  be written in parallel once Phase 2 is done.
+- **Phase 6**: T017, T018, T019 [P] edit three different existing pages — parallelizable (T016
+  edits `sidebars.ts` separately).
+- **Phase 7**: T021 and T022 [P] are independent review passes.
+
+## Implementation Strategy
+
+- **MVP**: Phases 1–3 (Setup + Foundational + US1 topic). Delivers a correct conceptual page a
+  reader can use immediately; previewable via `docs.serve` without the rest.
+- **Incremental delivery**: add US2 (operate the feature), then US3 (precise reference), then US4
+  (discoverability), validating lint after each page.
+- **Single PR** to `stable`/`develop` is reasonable given the small surface; could also ship the
+  topic first and the guide/reference as a follow-up if the UI is still settling.

--- a/docs/docs/development-resources/graphql/queries-and-mutations.mdx
+++ b/docs/docs/development-resources/graphql/queries-and-mutations.mdx
@@ -250,3 +250,12 @@ In addition to the queries and the mutations automatically generated based on th
 - **Mutation**: `BranchRebase`, Rebase an existing branch with the main branch
 - **Mutation**: `BranchMerge`, Merge a branch into main
 - **Mutation**: `BranchValidate`, Validate if a branch has some conflicts
+
+## Graph traversal
+
+Two top-level queries let you walk relationships across the graph rather than fetching a single object at a time.
+
+- **Query**: `InfrahubPathTraversal`, Find the paths between two objects
+- **Query**: `InfrahubReachableNodes`, Find the objects of given kinds reachable from a source object
+
+See the [graph traversal reference](../../graph-traversal/reference.mdx) for their parameters, defaults, and limits.

--- a/docs/docs/graph-traversal/overview.mdx
+++ b/docs/docs/graph-traversal/overview.mdx
@@ -1,0 +1,47 @@
+---
+title: Graph traversal
+---
+
+Infrahub stores your data as a graph, and graph traversal lets you walk that graph to answer questions about how objects connect. Rather than fetching a single object and its immediate relationships, traversal follows relationships across the whole model — physical cabling, logical dependencies, ownership, or any other relationship you have defined — to surface the objects that sit between or beyond a starting point.
+
+:::info
+
+Graph traversal is available since Infrahub 1.10.0.
+
+:::
+
+## How graph traversal works
+
+Traversal starts from one or more objects and follows their relationships, hop by hop, until it reaches a target or runs out of allowed depth. Infrahub exposes two ways to traverse, each answering a different question:
+
+- **Path discovery** answers *"how are these two objects connected?"* Given a start object and an end object, it returns the paths that link them, shortest first. This is useful for understanding a dependency chain or troubleshooting connectivity between two points.
+- **Dependency discovery** answers *"what depends on this object?"* Given one source object and a list of target kinds, it returns every reachable object of those kinds, together with the shortest path to each. This is useful for blast-radius and impact analysis, for example *"if this device goes offline, what is affected?"*.
+
+Both are read-only: traversal inspects the graph but never changes it.
+
+## Key concepts
+
+- **Path**: An ordered sequence of objects connected by relationships, from a start object to an end object.
+- **Hop**: A single step in a path — one object and the relationship traversed to reach it from the previous object. The first hop has no incoming relationship.
+- **Depth**: The number of relationships (edges) in a path. Traversal is bounded by a maximum depth so queries stay predictable on large graphs.
+- **Path limit**: The maximum number of paths a query returns, so a highly connected graph cannot produce an unbounded result.
+- **Shortest first**: Results are ordered shortest path first. For path discovery, only the shortest path through each intermediate object is returned; longer routes through the same intermediate are omitted.
+
+The exact defaults and limits for each of these are listed on the [graph traversal reference](./reference.mdx) page.
+
+## Branch and time awareness
+
+Traversal respects Infrahub's branching and temporal model. A query only follows relationships that are active on the current branch at the point in time being queried. The same traversal run against two different branches can therefore return different results, reflecting the state of the graph on each branch. See [branch awareness](../schema/branch-awareness.mdx) for how relationships behave across branches.
+
+## Permissions and excluded data
+
+Traversal is permission-safe. If a path would cross an object that the current user is not allowed to read, the entire path is dropped rather than partially revealed — traversal never leaks the existence of objects through paths.
+
+To keep results focused on your data, a set of internal namespaces is always excluded from traversal: `Core`, `Internal`, `Builtin`, `Lineage`, `Profile`, and `Template`. You can exclude additional namespaces or kinds per query, but these defaults cannot be re-included. See the [reference](./reference.mdx#excluded-kinds-and-namespaces) for the full exclusion rules.
+
+## What you can do with graph traversal
+
+- **[Explore topology and trace paths](./topology-explorer.mdx)** — Use the Topology Explorer to discover paths, find dependencies, and visualize results.
+- **[Graph traversal reference](./reference.mdx)** — Look up the GraphQL queries and Python SDK methods, their parameters, defaults, and limits.
+
+Traversal is available in the Topology Explorer UI, over the GraphQL API, through the [Python SDK](https://docs.infrahub.app/python-sdk/guides/graph_traversal), and to AI assistants over the MCP server. It operates on [objects](../objects/overview.mdx) and the [relationships](../schema/relationships.mdx) between them, so a clear schema makes traversal results easier to interpret.

--- a/docs/docs/graph-traversal/reference.mdx
+++ b/docs/docs/graph-traversal/reference.mdx
@@ -1,0 +1,134 @@
+---
+title: Graph traversal reference
+---
+
+[Graph traversal](./overview.mdx) is exposed through two top-level GraphQL queries: `InfrahubPathTraversal` for path discovery and `InfrahubReachableNodes` for dependency discovery. This page is the authoritative reference for their parameters, defaults, limits, and results. Both queries are read-only, branch- and time-aware, and permission-safe.
+
+## InfrahubPathTraversal
+
+Finds the paths between two objects, shortest first. Only the shortest path through each intermediate object is returned; longer routes through the same intermediate are omitted.
+
+### Input
+
+The query takes a single `data` argument of type `PathTraversalInput`:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source_id` | `String` | Yes | — | ID of the start object. |
+| `destination_id` | `String` | Yes | — | ID of the end object. |
+| `max_depth` | `Int` | No | `5` | Maximum number of hops. Maximum value `30`. |
+| `max_paths` | `Int` | No | `10` | Maximum number of paths to return. Maximum value `100`. |
+| `kind_filter` | `[String!]` | No | — | Only traverse through objects of these kinds. |
+| `relationship_filter` | `[String!]` | No | — | Only follow relationships with these schema identifiers, for example `device__interface` — not relationship names such as `interfaces`. |
+| `excluded_namespaces` | `[String!]` | No | — | Additional namespaces to exclude. Added to the always-excluded set; the defaults cannot be opted out. |
+| `excluded_kinds` | `[String!]` | No | — | Additional object kinds to exclude. Added to the default excluded kinds. |
+| `included_kinds` | `[String!]` | No | — | Default-excluded kinds to re-include. Has no effect on kinds also passed in `excluded_kinds`. |
+
+### Result
+
+The query returns a `PathTraversalResultType`:
+
+- `paths`: The discovered paths, ordered shortest first. Each path has:
+  - `hops`: The ordered hops from source to destination. Each hop has a `node` and the `relationship` traversed to reach it (`null` on the first hop).
+  - `depth`: The number of relationships in the path.
+- `source`, `destination`: The start and end objects.
+- `count`: The total number of paths discovered.
+- `excluded_kinds`: The effective exclusions applied to this traversal — the defaults plus the requested `excluded_kinds`, minus `included_kinds`.
+
+Each object (`node`) reports its `id`, `kind`, `label`, `display_label`, and `hfid`. Each relationship reports `from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`.
+
+### Example
+
+```graphql
+query {
+  InfrahubPathTraversal(data: { source_id: "<id-of-object-A>", destination_id: "<id-of-object-B>", max_depth: 5 }) {
+    count
+    paths {
+      depth
+      hops {
+        node {
+          kind
+          display_label
+        }
+        relationship {
+          kind
+          from_rel
+          to_rel
+        }
+      }
+    }
+  }
+}
+```
+
+## InfrahubReachableNodes
+
+Finds the objects of given kinds that are reachable from a single source object, with the shortest path to each. Use it for dependency, blast-radius, and impact analysis.
+
+### Input
+
+The query takes a single `data` argument of type `ReachableNodesInput`:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source_id` | `String` | Yes | — | ID of the source object. |
+| `target_kinds` | `[String!]` | Yes | — | The object kinds to search for. |
+| `max_depth` | `Int` | No | `5` | Maximum traversal depth. Maximum value `30`. |
+| `max_results` | `Int` | No | `50` | Maximum number of distinct reachable objects to discover. Maximum value `200`. |
+| `max_paths` | `Int` | No | `500` | Maximum total paths returned across all discovered objects. Maximum value `5000`. |
+| `shortest_paths_only` | `Boolean` | No | `true` | When `true`, return only the shortest path(s) to each reachable object. When `false`, return every path within `max_depth` that meets the filters. |
+
+### Result
+
+The query returns a `ReachableNodesResultType`:
+
+- `source`: The source object.
+- `dependencies`: The reachable objects of the requested kinds, one entry per object-and-path pair. Each entry has the reachable `node`, its `depth` (hops from the source), and the full `path` from the source to it.
+- `count`: The number of dependency entries returned.
+
+## Defaults and limits
+
+| Query | Parameter | Default | Maximum |
+|-------|-----------|---------|---------|
+| `InfrahubPathTraversal` | `max_depth` | `5` | `30` |
+| `InfrahubPathTraversal` | `max_paths` | `10` | `100` |
+| `InfrahubReachableNodes` | `max_depth` | `5` | `30` |
+| `InfrahubReachableNodes` | `max_results` | `50` | `200` |
+| `InfrahubReachableNodes` | `max_paths` | `500` | `5000` |
+
+## Excluded kinds and namespaces
+
+The namespaces `Core`, `Internal`, `Builtin`, `Lineage`, `Profile`, and `Template` are always excluded from traversal. The `excluded_namespaces` input only adds to this set; these defaults cannot be re-included.
+
+Objects of kind `BuiltinIPNamespace` (and every kind inheriting from it) are excluded by default. Use `included_kinds` to re-include them — passing the generic re-includes every implementer. The `excluded_kinds` input adds further kinds to exclude and takes precedence over `included_kinds` within the same request.
+
+## Python SDK
+
+The [Python SDK](https://docs.infrahub.app/python-sdk) exposes graph traversal through three client methods, available in both asynchronous and synchronous form. They require Infrahub 1.10 or later and raise `VersionNotSupportedError` against an older server.
+
+- `traverse_paths(source, destination, ...)`: Find the shortest path(s) between two objects. Accepts `max_depth`, `max_paths`, `kind_filter`, `relationship_filter`, `included_kinds`, and `excluded_kinds`, mirroring the `InfrahubPathTraversal` parameters above. Returns a result exposing `.paths` (each path exposes `.hops`) and `.count`.
+- `reachable_nodes(source, target_kinds, ...)`: Find reachable objects of given kinds. Accepts `max_depth`, `max_results`, and `shortest_paths_only`. Returns a result whose `.dependencies` list holds each reachable node, its `depth`, and the full `path`.
+- `path_exists(source, destination, ...)`: A boolean connectivity check between two objects. Accepts the same filter arguments as `traverse_paths`.
+
+The `source` and `destination` arguments accept either an object ID or an `InfrahubNode` instance. Returned `PathNode` objects expose `.id`, `.kind`, and `.display_label`, plus a `.fetch()` method to load the full object.
+
+```python
+result = await client.traverse_paths(source=device_a, destination=device_b, max_depth=5)
+for path in result.paths:
+    print(path.hops)
+
+if await client.path_exists(source=device_a, destination=core_router):
+    ...
+```
+
+See the [SDK graph traversal guide](https://docs.infrahub.app/python-sdk/guides/graph_traversal) for the full method reference and examples.
+
+## Availability
+
+Because traversal is exposed over GraphQL, the same queries are available to AI assistants through the Infrahub MCP server, letting agents reason about how objects in your infrastructure graph connect.
+
+## Related
+
+- [Graph traversal](./overview.mdx) — concepts and behavior
+- [Explore topology and trace paths](./topology-explorer.mdx) — the visual interface
+- [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx) — the schema-generated GraphQL queries

--- a/docs/docs/graph-traversal/topology-explorer.mdx
+++ b/docs/docs/graph-traversal/topology-explorer.mdx
@@ -1,0 +1,79 @@
+---
+title: Explore topology and trace paths
+---
+
+The Topology Explorer is the visual interface for [graph traversal](./overview.mdx). It lets you discover how two objects connect, find everything that depends on an object, and read the result as an interactive graph. This guide walks through both modes and the controls available.
+
+Before you start, you need a running Infrahub instance with data loaded, and permission to read the objects you want to traverse.
+
+## Open the Topology Explorer
+
+Open the Topology Explorer from the main navigation menu under **Path Traversal**. The explorer opens with two modes you can switch between:
+
+- **Path mode** traces the paths between two specific objects.
+- **Dependency mode** finds the objects of chosen kinds that are reachable from a single source object.
+
+## Trace a path between two objects
+
+Use path mode to understand how two objects are connected.
+
+1. Select **Path mode**.
+2. Choose a **source** object and a **destination** object. You can search for an object by kind, or paste an object's ID directly.
+3. Run the traversal.
+
+The explorer renders the discovered paths as a graph: each object is a node and each relationship is an edge between two nodes, laid out automatically from source to destination. Paths are ordered shortest first. When several paths exist, you can highlight an individual path to isolate it, and step between paths from the keyboard.
+
+## Discover what depends on an object
+
+Use dependency mode to answer *"what depends on this object?"* — for example, the services affected if a device goes offline.
+
+1. Select **Dependency mode**.
+2. Choose a **source** object.
+3. Choose one or more **target kinds** — the kinds of object you want to discover.
+4. Run the traversal.
+
+The explorer returns every reachable object of the chosen kinds, with the shortest path from the source to each. The result is rendered as the same interactive graph, so you can trace each dependency back to the source.
+
+## Filter and bound a traversal
+
+Both modes let you narrow and bound a traversal so results stay relevant on large graphs:
+
+- **Filter by kind**: Restrict traversal to pass through (or stop at) specific object kinds.
+- **Filter by namespace**: Exclude additional namespaces beyond the always-excluded internal ones.
+- **Adjust depth and path limits**: Increase or decrease how many hops traversal follows and how many paths it returns.
+
+The internal namespaces `Core`, `Internal`, `Builtin`, `Lineage`, `Profile`, and `Template` are always excluded and cannot be re-included. For the exact parameters, defaults, and limits behind these controls, see the [graph traversal reference](./reference.mdx).
+
+## Trace from an object's detail page
+
+You do not have to start in the Topology Explorer. On an object's detail page, use the **Trace from this object** action to open the explorer pre-seeded with that object as the source. This is the quickest way to start a dependency analysis from an object you are already looking at.
+
+## What you'll see in edge cases
+
+- **No path found**: When no path connects the two objects within the depth and filters you set, the explorer returns an empty result and indicates that no path exists. Try increasing the depth or relaxing filters.
+- **Same source and destination**: The source and destination must be different objects. Choosing the same object for both is reported rather than traversed.
+- **An object no longer exists**: If a selected object cannot be found, the explorer reports which object was not found.
+- **Results hit the limit**: Highly connected graphs can produce more paths than the configured limit. Results are capped at the path limit (shortest first); narrow the traversal with filters or a lower depth to focus the result.
+
+## Use graph traversal in automation
+
+The Topology Explorer is the interactive entry point, but the same traversal is available programmatically. Over the GraphQL API and the [Python SDK](https://docs.infrahub.app/python-sdk/guides/graph_traversal) you can run the same queries from scripts, generators, and checks. See the [graph traversal reference](./reference.mdx#python-sdk) for the queries and the SDK methods.
+
+### Use graph traversal in a check
+
+Because traversal is available wherever the Python SDK runs, an Infrahub [check](../checks/overview.mdx) can use it to validate structural requirements that span relationships, then fail a [proposed change](../proposed-changes/overview.mdx) when they are not met. Common patterns are:
+
+- **Connectivity requirements**: Assert that two objects stay connected — for example, that every site keeps a redundant path to the core — using `path_exists` or `traverse_paths`.
+- **Isolation verification**: Assert that two objects are *not* connected, for example that a production device and a lab device share no path.
+- **Dependency analysis**: Use `reachable_nodes` to find everything that depends on an object and validate it against a policy.
+
+Because traversal is branch- and time-aware, a check evaluates connectivity on the branch of the proposed change, catching violations the change would introduce before it merges.
+
+See [Build a check](../academy/tutorials/build-a-check.mdx) to set up a check end to end, and the [SDK graph traversal guide](https://docs.infrahub.app/python-sdk/guides/graph_traversal) for the traversal methods.
+
+## Related
+
+- [Graph traversal](./overview.mdx) — concepts, modes, and branch and permission behavior
+- [Graph traversal reference](./reference.mdx) — the GraphQL queries, parameters, defaults, and limits
+- [Objects](../objects/overview.mdx) — what traversal walks between
+- [Relationships](../schema/relationships.mdx) — the typed links traversal follows

--- a/docs/docs/objects/overview.mdx
+++ b/docs/docs/objects/overview.mdx
@@ -40,3 +40,4 @@ Objects, their attribute values, and their relationships all carry metadata. At 
 - **[Convert object kind](./convert-object-kind.mdx)** — Change the schema kind of an existing object while preserving its data
 - **[Metadata & lineage](./metadata.mdx)** — Inspect where each attribute value came from and track data origin
 - **[Load data in bulk using YAML file](./load-from-yaml.mdx)** — Bulk-create or update objects by loading structured YAML files
+- **[Graph traversal](../graph-traversal/overview.mdx)** — Trace the paths and dependencies between objects across the graph

--- a/docs/docs/schema/relationships.mdx
+++ b/docs/docs/schema/relationships.mdx
@@ -372,4 +372,5 @@ This prevents users from adding interfaces from different devices to the same LA
 
 - [Nodes & attributes](./nodes-and-attributes) — Node and attribute definitions
 - [Generics & inheritance](./generics-and-inheritance) — Sharing relationships across node types
+- [Graph traversal](../graph-traversal/overview) — Walk relationships to discover paths and dependencies between objects
 - [Reference: Relationship](../reference/schema/relationship) — Full relationship property reference

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -152,6 +152,15 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Graph traversal',
+          link: { type: 'doc', id: 'graph-traversal/overview' }, // hub
+          items: [
+            { type: 'doc', id: 'graph-traversal/topology-explorer', label: 'Explore topology and trace paths' },
+            { type: 'doc', id: 'graph-traversal/reference', label: 'Graph traversal reference' },
+          ],
+        },
+        {
+          type: 'category',
           label: 'IPAM',
           link: { type: 'doc', id: 'ipam/overview' },
           items: [


### PR DESCRIPTION
## Summary

Documents the **graph traversal** feature shipped in Infrahub **1.10.0** (JPD `infp-1991`) — the `InfrahubPathTraversal` and `InfrahubReachableNodes` GraphQL queries and the **Topology Explorer** UI. No product code changes; documentation only.

Adds a dedicated `docs/graph-traversal/` section following Diátaxis:

| Page | Type | Covers |
|------|------|--------|
| `overview.mdx` | Topic | What graph traversal is, path vs dependency discovery, concepts, branch/time awareness, permission safety, excluded namespaces |
| `topology-explorer.mdx` | Guide | Using the Topology Explorer (path & dependency mode), filtering, "Trace from this object", edge cases, and using traversal from the Python SDK and in checks |
| `reference.mdx` | Reference | Full parameters / defaults / limits for both queries, a GraphQL example, the Python SDK methods (`traverse_paths`, `reachable_nodes`, `path_exists`), and MCP availability |

Registers the section in `sidebars.ts` (under **Schema & Data → Graph traversal**) and cross-links from the **objects**, **relationships**, and **GraphQL queries & mutations** pages, plus links out to the [Python SDK graph traversal guide](https://docs.infrahub.app/python-sdk/guides/graph_traversal).

The spec-kit artifacts for this work are included under `dev/specs/infp-1991-graph-traversal-docs/`, consistent with the repo convention.

## Notes for reviewers

- Reference values (e.g. `max_depth` default 5 / max 30, distinct `max_paths` regimes for the two queries, snake_case args, `included_kinds` / `shortest_paths_only`) were taken from the shipped 1.10.0 backend, not the spec's earlier assumptions.
- Edge-case wording and SDK attribute names were drawn from the release notes and the SDK guide — worth a spot-check against a live instance / the SDK before merge.
- Base is `stable` (where 1.10.0 shipped); `develop` is currently behind stable.

## Validation

- `invoke docs.format` — 0 errors
- `invoke docs.lint` — 0 errors (one pre-existing-style proper-noun warning on "Topology Explorer", consistent with other feature pages)
- `invoke docs.build` — succeeded; all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Graph Traversal docs section for Infrahub 1.10.0, covering `InfrahubPathTraversal`, `InfrahubReachableNodes`, and the Topology Explorer. Improves discoverability with a new sidebar category and cross-links; no product code changes. Aligns with `infp-1991` by documenting exact parameters, defaults, limits, and safety semantics.

- **New Features**
  - New `docs/graph-traversal/` section:
    - Overview: concepts, path vs dependency, branch/time awareness, permission safety, excluded namespaces.
    - Guide: Topology Explorer usage (path and dependency modes), filtering, “Trace from this object”, edge cases, SDK/check examples.
    - Reference: full inputs/results with verified defaults/limits (e.g., `max_depth` 5/max 30), GraphQL example, Python SDK methods, MCP availability.
  - Navigation: sidebar category registered and links added from GraphQL queries, relationships, and objects pages.

<sup>Written for commit 71922fb605adec0adb46913d4327a8fcfb70a563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

