### PR TITLE
chore: ignore npm package-lock.json in frontend

### DIFF
--- a/frontend/app/.gitignore
+++ b/frontend/app/.gitignore
@@ -22,6 +22,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
 /test-results/
 /playwright-report/


### PR DESCRIPTION
Ignore `package-lock.json` in the frontend app — the project uses pnpm, so a stray npm lockfile shouldn't be committed.

Recreated off `stable` (the original branch was cut from `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `package-lock.json` to `frontend/app/.gitignore` to align with our `pnpm` workflow. Prevents accidental `npm` lockfile commits and lockfile drift.

<sup>Written for commit 1aceb2cc4df929d2f2a70479e0a63a31f3a2dfe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

