### PR TITLE
docs(skills): add optimizing-neo4j-cypher-query skill

### DIFF
--- a/.agents/skills/neo4j-cypher-guide/SKILL.md
+++ b/.agents/skills/neo4j-cypher-guide/SKILL.md
@@ -201,6 +201,8 @@ Before finalizing any generated query:
 5. **Use EXISTS for existence checks** - More efficient than counting
 6. **Profile queries** - Use PROFILE to identify bottlenecks
 
+> These are generic, write-time tips. When a **specific Infrahub query is measurably slow** and you need to reproduce it, pull it from `query.log`, PROFILE it, and read the plan against a curated operator-level anti-pattern checklist (`AllNodesScan`, `Expand(All)` db hits, `Eager`, the `$param IS NULL` UNION trap, etc.), use the `optimizing-neo4j-cypher-query` skill — that's the performance-debugging counterpart to this syntax guide.
+
 ## Modern Cypher Features
 
 ### Label Expressions

--- a/.agents/skills/optimizing-neo4j-cypher-query/SKILL.md
+++ b/.agents/skills/optimizing-neo4j-cypher-query/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: optimizing-neo4j-cypher-query
+description: Use when an Infrahub API call, branch diff, GraphQL query, or other backend operation is slow on a realistic-sized dataset, and the suspicion is a slow Cypher query. Walks through reproducing the slow path, pulling the exact query and parameters from neo4j's query.log, running PROFILE, and reading the plan against a curated anti-pattern reference.
+---
+
+# Optimize Neo4j Cypher Query
+
+## Overview
+
+Slow Infrahub endpoints are almost always slow Cypher queries underneath. This skill drives the loop: **reproduce → find → extract → PROFILE → analyze → fix → re-PROFILE**. It does not try to be clever about which query to optimize — it gives you the tools to find the slowest one against a realistic dataset and read the plan.
+
+The single source of truth for "which query ran with which parameters" is the neo4j container's `logs/query.log*` — every executed query is logged with its parameters, duration, and query name. Each entry also carries a `bolt_id` (the per-connection sequence number neo4j stamps on every query) which is the primary identifier the helper script uses. When the API server is started with `INFRAHUB_TRACE_ENABLE=true`, the log also carries the OTel span id as `infrahub_id`, which lets you cross-reference from Tempo/Grafana — but tracing is **not required** for any of the steps below.
+
+## When NOT to use
+
+- The slow path isn't database-bound (CPU profiling, network, file I/O). Profile the Python side first if you don't already know it's the DB.
+- The dataset is tiny. Optimizing against an empty DB just teaches you nothing about the production plan.
+- You're chasing a correctness bug, not a performance bug.
+
+## Prerequisites
+
+```dot
+digraph prereq {
+    "Start" [shape=doublecircle];
+    "Large dataset loaded?" [shape=diamond];
+    "Load it" [shape=box];
+    "DB container running?" [shape=diamond];
+    "Start dev.deps" [shape=box];
+    "Ready" [shape=doublecircle];
+
+    "Start" -> "DB container running?";
+    "DB container running?" -> "Start dev.deps" [label="no"];
+    "DB container running?" -> "Large dataset loaded?" [label="yes"];
+    "Start dev.deps" -> "Large dataset loaded?";
+    "Large dataset loaded?" -> "Load it" [label="no"];
+    "Large dataset loaded?" -> "Ready" [label="yes"];
+    "Load it" -> "Ready";
+}
+```
+
+Check large-dataset presence with:
+```bash
+docker exec infrahub-database-1 cypher-shell --format plain -u neo4j -p admin -d neo4j \
+  "MATCH (n) RETURN count(n);"
+```
+If the count is under ~100k, the dataset is not the realistic one. **REQUIRED SUB-SKILL:** Use `loading-infrahub-test-dataset` to restore a team snapshot before continuing — optimizing against an empty DB is a waste of cycles.
+
+The neo4j query log is on by default in the bundled image (`logs/query.log`, rotating to `query.log.01`, etc.); no extra config needed.
+
+**Optional — distributed tracing.** If the user wants to correlate Cypher queries to a higher-level trace (which HTTP request triggered them, which other queries ran in the same flow), set these in the API server's environment and restart it:
+
+```
+INFRAHUB_TRACE_ENABLE=true
+INFRAHUB_TRACE_EXPORTER_TYPE=console   # or `otlp` if the observability stack is running with `--profile trace`
+```
+
+With tracing on, every query.log entry's `infrahub_id` field equals the OTel span id, so you can pivot from Grafana/Tempo into the log. The workflow below does not require this — `bolt_id` alone is enough.
+
+## Workflow
+
+### 1. Reproduce the slow path
+
+Get a precise description from the user of the action that triggers the slow query — e.g. "GET `/api/branch/X/diff` between `main` and `feature-Y`", "GraphQL `DcimDevice` query with filter Z", "branch merge for branch X". Then have the user trigger it once against the running server (UI, curl, or `infrahubctl`) so a fresh entry lands in `logs/query.log`.
+
+If the path runs many queries, ask the user to wait for the slow part to finish before continuing — otherwise the slowest query may still be running and absent from the log.
+
+### 2. Find the slowest query
+
+If you already know the query name behind the scenario, scope the list to it rather than eyeballing the full dump — pass `--name` and/or a `--min-ms` floor so the result *is* the scoped source of truth:
+
+```bash
+# scoped to a known query name (preferred when the scenario maps to one)
+python .agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py find-slow --name diff_property_paths --min-ms 200
+
+# unscoped — only when you don't yet know which query name to expect
+python .agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py find-slow --limit 15
+```
+
+Reads `logs/query.log*` from `infrahub-database-1` and prints the slowest queries with their duration, runtime, query name, and `bolt_id` (span_id too if tracing was enabled). Pick the entry whose name matches the user's scenario — `diff_property_paths`, `relationship_get_peer`, `node_get_list`, etc.
+
+If you can't tell which query name corresponds to the scenario, ask the user. Don't guess.
+
+If `find-slow` prints a `[warning] skipped N unparseable log entries` line, treat an empty or suspiciously short result with suspicion — see the note under step 5 about log-format drift.
+
+### 3. Extract the query + parameters
+
+```bash
+python .agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py extract <bolt_id>
+```
+
+Prints the full query text and the parameter map in neo4j map-literal syntax (directly usable as `:params <...>` in cypher-shell). Sanity-check that the params look right for the scenario (branch name, node uuids, time window). Pass `<span_id>` instead of `<bolt_id>` if you got here from a trace.
+
+### 4. Run PROFILE
+
+```bash
+python .agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py profile <bolt_id> --no-parallel --out ./profile-out
+```
+
+The script:
+- prepends `PROFILE` to the query;
+- strips any `CYPHER runtime=parallel` (or other) prefix when `--no-parallel` is set — parallel runtime hides single-thread cost and makes the plan harder to read, always profile non-parallel first;
+- runs it via `cypher-shell` in the database container with the extracted params;
+- writes `profile_<tag>.cypher`, `.params`, `.out`, `.meta` under `--out` (tag is `bolt<N>` or the span_id).
+
+Confirm the elapsed time roughly matches what query.log reported — if it's way faster on the second run, the data is now in page cache and the original measurement was cold. Either way, the plan shape is what matters; absolute numbers are secondary.
+
+### 5. Read the plan
+
+Open the `.out` file. Read it against the anti-pattern reference:
+
+**REQUIRED READ:** `.agents/skills/optimizing-neo4j-cypher-query/references/cypher-profile-anti-patterns.md`
+
+Tag every operator with high `db hits` or high `rows` going in vs out, and map them to anti-patterns. Prefer the first bad operator from the top of the plan — that's the planner's choice of entry point, which is usually where the win is.
+
+> **Log-format drift.** The whole workflow depends on `profile_slow_query.py` parsing neo4j's `query.log` layout, which can change across neo4j upgrades. The parser is pinned by `scripts/test_profile_slow_query.py` (stdlib, no container needed — `python scripts/test_profile_slow_query.py`). If `find-slow` returns empty/short or prints the `skipped N unparseable` warning right after a neo4j bump, run that test first: a failure there means the log format moved and the regexes in the script need updating, not that the database is fast.
+
+### 6. Propose a fix and re-PROFILE
+
+Apply the smallest change that addresses the worst operator (add a property/rel index, restructure the query, drop a function call that defeats an index, build conditional Cypher in Python instead of using a `$param IS NULL`-guarded `UNION`). Re-run step 4 against the same span scenario — confirm the bad operator is gone and total `db hits` dropped.
+
+If adding an index, it must go in `backend/infrahub/core/graph/index.py` so it persists across migrations. **This is a migration-carried database-schema change — `AGENTS.md` lists it under *Ask First*. Before editing `index.py`:**
+
+1. **Confirm the index isn't already there.** Grep `index.py` for the same label/relationship + property — an existing one may simply not be getting used (a `toString()` / type coercion on the indexed property defeats it; strip that first and re-PROFILE before adding anything).
+2. **Get explicit user confirmation** of the proposed index (label/rel, property, type) before writing it. Don't add the index as a silent side effect of the profiling loop.
+
+### 7. Report
+
+When done, summarize for the user:
+- the query name and what triggered it,
+- the original plan's worst operator + db hits,
+- the change applied and why,
+- the new plan's worst operator + db hits.
+
+Skip the play-by-play of how you got the span id — the user cares about cause and fix.
+
+## Reference
+
+- **Anti-patterns:** `references/cypher-profile-anti-patterns.md` — operator-level PROFILE checklist (the focus of this skill).
+- **Modern Cypher syntax:** see the `neo4j-cypher-guide` skill — the write-time counterpart. Reach for it in step 6 when restructuring a query (QPP rewrites, CALL subqueries, null-safe sorting, replacing deprecated syntax). It covers *how to write* correct Cypher; this skill covers *how to diagnose* a slow one.
+- **Example PR:** opsmill/infrahub#9225 (slow branch diffs — fixed via entry-path restructure + rel indexes + removing `toString` on indexed property).
+
+## Common mistakes
+
+- **Optimizing the wrong query.** The first slow span in a trace is rarely the bottleneck; pick the one with the worst (duration × frequency) for the scenario, not whatever appears first.
+- **Profiling with `runtime=parallel`.** Always strip it for first analysis. Parallel runtime can mask serial inefficiency and the plan diagrams are harder to read.
+- **Trusting cold-cache numbers only.** Run the same PROFILE twice; the first run is often page-cache cold. Compare plan shape, not just elapsed.
+- **Adding an index just because PROFILE shows a scan.** A scan over 1k nodes that returns 1k rows is fine. A scan over 10M to return 5 rows is the problem. Look at `db hits` ÷ `rows`, not just operator names.
+- **Skipping the re-PROFILE step.** If you don't measure after, you're guessing whether the fix worked.
+
+## Red flags — stop and reconsider
+
+- Reading the plan without first running with `--no-parallel` → the parallel scheduling hides where time goes. Re-run.
+- Recommending an index without checking `index.py` for an existing one → may be there but not picked due to a `toString()` / type coercion. Strip the coercion first.
+- Making three changes in one pass → if perf changes, you won't know which one mattered. One change per PROFILE iteration.
+- Skipping the user's exact scenario in favour of a synthetic query → the param shape (branch name, IN-list size, time window) is often what makes the planner pick a bad path.

