### PR TITLE
fix release notes for 1.10.0

### DIFF
--- a/docs/docs/release-notes/infrahub/release-1_10_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_10_0.mdx
@@ -100,11 +100,11 @@ nodes:
         kind: Text
 ```
 
-The same grammar is available at query time through the GraphQL `order` argument, which accepts an `order_by: [String!]` list at the root level, on many-relationship fields, and on hierarchical relationships:
+The same grammar is available at query time through the GraphQL `order` argument, which accepts an `by: [OrderByItem!]` list at the root level:
 
 ```graphql
 query {
-  DocumentationNote(order: { order_by: ["node_metadata__created_at__desc"] }) {
+  DocumentationNote(order: { by: [{field: "node_metadata__created_at", direction: DESC}]}) {
     edges { node { title { value } } }
   }
 }
@@ -124,7 +124,7 @@ member_of_groups_for_instances:
 
 ### Smarter artifact regeneration on repository changes
 
-When a Proposed Change includes commits to a linked repository, Infrahub now regenerates **only the artifacts whose transform source, GraphQL query, or artifact definition was actually affected** by the change - instead of regenerating every artifact in the repository. A typo fixed in an unrelated README no longer triggers a regeneration sweep across thousands of nodes. Each regeneration decision is recorded in the Proposed Change's task log, naming the file, query, or definition field that triggered it.
+When a Proposed Change includes commits to a linked repository, Infrahub now regenerates **only the artifacts whose transform source, GraphQL query, or artifact definition was actually affected** by the change - instead of regenerating every artifact in the repository. A typo fixed in an unrelated README no longer triggers a regeneration sweep across thousands of nodes.
 
 Detection automatically follows Jinja2 transitive includes (`{% include %}`, `{% import %}`, `{% extends %}`) and a Python transform's package directory. For dependencies Infrahub cannot detect automatically - templates loaded dynamically, or helper modules imported at runtime - you can declare extra files with a new optional `watch:` key on `jinja2_transforms` and `python_transforms` entries in `.infrahub.yml`. Track dependencies explicitly for both `Python` and `Jinja2` transforms. 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the 1.10.0 release notes to match the shipped API and behavior. Updated GraphQL ordering docs: `order` uses `by: [OrderByItem!]` at the root level (replaces `order_by` and removes relationship-level support), and removed the inaccurate claim about per-artifact task log entries during regeneration.

<sup>Written for commit 093fce9a235f478e9e6a92d322eed351b7373944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

