### PR TITLE
[FIX] fix branch selector overflow with status badges

### DIFF
--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -3,12 +3,7 @@ import { Button, LinkButton } from "@infrahub/ui";
 import { ArrowUpRightIcon, CheckIcon, ChevronsUpDownIcon, PlusIcon } from "lucide-react";
 import { useQueryState } from "nuqs";
 import React from "react";
-import {
-  type ButtonProps as AriaButtonProps,
-  Collection,
-  ListLayout,
-  Virtualizer,
-} from "react-aria-components";
+import { type ButtonProps as AriaButtonProps, Collection } from "react-aria-components";
 
 import { constructPath } from "@/shared/api/rest/fetch";
 import { Autocomplete } from "@/shared/components/aria/autocomplete";
@@ -71,7 +66,7 @@ export function BranchSelector() {
         <ChevronsUpDownIcon className="ml-0.5" />
       </Button>
 
-      <Popover className="w-(--trigger-width)">
+      <Popover placement="bottom start">
         <PopoverDialog>
           {({ close }) =>
             isCreating ? (
@@ -123,54 +118,47 @@ function BranchList({ closePopover, openCreateForm }: BranchListProps) {
         onInputChange={setSearch}
         suffix={<BranchFormTriggerButton onPress={() => openCreateForm(trimmedSearch)} />}
       >
-        <Virtualizer
-          layout={ListLayout}
-          layoutOptions={{ rowHeight: 30, loaderHeight: 30, padding: 4 }}
+        <ListBox
+          aria-label="branch list"
+          className="max-h-125 p-1"
+          renderEmptyState={() =>
+            !isPending && (
+              <div className="px-2 py-1.5 text-neutral-600 text-sm">No branch found</div>
+            )
+          }
         >
-          <ListBox
-            aria-label="branch list"
-            className="max-h-125"
-            renderEmptyState={() =>
-              !isPending && (
-                <div className="px-2 py-1.5 text-neutral-600 text-sm">No branch found</div>
-              )
-            }
-          >
-            <Collection items={branches}>
-              {(branch) => (
-                <ListBoxItem textValue={branch.name} onAction={() => handleBranchChange(branch)}>
-                  <span className="truncate" title={branch.name}>
-                    {branch.name}
-                  </span>
+          <Collection items={branches}>
+            {(branch) => (
+              <ListBoxItem textValue={branch.name} onAction={() => handleBranchChange(branch)}>
+                <span className="truncate" title={branch.name}>
+                  {branch.name}
+                </span>
 
-                  <Row className="ml-auto">
-                    {currentBranch.name === branch.name && (
-                      <CheckIcon className="size-4 shrink-0" />
-                    )}
-                    {branch.is_default && <BranchDefaultBadge />}
-                    <BranchStatusBadge status={branch.status} />
-                    {branch.sync_with_git && <Icon icon="mdi:source-branch-sync" />}
-                  </Row>
-                </ListBoxItem>
-              )}
-            </Collection>
-
-            <ListBoxLoadMoreItem
-              isLoading={isPending || isFetchingNextPage}
-              onLoadMore={fetchNextPage}
-            />
-
-            {isAuthenticated && trimmedSearch && (
-              <ListBoxItem
-                textValue={CREATE_BRANCH_ITEM_VALUE}
-                onAction={() => openCreateForm(trimmedSearch)}
-                className="gap-1 whitespace-nowrap"
-              >
-                Create branch <span className="truncate font-semibold">{trimmedSearch}</span>
+                <Row className="ml-auto">
+                  {currentBranch.name === branch.name && <CheckIcon className="size-4 shrink-0" />}
+                  {branch.is_default && <BranchDefaultBadge />}
+                  {branch.sync_with_git && <Icon icon="mdi:source-branch-sync" />}
+                  <BranchStatusBadge status={branch.status} />
+                </Row>
               </ListBoxItem>
             )}
-          </ListBox>
-        </Virtualizer>
+          </Collection>
+
+          <ListBoxLoadMoreItem
+            isLoading={isPending || isFetchingNextPage}
+            onLoadMore={fetchNextPage}
+          />
+
+          {isAuthenticated && trimmedSearch && (
+            <ListBoxItem
+              textValue={CREATE_BRANCH_ITEM_VALUE}
+              onAction={() => openCreateForm(trimmedSearch)}
+              className="gap-1 whitespace-nowrap"
+            >
+              Create branch <span className="truncate font-semibold">{trimmedSearch}</span>
+            </ListBoxItem>
+          )}
+        </ListBox>
       </Autocomplete>
 
       <Separator />


### PR DESCRIPTION
## Summary
- The branch selector popover was locked to the trigger width (`w-(--trigger-width)`), so rows overflowed/truncated when branch **status badges** were visible. Switched the popover to `placement="bottom start"` so it sizes to its content.
- Dropped the react-aria `Virtualizer`/`ListLayout` and render the `ListBox` directly (with `p-1` padding).
- Reordered the row badges so `BranchStatusBadge` trails the git-sync indicator.

## Test plan
- [ ] Open the branch selector and confirm the popover sizes to its content rather than the trigger width.
- [ ] With branches that have status badges + git-sync icons, verify rows no longer overflow/truncate.
- [ ] Confirm scrolling, "load more", search filtering, and "Create branch" still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch selector overflow when status badges are shown by letting the popover size to its content. Also simplifies list rendering and adjusts badge order to prevent truncation.

- **Bug Fixes**
  - Popover now uses `placement="bottom start"`; no longer locked to `w-(--trigger-width)`.
  - Replaced `Virtualizer`/`ListLayout` with a direct `ListBox` (adds `p-1` padding).
  - Reordered row badges so git-sync appears before `BranchStatusBadge`.

<sup>Written for commit 22a394b3527dfdaa6828599d1a8b17a6a96b522c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

