### PR TITLE
fix(frontend): prevent flaky vitest failures from mid-run Vite reloads

### DIFF
--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -6,6 +6,21 @@ import viteConfig from "./vite.config";
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    // Pre-bundle dependencies that are only reached through dynamic/conditional
+    // imports (e.g. the devtools loader in src/app/devtools.tsx) so Vite's
+    // dependency scanner does not discover them mid-run. When that happens in
+    // browser mode, Vite re-optimizes and reloads the page ("Vite unexpectedly
+    // reloaded a test"), which drops module mocks registered via vi.mock() and
+    // makes mock-using tests fail intermittently (e.g.
+    // "mockClear is not a function"). See vitest-dev/vitest#8447 and #7333.
+    optimizeDeps: {
+      include: [
+        "@tanstack/react-query-devtools",
+        "react-dom/client",
+        "react-error-boundary",
+        "react-scan",
+      ],
+    },
     test: {
       browser: {
         enabled: true,


### PR DESCRIPTION
## Problem

Browser-mode frontend unit tests fail intermittently on CI with `TypeError: mockClear is not a function`. Most recently this turned the `frontend-tests` job red on an unrelated Dependabot PR ([#9660](https://github.com/opsmill/infrahub/pull/9660)), where the three `is-task-running-on-branch.test.ts` cases all failed in `beforeEach`.

It is **flaky**, not a real regression: `frontend-tests` is green on every recent `stable` run, and the failing PR's only diff (an `actions/checkout` bump) cannot affect a unit test.

## Root cause

The failing log always contains `[vitest] Vite unexpectedly reloaded a test. This may cause tests to fail`, immediately after `new dependencies optimized: @tanstack/react-query-devtools, react-dom/client, react-error-boundary, react-scan`.

`src/app/devtools.tsx` loads some of these via **dynamic imports** (`await import("react-scan")`, `import("@tanstack/react-query-devtools")`). Vite's dependency pre-scan misses dynamic imports, so when a test first triggers them **mid-run**, Vite re-optimizes and **reloads the page**. The reload wipes `vi.mock()` module-mock registrations; afterwards `vi.mocked(getBranchTaskStatusFromApi)` returns the *real* function, and `beforeEach`'s `.mockClear()` throws. Whichever mock-using test runs across the reload boundary loses the race — hence the timing/order-dependent flakiness that only shows on CI.

## Fix

Pre-bundle the offending dependencies via `optimizeDeps.include` in `vitest.config.ts` so Vite resolves them up front and never re-optimizes mid-run. This is the [maintainer-recommended remedy](https://github.com/vitest-dev/vitest/issues/8447) for this warning (also [#7333](https://github.com/vitest-dev/vitest/issues/7333)).

## Verification

Local browser-mode reproduction of the *timing* failure was not possible across 7 cold-cache runs (it is CI-environment specific), so the fix is verified by **eliminating the trigger deterministically**:

- **Before:** the four deps are absent from the Vite optimizer cache → discoverable mid-run → reload possible.
- **After:** all four (`react-dom/client`, `react-error-boundary`, `@tanstack/react-query-devtools`, `react-scan`) are pre-bundled in the optimizer cache up front (chunk files present) → no mid-run discovery → no reload possible.
- Suite stays green: **803 passed / 116 files, 0 reload warnings** (7 cold-cache runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents flaky browser-mode Vitest failures by pre-bundling dynamically imported devtools deps so Vite doesn’t reload mid-run and drop `vi.mock()` state. Eliminates the “mockClear is not a function” CI flake.

- **Bug Fixes**
  - Pre-bundled `@tanstack/react-query-devtools`, `react-dom/client`, `react-error-boundary`, `react-scan` via `optimizeDeps.include` in `frontend/app/vitest.config.ts` to stop mid-run discovery and reloads.
  - Result: no Vite reload warnings; mock-using tests remain stable on CI.

<sup>Written for commit 889c0c825390fb2767e8413cdb8fe69f15b64857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