--- a/.agents/skills/optimizing-neo4j-cypher-query/references/cypher-profile-anti-patterns.md
+++ b/.agents/skills/optimizing-neo4j-cypher-query/references/cypher-profile-anti-patterns.md
@@ -1,0 +1,145 @@
+# Cypher PROFILE anti-patterns
+
+Reference checklist for reading the `PROFILE` plain-text output of a slow Cypher query against the Infrahub graph. Walk top-down through the plan, focus on the first operator with bad numbers — that is usually the planner's choice of entry point and where the biggest win is.
+
+## What to look at, in order
+
+1. **Total `db hits`** — order of magnitude only. 10s of millions for a query that returns a handful of rows = something wrong.
+2. **Top-level operator (the entry point)** — the first thing the planner does. A bad choice here cascades into the rest.
+3. **`db hits` ÷ `rows` per operator** — selectivity. A scan over 1M nodes returning 1M rows is fine; a scan over 1M returning 5 is a missed index.
+4. **`Estimated rows` vs actual `rows`** — large estimation errors (off by 10×+) signal stale statistics or a query shape the planner can't reason about; rewrite or add hints.
+5. **`page hits`** — high `page faults` mean cold cache; re-run before drawing conclusions.
+
+## Anti-patterns
+
+### 1. `AllNodesScan` near the top
+
+```
++----------+----------------+------+---------+
+| Operator | Details        | Rows | DB hits |
++----------+----------------+------+---------+
+| AllNodes…|                |  9M  |  9M+1   |
+```
+
+The planner couldn't find a label or index to start from. Fix: add a label on the start vertex, or filter by an indexed property in the same `MATCH`.
+
+### 2. `NodeByLabelScan` + downstream `Filter`
+
+```
+| NodeByLabelScan | Node     |  9M  |
+| Filter          | n.uuid = …|  1  |
+```
+
+Label scan then post-filter on a property. Add a property index for that label (`backend/infrahub/core/graph/index.py`) so the planner uses `NodeIndexSeek` instead.
+
+### 3. Function call defeating an indexed property
+
+```
+WHERE toString(n.uuid) = $id   -- ❌
+WHERE n.uuid = $id             -- ✅
+```
+
+`toString`, `toInteger`, `toLower`, `apoc.text.…`, or any function wrapping an indexed property will fall back to a scan. This is the exact bug PR #9225 hit on `node_get_kind_query`. Strip the conversion; convert the param in Python before passing.
+
+### 4. `Expand(All)` with high `db hits`
+
+```
+| Expand(All) | (n)-[:IS_RELATED]->(m) |  120k rows  |  4.5M db hits |
+```
+
+The expansion is reading many relationship properties to filter. If you're filtering `IS_RELATED` (or `IS_PART_OF`, `HAS_SOURCE`, `HAS_OWNER`, `IS_PROTECTED`) by `branch` / `from` / `status`, add a **relationship-property index** in `index.py`. PR #9225 added these specifically for the diff queries.
+
+### 5. `$param IS NULL`-guarded `UNION`
+
+```cypher
+CALL {
+  ...
+  WHERE $node_ids IS NOT NULL AND n.uuid IN $node_ids
+  ...
+  UNION
+  ...
+  WHERE $node_ids IS NULL
+  ...
+}
+```
+
+The planner does **not** prune the dead `UNION` branch at runtime based on a `$param IS NULL` guard — it still plans and executes both, and the unguarded branch typically triggers a wide scan (catastrophic when the missing param means "all branches" or "all nodes"). Fix: build two queries in Python and pick which to run based on whether the list is set. PR #9225 fixes diff queries this way.
+
+### 6. `CartesianProduct`
+
+```
+| CartesianProduct | (a) × (b) |  10M  |
+```
+
+Two `MATCH` patterns with no connecting relationship — the planner takes their cross product. Add a path between them or `WITH …` + reorder to gate the second match on the first.
+
+### 7. `Eager` operator
+
+```
+| Eager | … | 9M |
+```
+
+An "Eager" forces the previous pipeline to fully materialise before the next can start — a sync point. Causes by:
+
+- writes that depend on reads of the same labels/properties,
+- aggregation that the planner thinks must be globally consistent,
+- `DETACH DELETE` after a match it wrote into.
+
+Move the read above the write, split into multiple statements, or push the filter earlier so less work is materialised.
+
+### 8. `runtime=parallel` masking the plan
+
+The OTel-traced Cypher may have a `CYPHER runtime=parallel\n` prefix when running on Neo4j Enterprise. Parallel runtime can hide serial inefficiencies and the plan text is harder to read (per-pipeline rows multiply across workers). Always strip it for the first analysis (`profile_slow_query.py profile … --no-parallel`). Re-introduce parallel only after the single-thread plan is clean.
+
+### 9. `OrderedDistinct` or `Sort` over a huge intermediate
+
+```
+| Sort | n.name |  9M  |  9M |
+```
+
+Sorting/deduplicating before filtering. Push the `WHERE` above the `WITH … ORDER BY` so the sort runs on the small set.
+
+### 10. Skewed `IN` list parameters
+
+```
+WHERE n.uuid IN $ids
+```
+
+with `$ids` containing 50k entries → may switch from index lookup to a hash join over a giant temp. If the list is large, consider batching in Python (UNWIND a few hundred at a time).
+
+### 11. Planner picks the wrong start node
+
+When two indexed nodes could serve as entry point and the planner picks the one with lower selectivity:
+
+```cypher
+MATCH (a:Foo {uuid: $a_uuid})-[…]-(b:Bar {uuid: $b_uuid})
+```
+
+Force the right side with a hint:
+
+```cypher
+USING INDEX b:Bar(uuid)
+```
+
+Only use hints when PROFILE proves the planner is wrong — hints calcify the plan and can rot when data shape changes.
+
+## Operators that are usually fine
+
+- `NodeIndexSeek`, `NodeUniqueIndexSeek`, `NodeByIdSeek` — the planner found an index. Good.
+- `Expand(Into)` — both endpoints already pinned. Cheap.
+- `Apply` / `Optional` with small inputs.
+- `Distinct` with small input cardinality.
+
+## When to add an index vs restructure the query
+
+- **Add an index** when the same operator appears across multiple slow queries and the property/relationship has a clear access pattern (`branch`, `from`, `uuid`, `name`). Put it in `backend/infrahub/core/graph/index.py` so migrations carry it.
+- **Restructure the query** when the planner has the right indexes but is still picking a bad entry point (often because of an `IS NULL` guard, function on indexed prop, or unnecessary `UNION`).
+
+When in doubt: add the index, re-PROFILE, see if the planner uses it. If it does and the plan is clean, ship. If it doesn't, the issue is structural.
+
+## Sanity check after a fix
+
+- Re-run `profile_slow_query.py profile <span_id> --no-parallel` against the same scenario.
+- Compare total `db hits` and the operator at the top of the plan.
+- Run twice and ignore the first run's elapsed time (page-cache cold).
+- If the user-visible API call doesn't get faster despite the plan being clean, the bottleneck is elsewhere (Python serialization, GraphQL resolver, multiple round-trips).

