### PR TITLE
chore: add fastapi library-skill and CI check to keep skills current

### DIFF
--- a/.agents/skills/fastapi/SKILL.md
+++ b/.agents/skills/fastapi/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: fastapi
+description: FastAPI best practices and conventions. Use when working with FastAPI APIs and Pydantic models for them. Keeps FastAPI code clean and up to date with the latest features and patterns, updated with new versions. Write new code or refactor and update old code.
+---
+
+# FastAPI
+
+Official FastAPI skill to write code with best practices, keeping up to date with new versions and features.
+
+## Use the `fastapi` CLI
+
+Run the development server on localhost with reload:
+
+```bash
+fastapi dev
+```
+
+
+Run the production server:
+
+```bash
+fastapi run
+```
+
+### Add an entrypoint in `pyproject.toml`
+
+FastAPI CLI will read the entrypoint in `pyproject.toml` to know where the FastAPI app is declared.
+
+```toml
+[tool.fastapi]
+entrypoint = "my_app.main:app"
+```
+
+### Use `fastapi` with a path
+
+When adding the entrypoint to `pyproject.toml` is not possible, or the user explicitly asks not to, or it's running an independent small app, you can pass the app file path to the `fastapi` command:
+
+```bash
+fastapi dev my_app/main.py
+```
+
+Prefer to set the entrypoint in `pyproject.toml` when possible.
+
+## Use `Annotated`
+
+Always prefer the `Annotated` style for parameter and dependency declarations.
+
+It keeps the function signatures working in other contexts, respects the types, allows reusability.
+
+### In Parameter Declarations
+
+Use `Annotated` for parameter declarations, including `Path`, `Query`, `Header`, etc.:
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Path, Query
+
+app = FastAPI()
+
+
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: Annotated[int, Path(ge=1, description="The item ID")],
+    q: Annotated[str | None, Query(max_length=50)] = None,
+):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: int = Path(ge=1, description="The item ID"),
+    q: str | None = Query(default=None, max_length=50),
+):
+    return {"message": "Hello World"}
+```
+
+### For Dependencies
+
+Use `Annotated` for dependencies with `Depends()`.
+
+Unless asked not to, create a new type alias for the dependency to allow re-using it.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_current_user():
+    return {"username": "johndoe"}
+
+
+CurrentUserDep = Annotated[dict, Depends(get_current_user)]
+
+
+@app.get("/items/")
+async def read_item(current_user: CurrentUserDep):
+    return {"message": "Hello World"}
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+@app.get("/items/")
+async def read_item(current_user: dict = Depends(get_current_user)):
+    return {"message": "Hello World"}
+```
+
+## Do not use Ellipsis for *path operations* or Pydantic models
+
+Do not use `...` as a default value for required parameters, it's not needed and not recommended.
+
+Do this, without Ellipsis (`...`):
+
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, Query
+from pydantic import BaseModel, Field
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+    price: float = Field(gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query()]): ...
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+class Item(BaseModel):
+    name: str = ...
+    description: str | None = None
+    price: float = Field(..., gt=0)
+
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(item: Item, project_id: Annotated[int, Query(...)]): ...
+```
+
+## Return Type or Response Model
+
+When possible, include a return type. It will be used to validate, filter, document, and serialize the response.
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me")
+async def get_item() -> Item:
+    return Item(name="Plumbus", description="All-purpose home device")
+```
+
+**Important**: Return types or response models are what filter data ensuring no sensitive information is exposed. And they are used to serialize data with Pydantic (in Rust), this is the main idea that can increase response performance.
+
+The return type doesn't have to be a Pydantic model, it could be a different type, like a list of integers, or a dict, etc.
+
+### When to use `response_model` instead
+
+If the return type is not the same as the type that you want to use to validate, filter, or serialize, use the `response_model` parameter on the decorator instead.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    return {"name": "Foo", "description": "A very nice Item"}
+```
+
+This can be particularly useful when filtering data to expose only the public fields and avoid exposing sensitive information.
+
+```python
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class InternalItem(BaseModel):
+    name: str
+    description: str | None = None
+    secret_key: str
+
+
+class Item(BaseModel):
+    name: str
+    description: str | None = None
+
+
+@app.get("/items/me", response_model=Item)
+async def get_item() -> Any:
+    item = InternalItem(
+        name="Foo", description="A very nice Item", secret_key="supersecret"
+    )
+    return item
+```
+
+## Performance
+
+Do not use `ORJSONResponse` or `UJSONResponse`, they are deprecated.
+
+Instead, declare a return type or response model. Pydantic will handle the data serialization on the Rust side.
+
+## Including Routers
+
+When declaring routers, prefer to add router level parameters like prefix, tags, etc. to the router itself, instead of in `include_router()`.
+
+Do this:
+
+```python
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router)
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_items():
+    return []
+
+
+# In main.py
+app.include_router(router, prefix="/items", tags=["items"])
+```
+
+There could be exceptions, but try to follow this convention.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Dependency Injection
+
+See [the dependency injection reference](references/dependencies.md) for detailed patterns including `yield` with `scope`, and class dependencies.
+
+Use dependencies when the logic can't be declared in Pydantic validation, depends on external resources, needs cleanup (with `yield`), or is shared across endpoints.
+
+Apply shared dependencies at the router level via `dependencies=[Depends(...)]`.
+
+## Async vs Sync *path operations*
+
+Use `async` *path operations* only when fully certain that the logic called inside is compatible with async and await (it's called with `await`) or that doesn't block.
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+# Use async def when calling async code
+@app.get("/async-items/")
+async def read_async_items():
+    data = await some_async_library.fetch_items()
+    return data
+
+
+# Use plain def when calling blocking/sync code or when in doubt
+@app.get("/items/")
+def read_items():
+    data = some_blocking_library.fetch_items()
+    return data
+```
+
+In case of doubt, or by default, use regular `def` functions, those will be run in a threadpool so they don't block the event loop.
+
+The same rules apply to dependencies.
+
+Make sure blocking code is not run inside of `async` functions. The logic will work, but will damage the performance heavily.
+
+When needing to mix blocking and async code, see Asyncer in [the other tools reference](references/other-tools.md).
+
+## Streaming (JSON Lines, SSE, bytes)
+
+See [the streaming reference](references/streaming.md) for JSON Lines, Server-Sent Events (`EventSourceResponse`, `ServerSentEvent`), and byte streaming (`StreamingResponse`) patterns.
+
+## Tooling
+
+See [the other tools reference](references/other-tools.md) for details on uv, Ruff, ty for package management, linting, type checking, formatting, etc.
+
+## Other Libraries
+
+See [the other tools reference](references/other-tools.md) for details on other libraries:
+
+* Asyncer for handling async and await, concurrency, mixing async and blocking code, prefer it over AnyIO or asyncio.
+* SQLModel for working with SQL databases, prefer it over SQLAlchemy.
+* HTTPX for interacting with HTTP (other APIs), prefer it over Requests.
+
+## Do not use Pydantic RootModels
+
+Do not use Pydantic `RootModel`, instead use regular type annotations with `Annotated` and Pydantic validation utilities.
+
+For example, for a list with validations you could do:
+
+```python
+from typing import Annotated
+
+from fastapi import Body, FastAPI
+from pydantic import Field
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_items(items: Annotated[list[int], Field(min_length=1), Body()]):
+    return items
+```
+
+instead of:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import FastAPI
+from pydantic import Field, RootModel
+
+app = FastAPI()
+
+
+class ItemList(RootModel[Annotated[list[int], Field(min_length=1)]]):
+    pass
+
+
+@app.post("/items/")
+async def create_items(items: ItemList):
+    return items
+
+```
+
+FastAPI supports these type annotations and will create a Pydantic `TypeAdapter` for them, so that types can work as normally and there's no need for the custom logic and types in RootModels.
+
+## Use one HTTP operation per function
+
+Don't mix HTTP operations in a single function, having one function per HTTP operation helps separate concerns and organize the code.
+
+Do this:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.get("/items/")
+async def list_items():
+    return []
+
+
+@app.post("/items/")
+async def create_item(item: Item):
+    return item
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+
+
+@app.api_route("/items/", methods=["GET", "POST"])
+async def handle_items(request: Request):
+    if request.method == "GET":
+        return []
+```

