### PR TITLE
chore(dev): use pnpm in startup setup script

### DIFF
--- a/dev/setup-environment.sh
+++ b/dev/setup-environment.sh
@@ -89,18 +89,18 @@ fi
 # Frontend Dependencies
 # ------------------------------------------------------------------------------
 echo ""
-echo "Installing frontend dependencies with npm..."
-if command -v npm &> /dev/null; then
+echo "Installing frontend dependencies with pnpm..."
+if command -v pnpm &> /dev/null; then
     if [ -d "$PROJECT_DIR/frontend/app" ]; then
         cd "$PROJECT_DIR/frontend/app"
-        npm install
+        pnpm install
         echo "Frontend dependencies installed"
         cd "$PROJECT_DIR"
     else
         echo "Warning: Frontend directory not found at $PROJECT_DIR/frontend/app"
     fi
 else
-    echo "Warning: npm not found. Please install Node.js first"
+    echo "Warning: pnpm not found. Please install pnpm first (e.g. 'corepack enable pnpm')"
 fi
 
 # ------------------------------------------------------------------------------
@@ -167,8 +167,8 @@ echo "Available commands:"
 echo "  uv run invoke backend.test-unit    - Run backend unit tests"
 echo "  uv run invoke format               - Format Python code"
 echo "  uv run invoke lint                 - Lint Python code"
-echo "  cd frontend/app && npm run test    - Run frontend tests"
-echo "  cd frontend/app && npm run biome:fix - Format/lint frontend"
+echo "  cd frontend/app && pnpm test       - Run frontend tests"
+echo "  cd frontend/app && pnpm biome:fix  - Format/lint frontend"
 echo ""
 
 exit 0


### PR DESCRIPTION
## Problem

The `SessionStart:startup` hook (`.claude/settings.json`) runs `dev/setup-environment.sh`, which installed frontend dependencies with `npm install`. This is a **pnpm** project — `frontend/app/pnpm-lock.yaml` is the committed lockfile and AGENTS.md declares pnpm as the frontend package manager.

As a result, every session start regenerated a stray `frontend/app/package-lock.json` and could resolve a dependency tree divergent from what `pnpm-lock.yaml` pins.

## Changes

- Frontend install step now uses `pnpm install` instead of `npm install` (with a `command -v pnpm` guard and a corepack hint if missing).
- Updated the summary's "Available commands" to the `pnpm` equivalents (`pnpm test`, `pnpm biome:fix`).

## Notes

A few docs (`dev/constitution.md`, `dev/knowledge/backend/code-generation.md`) still reference `npm run …` in prose examples. They don't auto-run so they don't cause the stray artifact, and are left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the startup setup script to use `pnpm install` for the frontend to match `pnpm-lock.yaml` and avoid stray `package-lock.json` and inconsistent resolutions. Also updates the printed command hints to `pnpm` and adds a guard that suggests `corepack enable pnpm` if `pnpm` is missing.

<sup>Written for commit 31c2e165d05660276c66c54cf9abf98b4cf4de15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

