### PR TITLE
Update SDK commit for generator watch

### DIFF
--- a/docs/docs/reference/dotinfrahub.mdx
+++ b/docs/docs/reference/dotinfrahub.mdx
@@ -120,6 +120,7 @@ To help with the development process of a repository configuration file, you can
 | convert_query_response | boolean | When true, converts the raw GraphQL dict into SDK InfrahubNode objects accessible via self.nodes and self.store. | False |
 | execute_in_proposed_change | boolean | When true (default), the Generator runs as a CI check during proposed changes. | False |
 | execute_after_merge | boolean | When true (default), the Generator runs after a branch merge. Set to false for Generators that only run via event triggers. | False |
+| watch | InfrahubWatchConfig | Extra files and directories this generator depends on, in addition to the ones Infrahub detects automatically. | False |
 
 <!-- vale off -->
 ## Queries


### PR DESCRIPTION
# Why

Update SDK commit to include the watch statement on generators

## What changed

* SDK commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `python_sdk` submodule to add generator watch support and document the new `watch` option in generator config. This lets generators declare extra files and directories to watch beyond those auto-detected.

<sup>Written for commit cd9c50c67952cc591285caa88811c838f70d01c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

