### PR TITLE
chore(frontend): improve dev environment setup

### DIFF
--- a/dev/setup-environment.sh
+++ b/dev/setup-environment.sh
@@ -89,18 +89,18 @@ fi
 # Frontend Dependencies
 # ------------------------------------------------------------------------------
 echo ""
-echo "Installing frontend dependencies with npm..."
-if command -v npm &> /dev/null; then
+echo "Installing frontend dependencies with pnpm..."
+if command -v pnpm &> /dev/null; then
     if [ -d "$PROJECT_DIR/frontend/app" ]; then
         cd "$PROJECT_DIR/frontend/app"
-        npm install
+        pnpm install
         echo "Frontend dependencies installed"
         cd "$PROJECT_DIR"
     else
         echo "Warning: Frontend directory not found at $PROJECT_DIR/frontend/app"
     fi
 else
-    echo "Warning: npm not found. Please install Node.js first"
+    echo "Warning: pnpm not found. Please install pnpm first: npm install -g pnpm"
 fi
 
 # ------------------------------------------------------------------------------
@@ -167,8 +167,8 @@ echo "Available commands:"
 echo "  uv run invoke backend.test-unit    - Run backend unit tests"
 echo "  uv run invoke format               - Format Python code"
 echo "  uv run invoke lint                 - Lint Python code"
-echo "  cd frontend/app && npm run test    - Run frontend tests"
-echo "  cd frontend/app && npm run biome:fix - Format/lint frontend"
+echo "  cd frontend/app && pnpm test       - Run frontend tests"
+echo "  cd frontend/app && pnpm biome:fix  - Format/lint frontend"
 echo ""
 
 exit 0

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -19,7 +19,10 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_API_CORS_ALLOW_CREDENTIALS: ${INFRAHUB_API_CORS_ALLOW_CREDENTIALS:-true}
   INFRAHUB_API_CORS_ALLOW_HEADERS:
   INFRAHUB_API_CORS_ALLOW_METHODS:
-  INFRAHUB_API_CORS_ALLOW_ORIGINS:
+  # Default-allow the Vite dev server origin (frontend/app `pnpm dev` on :8080) so
+  # frontend development against this stack works out of the box. Value is a JSON list;
+  # override by exporting INFRAHUB_API_CORS_ALLOW_ORIGINS before bringing the stack up.
+  INFRAHUB_API_CORS_ALLOW_ORIGINS: '${INFRAHUB_API_CORS_ALLOW_ORIGINS:-["http://localhost:8080"]}'
   INFRAHUB_BROKER_ADDRESS: ${INFRAHUB_BROKER_ADDRESS:-localhost}
   INFRAHUB_BROKER_DRIVER: ${INFRAHUB_BROKER_DRIVER:-rabbitmq}
   INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES: ${INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES:-2}

--- a/frontend/app/.vscode/extensions.json
+++ b/frontend/app/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "bradlc.vscode-tailwindcss",
+    "graphql.vscode-graphql",
+    "graphql.vscode-graphql-syntax",
+    "ms-playwright.playwright",
+    "vitest.explorer",
+    "ms-vscode.vscode-typescript-next",
+    "blazejkustra.react-compiler-marker"
+  ]
+}

--- a/frontend/app/.vscode/extensions.json
+++ b/frontend/app/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "graphql.vscode-graphql-syntax",
     "ms-playwright.playwright",
     "vitest.explorer",
-    "ms-vscode.vscode-typescript-next",
     "blazejkustra.react-compiler-marker"
   ]
 }

--- a/infrahub.code-workspace
+++ b/infrahub.code-workspace
@@ -1,0 +1,19 @@
+{
+  "folders": [
+    {
+      "name": "infrahub",
+      "path": "."
+    },
+    {
+      "name": "frontend · app",
+      "path": "frontend/app"
+    }
+  ],
+  "settings": {
+    // Hide the nested frontend/app from the infrahub root tree so it
+    // only appears once, under its own "frontend · app" folder.
+    "files.exclude": {
+      "frontend/app": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Quality-of-life improvements for frontend development:

- **dev/setup-environment.sh** — migrate frontend bootstrap from `npm` to `pnpm` (install + printed help commands)
- **development/docker-compose.yml** — default-allow the Vite dev server origin (`http://localhost:8080`) for CORS so `pnpm dev` against this stack works out of the box; still overridable via `INFRAHUB_API_CORS_ALLOW_ORIGINS`
- **infrahub.code-workspace** — multi-root VS Code workspace (repo root + `frontend · app`), hiding the nested `frontend/app` from the root tree
- **frontend/app/.vscode/extensions.json** — recommended VS Code extensions for frontend work (Biome, Tailwind, GraphQL, Playwright, Vitest, etc.)

## Test plan

- `dev/setup-environment.sh` runs and installs frontend deps via pnpm
- Stack comes up with the Vite origin allowed for CORS

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines the frontend dev setup by switching bootstrap to `pnpm`, default-allowing the Vite dev server for CORS in Docker, adding a VS Code multi-root workspace, and dropping the TypeScript Nightly extension recommendation. This makes `pnpm dev` work out of the box against the local stack.

- **New Features**
  - `dev/setup-environment.sh`: use `pnpm install` and update printed help commands to `pnpm`.
  - `development/docker-compose.yml`: default `INFRAHUB_API_CORS_ALLOW_ORIGINS` to ["http://localhost:8080"]; still overridable via env var.
  - `infrahub.code-workspace`: add multi-root workspace and hide nested `frontend/app` in the root tree.
  - `frontend/app/.vscode/extensions.json`: add recommended extensions (`biomejs.biome`, `bradlc.vscode-tailwindcss`, `graphql.vscode-graphql`, `graphql.vscode-graphql-syntax`, `ms-playwright.playwright`, `vitest.explorer`, `blazejkustra.react-compiler-marker`) and remove `ms-vscode.vscode-typescript-next`.

- **Migration**
  - Ensure `pnpm` is installed: `npm install -g pnpm`.
  - Use `pnpm dev` in `frontend/app`. If needed, override CORS by setting `INFRAHUB_API_CORS_ALLOW_ORIGINS` before starting the stack.

<sup>Written for commit 2e092554ecaf28543703bebb0fa249410fe68caa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