--- a/.agents/skills/fastapi/references/dependencies.md
+++ b/.agents/skills/fastapi/references/dependencies.md
@@ -1,0 +1,142 @@
+# Dependency Injection
+
+Use dependencies when:
+
+* They can't be declared in Pydantic validation and require additional logic
+* The logic depends on external resources or could block in any other way
+* Other dependencies need their results (it's a sub-dependency)
+* The logic can be shared by multiple endpoints to do things like error early, authentication, etc.
+* They need to handle cleanup (e.g., DB sessions, file handles), using dependencies with `yield`
+* Their logic needs input data from the request, like headers, query parameters, etc.
+
+## Dependencies with `yield` and `scope`
+
+When using dependencies with `yield`, they can have a `scope` that defines when the exit code is run.
+
+Use the default scope `"request"` to run the exit code after the response is sent back.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_db():
+    db = DBSession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+DBDep = Annotated[DBSession, Depends(get_db)]
+
+
+@app.get("/items/")
+async def read_items(db: DBDep):
+    return db.query(Item).all()
+```
+
+Use the scope `"function"` when they should run the exit code after the response data is generated but before the response is sent back to the client.
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+UserNameDep = Annotated[str, Depends(get_username, scope="function")]
+
+@app.get("/users/me")
+def get_user_me(username: UserNameDep):
+    return username
+```
+
+## Class Dependencies
+
+Avoid creating class dependencies when possible.
+
+If a class is needed, instead create a regular function dependency that returns a class instance.
+
+Do this:
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+@dataclass
+class DatabasePaginator:
+    offset: int = 0
+    limit: int = 100
+    q: str | None = None
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+def get_db_paginator(
+    offset: int = 0, limit: int = 100, q: str | None = None
+) -> DatabasePaginator:
+    return DatabasePaginator(offset=offset, limit=limit, q=q)
+
+
+PaginatorDep = Annotated[DatabasePaginator, Depends(get_db_paginator)]
+
+
+@app.get("/items/")
+async def read_items(paginator: PaginatorDep):
+    return paginator.get_page()
+```
+
+instead of this:
+
+```python
+# DO NOT DO THIS
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+class DatabasePaginator:
+    def __init__(self, offset: int = 0, limit: int = 100, q: str | None = None):
+        self.offset = offset
+        self.limit = limit
+        self.q = q
+
+    def get_page(self) -> dict:
+        # Simulate a page of data
+        return {
+            "offset": self.offset,
+            "limit": self.limit,
+            "q": self.q,
+            "items": [],
+        }
+
+
+@app.get("/items/")
+async def read_items(paginator: Annotated[DatabasePaginator, Depends()]):
+    return paginator.get_page()
+```

--- a/.agents/skills/fastapi/references/other-tools.md
+++ b/.agents/skills/fastapi/references/other-tools.md
@@ -1,0 +1,76 @@
+# Other Tools
+
+## uv
+
+If uv is available, use it to manage dependencies.
+
+## Ruff
+
+If Ruff is available, use it to lint and format the code. Consider enabling the FastAPI rules.
+
+## ty
+
+If ty is available, use it to check types.
+
+## Asyncer
+
+When needing to run blocking code inside of async functions, or async code inside of blocking functions, suggest using Asyncer.
+
+Prefer it over AnyIO or asyncio.
+
+Install:
+
+```bash
+uv add asyncer
+```
+
+Run blocking sync code inside of async with `asyncify()`:
+
+```python
+from asyncer import asyncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def do_blocking_work(name: str) -> str:
+    # Some blocking I/O operation
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+async def read_items():
+    result = await asyncify(do_blocking_work)(name="World")
+    return {"message": result}
+```
+
+And run async code inside of blocking sync code with `syncify()`:
+
+```python
+from asyncer import syncify
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+async def do_async_work(name: str) -> str:
+    return f"Hello {name}"
+
+
+@app.get("/items/")
+def read_items():
+    result = syncify(do_async_work)(name="World")
+    return {"message": result}
+```
+
+## SQLModel for SQL databases
+
+When working with SQL databases, prefer using SQLModel as it is integrated with Pydantic and will allow declaring data validation with the same models.
+
+Prefer it over SQLAlchemy.
+
+## HTTPX
+
+Use HTTPX for handling HTTP communication (e.g. with other APIs). It support sync and async usage.
+
+Prefer it over Requests.

--- a/.agents/skills/fastapi/references/streaming.md
+++ b/.agents/skills/fastapi/references/streaming.md
@@ -1,0 +1,105 @@
+# Streaming
+
+## Stream JSON Lines
+
+To stream JSON Lines, declare the return type and use `yield` to return the data.
+
+```python
+@app.get("/items/stream")
+async def stream_items() -> AsyncIterable[Item]:
+    for item in items:
+        yield item
+```
+
+## Server-Sent Events (SSE)
+
+To stream Server-Sent Events, use `response_class=EventSourceResponse` and `yield` items from the endpoint.
+
+Plain objects are automatically JSON-serialized as `data:` fields, declare the return type so the serialization is done by Pydantic:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+@app.get("/items/stream", response_class=EventSourceResponse)
+async def stream_items() -> AsyncIterable[Item]:
+    yield Item(name="Plumbus", price=32.99)
+    yield Item(name="Portal Gun", price=999.99)
+```
+
+For full control over SSE fields (`event`, `id`, `retry`, `comment`), yield `ServerSentEvent` instances:
+
+```python
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+
+app = FastAPI()
+
+
+@app.get("/events", response_class=EventSourceResponse)
+async def stream_events() -> AsyncIterable[ServerSentEvent]:
+    yield ServerSentEvent(data={"status": "started"}, event="status", id="1")
+    yield ServerSentEvent(data={"progress": 50}, event="progress", id="2")
+```
+
+Use `raw_data` instead of `data` to send pre-formatted strings without JSON encoding:
+
+```python
+yield ServerSentEvent(raw_data="plain text line", event="log")
+```
+
+## Stream bytes
+
+To stream bytes, declare a `response_class=` of `StreamingResponse` or a sub-class, and use `yield` to return the data.
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+@app.get("/image", response_class=PNGStreamingResponse)
+def stream_image_no_async_no_annotation():
+    with read_image() as image_file:
+        yield from image_file
+```
+
+prefer this over returning a `StreamingResponse` directly:
+
+```python
+# DO NOT DO THIS
+
+import anyio
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from app.utils import read_image
+
+app = FastAPI()
+
+
+class PNGStreamingResponse(StreamingResponse):
+    media_type = "image/png"
+
+
+@app.get("/")
+async def main():
+    return PNGStreamingResponse(read_image())
+```

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -58,6 +58,9 @@ vale_files: &vale_files
   - ".vale/**"
   - ".vale.ini"
 
+library_skills_files: &library_skills_files
+  - ".agents/skills/**"
+
 doc_files: &doc_files
   - "docs/**"
   - package.json
@@ -125,6 +128,11 @@ graphql_schema_all:
 
 error_catalogue_all:
   - *error_catalogue_files
+
+library_skills_all:
+  - *library_skills_files
+  - *infrahub_uv_files
+  - *ci_config
 
 observability_standalone_all:
   - "development/docker-compose-observability.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       error_catalogue: ${{ steps.changes.outputs.error_catalogue_all }}
       dev_guidelines: ${{ steps.changes.outputs.dev_guidelines }}
       observability_standalone: ${{ steps.changes.outputs.observability_standalone_all }}
+      library_skills: ${{ steps.changes.outputs.library_skills_all }}
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v7"
@@ -375,6 +376,58 @@ jobs:
     uses: "./.github/workflows/uv-check.yml"
     with:
       directory: "./"
+
+  library-skills-check:
+    if: |
+      needs.files-changed.outputs.library_skills == 'true' ||
+      github.ref_name == 'stable' ||
+      github.ref_name == 'develop'
+    needs:
+      - files-changed
+      - prepare-environment
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v7"
+        with:
+          submodules: true
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
+      - name: Install dependencies
+        run: "uv sync --all-groups"
+      - name: "Regenerate library-provided skills from their packages"
+        run: |
+          set -euo pipefail
+          skills=$(uvx library-skills scan --json | jq -r '.skills[].name')
+          if [ -z "$skills" ]; then
+            echo "No library-provided skills discovered; nothing to verify."
+            exit 0
+          fi
+          for skill in $skills; do
+            echo "Regenerating skill: ${skill}"
+            rm -rf ".agents/skills/${skill}"
+            uvx library-skills install --skill "${skill}" --yes --copy
+          done
+      - name: "Verify library-provided skills are up to date"
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain -- .agents/skills)" ]; then
+            echo "::error::Skills installed via 'uvx library-skills' are out of date. Regenerate them and commit the result."
+            echo "Run locally:"
+            echo "  for s in \$(uvx library-skills scan --json | jq -r '.skills[].name'); do rm -rf \".agents/skills/\$s\"; uvx library-skills install --skill \"\$s\" --yes --copy; done"
+            git status --porcelain -- .agents/skills
+            git --no-pager diff -- .agents/skills
+            exit 1
+          fi
+          echo "All library-provided skills are up to date."
 
   infrahub-testcontainers-check:
     if: needs.files-changed.outputs.infrahub_uv_files == 'true'


### PR DESCRIPTION
# Why

Skills installed via `uvx library-skills` (sourced from installed packages) can silently fall out of date when a package ships an updated skill. Nothing verified that the copies committed under `.agents/skills/` still match what the packages provide.

## What changed

- Added the FastAPI best-practices skill (`fastapi` 0.136.3) under `.agents/skills/fastapi/`, installed via `uvx library-skills`.
- Added a `library-skills-check` CI job that regenerates every package-provided skill (`uvx library-skills install --copy`) and fails if the working tree drifts from what the packages provide, with a copy-paste remediation command in the failure output.
- Added a `library_skills` path filter (`.agents/skills/**` + uv lock/pyproject + CI config) so the job runs on skill or dependency changes and always on `stable`/`develop`.

Skills are stored as copies (portable, reviewable). `uvx library-skills --check` only validates *symlink* installs, so the job regenerates-and-diffs instead — an equivalent guarantee without committing Python-version-pinned symlinks.

## How to test

```bash
uv sync --all-groups
for s in $(uvx library-skills scan --json | jq -r '.skills[].name'); do
  rm -rf ".agents/skills/$s"; uvx library-skills install --skill "$s" --yes --copy
done
git status --porcelain -- .agents/skills   # empty == up to date
```

## Impact & rollout

- **Backward compatibility:** none — additive CI job + new skill files.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the FastAPI best-practices skill from `fastapi` 0.136.3 and a CI job that keeps library-provided skills in `.agents/skills` current. Prevents stale skill copies and surfaces drift early.

- **New Features**
  - Added `library-skills-check` CI job that regenerates all skills via `uvx library-skills install --copy` and fails if `.agents/skills` drifts; logs include a copy-paste remediation.
  - Added `library_skills` path filter to trigger the job on `.agents/skills/**`, `uv.lock`/`pyproject.toml`, and CI config changes; runs on `stable` and `develop`.

- **Migration**
  - If CI fails, re-install skills and commit: `for s in $(uvx library-skills scan --json | jq -r '.skills[].name'); do rm -rf ".agents/skills/$s"; uvx library-skills install --skill "$s" --yes --copy; done`

<sup>Written for commit 110da01f93e2c10108051a2a6ef0b0d63eb8baf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