--- a/.agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py
+++ b/.agents/skills/optimizing-neo4j-cypher-query/scripts/profile_slow_query.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Find, extract, and PROFILE slow Cypher queries from the running infrahub-database-1 container.
+
+Reads neo4j's `logs/query.log*` to find slow query executions and extract the exact query
+text and parameter map. Runs `PROFILE` via cypher-shell with the extracted params.
+
+Primary identifier is `bolt_id` (the per-connection sequence number neo4j stamps on every
+query: `id:NNN` at the start of each log line). It is always present. If the API server is
+started with `INFRAHUB_TRACE_ENABLE=true`, every query is also tagged with `infrahub_id`
+(the OTel span id in hex) — that lets you cross-reference from a trace, but it is not
+required for any of the workflows here.
+
+Subcommands:
+  find-slow                                  Print the slowest completed queries
+  extract <bolt_id|span_id>                  Print the query text + params for one entry
+  profile <bolt_id|span_id> [--no-parallel]  Run PROFILE and save outputs
+
+Assumes the database container is named `infrahub-database-1` and accepts the local-dev
+credentials neo4j/admin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+CONTAINER = "infrahub-database-1"
+DB_USER = "neo4j"
+# Local-dev default per development/docker-compose-database-neo4j.yml; override via env if needed.
+DB_PASS = os.environ.get("NEO4J_PASSWORD", "admin")
+DB_NAME = "neo4j"
+
+# A finished-query line carries, in order: a timestamp + `INFO id:<bolt> - transaction id:<n>`
+# header, the duration (`<ms> ms:`), byte/page-hit counters, the bolt-session preamble, then
+# `neo4j - neo4j - <QUERY> - <PARAMS> - runtime=<R> - {name: '<NAME>', infrahub_id: '<HEX>'}`.
+# See scripts/test_profile_slow_query.py for a concrete pinned example.
+# "Query started:" lines have no duration; ignore them.
+HEAD_RE = re.compile(r"^(?P<ts>\S+ \S+)\s+INFO\s+id:(?P<id>\d+)\s+-\s+transaction id:\d+\s+-\s+(?P<ms>\d+)\s+ms:")
+# Body starts after the bolt-session preamble, marked by `>\tneo4j - neo4j - `.
+BODY_START_RE = re.compile(r">\s+neo4j\s+-\s+neo4j\s+-\s+")
+META_SPAN_RE = re.compile(r"infrahub_id:\s*'(?P<span>[0-9a-f]+)'")
+META_NAME_RE = re.compile(r"name:\s*'(?P<name>[^']+)'")
+
+
+@dataclass
+class LogEntry:
+    ts: str
+    bolt_id: int
+    ms: int
+    query: str
+    params: str  # neo4j map literal, directly usable as cypher-shell `:params <...>`
+    runtime: str | None
+    name: str | None
+    span: str | None  # hex; "0" when tracing was disabled on the API server
+
+
+def _exec(cmd: list[str], stdin: str | None = None) -> subprocess.CompletedProcess:
+    # `cmd` is always a fixed argv vector (docker / cypher-shell), never a shell string.
+    return subprocess.run(cmd, capture_output=True, text=True, input=stdin, check=False)
+
+
+def _docker_exec(in_container_cmd: list[str], stdin: str | None = None) -> subprocess.CompletedProcess:
+    return _exec(["docker", "exec", "-i", CONTAINER, *in_container_cmd], stdin=stdin)
+
+
+def _assert_container_running() -> None:
+    res = _exec(["docker", "ps", "--filter", f"name=^{CONTAINER}$", "--format", "{{.Names}}"])
+    if CONTAINER not in res.stdout:
+        sys.exit(f"error: container '{CONTAINER}' is not running. Start the dev/demo compose stack first.")
+
+
+def _read_logs() -> str:
+    """Return the concatenated content of all /logs/query.log* (newest file first)."""
+    listing = _docker_exec(["sh", "-c", "ls -t /logs/query.log /logs/query.log.* 2>/dev/null"])
+    files = [f for f in listing.stdout.strip().splitlines() if f]
+    if not files:
+        sys.exit("error: no query.log files found in /logs inside the database container")
+    return "\n".join(_docker_exec(["cat", f]).stdout for f in files)
+
+
+# Each log entry begins with a line matching this anchor at column 0.
+# Queries span multiple lines (literal newlines inside the Cypher), so we have to
+# split the log on this anchor rather than process it line-by-line.
+ENTRY_ANCHOR_RE = re.compile(r"(?m)^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+\+\d+\s+INFO\s+")
+
+
+def _split_entries(text: str) -> list[str]:
+    """Split the concatenated log into one string per query entry."""
+    matches = list(ENTRY_ANCHOR_RE.finditer(text))
+    entries: list[str] = []
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        entries.append(text[start:end].rstrip("\n"))
+    return entries
+
+
+def _is_started_line(entry: str) -> bool:
+    """A `Query started:` line carries no duration and is an *expected* skip, not a parse failure."""
+    lines = entry.splitlines()
+    return bool(lines) and "Query started:" in lines[0]
+
+
+def _parse(entry: str) -> LogEntry | None:
+    """Parse one finished-query entry. Returns None only on a genuine format mismatch.
+
+    Callers must pre-filter `Query started:` lines via `_is_started_line` so that a None
+    here unambiguously means "this looked like a finished query but did not match the
+    expected query.log layout" — i.e. a signal that the log format may have drifted.
+    """
+    head = HEAD_RE.search(entry)
+    if not head:
+        return None
+    body_start = BODY_START_RE.search(entry)
+    if not body_start:
+        return None
+    body = entry[body_start.end() :]
+
+    # The body trails as query, then params map, then runtime, then the name/infrahub_id meta.
+    # Slice from the right so commas/dashes inside the query text don't confuse the boundaries.
+    meta_split = body.rfind(" - {name:")
+    if meta_split < 0:
+        return None
+    meta = body[meta_split + 3 :]
+    pre_meta = body[:meta_split]
+
+    rt_idx = pre_meta.rfind(" - runtime=")
+    if rt_idx < 0:
+        return None
+    runtime = pre_meta[rt_idx + len(" - runtime=") :].strip()
+    pre_runtime = pre_meta[:rt_idx]
+
+    params_idx = pre_runtime.rfind(" - {")
+    if params_idx < 0:
+        return None
+    query = pre_runtime[:params_idx].strip()
+    params = pre_runtime[params_idx + 3 :].strip()
+
+    span_m = META_SPAN_RE.search(meta)
+    name_m = META_NAME_RE.search(meta)
+
+    return LogEntry(
+        ts=head.group("ts"),
+        bolt_id=int(head.group("id")),
+        ms=int(head.group("ms")),
+        query=query,
+        params=params,
+        runtime=None if runtime == "null" else runtime,
+        name=name_m.group("name") if name_m else None,
+        span=span_m.group("span") if span_m else None,
+    )
+
+
+def _iter_entries(skipped: list[str] | None = None) -> Iterator[LogEntry]:
+    """Yield parsed finished-query entries.
+
+    `Query started:` lines are skipped silently (expected). Any other entry that fails to
+    parse is appended to `skipped` (when provided) so callers can warn — a non-empty
+    `skipped` on a real log usually means neo4j's query.log format has drifted and the
+    regexes above need updating, NOT that there were no slow queries.
+    """
+    for entry in _split_entries(_read_logs()):
+        if _is_started_line(entry):
+            continue
+        e = _parse(entry)
+        if e is None:
+            if skipped is not None:
+                skipped.append(entry)
+            continue
+        yield e
+
+
+def _find_by_id(ident: str) -> LogEntry:
+    """Identify a log entry by bolt_id (numeric) or non-zero span_id (hex)."""
+    matches: list[LogEntry] = []
+    if ident.isdigit():
+        target = int(ident)
+        matches = [e for e in _iter_entries() if e.bolt_id == target]
+        key = f"bolt_id={ident}"
+    else:
+        matches = [e for e in _iter_entries() if e.span == ident]
+        key = f"span_id={ident}"
+    if not matches:
+        sys.exit(f"no completed query.log entry for {key}")
+    # Prefer the slowest match (in case of duplicate bolt_ids across log rotations).
+    matches.sort(key=lambda e: e.ms, reverse=True)
+    return matches[0]
+
+
+def cmd_find_slow(args: argparse.Namespace) -> None:
+    _assert_container_running()
+    skipped: list[str] = []
+    entries = list(_iter_entries(skipped))
+    if skipped:
+        print(
+            f"[warning] skipped {len(skipped)} unparseable log entr"
+            f"{'y' if len(skipped) == 1 else 'ies'} — if this is large or the result below is "
+            "empty/short, neo4j's query.log format likely drifted; update the regexes in this script.",
+            file=sys.stderr,
+        )
+    if args.min_ms:
+        entries = [e for e in entries if e.ms >= args.min_ms]
+    if args.name:
+        entries = [e for e in entries if e.name == args.name]
+    entries.sort(key=lambda e: e.ms, reverse=True)
+    if not entries:
+        sys.exit(
+            "no completed queries found in query.log* — has the slow scenario been triggered yet? "
+            "(if the [warning] above reported many skipped entries, the log format may have changed)"
+        )
+
+    shown = entries[: args.limit]
+    name_width = min(max((len(e.name or "?") for e in shown), default=4), 40)
+    name_width = max(name_width, 12)
+    has_trace = any(e.span and e.span != "0" for e in shown)
+
+    if has_trace:
+        print(f"{'ms':>7}  {'bolt_id':>8}  {'runtime':<8}  {'name':<{name_width}}  span_id")
+        print(f"{'-' * 7}  {'-' * 8}  {'-' * 8}  {'-' * name_width}  {'-' * 16}")
+        for e in shown:
+            span = e.span if (e.span and e.span != "0") else "-"
+            print(
+                f"{e.ms:>7}  {e.bolt_id:>8}  {(e.runtime or '-'):<8}  {(e.name or '?')[:name_width]:<{name_width}}  {span}"
+            )
+    else:
+        print(f"{'ms':>7}  {'bolt_id':>8}  {'runtime':<8}  {'name'}")
+        print(f"{'-' * 7}  {'-' * 8}  {'-' * 8}  {'-' * name_width}")
+        for e in shown:
+            print(f"{e.ms:>7}  {e.bolt_id:>8}  {(e.runtime or '-'):<8}  {(e.name or '?')[:name_width]}")
+        print(
+            "\n[note] all span_ids are '0' — the API server was started without INFRAHUB_TRACE_ENABLE=true.",
+            file=sys.stderr,
+        )
+        print(
+            "       bolt_id is sufficient for `extract` / `profile`; tracing is only needed "
+            "for cross-referencing with Tempo/Grafana.",
+            file=sys.stderr,
+        )
+
+
+def cmd_extract(args: argparse.Namespace) -> None:
+    _assert_container_running()
+    e = _find_by_id(args.identifier)
+    print(f"# {e.ms} ms  runtime={e.runtime or '-'}  name={e.name}  bolt_id={e.bolt_id}  span_id={e.span or '-'}")
+    print("=== QUERY ===")
+    print(e.query)
+    print()
+    print("=== PARAMS (cypher map literal — usable as `:params <...>` in cypher-shell) ===")
+    print(e.params)
+
+
+def _strip_parallel_prefix(query: str) -> tuple[str, bool]:
+    """Strip a leading `CYPHER runtime=...` clause if present."""
+    lines = query.splitlines()
+    if lines and lines[0].lstrip().upper().startswith("CYPHER RUNTIME"):
+        return "\n".join(lines[1:]).lstrip(), True
+    return query, False
+
+
+def cmd_profile(args: argparse.Namespace) -> None:
+    _assert_container_running()
+    e = _find_by_id(args.identifier)
+
+    query = e.query
+    stripped = False
+    if args.no_parallel:
+        query, stripped = _strip_parallel_prefix(query)
+        if stripped:
+            print("[stripped leading `CYPHER runtime=...` prefix]", file=sys.stderr)
+
+    profiled = "PROFILE " + query
+    cypher_input = f":params {e.params}\n{profiled};\n"
+
+    cmd = [
+        "docker",
+        "exec",
+        "-i",
+        CONTAINER,
+        "cypher-shell",
+        "-u",
+        DB_USER,
+        "-p",
+        DB_PASS,
+        "-d",
+        DB_NAME,
+        "--format",
+        "verbose",
+    ]
+    res = _exec(cmd, stdin=cypher_input)
+
+    out_dir = pathlib.Path(args.out) if args.out else pathlib.Path.cwd() / "profile-out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tag = e.span if (e.span and e.span != "0") else f"bolt{e.bolt_id}"
+    base = out_dir / f"profile_{tag}"
+    base.with_suffix(".cypher").write_text(profiled + "\n")
+    base.with_suffix(".params").write_text(e.params + "\n")
+    base.with_suffix(".out").write_text(res.stdout + ("\n--- STDERR ---\n" + res.stderr if res.stderr else ""))
+    base.with_suffix(".meta").write_text(
+        f"ms_from_log={e.ms}\n"
+        f"runtime_from_log={e.runtime or '-'}\n"
+        f"name={e.name}\n"
+        f"bolt_id={e.bolt_id}\n"
+        f"span_id={e.span or '-'}\n"
+        f"stripped_parallel={stripped}\n"
+    )
+
+    print(res.stdout)
+    if res.returncode != 0:
+        print(res.stderr, file=sys.stderr)
+        sys.exit(res.returncode)
+    print(f"\n[wrote {base}.cypher / .params / .out / .meta]", file=sys.stderr)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    fs = sub.add_parser("find-slow", help="Print the slowest queries from query.log*")
+    fs.add_argument("--limit", type=int, default=15)
+    fs.add_argument("--min-ms", type=int, default=0, help="Only show queries that took at least this many ms")
+    fs.add_argument("--name", default=None, help="Filter by query name (e.g. diff_property_paths)")
+    fs.set_defaults(fn=cmd_find_slow)
+
+    ex = sub.add_parser("extract", help="Print query + params for a bolt_id or span_id")
+    ex.add_argument("identifier", help="bolt_id (numeric) or span_id (hex)")
+    ex.set_defaults(fn=cmd_extract)
+
+    pr = sub.add_parser("profile", help="Run PROFILE on a bolt_id's or span_id's query")
+    pr.add_argument("identifier", help="bolt_id (numeric) or span_id (hex)")
+    pr.add_argument(
+        "--no-parallel", action="store_true", help="Strip a leading `CYPHER runtime=...` clause before profiling"
+    )
+    pr.add_argument("--out", default=None, help="Output directory (default: ./profile-out)")
+    pr.set_defaults(fn=cmd_profile)
+
+    args = p.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/optimizing-neo4j-cypher-query/scripts/test_profile_slow_query.py
+++ b/.agents/skills/optimizing-neo4j-cypher-query/scripts/test_profile_slow_query.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Stdlib tests for the query.log parser in profile_slow_query.py.
+
+The parser is the skill's deterministic unique value, and it is tightly coupled to neo4j's
+exact `query.log` line layout. If neo4j changes that format on an upgrade, the parser starts
+returning None for finished-query entries and `find-slow` looks like "nothing is slow" — a
+false negative. These tests pin the current format so that drift fails *here*, loudly, instead
+of silently degrading the skill.
+
+No third-party deps and no running container required — every test feeds the pure parsing
+functions hand-built log text. Run directly (`python test_profile_slow_query.py`) or under
+pytest (`pytest test_profile_slow_query.py`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+_MOD_PATH = pathlib.Path(__file__).with_name("profile_slow_query.py")
+_spec = importlib.util.spec_from_file_location("profile_slow_query", _MOD_PATH)
+if _spec is None or _spec.loader is None:
+    msg = f"could not load module spec from {_MOD_PATH}"
+    raise RuntimeError(msg)
+psq = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass can resolve the module under `from __future__ import annotations`.
+sys.modules[_spec.name] = psq
+_spec.loader.exec_module(psq)
+
+# A faithful single finished-query entry, matching the layout documented at the top of
+# profile_slow_query.py. Two entries are concatenated to also exercise _split_entries.
+FINISHED = (
+    "2026-05-28 18:31:00.846+0000 INFO  id:7187 - transaction id:5344 - 42 ms: "
+    "(planning: 0, waiting: 0) - 100 B - 5 page hits, 0 page faults - "
+    "bolt-session\tbolt\tdriver\t\tclient\tserver> neo4j - neo4j - "
+    "MATCH (n) RETURN n - {branch: 'main'} - runtime=pipelined - "
+    "{name: 'node_get_list', infrahub_id: 'abcdef01'}"
+)
+STARTED = "2026-05-28 18:31:00.800+0000 INFO  id:7187 - transaction id:5344 - Query started: MATCH (n) RETURN n"
+
+# Expected values embedded in FINISHED, named so the assertions read intentionally.
+EXPECTED_BOLT_ID = 7187
+EXPECTED_MS = 42
+EXPECTED_ENTRY_COUNT = 2
+
+
+def test_finished_entry_fields() -> None:
+    e = psq._parse(FINISHED)
+    assert e is not None, "a well-formed finished-query line must parse"
+    assert e.bolt_id == EXPECTED_BOLT_ID
+    assert e.ms == EXPECTED_MS
+    assert e.query == "MATCH (n) RETURN n"
+    assert e.params == "{branch: 'main'}"
+    assert e.runtime == "pipelined"
+    assert e.name == "node_get_list"
+    assert e.span == "abcdef01"
+
+
+def test_started_line_is_an_expected_skip_not_a_parse_failure() -> None:
+    # The iterator pre-filters these; the classifier must recognise them.
+    assert psq._is_started_line(STARTED) is True
+    assert psq._is_started_line(FINISHED) is False
+
+
+def test_format_drift_returns_none() -> None:
+    # A finished-query line missing the ` - runtime=` / ` - {name:` tail is exactly the drift
+    # case: it must return None (so callers can count and warn), not raise.
+    drifted = (
+        "2026-05-28 18:31:00.846+0000 INFO  id:9 - transaction id:1 - 10 ms: server> neo4j - neo4j - MATCH (n) RETURN n"
+    )
+    assert psq._parse(drifted) is None
+
+
+def test_splits_on_timestamp_anchor() -> None:
+    entries = psq._split_entries(STARTED + "\n" + FINISHED)
+    assert len(entries) == EXPECTED_ENTRY_COUNT
+    assert psq._is_started_line(entries[0]) is True
+    assert psq._parse(entries[1]) is not None
+
+
+def test_strips_leading_runtime_clause() -> None:
+    q, stripped = psq._strip_parallel_prefix("CYPHER runtime=parallel\nMATCH (n) RETURN n")
+    assert stripped is True
+    assert q == "MATCH (n) RETURN n"
+
+
+def test_leaves_plain_query_untouched() -> None:
+    q, stripped = psq._strip_parallel_prefix("MATCH (n) RETURN n")
+    assert stripped is False
+    assert q == "MATCH (n) RETURN n"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} passed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -588,6 +588,19 @@ allow-dunder-method-names = [
 
 [tool.ruff.lint.per-file-ignores]
 
+# Dev-only helper scripts under .agents/skills drive docker/cypher-shell by design, so the
+# subprocess-security rules do not apply the way they would in shipped application code.
+".agents/skills/**/scripts/*.py" = [
+    "S404",  # `subprocess` import flagged insecure
+    "S603",  # `subprocess` call: check for execution of untrusted input
+]
+
+# ...and their tests assert and exercise the scripts' private parsing helpers (mirrors backend/tests).
+".agents/skills/**/scripts/test_*.py" = [
+    "S101",    # Use of `assert` detected
+    "SLF001",  # Private member accessed
+]
+
 "backend/infrahub/**.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule


### PR DESCRIPTION
## What

Adds the **optimizing-neo4j-cypher-query** skill: a profile-driven workflow for diagnosing the slow Cypher behind a slow Infrahub endpoint — reproduce → pull the exact query + params from neo4j's `query.log` → `PROFILE` → read the plan against a curated operator-level anti-pattern reference → fix → re-PROFILE.

Ships `profile_slow_query.py` (the log parser / PROFILE runner) plus `test_profile_slow_query.py`, a stdlib test that pins neo4j's `query.log` line format so an upgrade-driven format drift fails loudly in the test instead of silently making `find-slow` report "nothing is slow".

## Relationship to `neo4j-cypher-guide`

The two are complementary, not overlapping — they sit on different axes, and this PR cross-links them both ways:

- **`neo4j-cypher-guide`** is the *write-time* counterpart: how to write correct modern Cypher (deprecated syntax, QPP, CALL subqueries, null-safe sorting). Generic, portable, used for query generation.
- **`optimizing-neo4j-cypher-query`** (this PR) is the *diagnose-time* counterpart: why a *specific* query is slow and how to fix it (PROFILE operators, db-hits selectivity, Infrahub-specific anti-patterns like the `index.py` rel indexes and the `$param IS NULL` UNION trap).

The anti-pattern reference deliberately lives with this skill rather than in the guide, so the guide stays generic and free of Infrahub-internal detail.

## Notes

- `ruff check` / `ruff format` / `ty check` clean; the 6 parser tests pass (`python scripts/test_profile_slow_query.py`).
- This is the first Python under `.agents/skills/`, which CI lints repo-wide (`ruff check .`, `select = ["ALL"]`). The scripts are kept **noqa-free**; instead `pyproject.toml` gains two scoped `per-file-ignores` entries for `.agents/skills/**/scripts` — `S404`/`S603` (the helper drives docker/cypher-shell by design) and `S101`/`SLF001` in its test — mirroring the existing `backend/tests/**` convention. The DB password now reads from `NEO4J_PASSWORD` (default `admin`) rather than a hardcoded literal.
- Otherwise pure docs + dev-tooling under `.agents/skills/`; no product code or changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)