### PR TITLE
docs(webhook): webhook delivery operability specification

### DIFF
--- a/dev/specs/ifc-2755-webhook-delivery-operability/checklists/requirements.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Webhook Delivery Operability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Resend is gated on **any terminal state** (including succeeded), not only failed/cancelled, per explicit product direction; a confirmation step guards re-delivery of a succeeded delivery (FR-021).
+- Resend and cancel are exposed as a **generic task query/mutation interface**; genericity is confined to the interface shape. Only webhook deliveries support the actions in this feature (FR-017); other task types resolve them as unavailable.
+- The structural split (orchestrator vs. user-visible send with its own retries) is assumed already in place on the current branch; this spec covers the operability layer added on top.
+- Two design open points (one grouped capture record vs. separate request/response records; capture per-attempt vs. last-attempt) are treated as implementation details; the spec fixes only the operator-facing outcome (last attempt is shown).

--- a/dev/specs/ifc-2755-webhook-delivery-operability/contracts/graphql.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/contracts/graphql.md
@@ -1,0 +1,118 @@
+# GraphQL Contract: Webhook Delivery Operability
+
+The authoritative schema is generated (`schema/schema.graphql`, frontend codegen). This file is the design-time contract the implementation must produce. SDL is illustrative — field names are normative, exact Graphene wiring follows the events/branch precedents.
+
+## Query — task typing (object → interface)
+
+`InfrahubTask` already exists; the change makes its node a polymorphic interface.
+
+```graphql
+interface TaskNodeInterface {
+  id: String!
+  title: String
+  conclusion: String
+  state: TaskState
+  progress: Float
+  workflow: String          # discriminant (run's workflow name)
+  branch: String
+  created_at: DateTime
+  updated_at: DateTime
+  start_time: DateTime
+  parameters: GenericScalar  # carries the frozen payload for deliveries
+  tags: [String]
+  related_nodes: [RelatedNode!]
+  logs(...): TaskLogEdge
+  available_actions: [TaskAction!]!   # NEW — empty list for non-actionable runs
+}
+
+type TaskNode implements TaskNodeInterface { ...all interface fields... }
+
+type WebhookDeliveryTask implements TaskNodeInterface {
+  # ...all interface fields...
+  http_request: HttpRequest
+  http_response: HttpResponse
+  error: DeliveryError
+}
+
+type HttpRequest  { url: String!, headers: GenericScalar! }   # headers already redacted at capture
+type HttpResponse { status_code: Int, body: String, latency_ms: Float }
+type DeliveryError { status_class: String!, message: String!, remediation: String! }
+
+type TaskAction { action: TaskActionName!, available: Boolean!, unavailability_reason: String }
+enum TaskActionName { RESEND, CANCEL }
+```
+
+**Backward compatibility**: `TaskNodes.node` changes from `TaskNode` (object) to `TaskNodeInterface`. Existing selections of common fields continue to resolve. `TaskNode` keeps its name, so SDK / fragments / `__typename` checks for `TaskNode` are unaffected. `WebhookDeliveryTask` is reachable only through `resolve_type` and must be registered explicitly.
+
+### Example consumer query
+
+```graphql
+query GET_TASK_DETAILS($ids: [String], $relatedNodeIds: [String]) {
+  InfrahubTask(ids: $ids, related_node__ids: $relatedNodeIds) {
+    count
+    edges {
+      node {
+        id
+        title
+        state
+        conclusion
+        workflow
+        updated_at
+        available_actions { action available unavailability_reason }
+        ... on WebhookDeliveryTask {
+          http_request  { url headers }
+          http_response { status_code body latency_ms }
+          error { status_class message remediation }
+        }
+      }
+    }
+  }
+}
+```
+
+## Mutations — generic task actions
+
+Bespoke (non-CRUD) mutations modeled on `BranchCreate`, registered as direct fields on the base mutation. The interface is generic (task id); only webhook deliveries are actionable.
+
+```graphql
+input TaskActionInput { id: String! }
+
+type TaskResend {
+  ok: Boolean!
+  task: TaskNodeInterface     # the NEW delivery produced by the resend
+}
+
+type TaskCancel {
+  ok: Boolean!
+  task: TaskNodeInterface     # the cancelled (now non-terminal→cancelling) delivery
+}
+
+extend type Mutation {
+  InfrahubTaskResend(data: TaskActionInput!): TaskResend
+  InfrahubTaskCancel(data: TaskActionInput!): TaskCancel
+}
+```
+
+### Behavioral contract
+
+**InfrahubTaskResend(id)**
+- Auth: requires update permission on the target webhook node (resolved from the run's `webhook_id`). Mutating op ⇒ authentication required.
+- Precondition: target is a `WEBHOOK_SEND` run in a **terminal** state (any, including COMPLETED). Otherwise → error "resend unavailable: delivery still in progress".
+- Not found: original run purged from retention → error "delivery no longer available" (FR-020).
+- Effect: read frozen `parameters` by id; resubmit `WEBHOOK_SEND` with the same `{webhook_id, webhook_kind, webhook_name, payload}`; new standalone run re-tags + re-resolves config + re-signs. Original unchanged. Returns the new task.
+- Re-validates availability at execution (rejects a stale action, FR-026).
+
+**InfrahubTaskCancel(id)**
+- Auth: same as resend.
+- Precondition: target is a `WEBHOOK_SEND` run in a **non-terminal** state. Otherwise → error "cancel unavailable: delivery already settled".
+- Effect: set run state to CANCELLING (force). Stops further scheduled auto-retries. Best-effort for an in-flight request (not recalled). Returns the task.
+
+### Error surface
+
+Errors are returned as GraphQL errors with clean messages (no stacktrace, Principle VI). Classified delivery failures are surfaced on the run's `error` field, not as mutation errors — a resubmitted run that later fails carries its `DeliveryError` like any delivery.
+
+## Non-goals (contract scope)
+
+- No change to existing task list filters/pagination.
+- No new global permission type.
+- No webhook-specific mutation names (`CoreWebhookResend`/`CoreWebhookCancel` are explicitly **not** introduced).

--- a/dev/specs/ifc-2755-webhook-delivery-operability/data-model.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/data-model.md
@@ -40,7 +40,7 @@ class TaskNodeInterface(Interface):
 class TaskNode(ObjectType):
     class Meta:
         interfaces = (TaskNodeInterface,)
-    # node-specific fields (related_nodes, logs, deprecated related_node*)
+    # node-specific fields: only the deprecated related_node / related_node_kind accessors
 
 class WebhookDeliveryTask(ObjectType):
     class Meta:

--- a/dev/specs/ifc-2755-webhook-delivery-operability/data-model.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/data-model.md
@@ -1,0 +1,165 @@
+# Phase 1 Data Model: Webhook Delivery Operability
+
+No new Neo4j nodes, attributes, relationships, or migrations. All "entities" below are either GraphQL output types or in-process Python models projected from Prefect run data (parameters, tags, artifacts, state). Persistence is Prefect's; retention is Prefect's.
+
+## GraphQL types
+
+### TaskNodeInterface (new interface)
+
+Carries every field currently on the task type, plus `available_actions`. All task results resolve to a concrete implementation of this interface.
+
+| Field | Type | Notes |
+|---|---|---|
+| id | String! | Prefect flow-run id |
+| title | String | Run name |
+| conclusion | String | Derived SUCCESS/FAILURE mapping (existing) |
+| state | TaskState | Raw Prefect state (existing, source of truth) |
+| progress | Float | From the progress artifact (existing) |
+| workflow | String | The run's workflow name — the type discriminant |
+| branch | String | Originating branch (existing) |
+| created_at / updated_at / start_time | DateTime | Existing |
+| parameters | GenericScalar | Run parameters; carries the frozen payload for deliveries |
+| tags | [String] | Related-node tags (existing) |
+| related_nodes | [RelatedNode] | Existing |
+| logs | TaskLogEdge | Existing; per-attempt progress visible here |
+| available_actions | [TaskAction!]! | NEW — server-computed recovery actions (empty for non-actionable runs) |
+
+### TaskNode (unchanged name, standard implementation)
+
+`implements TaskNodeInterface`. Keeps its current name so existing queries / SDK / fragments / `__typename` are unaffected. The only schema change is that `TaskNodes.node` becomes the interface type instead of this object type.
+
+**Derivation mechanism (mirror of events, not subclassing).** Today `TaskNode` derives by subclassing the `Task` ObjectType (`graphql/types/task.py:36`). The events-faithful form moves the common fields onto `TaskNodeInterface(Interface)` and declares each concrete type via `class Meta: interfaces = (TaskNodeInterface,)` — exactly as concrete event types declare `interfaces = (EventNodeInterface,)` (`graphql/types/event.py:101-103`). So:
+
+```python
+class TaskNodeInterface(Interface):
+    # common fields + available_actions
+    @classmethod
+    def resolve_type(cls, instance: dict[str, Any], info) -> type[ObjectType]:
+        return TASK_TYPES.get(instance["workflow"], TaskNode)
+
+class TaskNode(ObjectType):
+    class Meta:
+        interfaces = (TaskNodeInterface,)
+    # node-specific fields (related_nodes, logs, deprecated related_node*)
+
+class WebhookDeliveryTask(ObjectType):
+    class Meta:
+        interfaces = (TaskNodeInterface,)
+    http_request = Field(HttpRequest)
+    http_response = Field(HttpResponse)
+    error = Field(DeliveryError)
+
+TASK_TYPES: dict[str, type[ObjectType]] = {WEBHOOK_SEND.name: WebhookDeliveryTask}
+```
+
+The `parameters: GenericScalar` field stays on the interface; the frozen payload is read from it, so `WebhookDeliveryTask` adds no payload field of its own (it adds only what is specific to a delivery, mirroring how event concrete types add only their specifics).
+
+### WebhookDeliveryTask (new concrete type)
+
+`implements TaskNodeInterface`, reachable only via `resolve_type`. Adds the delivery-specific fields.
+
+| Field | Type | Notes |
+|---|---|---|
+| http_request | HttpRequest | URL + redacted headers as sent (last attempt) |
+| http_response | HttpResponse | Status, body, latency (last attempt) |
+| error | DeliveryError | Classified reason + remediation hint; null unless failed |
+
+The delivered **payload** is not a field here — it is read from `parameters` (frozen).
+
+### Supporting GraphQL types
+
+```
+type HttpRequest      { url: String!, headers: GenericScalar! }            # headers already redacted
+type HttpResponse      { status_code: Int, body: String, latency_ms: Float }
+type DeliveryError     { status_class: String!, message: String!, remediation: String! }
+type TaskAction        { action: TaskActionName!, available: Boolean!, unavailability_reason: String }
+enum TaskActionName    { RESEND, CANCEL }
+```
+
+### resolve_type / registration
+
+- `TASK_TYPES: dict[str, type] = { WEBHOOK_SEND.name: WebhookDeliveryTask }` (key = catalogue constant name).
+- `TaskNodeInterface.resolve_type(instance, info)`: return `TASK_TYPES.get(instance["workflow"], TaskNode)`.
+- The instance dict must carry `workflow` (already serialized) so the discriminant is present.
+- GraphQL manager registers each concrete task type (mirror `_load_event_types`).
+
+## In-process Python models (frozen / Pydantic)
+
+### CapturedHeaders
+
+Redaction domain object built at capture time.
+
+| Field | Rule |
+|---|---|
+| standard headers (`Accept`, `Content-Type`) | verbatim |
+| `webhook-id`, `webhook-timestamp` | verbatim (signature inputs, not secret) |
+| `webhook-signature` | masked |
+| custom header, kind = STATIC | verbatim |
+| custom header, kind = ENVIRONMENT | masked |
+
+Entry: `CapturedHeaders.from_resolved(headers_with_kind) -> dict[str, str]` (redacted). Redaction happens before any artifact write, so no raw secret is persisted.
+
+### ClassifiedFailure
+
+| Field | Type | Notes |
+|---|---|---|
+| status_class | StatusClass (enum) | CONFIG / CONNECTION / TLS / TIMEOUT / HTTP_CLIENT_ERROR / HTTP_SERVER_ERROR / UNKNOWN |
+| message | str | Clean, no stacktrace |
+| remediation | str | Hint by class (4xx→URL/auth; CONNECTION→reachability; TIMEOUT/5xx→retry/target; CONFIG→webhook config) |
+| transient | bool | True for TIMEOUT/CONNECTION/HTTP_SERVER_ERROR; drives `retry_condition_fn` |
+
+Produced by `WebhookFailureClassifier.classify(exc, response) -> ClassifiedFailure` (pure, injected).
+
+### CapturedHttp (artifact payload)
+
+JSON-serializable dict written as the single `http` artifact (key `infrahub-webhook-http`), reflecting the last attempt:
+
+```
+{ request:  { url, headers },          # headers redacted
+  response: { status_code, body, latency_ms } | null,
+  error:    { status_class, message, remediation } | null }
+```
+
+Read back via `read_artifacts(ArtifactFilter(key=...), FlowRunFilter(id=...))` (mirrors `read_progress`) and projected onto `http_request` / `http_response` / `error`, gated on GraphQL selection.
+
+### AvailableActions (server computation)
+
+Pure function of `(workflow_name, prefect_state)`:
+
+| Run type | Action | available iff | unavailability_reason |
+|---|---|---|---|
+| WEBHOOK_SEND | RESEND | state is terminal (COMPLETED / FAILED / CRASHED / CANCELLED) | "Delivery still in progress" |
+| WEBHOOK_SEND | CANCEL | state is non-terminal (RUNNING / SCHEDULED / PENDING / AwaitingRetry) | "Delivery already settled" |
+| any other | — | (empty list) | — |
+
+RESEND is available on **any terminal state including COMPLETED** (FR-018).
+
+## State model (delivery lifecycle)
+
+Raw Prefect states; the frontend maps presentation labels over them (no backend status enum).
+
+```
+            ┌────────────┐  attempt fails (transient, <3)   ┌──────────────┐
+ SCHEDULED→ │  RUNNING    │ ───────────────────────────────▶ │ AwaitingRetry │
+            └────┬───┬────┘ ◀─────────────── retry fires ─────└──────────────┘
+   success ┌─────┘   └────┐ non-transient OR attempts exhausted
+           ▼              ▼
+      COMPLETED        FAILED ───┐
+           │            │        │  (genuine infra crash) → CRASHED
+   CANCEL  │            │        │
+ (non-term)│            ▼        ▼
+           └────────▶ CANCELLING → CANCELLED
+```
+
+- Non-terminal: SCHEDULED, PENDING, RUNNING, AwaitingRetry, CANCELLING.
+- Terminal: COMPLETED, FAILED, CRASHED, CANCELLED.
+- CANCEL: allowed only from non-terminal; flips toward CANCELLED (best-effort for an in-flight request).
+- RESEND: allowed only from terminal; produces a **new** run (does not transition the original).
+- `status_class` exists only when conclusion is FAILURE.
+
+## Relationships & identity
+
+- A delivery is identified by its Prefect flow-run id (the GraphQL task `id`).
+- A delivery references its webhook via the `webhook_id` run parameter and the related-node tag (drives Tasks-tab visibility and authorization).
+- A resend produces a new delivery with no parent link; it carries the same `payload` parameter and re-tags itself. Original and resend are independent records.
+- Validation rules enforced at boundaries: resend/cancel re-validate `available_actions` server-side at execution (reject stale, FR-026); resend re-checks the original run still exists in retention (FR-020).

--- a/dev/specs/ifc-2755-webhook-delivery-operability/plan.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/plan.md
@@ -7,7 +7,7 @@
 
 Make a webhook delivery a first-class, inspectable, recoverable object in the Tasks tab, built entirely on Prefect primitives with no new Neo4j node and no migration. The delivery is the user-visible `webhook_send` run; the operability layer adds: (1) capture of the request/response as a redacted artifact on the run, (2) a pure failure classifier producing a clean reason + smart (transient-only) retry over the existing fixed-delay policy, (3) polymorphic GraphQL task typing (`WebhookDeliveryTask`) discriminated by the run's workflow name, mirroring the events type hierarchy, and (4) generic, task-id-addressable resend and cancel mutations gated by a server-computed `available_actions` capability on every task.
 
-The structural split (orchestrator freezes payload → `webhook_send` carries its own retries) already exists on the branch. The one structural prerequisite uncovered in research is that `webhook_send` must be promoted to a registered workflow/deployment so it can be resubmitted by id and discriminated by name.
+The structural split (orchestrator freezes payload → `webhook_send` carries its own fixed-delay bounded retries) already exists on the branch, along with the retry policy itself (3 attempts, ~120s fixed delay, retrying on every failure) and webhook-node-id tagging on the flow runs — see the Implementation Sync revision below. The one structural prerequisite uncovered in research and still outstanding is that `webhook_send` must be promoted to a registered workflow/deployment so it can be resubmitted by id and discriminated by name.
 
 ## Technical Context
 
@@ -139,3 +139,16 @@ Both surfaces require `available_actions` (and, for the row, the `... on Webhook
 ## Complexity Tracking
 
 No constitution violations to justify.
+
+## Revision: Implementation Sync — 2026-06-26
+
+Reason: Reconcile the plan with foundation work merged ahead of the operability layer. Documentation-only sync; no constitution, `dev/guidelines/`, or `dev/adr/` conflict.
+
+| Foundation piece | State |
+|---|---|
+| `webhook_send` flow split (#9672) | Landed |
+| Fixed-delay bounded retry policy, 3 attempts / ~120s, retrying on all failures (#9676) | Landed |
+| Webhook-node-id tagging on flow runs | Landed |
+| Register `WEBHOOK_SEND` in the workflow catalogue (Phasing → Foundation) | Outstanding |
+| Transient-only `retry_condition_fn` over the landed policy (Phasing → US2) | Outstanding |
+| Capture/redaction, typing, classification, resend, cancel (US1–US4) | Outstanding |

--- a/dev/specs/ifc-2755-webhook-delivery-operability/plan.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Webhook Delivery Operability
+
+**Branch**: `pmi-20260624-speckit-end-of-webhooks` | **Date**: 2026-06-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/ifc-2755-webhook-delivery-operability/spec.md`
+
+## Summary
+
+Make a webhook delivery a first-class, inspectable, recoverable object in the Tasks tab, built entirely on Prefect primitives with no new Neo4j node and no migration. The delivery is the user-visible `webhook_send` run; the operability layer adds: (1) capture of the request/response as a redacted artifact on the run, (2) a pure failure classifier producing a clean reason + smart (transient-only) retry over the existing fixed-delay policy, (3) polymorphic GraphQL task typing (`WebhookDeliveryTask`) discriminated by the run's workflow name, mirroring the events type hierarchy, and (4) generic, task-id-addressable resend and cancel mutations gated by a server-computed `available_actions` capability on every task.
+
+The structural split (orchestrator freezes payload → `webhook_send` carries its own retries) already exists on the branch. The one structural prerequisite uncovered in research is that `webhook_send` must be promoted to a registered workflow/deployment so it can be resubmitted by id and discriminated by name.
+
+## Technical Context
+
+**Language/Version**: Python 3.14 (backend), TypeScript 5.9 / React 19.2 (frontend)
+**Primary Dependencies**: FastAPI, Graphene (GraphQL), Prefect (flow runs, artifacts, run state), httpx (via `InfrahubHTTP` adapter), Pydantic 2.12; frontend: Apollo + gql.tada, TanStack Query, `@infrahub/ui`, react-aria-components
+**Storage**: No new persisted domain schema. Delivery data lives in Prefect (flow-run parameters, tags, artifacts, run state) subject to Prefect retention (~30 days). Neo4j unchanged.
+**Testing**: pytest (unit/component/functional), Vitest (frontend unit), Playwright (frontend E2E)
+**Target Platform**: Linux server (backend workers + API), browser (frontend)
+**Project Type**: Web application (backend + frontend)
+**Performance Goals**: No additional per-task query cost beyond what the Tasks list already fetches — workflow-name resolution is already batched; the `http` artifact is read back in one batched call mirroring progress read-back, gated on GraphQL field selection.
+**Constraints**: No raw secret ever persisted (redaction at capture time); no new Neo4j node; no migration; existing task queries must keep working unchanged.
+**Scale/Scope**: Bounded by Prefect retention. Backend: ~1 new GraphQL interface + 1 concrete type + 2 mutations + 1 classifier + 1 capture/redaction component + 1 catalogue entry + retry condition. Frontend: extend task detail with a polymorphic section + 2 actions.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Schema-Driven Integrity | PASS | No new Neo4j node, no migration. Only generated GraphQL schema changes (`schema/schema.graphql`, frontend codegen) — regenerated, not hand-edited. |
+| II. Branch-Safe by Default | PASS | Deliveries are Prefect runs, not branch-versioned graph data. The delivery carries the originating branch as a tag; the task query already filters by branch. Resend re-tags from the original run's parameters. No cross-branch graph writes. |
+| III. Type Safety & Explicit Contracts | PASS | New internal models are frozen dataclasses / Pydantic (`CapturedHeaders`, classifier result, captured request/response). GraphQL interface + concrete type defined before implementation (see contracts/). `str \| None` style. |
+| IV. Test Discipline | PASS | Unit: classifier, header redaction, available-actions gating (pure logic, injected deps). Functional: capture on success/failure, resend resubmit, cancel state flip. Frontend E2E: resend + cancel happy paths. Reuse existing webhook + task fixtures. |
+| V. Query Performance & Efficiency | PASS | Workflow-name resolution already batched in the task service. `http` artifact read back in one batched `read_artifacts` call (mirrors `read_progress`), only when the GraphQL selection requests delivery fields. `available_actions` derived from already-fetched run state — no extra query. |
+| VI. Security & Input Boundaries | PASS | Redaction before artifact write (no raw secret persisted). Resend/cancel authorized at the API layer via object-level update permission on the target webhook node. Classified messages never leak stacktraces (FR-014 keeps genuine crashes distinct). Mutations require auth. |
+| VII. Simplicity & Maintainability | PASS | Reuses Prefect primitives and the existing events polymorphic pattern instead of inventing parallels. No new global permission (reuses object permission). Fixed-delay retry (no new backoff machinery). One catalogue entry promotes an existing flow. |
+
+**Result**: PASS, no violations. Complexity Tracking not required.
+
+One design decision worth surfacing (resolved in research.md, not a violation): authorization reuses the **object-level update permission** on the target webhook node rather than introducing a new `MANAGE_WEBHOOKS` global permission, because no webhook global permission exists today and adding one would exceed the clarified scope ("no new permission model").
+
+### Frontend principles (feature includes UI)
+
+| Principle | Status | Notes |
+|---|---|---|
+| Reuse Before Reinvent | PASS | Reuses `DataViewer` (payload/response body), `PropertyList` (headers/metadata), `Badge` (status/reason), `ModalConfirm` (resend/cancel confirmation), `Button` (`isPending`). No new primitives. |
+| Single State Owner | PASS | Task data owned by TanStack Query; confirmation modal open-state local `useState`; no mirrored server data. |
+| Backend Authoritative | PASS | `available_actions` (availability + reason) computed server-side; the frontend only renders it and disables controls accordingly. No client-side re-derivation of gating rules. |
+| Component Contracts Designed for All Callers | PASS | Task detail renders polymorphically by `__typename`; the webhook section is additive and does not break the generic task detail used by other task types. |
+| E2E Happy Path | PASS | New Playwright tests for every user-facing story: inspect (US1), failure reason (US2), resend (US3), cancel (US4) — Principle IV requires E2E for all user-facing features, not only the mutating ones. |
+
+### Shared Components Inventory (frontend)
+
+| Need | Reusing | Source |
+|---|---|---|
+| Display payload / request body / response body (JSON) | `DataViewer` | `shared/components/data-viewer/data-viewer.tsx` |
+| Key-value display for headers + delivery metadata | `PropertyList` | `shared/components/table/property-list.tsx` |
+| Status / classified-reason pill | `Badge` | `shared/components/ui/badge.tsx` |
+| Resend / cancel confirmation dialog | `ModalConfirm` | `shared/components/modals/modal-confirm.tsx` |
+| Action buttons with pending state | `Button` | `@infrahub/ui` |
+| Tooltip for disabled row actions (shows `unavailability_reason`) | `Tooltip` | `@infrahub/ui` |
+| Shared resend/cancel control (row compact + detail labeled) | `TaskActions` (building new) | `entities/tasks/ui/task-actions.tsx` |
+| Success / error feedback | `Alert` + `toast` | `shared/components/ui/alert.tsx` |
+| Mutation wiring (3-layer api → domain → ui hook) | existing pattern | `entities/repository/...reimport-last-commit*` (reference) |
+| Polymorphic GraphQL selection (`... on WebhookDeliveryTask`) | inline-fragment pattern | `entities/proposed-changes/api/get-proposed-change-thread-from-api.ts` (reference) |
+
+`TaskActions` is a feature-level composition of existing primitives (`Button`, `ModalConfirm`, `Tooltip`, `toast`), not a new shared UI primitive — it reads `available_actions` and renders compact in the delivery row and labeled in the detail panel. No Complexity Tracking entry needed (no new primitive, no constitution deviation).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/ifc-2755-webhook-delivery-operability/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — decisions resolving design open points
+├── data-model.md        # Phase 1 output — entities + GraphQL shape + state machine
+├── quickstart.md        # Phase 1 output — how to validate each user story
+├── contracts/
+│   └── graphql.md       # GraphQL SDL for the task interface, WebhookDeliveryTask, mutations
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+backend/infrahub/
+├── webhook/
+│   ├── tasks/process.py          # add retry_condition_fn (transient-only); write http capture in send body
+│   ├── models.py                 # add CapturedHeaders redaction; captured request/response models
+│   ├── classifier.py             # NEW — pure failure classifier (CONFIG/CONNECTION/TLS/TIMEOUT/4xx/5xx/UNKNOWN)
+│   └── capture.py                # NEW — build + write the redacted http artifact on the run
+├── workflows/
+│   └── catalogue.py              # add WEBHOOK_SEND WorkflowDefinition; register in WORKFLOWS
+├── graphql/
+│   ├── types/task.py             # TaskNodeInterface; keep TaskNode; add WebhookDeliveryTask; available_actions; TASK_TYPES + resolve_type
+│   ├── queries/task.py           # serializer: emit workflow discriminator + delivery fields (gated); compute available_actions
+│   ├── mutations/task.py         # NEW — generic TaskResend, TaskCancel mutations (by task id)
+│   ├── manager.py                # register concrete task types (mirror _load_event_types)
+│   └── schema.py                 # wire the new mutations into InfrahubBaseMutation
+└── task_manager/flow_run/        # reader: add read of the http artifact (mirror read_progress); read params by id for resend
+
+backend/tests/
+├── unit/webhook/                 # classifier, CapturedHeaders redaction, available-actions gating
+├── functional/webhook/           # capture on success/failure, resend resubmit, cancel state flip
+└── component/graphql/            # task typing resolve_type; mutation auth gating
+
+frontend/app/src/
+├── entities/tasks/
+│   ├── api/                      # extend task-list AND task-details queries with available_actions + `... on WebhookDeliveryTask`; resend/cancel mutations
+│   ├── domain/                   # resend/cancel domain fns (error mapping)
+│   └── ui/
+│       ├── task-actions.tsx      # NEW — shared <TaskActions task> (button + confirm modal + toast), reads available_actions
+│       ├── task-items.tsx        # render <TaskActions> compact (icon + tooltip) in each delivery row
+│       ├── task-item-details.tsx # polymorphic section: payload/request/response/reason + <TaskActions> labeled
+│       └── queries/              # useResendDelivery / useCancelDelivery mutation hooks
+└── (generated types regenerated via `pnpm codegen`)
+
+changelog/
+└── +ifc-2755-webhook-delivery-operability.added.md   # towncrier fragment
+```
+
+**Structure Decision**: Web application (backend + frontend). Backend changes concentrate in `webhook/`, `workflows/catalogue.py`, and `graphql/`; Prefect access goes through the existing `task_manager/flow_run` adapter. Frontend changes are additive within `entities/tasks/`. No new top-level modules.
+
+## Phasing (maps to spec user stories)
+
+The four spec user stories form the delivery order; the typing foundation is a shared enabler landed with US1.
+
+- **Foundation (enabler, with US1)**: `TaskNodeInterface` + `resolve_type` + `TASK_TYPES`, `TaskNodes.node` object→interface, manager registration, register `WEBHOOK_SEND` in the catalogue.
+- **US1 (P1) — Inspect request/response**: capture component + redaction, write `http` artifact in the send body, read-back in the serializer, `WebhookDeliveryTask` fields, frontend display section.
+- **US2 (P2) — Classified failure + smart retry**: classifier component, `retry_condition_fn`, clean re-raise, surface reason + remediation hint.
+- **US3 (P3) — Resend**: generic `TaskResend` mutation (read frozen params by run id, resubmit `WEBHOOK_SEND`), `available_actions` RESEND gating (any terminal state), confirm-on-every-resend UI via the shared `<TaskActions>` in both the delivery row and the detail panel.
+- **US4 (P4) — Cancel**: generic `TaskCancel` mutation (state flip to CANCELLING), `available_actions` CANCEL gating (non-terminal), exposed through the same shared `<TaskActions>` in row + detail panel (disabled with tooltip reason when unavailable).
+
+Both surfaces require `available_actions` (and, for the row, the `... on WebhookDeliveryTask` discriminant) on the **task-list** query, not just the detail query — the list query gains these fields as part of US1's foundation.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/dev/specs/ifc-2755-webhook-delivery-operability/quickstart.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Validating Webhook Delivery Operability
+
+How to exercise each user story end-to-end. Assumes a running Infrahub dev stack with the task-manager (Prefect) worker active.
+
+## Prerequisites
+
+```bash
+uv sync --all-groups
+cd frontend/app && pnpm install
+```
+
+Set up a target you control to observe deliveries — a request bin, a local echo server, or an endpoint you can take up/down to drive failures.
+
+## Setup: a webhook to exercise
+
+1. In the UI, create a Standard or Custom webhook pointing at your test endpoint. Optionally add a shared key (to exercise signature redaction) and an ENVIRONMENT-sourced custom header (to exercise secret redaction).
+2. Trigger the webhook's event (e.g. create/update the watched node kind) to produce a delivery.
+3. Open the webhook → **Tasks** tab. Each delivery is a `webhook_send` run row.
+
+## US1 — Inspect what a delivery sent and received (P1)
+
+1. Click a delivery to open its detail.
+2. Verify the **payload** (from run parameters), **request** (URL + headers), **response** (status, body, latency) are shown.
+3. Verify redaction: the ENVIRONMENT-sourced header and `webhook-signature` are masked; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and STATIC custom headers are verbatim.
+4. Point the webhook at an endpoint that returns an error; trigger again; confirm the captured request/response are still present and reflect the **last attempt**.
+
+Backend check: the run carries one `http` artifact (key `infrahub-webhook-http`); no raw secret appears in the artifact.
+
+## US2 — Understand why a delivery failed (P2)
+
+Drive each failure class and confirm the classified reason + remediation hint (no stacktrace), and the retry behavior:
+
+| Target | Expected class | Retried? |
+|---|---|---|
+| Unreachable host | CONNECTION | yes (3 attempts, ~2m apart) |
+| Endpoint returning 404 | HTTP_CLIENT_ERROR | no (immediate fail) |
+| Endpoint returning 500 | HTTP_SERVER_ERROR | yes |
+| Endpoint with invalid TLS cert (validate_certificates on) | TLS | no |
+| Slow endpoint past timeout | TIMEOUT | yes |
+| Webhook config that cannot resolve | CONFIG | no |
+
+Confirm per-attempt progress is visible in the delivery **logs**, and the final reason reflects the settling attempt.
+
+## US3 — Resend a delivery (P3)
+
+1. Trigger a delivery against a **down** endpoint so it fails. Bring the endpoint up.
+2. On the failed delivery, click **Resend**, confirm in the dialog → a **new** delivery row appears, carries the same payload, recomputes its signature, and succeeds. The original failed row is unchanged.
+3. On a **succeeded** delivery, click Resend → the confirmation explicitly calls out re-delivering an already-processed event; on confirm, a new delivery is produced.
+4. On an **in-progress / awaiting-retry** delivery, confirm Resend is disabled with a reason.
+5. (Retention) For a delivery whose run has aged out, confirm Resend reports "delivery no longer available".
+
+GraphQL check:
+```graphql
+mutation { InfrahubTaskResend(data: {id: "<run-id>"}) { ok task { id state } } }
+```
+
+## US4 — Cancel an in-progress delivery (P4)
+
+1. Trigger a delivery against a slow/failing endpoint so it enters AwaitingRetry.
+2. Click **Cancel** → the delivery transitions to cancelled and no further attempts are made.
+3. Confirm Cancel is disabled (with a reason) on already-settled deliveries.
+4. Confirm a cancelled delivery can then be **resent** (cancel→resend is the two-step restart).
+
+GraphQL check:
+```graphql
+mutation { InfrahubTaskCancel(data: {id: "<run-id>"}) { ok task { id state } } }
+```
+
+## Authorization
+
+As an account **without** update permission on the webhook node, confirm Resend/Cancel are rejected at the API layer with a clear permission error.
+
+## Automated tests
+
+```bash
+uv run invoke backend.test-unit            # classifier, CapturedHeaders redaction, available-actions gating
+uv run invoke backend.test-integration     # capture, resend resubmit, cancel state flip, task typing
+cd frontend/app && pnpm test               # mutation hooks / rendering
+cd frontend/app && pnpm test:e2e           # resend + cancel happy paths
+```
+
+## Regenerate artifacts after schema changes
+
+```bash
+uv run invoke backend.generate                 # protocols / generated backend
+uv run invoke schema.generate-graphqlschema    # schema/schema.graphql
+cd frontend/app && pnpm codegen                # frontend GraphQL types
+uv run invoke docs.generate                    # reference docs (events/schema/etc.)
+```
+
+Run `/pre-ci` before pushing to catch generated-file drift.

--- a/dev/specs/ifc-2755-webhook-delivery-operability/research.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/research.md
@@ -1,0 +1,102 @@
+# Phase 0 Research: Webhook Delivery Operability
+
+All decisions are grounded in the current branch code (paths are project-relative). Three of these resolve open points from the design doc; the rest record the codebase-anchored approach for each subsystem.
+
+## D1 — Promote `webhook_send` to a registered workflow
+
+**Decision**: Add a `WEBHOOK_SEND` `WorkflowDefinition` to `backend/infrahub/workflows/catalogue.py` and register it in `WORKFLOWS`. `webhook_process` invokes it as a deployment via the existing `submit_workflow` path so each delivery is a standalone, resubmittable run.
+
+**Rationale**: Today `webhook_send` is an inline `@flow(name="webhook-send")` in `backend/infrahub/webhook/tasks/process.py:45` called directly as a subflow (`process.py:154`); it is **not** in the catalogue (only `WEBHOOK_PROCESS`, `WEBHOOK_CONFIGURE`, `WEBHOOK_INVALIDATE_HEADERS` exist). Two features require it to be a registered workflow:
+- **Resend** resubmits by workflow name with the frozen parameters (`run_deployment` / `submit_workflow` need a deployment, per `services/adapters/workflow/worker.py:86`).
+- **Type discrimination** keys `TASK_TYPES` on the catalogue constant's `name` (`WEBHOOK_SEND.name → WebhookDeliveryTask`); the discriminant is the run's workflow name, already resolved into `EnrichedFlowRun.workflow_name` (`task_manager/flow_run/service.py:85`).
+
+**Alternatives considered**: Keep `webhook_send` an inline subflow and resend by re-invoking `webhook_process` — rejected: that re-runs the transform and re-derives the payload (not a true frozen replay), and re-introduces the orchestrator parent the design deliberately drops for resends.
+
+## D2 — Retry policy: fixed delay, transient-only (resolves spec Q1)
+
+**Decision**: Keep the existing `retries=3, retry_delay_seconds=120` on the `webhook_send` flow and add a `retry_condition_fn` that retries only transient classes (TIMEOUT, CONNECTION, HTTP_SERVER_ERROR). No exponential backoff.
+
+**Rationale**: The clarified spec (FR-012a) mandates fixed ~2-minute delay, transient-only, bounded to 3 attempts; exponential backoff is rejected because a long back-off parks many runs holding execution slots. The current flow already has the fixed delay (`process.py:31-32,48-49`) but retries on every exception. The only change is the condition function, reusing the classifier (D4) so the retry predicate and the surfaced reason agree.
+
+**Alternatives considered**: Prefect `exponential_backoff` + jitter (design-doc original) — rejected per Q1.
+
+## D3 — Capture as one redacted `http` artifact, last attempt (resolves both design open points)
+
+**Decision**: Write a single grouped `http` artifact per run (request + response + error together), reflecting the **last attempt**. The payload is not in the artifact — it is read from the run's frozen parameters.
+
+**Rationale**: The design doc left two open points: (a) one grouped artifact vs separate request/response artifacts, (b) per-attempt vs last-attempt. One artifact keyed per run mirrors the existing `progress` artifact read path exactly (`task_manager/flow_run/reader.py:108`, `read_artifacts(ArtifactFilter(...), FlowRunFilter(id=...))`), so read-back is one batched call and the serializer projection is trivial. Last-attempt matches the operator's mental model (the run shows AwaitingRetry between attempts; only the settling attempt's request/response is meaningful) and avoids unbounded artifact growth. The artifact is written from the `webhook_send` body so Prefect binds it to the visible run id regardless of trigger (event, resend, cron).
+
+**Implementation note**: The existing `progress` artifact stores a float (`type="progress"`). The `http` artifact stores a JSON-serializable dict; use a result/JSON artifact with a fixed key (e.g. `infrahub-webhook-http`) so it is filterable like progress. Confirm artifact `data` accepts a dict at write time and round-trips on read.
+
+**Alternatives considered**: Separate request/response artifacts (two reads, two keys) — rejected for no operator benefit; per-attempt capture (list artifact) — rejected as unbounded and not requested.
+
+## D4 — Pure failure classifier (IFC-2754)
+
+**Decision**: A pure, injected `WebhookFailureClassifier.classify(exc, response) -> ClassifiedFailure` mapping to one of `CONFIG · CONNECTION · TLS · TIMEOUT · HTTP_CLIENT_ERROR · HTTP_SERVER_ERROR · UNKNOWN`, each with a remediation hint. Invoked both in the send body (to build the clean failure message and capture) and by `retry_condition_fn`.
+
+**Rationale**: The `InfrahubHTTP` adapter already raises typed exceptions that map cleanly:
+- `HTTPServerSSLError` → TLS, `HTTPServerTimeoutError` → TIMEOUT, `HTTPServerError`/connect failures → CONNECTION (`services/adapters/http/httpx.py:97-106`).
+- `response.raise_for_status()` (`webhook/tasks/process.py:41`) raises `httpx.HTTPStatusError`; classify by status → HTTP_CLIENT_ERROR (4xx) / HTTP_SERVER_ERROR (5xx).
+- `WebhookHeaderResolutionError` and config-resolution failures → CONFIG.
+- anything else → UNKNOWN (re-raised with trace as a genuine crash, per FR-014).
+
+A pure function with injected inputs satisfies the no-mock testing rule and the SOLID/DI guideline. Expected delivery failures are caught and re-raised as a clean `WebhookDeliveryFailed(message)` (no stacktrace); unexpected errors propagate untouched so Prefect can mark a real CRASHED.
+
+**Alternatives considered**: Inline `isinstance` ladder in the flow body — rejected: not unit-testable in isolation and not reusable by the retry condition.
+
+## D5 — Header redaction via `CapturedHeaders` (IFC-2755)
+
+**Decision**: A `CapturedHeaders` domain object redacts at capture time, before the artifact write. Masked: every `HeaderKind.ENVIRONMENT`-sourced custom header and the `webhook-signature` header. Verbatim: standard headers (`Accept`, `Content-Type`), `webhook-id`, `webhook-timestamp`, and `HeaderKind.STATIC` custom headers. The `shared_key` is never in the request (only its derived signature).
+
+**Rationale**: `_build_headers` (`webhook/models.py:255-285`) is the single construction site; header provenance is known from `WebhookHeader.kind`. Redacting before the write guarantees no raw secret is ever persisted (SC-002, Principle VI). `webhook-id`/`webhook-timestamp` are signature inputs but not secret, so they stay verbatim to keep the capture diagnosable.
+
+**Implementation note**: Capture needs the provenance of each header, which is lost once `_build_headers` returns a flat `dict[str, str]`. Have header assembly return (or expose) the resolved headers alongside their `HeaderKind` so `CapturedHeaders` can decide per key, rather than re-guessing from the flat dict.
+
+**Alternatives considered**: Redact by key-name allowlist/denylist — rejected: brittle, misses arbitrary env-sourced custom header keys.
+
+## D6 — Polymorphic task typing mirrors the events hierarchy (IFC-2755 part 1)
+
+**Decision**: Introduce `TaskNodeInterface` carrying all current task fields plus `available_actions`. Keep `TaskNode` as the standard implementation (name unchanged). Add `WebhookDeliveryTask(interfaces=(TaskNodeInterface,))` with `http_request`, `http_response`, `error`. Discriminate via `resolve_type` against `TASK_TYPES = {WEBHOOK_SEND.name: WebhookDeliveryTask}`, fallback `TaskNode`. Register concrete types in the GraphQL manager. Change `TaskNodes.node` from object to interface.
+
+**Rationale**: Directly mirrors the proven events pattern: `EventNodeInterface` + `resolve_type` keyed on a discriminant + `EVENT_TYPES` map + `_load_event_types` registration (`graphql/types/event.py:31-60,313-340`, `graphql/manager.py:245-247`). Current task types are `Task` (object), `TaskNode(Task)`, `TaskNodes.node` (`graphql/types/task.py:16,36,49`). The discriminant (`run.workflow_name`) is already serialized as the `workflow` field (`graphql/queries/task.py:59`). Object→interface on `node` is query-compatible: existing selections of common fields keep resolving; no SDK/fragment/`__typename` breakage because `TaskNode` keeps its name.
+
+**Alternatives considered**: A `task_type` enum/field or a tag — rejected by the design: the workflow name is intrinsic to every run, so historical runs type correctly with no backfill and no extra stored field.
+
+## D7 — Generic, task-id-addressable resend/cancel mutations (IFC-2119, IFC-2753; resolves spec Q on genericity)
+
+**Decision**: Two new mutations, `InfrahubTaskResend(id)` and `InfrahubTaskCancel(id)`, modeled on the custom (non-CRUD) `BranchCreate` mutation pattern (`graphql/mutations/branch.py:55-114`), registered as direct fields on `InfrahubBaseMutation` (`graphql/schema.py`). They accept a task id and dispatch by the run's workflow type. The mutation **interface** is generic; support is per task type — only `WEBHOOK_SEND` runs are actionable, anything else returns the action as unavailable.
+
+- **Resend**: read the original run's frozen parameters by id (`read_flow_runs` with id filter → `flow_run.parameters`), then `submit_workflow(WEBHOOK_SEND, parameters=...)`. New standalone run; original left immutable.
+- **Cancel**: `set_flow_run_state(id, State(type=CANCELLING), force=True)` via the retention client (`task_manager/flow_run/prefect_client.py:85`).
+
+**Rationale**: Honors the clarified directive — the query/mutation surface is generic (not `CoreWebhookCancel`), but genericity is confined to the interface (FR-017). CRUD-schema mutations (`InfrahubMutationMixin`) are the wrong base; `BranchCreate` is the precedent for a bespoke action mutation. Resend retention failure (run purged) surfaces as a clear "not found" (FR-020); config-no-longer-resolves surfaces at runtime on the new run (FR-005-class CONFIG failure, US3 scenario 5).
+
+**Alternatives considered**: Webhook-specific mutations — rejected by Q2/Q3 direction. A generic mutation that every task type implements — rejected: only webhook deliveries support the actions; others resolve unavailable.
+
+## D8 — `available_actions` computed server-side from run state
+
+**Decision**: Compute `available_actions` in the task serializer from the already-fetched run state + workflow type. For a `WEBHOOK_SEND` run: `RESEND` available iff terminal (COMPLETED/FAILED/CRASHED/CANCELLED); `CANCEL` available iff non-terminal (RUNNING/SCHEDULED/PENDING/AwaitingRetry). Each unavailable action carries a reason. Non-webhook runs get an empty list.
+
+**Rationale**: Single source of truth server-side (FR-016, Principle "Backend Authoritative"). Derived from data the task query already loads — no extra round-trip (Principle V). Note the resend gate is **any terminal state including COMPLETED**, per spec Q (FR-018); a succeeded resend is allowed but the UI confirmation calls out re-delivery (FR-021). Mutations re-check availability at execution time and reject a stale action (FR-026).
+
+## D9 — Authorization reuses object-level webhook permission
+
+**Decision**: `TaskResend`/`TaskCancel` on a webhook delivery authorize against the **object-level update permission on the target webhook node** (resolved from the run's `webhook_id` parameter/tag), via `active_permissions.raise_for_permission(...)` at the mutation layer.
+
+**Rationale**: Research found no `MANAGE_WEBHOOKS` global permission; webhooks are governed by object permissions on the Standard/CustomWebhook nodes (`graphql/manager.py:542-556` maps both kinds to `InfrahubWebhookMutation`; no global permission gate). The clarified spec (FR-027) says "no new permission model", so reuse the existing object update permission rather than add a global one. Authorization is enforced at the API layer (Principle VI).
+
+**Open implementation detail (defer to tasks)**: exact resolution of the webhook node id from a run and the precise permission-decision level (ALLOW_ALL vs branch-scoped) — both determinable during implementation, neither changes the design.
+
+## Resolved unknowns summary
+
+| Unknown | Resolution |
+|---|---|
+| `webhook_send` not resubmittable / not in catalogue | D1 — register `WEBHOOK_SEND`, invoke as deployment |
+| Backoff strategy + attempt count | D2 — fixed 120s, transient-only, 3 attempts |
+| One vs two capture artifacts; per-attempt vs last | D3 — one `http` artifact, last attempt |
+| Failure taxonomy + retry predicate source | D4 — pure classifier shared by body + retry condition |
+| Which headers to mask | D5 — env-sourced + signature masked; rest verbatim |
+| Task polymorphism mechanism | D6 — interface + resolve_type on workflow name (mirror events) |
+| Mutation shape (generic vs webhook-specific) | D7 — generic by task id, per-type support |
+| Where action availability is decided | D8 — server-side from run state, no extra query |
+| Authorization model | D9 — object-level webhook update permission, no new global permission |

--- a/dev/specs/ifc-2755-webhook-delivery-operability/spec.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Webhook Delivery Operability
+
+**Feature Branch**: `pmi-20260624-speckit-end-of-webhooks`
+**Created**: 2026-06-24
+**Status**: Draft
+**Input**: IFC-2753 (manual cancel), IFC-2755 (task typing + HTTP capture/display), IFC-2119 (manual resend), IFC-2754 (enhanced logs + error classification); design: "Webhooks Delivery Operability" and "Webhook Delivery Operability: Prefect-native design"
+
+## Overview
+
+A webhook delivery is currently process exhaust: a background run plus log lines. When a delivery fails, an operator sees a raw stacktrace, no record of what was sent or what came back, no classified reason, and has no way to replay or stop it. The only recovery is to re-fire the original business event — impossible once the source node is deleted.
+
+This feature makes a delivery a first-class, inspectable, and recoverable object surfaced in the Tasks tab: operators can see the payload, the request and response, a clean classified failure reason with a remediation hint, and can resend or cancel a delivery. Recovery actions (resend, cancel) are exposed as **generic task actions** — any task carries them, and webhook deliveries are the first task type to populate them — rather than as webhook-specific operations.
+
+## Clarifications
+
+### Session 2026-06-24
+
+- Q: Retry policy — backoff strategy and attempt count? → A: Fixed delay (~2 min), transient-only, bounded to 3 attempts. Exponential backoff is rejected because a long back-off would leave many flow runs parked, waiting on a delayed retry attempt to resolve.
+- Q: Resend confirmation scope — confirm only on succeeded deliveries, or on every resend? → A: Confirm on every resend; each resend spawns a new independent flow run that warrants a deliberate acknowledgment. Re-delivering a succeeded delivery remains the higher-stakes case and is called out explicitly in the confirmation.
+- Q: Who may resend or cancel a delivery? → A: Require the existing webhook-management permission — whoever can configure a webhook can operate its deliveries. No new or dedicated permission concept is introduced.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Inspect what a delivery sent and received (Priority: P1)
+
+An operator opens a webhook delivery in the Tasks tab and sees the delivered payload, the request as sent (URL and headers, with secrets masked), and the response received (status code, body, latency). This works for any delivery in the retention window, whether it succeeded or failed, and reflects the last attempt made.
+
+**Why this priority**: Without a record of the request and response, an operator cannot answer the first question of any webhook integration problem — "what did we actually send, and what came back?" Every other recovery action depends on first being able to see this. It is the foundation the rest of the feature builds on.
+
+**Independent Test**: Configure a webhook against a test endpoint, trigger it, open the delivery, and confirm the payload, request headers (with environment-sourced headers and the signature masked), response status, response body, and latency are all visible. Verify a delivery to an endpoint returning an error still shows the captured request and response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a delivery that completed successfully, **When** the operator opens it, **Then** the delivered payload, the request URL and headers, the response status code and body, and the latency are displayed.
+2. **Given** a delivery whose request included an environment-sourced custom header and a signature header, **When** the operator views the captured request headers, **Then** those values are shown masked and no raw secret is exposed anywhere in the view.
+3. **Given** a delivery that was retried before settling, **When** the operator views the request/response, **Then** the captured request/response reflects the last attempt.
+4. **Given** a static (non-secret) custom header and the delivered payload, **When** the operator views the delivery, **Then** those are shown verbatim.
+
+---
+
+### User Story 2 - Understand why a delivery failed (Priority: P2)
+
+When a delivery fails, the operator sees a short, classified reason (for example: a connection problem, a TLS problem, a timeout, a client-side 4xx, a server-side 5xx, a configuration error) accompanied by a remediation hint, instead of a raw stacktrace. Deliveries are retried automatically only for failures that can plausibly succeed on retry (timeouts, connection failures, server 5xx); a 4xx or a configuration error fails immediately without wasting retry attempts.
+
+**Why this priority**: A classified reason turns an opaque failure into an actionable one and tells the operator whether to fix the target, fix the configuration, or simply resend. Smart retry stops the system from burning retry attempts on failures that can never succeed (a bad URL, a 404) while still covering transient outages.
+
+**Independent Test**: Point a webhook at (a) an unreachable host, (b) an endpoint returning 404, (c) an endpoint returning 500, and (d) an endpoint with an invalid certificate; trigger each and confirm the displayed reason is correctly classified, a remediation hint is shown, and only the transient cases (unreachable, 500) are retried.
+
+**Acceptance Scenarios**:
+
+1. **Given** a delivery to an unreachable target, **When** it fails, **Then** the operator sees a connection-class reason with a hint pointing at target reachability, and no stacktrace.
+2. **Given** a delivery that receives a 4xx response, **When** it fails, **Then** it is not retried and the reason points the operator at the URL or authentication.
+3. **Given** a delivery that receives a 5xx response or times out, **When** it fails an attempt, **Then** it is retried before settling as failed.
+4. **Given** a delivery whose configuration cannot be resolved, **When** it fails, **Then** it is classified as a configuration error and not retried.
+5. **Given** any failed delivery, **When** the operator inspects it, **Then** per-attempt progress is visible in the logs.
+
+---
+
+### User Story 3 - Resend a delivery (Priority: P3)
+
+An operator resends a settled delivery. The resend replays the original frozen payload against the webhook's current configuration, producing a new delivery with a freshly computed signature. Resend is available on any delivery that has reached a terminal state — including one that previously succeeded — so an operator can re-deliver an event on demand (for example after fixing a downstream system, or to re-trigger a handler during integration testing). Resend is not available while a delivery is still in progress or auto-retrying, because that would race the pending attempt and double-send.
+
+**Why this priority**: Resend is the long-standing recovery gap: today the only way to retry is to re-create the original event, which is impossible once the source node is gone. It depends on the delivery record (US1) existing to resend from. Allowing resend from any terminal state — not only failures — lets operators re-deliver and test on demand.
+
+**Independent Test**: Trigger a delivery against an endpoint that is down so it fails; bring the endpoint up; resend the delivery from the UI; confirm a new delivery is created, carries the same payload, recomputes its signature, and succeeds. Separately, resend a previously succeeded delivery and confirm a new delivery is produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a failed delivery whose target is now reachable, **When** the operator resends it and confirms, **Then** a new delivery is created with the same payload and a fresh signature, and it succeeds.
+2. **Given** a delivery that succeeded, **When** the operator resends it, **Then** the confirmation calls out that this re-delivers an already-processed event, and on confirming, a new delivery is created and delivered.
+3. **Given** a delivery still in progress or awaiting an auto-retry, **When** the operator views it, **Then** the resend action is unavailable with a reason indicating the delivery is still in progress.
+4. **Given** a delivery whose original run has aged out of the retention window, **When** the operator attempts to resend, **Then** the system reports the delivery as no longer available rather than producing a broken resend.
+5. **Given** a delivery whose webhook configuration no longer resolves (the webhook was deleted), **When** the operator resends, **Then** the resent delivery is created and fails at runtime with a clear configuration-class reason.
+6. **Given** the original delivery, **When** it is resent, **Then** the original record is left unchanged as an immutable record and the resend appears as a new delivery.
+
+---
+
+### User Story 4 - Cancel an in-progress delivery (Priority: P4)
+
+An operator cancels a delivery that is still in progress or awaiting an auto-retry, stopping its remaining auto-retry cycle. Cancellation is best-effort for an attempt already in flight — if the HTTP request has already left, it is not recalled — but it prevents any further scheduled attempts. A delivery that has already settled cannot be cancelled.
+
+**Why this priority**: Cancel gives an operator closure on a delivery that is uselessly retrying against a target known to be down or misconfigured, and is the natural counterpart to resend. It is lowest priority because the auto-retry window is bounded, so the cost of not cancelling is limited.
+
+**Independent Test**: Trigger a delivery against a slow/failing endpoint so it enters its auto-retry cycle; cancel it from the UI; confirm it transitions to a cancelled state and no further attempts are made.
+
+**Acceptance Scenarios**:
+
+1. **Given** a delivery that is in progress or awaiting an auto-retry, **When** the operator cancels it, **Then** it transitions to a cancelled state and no further auto-retry attempts are made.
+2. **Given** a delivery that has already settled (succeeded, failed, crashed, or already cancelled), **When** the operator views it, **Then** the cancel action is unavailable with a reason indicating the delivery is already settled.
+3. **Given** a cancelled delivery, **When** the operator views it later, **Then** it can be resent (cancel then resend is the two-step way to restart a delivery during its auto-retry window).
+
+---
+
+### Edge Cases
+
+- A custom header key appears more than once: the delivery proceeds; behavior on duplicates is deterministic and does not break capture.
+- An environment-sourced header references a variable that is not set: the delivery proceeds without that header and this is surfaced in the logs, not as a crash.
+- The same delivery is resent twice in quick succession: each resend produces its own independent new delivery.
+- A delivery is cancelled at the exact moment an attempt's HTTP request is already in flight: the in-flight request is not recalled, but no further attempts are scheduled.
+- A non-webhook task is viewed: it carries the generic action list (empty when no actions apply) and does not expose webhook-specific request/response fields.
+- An operator attempts an action that has become unavailable since the page was loaded (for example, resending a delivery that has since started auto-retrying again): the action is rejected server-side with a clear reason rather than silently double-sending.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Delivery as a first-class object
+
+- **FR-001**: The system MUST represent each webhook delivery as a distinct, inspectable object surfaced in the Tasks tab, decoupled from the internal orchestration that triggered it.
+- **FR-002**: The system MUST classify a delivery as a webhook delivery automatically from intrinsic run information, so that historical deliveries are recognized without any backfill.
+- **FR-003**: A webhook delivery MUST expose, in addition to the fields common to all tasks, its request, its response, and its error.
+- **FR-004**: Tasks that are not webhook deliveries MUST continue to behave exactly as before, with no change to their existing fields or queries.
+
+#### Capture and display
+
+- **FR-005**: The system MUST capture the delivered payload, the request as sent (URL and headers), and the response received (status code, body, and latency) for a delivery, on both success and failure.
+- **FR-006**: The captured request/response MUST reflect the last attempt made for the delivery.
+- **FR-007**: The system MUST mask, at the point of capture, every header whose value is secret by design (environment-sourced headers and the request signature), so that no raw secret is ever persisted with the delivery.
+- **FR-008**: The system MUST preserve non-secret headers and the delivered payload verbatim in the captured record.
+- **FR-009**: The operator-facing view MUST present the payload, request, response, latency, target URL, last-attempt timestamp, HTTP status code, and (on failure) the classified reason.
+
+#### Failure classification and retry
+
+- **FR-010**: When a delivery fails, the system MUST present a short classified reason drawn from a small fixed set of failure classes, instead of a raw stacktrace.
+- **FR-011**: Each classified failure reason MUST be accompanied by a remediation hint appropriate to its class.
+- **FR-012**: The system MUST automatically retry a failing delivery only for failure classes that can plausibly succeed on retry (timeout, connection, server-side 5xx) and MUST fail immediately for classes that cannot (client-side 4xx, configuration errors).
+- **FR-012a**: Auto-retry MUST use a fixed delay between attempts (approximately 2 minutes) and MUST be bounded to 3 attempts. A growing (exponential) back-off is explicitly rejected, because a long back-off would leave many deliveries parked in an awaiting-retry state, holding execution slots while waiting on a delayed attempt.
+- **FR-013**: The final classified reason MUST reflect the failure that settles the delivery after auto-retries are exhausted, not an intermediate attempt.
+- **FR-014**: An unexpected (non-delivery) error MUST remain distinguishable from an expected delivery failure, retaining its diagnostic detail rather than being flattened into a clean message.
+- **FR-015**: Per-attempt progress MUST remain visible in the delivery's logs.
+
+#### Generic task actions: resend and cancel
+
+- **FR-016**: The system MUST expose the available recovery actions for a task as a generic capability carried by every task, computed server-side as the single source of truth, with an availability state and a reason when unavailable.
+- **FR-017**: The resend and cancel mutations MUST present a generic interface addressable by task identifier (not a webhook-specific mutation shape). Genericity is confined to the query/mutation surface: it does NOT imply that every task type supports these actions. Actual support is determined per task type, and webhook deliveries are the only type that supports resend and cancel in this feature; for any other task type the actions resolve as unavailable.
+- **FR-018**: Resend MUST be available for a delivery in any terminal state — including one that succeeded — and MUST be unavailable while a delivery is in progress or awaiting an auto-retry.
+- **FR-019**: Resending a delivery MUST replay its original frozen payload against the webhook's current configuration, producing a new independent delivery with a freshly computed signature, and MUST leave the original delivery unchanged.
+- **FR-020**: Resending a delivery whose underlying record has aged out of retention MUST fail with a clear "no longer available" result rather than producing a broken resend.
+- **FR-021**: Every resend MUST require an explicit confirmation before it proceeds, because each resend spawns a new independent delivery. The confirmation for a succeeded delivery MUST additionally call out that it re-delivers an event the target has already processed.
+- **FR-022**: Cancel MUST be available only while a delivery is non-terminal, and MUST stop any further scheduled auto-retry attempts.
+- **FR-023**: Cancellation MUST be best-effort for an attempt already in flight; an HTTP request already sent is not recalled.
+- **FR-024**: A delivery that has settled MUST NOT be cancellable; the cancel action MUST report it as already settled.
+- **FR-025**: The frontend MUST drive the resend and cancel controls from the server-computed availability, disabling each control and showing its unavailability reason when the action does not apply.
+- **FR-026**: Any action attempted after it has become unavailable MUST be rejected server-side with a clear reason rather than performed.
+- **FR-027**: Resend and cancel MUST be authorized against the existing webhook-management permission; an operator who can configure a webhook can operate its deliveries, and no new or elevated permission is introduced.
+
+### Key Entities *(include if feature involves data)*
+
+- **Delivery**: A single attempt-set to send one frozen payload to one webhook target, surfaced as a task. Carries state, payload, request, response, latency, classified failure reason (when failed), and available actions. Lives within the background system's retention window.
+- **Captured request**: The URL and headers as sent on the last attempt, with secret-by-design values masked.
+- **Captured response**: The status code, body, and latency of the last attempt's response.
+- **Classified failure reason**: One of a small fixed set of failure classes plus a remediation hint; present only when the delivery failed.
+- **Available actions**: The generic, per-task set of recovery actions (resend, cancel) with, for each, whether it is currently available and, if not, why.
+- **Webhook configuration**: The target URL, custom headers, certificate-validation setting, and signing key, resolved per attempt (not frozen with the payload), so that fixing a misconfiguration and resending works.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For any delivery within the retention window, an operator can determine what was sent and what came back without leaving the delivery view and without consulting raw logs — in 100% of cases the payload, request, response, and latency are present.
+- **SC-002**: No raw secret value (environment-sourced header or signing material) is ever exposed in the delivery view or the persisted delivery record.
+- **SC-003**: 100% of delivery failures presented to the operator are a classified reason with a remediation hint; 0% present a raw stacktrace.
+- **SC-004**: Deliveries that cannot succeed on retry (4xx, configuration errors) consume no auto-retry attempts, while transient failures (timeout, connection, 5xx) are retried.
+- **SC-005**: An operator can recover a failed delivery against a now-healthy target in under one minute, using only the delivery view, without re-creating the original business event.
+- **SC-006**: An operator can stop a uselessly retrying delivery from the delivery view, after which no further attempts are made.
+- **SC-007**: The change introduces no data migration and no new persisted domain schema; existing task queries continue to work unchanged.
+
+## Assumptions
+
+- The structural foundation — splitting the orchestrator that freezes the payload from the user-visible send, which carries its own auto-retries — is already in place on the current branch; this feature adds the operability layer (capture, classification, typing, resend, cancel) on top.
+- Delivery data lives in the background execution system and is subject to its retention window (default 30 days); deliveries older than the window are not inspectable or resendable. This is an accepted trade for requiring no new domain schema or migration.
+- Resend replays the frozen payload against the *current* configuration with a fresh signature; it deliberately does not replay a byte-for-byte frozen request, so that fixing a misconfiguration and resending succeeds.
+- The payload is frozen once at delivery creation; headers, signature, and configuration are recomputed per attempt and per resend.
+- Whether the captured request/response is stored as one grouped record or as separate request and response records is an implementation detail not visible to the operator; the operator-facing requirement is only that both are shown.
+- Permission to resend or cancel a delivery is the existing webhook-management permission (see FR-027); this feature introduces no new permission model.
+- Resend and cancel are state-gated rather than coordinated through locking; concurrent or stale attempts are resolved by the server-side availability check at execution time (FR-026).
+- "Terminal" means a delivery has settled (succeeded, failed, crashed, or cancelled); "non-terminal" means it is in progress or awaiting an auto-retry.

--- a/dev/specs/ifc-2755-webhook-delivery-operability/spec.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/spec.md
@@ -167,7 +167,7 @@ An operator cancels a delivery that is still in progress or awaiting an auto-ret
 
 ## Assumptions
 
-- The structural foundation — splitting the orchestrator that freezes the payload from the user-visible send, which carries its own auto-retries — is already in place on the current branch; this feature adds the operability layer (capture, classification, typing, resend, cancel) on top.
+- The structural foundation — splitting the orchestrator that freezes the payload from the user-visible `webhook_send`, which carries its own fixed-delay bounded auto-retries — is already in place on the current branch (see the Implementation Sync revision below); this feature adds the operability layer (capture, classification, typing, resend, cancel) on top. The landed retry policy currently retries on every failure; FR-012 narrows it to transient-only.
 - Delivery data lives in the background execution system and is subject to its retention window (default 30 days); deliveries older than the window are not inspectable or resendable. This is an accepted trade for requiring no new domain schema or migration.
 - Resend replays the frozen payload against the *current* configuration with a fresh signature; it deliberately does not replay a byte-for-byte frozen request, so that fixing a misconfiguration and resending succeeds.
 - The payload is frozen once at delivery creation; headers, signature, and configuration are recomputed per attempt and per resend.
@@ -175,3 +175,17 @@ An operator cancels a delivery that is still in progress or awaiting an auto-ret
 - Permission to resend or cancel a delivery is the existing webhook-management permission (see FR-027); this feature introduces no new permission model.
 - Resend and cancel are state-gated rather than coordinated through locking; concurrent or stale attempts are resolved by the server-side availability check at execution time (FR-026).
 - "Terminal" means a delivery has settled (succeeded, failed, crashed, or cancelled); "non-terminal" means it is in progress or awaiting an auto-retry.
+
+## Revision: Implementation Sync — 2026-06-26
+
+Reason: Reconcile the specification with foundation work that has merged ahead of the operability layer, so the spec reflects shipped reality rather than a greenfield baseline. Documentation-only sync; no constitution, `dev/guidelines/`, or `dev/adr/` conflict.
+
+Landed prerequisites (structural; out of this spec's scope but the layer it builds on):
+
+| Change | Bearing on this spec |
+|---|---|
+| `webhook_send` split into its own flow (#9672) | The delivery this spec makes a first-class object (FR-001) already exists as a standalone run. |
+| Fixed-delay bounded retry policy on `webhook_send` (#9676) | FR-012a's retry mechanism (3 attempts, ~120s fixed delay) is implemented. It retries on every failure today; the transient-only gating in FR-012 is the remaining operability layer. |
+| Webhook flow runs tagged with the webhook node id | Underpins the per-delivery, object-level authorization in FR-027 and node-scoped lookup. |
+
+Outstanding (this feature's scope): capture and redaction (FR-005–FR-009), failure classification with remediation hints (FR-010–FR-014), polymorphic task typing (FR-001–FR-004), and the generic resend/cancel actions (FR-016–FR-027).

--- a/dev/specs/ifc-2755-webhook-delivery-operability/tasks.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/tasks.md
@@ -1,0 +1,213 @@
+---
+description: "Task list for Webhook Delivery Operability"
+---
+
+# Tasks: Webhook Delivery Operability
+
+**Input**: Design documents from `specs/ifc-2755-webhook-delivery-operability/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/graphql.md
+
+**Tests**: Included — the Infrahub constitution (Principle IV, Test Discipline) requires tests for new features.
+
+**Organization**: Tasks are grouped by user story. The typing foundation is a shared blocking prerequisite (Phase 2) consumed by every story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US4 maps to the spec user stories
+- Paths are project-relative
+
+## Path Conventions
+
+Web application: backend under `backend/`, frontend under `frontend/app/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Lightweight — dependencies and stack already exist on the branch.
+
+- [X] T001 [P] Add towncrier changelog fragment `changelog/+ifc-2755-webhook-delivery-operability.added.md` describing the delivery operability feature (user-facing).
+- [ ] T002 [P] Add a controllable HTTP-target test fixture (endpoint that can return success / 4xx / 5xx / timeout / TLS error / be unreachable) under `backend/tests/functional/webhook/conftest.py`, reusing existing webhook fixtures.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Promote `webhook_send` to a registered workflow and stand up the polymorphic task typing + `available_actions`. Mirrors the events GraphQL type derivation (interface + `resolve_type` + name→type map + manager registration).
+
+**⚠️ CRITICAL**: No user story can be completed until this phase is done.
+
+- [X] T003 Register `WEBHOOK_SEND` `WorkflowDefinition` and add it to `WORKFLOWS` in `backend/infrahub/workflows/catalogue.py`.
+- [ ] T004 Invoke `webhook_send` as the registered deployment from `webhook_process` (via the `submit_workflow` path) so each delivery is a standalone resubmittable run, in `backend/infrahub/webhook/tasks/process.py` (depends on T003).
+- [ ] T005 [P] Add supporting GraphQL types `HttpRequest`, `HttpResponse`, `DeliveryError`, `TaskAction`, and the `TaskActionName` enum (RESEND, CANCEL) in `backend/infrahub/graphql/types/task.py`.
+- [ ] T006 Introduce `TaskNodeInterface` (move the current common `Task` fields onto it, add `available_actions`), convert `TaskNode` to `class Meta: interfaces = (TaskNodeInterface,)`, add `WebhookDeliveryTask` (adds `http_request`/`http_response`/`error`), define `TASK_TYPES = {WEBHOOK_SEND.name: WebhookDeliveryTask}` + `resolve_type`, and change `TaskNodes.node` to the interface, in `backend/infrahub/graphql/types/task.py` (depends on T005, T003).
+- [ ] T007 Register the concrete task types so they are reachable via `resolve_type` (mirror `_load_event_types`) in `backend/infrahub/graphql/manager.py` (depends on T006).
+- [X] T008 [P] Implement the `available_actions` computation as a dedicated pure function/module from `(workflow_name, prefect_state)` — RESEND iff terminal (incl. COMPLETED), CANCEL iff non-terminal, empty for non-webhook runs, each with `unavailability_reason` — unit-testable in isolation, in `backend/infrahub/graphql/queries/task_actions.py` (depends on T003).
+- [ ] T009 Wire `available_actions` into the task serializer (`_serialize_node`) so every task node carries it, in `backend/infrahub/graphql/queries/task.py` (depends on T008, T006).
+- [X] T010 [P] Unit test the `available_actions` gating matrix (terminal/non-terminal, webhook vs other) in `backend/tests/unit/webhook/test_available_actions.py` (depends on T008).
+- [ ] T011 [P] Component test that `resolve_type` returns `WebhookDeliveryTask` for `webhook_send` runs and `TaskNode` otherwise, and that existing common-field selections still resolve, in `backend/tests/component/graphql/queries/test_task.py` (depends on T007).
+
+**Checkpoint**: Tasks are polymorphically typed; webhook deliveries resolve to `WebhookDeliveryTask`; `available_actions` is populated; `webhook_send` is resubmittable. **Regenerate and commit the GraphQL schema + frontend types now** — the object→interface change alters `schema/schema.graphql` — and re-run regeneration at each subsequent increment so the generated-file CI gate stays green (don't defer all regen to Polish).
+
+---
+
+## Phase 3: User Story 1 - Inspect what a delivery sent and received (Priority: P1) 🎯 MVP
+
+**Goal**: Operators see the payload, request (URL + redacted headers), response (status, body, latency) for any delivery, reflecting the last attempt.
+
+**Independent Test**: Trigger a delivery to a test endpoint; open it; confirm payload/request/response/latency are shown and that env-sourced headers + the signature are masked while static/standard headers and the payload are verbatim.
+
+### Implementation for User Story 1
+
+- [X] T012 [P] [US1] Implement the `CapturedHeaders` redaction domain object (mask ENVIRONMENT-sourced headers + `webhook-signature`; keep standard, `webhook-id`, `webhook-timestamp`, and STATIC headers verbatim) in `backend/infrahub/webhook/capture.py`.
+- [ ] T013 [US1] Expose per-header provenance (`HeaderKind`) from header assembly so capture can redact by kind rather than re-guessing the flat dict, in `backend/infrahub/webhook/models.py` (depends on T012).
+- [ ] T014 [P] [US1] Implement captured request/response models and the `CapturedHttp` artifact builder (one grouped `http` payload: request, response, error) in `backend/infrahub/webhook/capture.py`.
+- [ ] T015 [US1] Write the redacted `http` artifact (key `infrahub-webhook-http`, last attempt) on both success and failure inside the `webhook_send` body, in `backend/infrahub/webhook/tasks/process.py` (depends on T014, T013).
+- [ ] T016 [US1] Read the `http` artifact back (mirror `read_progress`: `read_artifacts(ArtifactFilter(key), FlowRunFilter(id))`) in `backend/infrahub/task_manager/flow_run/reader.py`.
+- [ ] T017 [US1] Project the captured artifact onto `http_request`/`http_response`/`error` in the serializer, gated on the GraphQL selection; payload continues to come from `parameters`, in `backend/infrahub/graphql/queries/task.py` (depends on T016, T006).
+- [X] T018 [P] [US1] Unit test `CapturedHeaders` redaction (env + signature masked; standard/static + payload verbatim; no raw secret) in `backend/tests/unit/webhook/test_captured_headers.py`.
+- [ ] T019 [P] [US1] Functional test that capture is present on success and failure, reflects the last attempt, and persists no raw secret, in `backend/tests/functional/webhook/test_capture.py` (depends on T015, T016).
+- [ ] T020 [P] [US1] Extend the task-list and task-details queries with `available_actions` and `... on WebhookDeliveryTask { http_request http_response error }` in `frontend/app/src/entities/tasks/api/get-task-list-from-api.ts` and `get-task-details-from-api.ts`.
+- [ ] T021 [US1] Regenerate frontend GraphQL types (`cd frontend/app && pnpm codegen`) (depends on T020 and backend schema types T006).
+- [ ] T022 [US1] Render the webhook delivery section (payload from `parameters`, request incl. target URL, response, latency, HTTP status, last-attempt timestamp) polymorphically by `__typename` in `frontend/app/src/entities/tasks/ui/task-item-details.tsx` (depends on T021).
+- [ ] T023 [P] [US1] Frontend unit test for the delivery detail rendering (request/response/redacted headers shown) in `frontend/app/src/entities/tasks/ui/task-item-details.test.tsx` (depends on T022).
+- [ ] T050 [US1] Playwright E2E (constitution Principle IV): open a webhook delivery, assert payload/request/response/latency are shown and env-sourced headers + signature are masked, in `frontend/app/tests/e2e/webhook-delivery-inspect.spec.ts` (depends on T022). _(added post-analysis; executes within US1)_
+
+**Checkpoint**: A delivery's request/response/payload are fully inspectable in the UI with secrets masked — MVP deliverable.
+
+---
+
+## Phase 4: User Story 2 - Understand why a delivery failed (Priority: P2)
+
+**Goal**: Failed deliveries show a classified reason + remediation hint (no stacktrace); only transient classes are auto-retried.
+
+**Independent Test**: Drive CONNECTION / 4xx / 5xx / TLS / TIMEOUT / CONFIG failures; confirm correct classification, remediation hint, no stacktrace, and that only TIMEOUT/CONNECTION/5xx are retried.
+
+### Implementation for User Story 2
+
+- [X] T024 [P] [US2] Implement the pure `WebhookFailureClassifier.classify(exc, response) -> ClassifiedFailure` (CONFIG/CONNECTION/TLS/TIMEOUT/HTTP_CLIENT_ERROR/HTTP_SERVER_ERROR/UNKNOWN, each with remediation + `transient` flag) in `backend/infrahub/webhook/classifier.py`.
+- [ ] T025 [US2] Use the classifier in the `webhook_send` body: catch expected delivery failures and re-raise a clean `WebhookDeliveryFailed(message)` (no stacktrace); let unexpected errors propagate as a genuine crash, in `backend/infrahub/webhook/tasks/process.py` (depends on T024, T015).
+- [ ] T026 [US2] Add a `retry_condition_fn` (transient-only) reusing the classifier on the `webhook_send` flow, keeping the fixed 120s delay / 3 attempts, in `backend/infrahub/webhook/tasks/process.py` (depends on T024).
+- [ ] T027 [US2] Include the classified error (`status_class`, `message`, `remediation`) in the `http` artifact and map it onto `DeliveryError` in the serializer, in `backend/infrahub/webhook/capture.py` and `backend/infrahub/graphql/queries/task.py` (depends on T024, T017).
+- [X] T028 [P] [US2] Unit test the classifier across every class and the transient predicate (using the typed HTTP adapter exceptions + status codes) in `backend/tests/unit/webhook/test_classifier.py`.
+- [ ] T029 [P] [US2] Functional test that each failure class surfaces a clean reason, only transient classes retry, the final reason reflects the settling attempt, and per-attempt progress remains visible in the run logs across retries, in `backend/tests/functional/webhook/test_classification.py` (depends on T025, T026).
+- [ ] T030 [US2] Frontend: render the classified reason + remediation hint (badge + hint) for failed deliveries in `frontend/app/src/entities/tasks/ui/task-item-details.tsx` (depends on T021).
+- [ ] T051 [US2] Playwright E2E (constitution Principle IV): open a failed delivery, assert the classified reason + remediation hint are shown and no stacktrace appears, in `frontend/app/tests/e2e/webhook-delivery-failure.spec.ts` (depends on T030). _(added post-analysis; executes within US2)_
+
+**Checkpoint**: Failures are actionable — classified reason + remediation, smart retry — independently testable.
+
+---
+
+## Phase 5: User Story 3 - Resend a delivery (Priority: P3)
+
+**Goal**: Resend a settled delivery (any terminal state, incl. succeeded) — replays the frozen payload against current config with a fresh signature, as a new run; confirm on every resend.
+
+**Independent Test**: Fail a delivery against a down endpoint; bring it up; resend → new delivery with same payload succeeds; original unchanged. Resend a succeeded delivery → confirmation calls out re-delivery. Resend unavailable while in progress.
+
+### Implementation for User Story 3
+
+- [ ] T031 [US3] Read a flow run's frozen `parameters` by id (for resubmit) in `backend/infrahub/task_manager/flow_run/reader.py`.
+- [ ] T032 [US3] Implement the generic `InfrahubTaskResend(id)` mutation (validate target is a terminal `WEBHOOK_SEND` run; retention not-found → clean "delivery no longer available"; resubmit `WEBHOOK_SEND` with the frozen params; authorize via object-level update permission on the target webhook node; re-validate availability at execution) in `backend/infrahub/graphql/mutations/task.py` (depends on T031, T003, T008).
+- [ ] T033 [US3] Register `InfrahubTaskResend` as a field on `InfrahubBaseMutation` in `backend/infrahub/graphql/schema.py` (depends on T032).
+- [ ] T034 [P] [US3] Functional test: resend authz, terminal-only gating (incl. COMPLETED allowed), retention not-found, and that resubmit creates a new run carrying the same payload with the original left immutable, in `backend/tests/functional/webhook/test_resend.py` (depends on T032, T033).
+- [ ] T035 [P] [US3] Frontend resend mutation (api → domain → `useResendDelivery` hook) in `frontend/app/src/entities/tasks/api/`, `domain/`, and `ui/queries/`.
+- [ ] T036 [US3] Implement the shared `<TaskActions task>` component (reads `available_actions`; `ModalConfirm` with confirm-on-every-resend and a succeeded-delivery re-delivery callout; toast feedback) in `frontend/app/src/entities/tasks/ui/task-actions.tsx` (depends on T035).
+- [ ] T037 [US3] Render `<TaskActions>` in the delivery row (compact + tooltip for unavailable reason) and the detail panel (labeled), in `frontend/app/src/entities/tasks/ui/task-items.tsx` and `task-item-details.tsx` (depends on T036).
+- [ ] T038 [US3] Playwright E2E: resend a failed delivery → a new delivery succeeds; resend a succeeded delivery → confirmation calls out re-delivery, in `frontend/app/tests/e2e/webhook-delivery-resend.spec.ts` (depends on T037).
+
+**Checkpoint**: Resend works from the row and detail panel, gated server-side, confirmed every time.
+
+---
+
+## Phase 6: User Story 4 - Cancel an in-progress delivery (Priority: P4)
+
+**Goal**: Cancel a non-terminal delivery, stopping further auto-retries; best-effort for an in-flight request; settled deliveries cannot be cancelled.
+
+**Independent Test**: Send a delivery to a slow/failing endpoint so it enters AwaitingRetry; cancel → transitions to cancelled, no further attempts; Cancel disabled on settled deliveries; a cancelled delivery is then resendable.
+
+### Implementation for User Story 4
+
+- [ ] T039 [US4] Implement the generic `InfrahubTaskCancel(id)` mutation (validate target is a non-terminal `WEBHOOK_SEND` run; set state to CANCELLING with force; authorize via object-level webhook update permission; re-validate availability at execution) in `backend/infrahub/graphql/mutations/task.py` (depends on T003, T008).
+- [ ] T040 [US4] Register `InfrahubTaskCancel` as a field on `InfrahubBaseMutation` in `backend/infrahub/graphql/schema.py` (depends on T039).
+- [ ] T041 [P] [US4] Functional test: cancel flips a non-terminal run to cancelling without recalling an in-flight attempt, is rejected on settled runs, enforces authz, and a cancelled delivery is resendable, in `backend/tests/functional/webhook/test_cancel.py` (depends on T039, T040).
+- [ ] T042 [P] [US4] Frontend cancel mutation (api → domain → `useCancelDelivery` hook) in `frontend/app/src/entities/tasks/api/`, `domain/`, and `ui/queries/`.
+- [ ] T043 [US4] Wire CANCEL into the shared `<TaskActions>` (confirm + toast) so it renders in the row and detail panel, in `frontend/app/src/entities/tasks/ui/task-actions.tsx` (depends on T036, T042).
+- [ ] T044 [US4] Playwright E2E: cancel an awaiting-retry delivery → no further attempts; then resend it, in `frontend/app/tests/e2e/webhook-delivery-cancel.spec.ts` (depends on T043).
+
+**Checkpoint**: All four stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T045 [P] Regenerate backend generated files and the GraphQL schema (`uv run invoke backend.generate`; `uv run invoke schema.generate-graphqlschema`) and commit the diffs.
+- [ ] T046 [P] User documentation for webhook delivery operability (inspection, classified failures, resend, cancel) under `docs/`, and a backend knowledge note under `dev/knowledge/backend/`.
+- [ ] T047 [P] Reference-doc regeneration if events/message-bus reference is affected (`uv run invoke docs.generate`).
+- [ ] T048 Run `/pre-ci` (format, lint, `ty` type check, generated-file + `docs.validate` checks) and fix any drift.
+- [ ] T049 Run `quickstart.md` validation end-to-end across all four user stories.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup; **blocks all user stories**. T003→T004; T005→T006→T007; T003→T008→T009; T010/T011 after their targets.
+- **US1 (Phase 3)**: depends on Foundational. The MVP.
+- **US2 (Phase 4)**: depends on Foundational; builds on US1's capture (T027 needs T017; T025 needs T015).
+- **US3 (Phase 5)**: depends on Foundational; T032 needs `available_actions` (T008) and `WEBHOOK_SEND` (T003).
+- **US4 (Phase 6)**: depends on Foundational; shares `<TaskActions>` (T036 from US3) — if US4 runs before US3, create `<TaskActions>` in US4 instead.
+- **Polish (Phase 7)**: after the desired stories are complete.
+
+### Story Independence
+
+- US1 is fully independent (capture + display).
+- US2 layers onto US1's capture but is independently testable (drive failures, assert classification).
+- US3 and US4 are independent of US1/US2 at the backend (mutations + gating), and share one frontend action component; whichever lands first creates `<TaskActions>`.
+
+### Within Each Story
+
+Models/pure components → flow/serializer wiring → tests → frontend query → codegen → UI → E2E.
+
+## Parallel Opportunities
+
+- **Setup**: T001, T002 in parallel.
+- **Foundational**: T005 ∥ T008 (different concerns); T010 ∥ T011 after their targets.
+- **US1**: T012 ∥ T014 (redaction vs artifact builder); T018 ∥ T019 ∥ T023 (tests, different files).
+- **US2**: T024 first; T028 ∥ T029 after wiring.
+- **US3/US4**: backend mutation tests (T034, T041) ∥ frontend mutation wiring (T035, T042).
+- **Polish**: T045 ∥ T046 ∥ T047.
+
+## Parallel Example: User Story 1
+
+```bash
+# Independent backend components:
+Task: "CapturedHeaders redaction in backend/infrahub/webhook/models.py"      # T012
+Task: "CapturedHttp artifact builder in backend/infrahub/webhook/capture.py" # T014
+
+# After capture + read-back wired, run the tests in parallel:
+Task: "Unit test CapturedHeaders redaction (T018)"
+Task: "Functional test capture on success/failure (T019)"
+Task: "Frontend unit test delivery detail rendering (T023)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (typing + `WEBHOOK_SEND` + `available_actions`) → 3. Phase 3 US1.
+4. **STOP and VALIDATE**: deliveries are inspectable with secrets masked. Demo.
+
+### Incremental Delivery
+
+Foundational → US1 (inspect) → US2 (classify) → US3 (resend) → US4 (cancel). Each adds operator value without breaking prior stories. Regenerate schema/types and run `/pre-ci` before each push.
+
+### Notes
+
+- `[P]` = different files, no incomplete dependency.
+- No source docstring/comment may reference ticket IDs or other code symbols (project rule); IDs live here and in commits only.
+- Commit after each task or logical group; never push without explicit approval.

--- a/dev/specs/ifc-2755-webhook-delivery-operability/tasks.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/tasks.md
@@ -184,7 +184,7 @@ Models/pure components → flow/serializer wiring → tests → frontend query �
 
 ```bash
 # Independent backend components:
-Task: "CapturedHeaders redaction in backend/infrahub/webhook/models.py"      # T012
+Task: "CapturedHeaders redaction in backend/infrahub/webhook/capture.py"     # T012
 Task: "CapturedHttp artifact builder in backend/infrahub/webhook/capture.py" # T014
 
 # After capture + read-back wired, run the tests in parallel:


### PR DESCRIPTION
## Summary

Adds the spec-kit specification package for **Webhook Delivery Operability**, the design umbrella over the in-flight webhook send-flow work. Specification only — no production code in this PR.

**Phase:** specification & planning (spec-kit) — no production code; the implementation lands in follow-up PRs.

## Prerequisite work (out of specification scope)

The structural send-flow work this specification builds on is tracked in its own PRs and is **not** part of this spec's scope:

- opsmill/infrahub#9672 — phase: split the webhook send into its own `webhook_send` subflow (the structural foundation the operability layer sits on).
- opsmill/infrahub#9676 — phase: automatic fixed-delay retry policy for the send (this PR's base branch).
- https://github.com/opsmill/infrahub/pull/9613 — independent bug fix.

`spec.md` and `plan.md` now carry an **Implementation Sync — 2026-06-26** revision recording this landed foundation against the requirements it satisfies (FR-001, FR-012a, FR-027) and marking the operability layer and the still-outstanding foundation (`WEBHOOK_SEND` catalogue registration, transient-only retry gating) as not yet implemented. `tasks.md` is unchanged.

## Scope it covers

Builds on the webhook send-flow split to make a delivery a first-class, inspectable, recoverable object in the Tasks tab:

- Inspect a delivery's request/response + payload (secrets redacted at capture)
- Classify failures into clean reasons with remediation hints; fixed-delay transient-only retry
- Generic, task-id-addressable resend (any terminal state) and cancel (non-terminal)
- Polymorphic task typing mirroring the events GraphQL type derivation — no new Neo4j node, no migration

Related: IFC-2755, IFC-2119, IFC-2753, IFC-2754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
