### PR TITLE
fix(computed-attribute): refresh derived values after a branch merge

### DIFF
--- a/backend/infrahub/core/merge/orchestrator.py
+++ b/backend/infrahub/core/merge/orchestrator.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
     from infrahub.core.diff.repository.repository import DiffRepository
+    from infrahub.core.models import SchemaDiff
     from infrahub.core.schema.manager import SchemaManager
     from infrahub.core.schema.update_coordinator import SchemaUpdateCoordinator
     from infrahub.database import InfrahubDatabase
@@ -74,6 +75,7 @@ class BranchMergeOrchestrator:
         merge_at = Timestamp()
         pre_merge_schema = registry.schema.get_schema_branch(name=self.destination_branch.name).duplicate()
         pre_merge_branched_from = self.source_branch.branched_from
+        schema_diff: SchemaDiff | None = None
 
         try:
             # Publish the shared write-protection key before any graph write so every worker rejects
@@ -104,6 +106,8 @@ class BranchMergeOrchestrator:
                 candidate_schema = await self.schema_manager.load_schema_from_db(
                     db=self.db, branch=self.destination_branch
                 )
+                # Scope for the post-merge derived-value refresh: what the merge changed on the destination.
+                schema_diff = pre_merge_schema.diff(other=candidate_schema)
                 migrations = await self.schema_analyzer.calculate_migrations(target_schema=candidate_schema)
                 await self.schema_update_coordinator.execute(
                     branch=self.destination_branch,
@@ -166,4 +170,5 @@ class BranchMergeOrchestrator:
             proposed_change_id=proposed_change_id,
             node_events=node_events,
             context=context,
+            schema_diff=schema_diff,
         )

--- a/backend/infrahub/core/merge/orchestrator.py
+++ b/backend/infrahub/core/merge/orchestrator.py
@@ -76,6 +76,7 @@ class BranchMergeOrchestrator:
         pre_merge_schema = registry.schema.get_schema_branch(name=self.destination_branch.name).duplicate()
         pre_merge_branched_from = self.source_branch.branched_from
         schema_diff: SchemaDiff | None = None
+        schema_updated_hash: str | None = None
 
         try:
             # Publish the shared write-protection key before any graph write so every worker rejects
@@ -108,6 +109,7 @@ class BranchMergeOrchestrator:
                 )
                 # Scope for the post-merge derived-value refresh: what the merge changed on the destination.
                 schema_diff = pre_merge_schema.diff(other=candidate_schema)
+                schema_updated_hash = candidate_schema.get_hash()
                 migrations = await self.schema_analyzer.calculate_migrations(target_schema=candidate_schema)
                 await self.schema_update_coordinator.execute(
                     branch=self.destination_branch,
@@ -171,4 +173,5 @@ class BranchMergeOrchestrator:
             node_events=node_events,
             context=context,
             schema_diff=schema_diff,
+            schema_hash=schema_updated_hash,
         )

--- a/backend/infrahub/core/merge/post_merge.py
+++ b/backend/infrahub/core/merge/post_merge.py
@@ -4,9 +4,11 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub import config
 from infrahub.core.constants import MutationAction
+from infrahub.core.registry import registry
 from infrahub.events.branch_action import BranchMergedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
+from infrahub.events.schema_action import SchemaUpdatedEvent, build_changed_elements_payload
 from infrahub.log import get_logger
 from infrahub.workflows.catalogue import (
     BRANCH_CANCEL_PROPOSED_CHANGES,
@@ -21,6 +23,7 @@ if TYPE_CHECKING:
     from infrahub.core.changelog.models import NodeChangelog
     from infrahub.core.constants import DiffAction
     from infrahub.core.diff.ipam_diff_parser import IpamNodeDetails
+    from infrahub.core.models import SchemaDiff
     from infrahub.log import InfrahubLogger
     from infrahub.services.adapters.event import InfrahubEventService
     from infrahub.services.adapters.workflow import InfrahubWorkflow
@@ -101,6 +104,7 @@ class PostMergeDispatcher:
         proposed_change_id: str | None,
         node_events: Sequence[tuple[DiffAction, NodeChangelog]],
         context: InfrahubContext,
+        schema_diff: SchemaDiff | None = None,
     ) -> None:
         event_context = context.to_event_context()
         merge_event = BranchMergedEvent(
@@ -111,6 +115,17 @@ class PostMergeDispatcher:
         )
 
         events: list[InfrahubEvent] = [merge_event]
+        if schema_diff is not None:
+            # Drive the display-label, HFID and computed-attribute backfills for destination-only nodes,
+            # scoped to the elements the merge changed so the recompute stays narrow.
+            events.append(
+                SchemaUpdatedEvent(
+                    branch_name=self.default_branch.name,
+                    schema_hash=registry.schema.get_schema_branch(name=self.default_branch.name).get_hash(),
+                    changed_elements=build_changed_elements_payload(schema_diff),
+                    meta=EventMeta.from_parent(parent=merge_event, branch=self.default_branch),
+                )
+            )
         for action, node_changelog in node_events:
             meta = EventMeta.from_parent(parent=merge_event, branch=self.default_branch)
             node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))

--- a/backend/infrahub/core/merge/post_merge.py
+++ b/backend/infrahub/core/merge/post_merge.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub import config
 from infrahub.core.constants import MutationAction
-from infrahub.core.registry import registry
 from infrahub.events.branch_action import BranchMergedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
@@ -105,6 +104,7 @@ class PostMergeDispatcher:
         node_events: Sequence[tuple[DiffAction, NodeChangelog]],
         context: InfrahubContext,
         schema_diff: SchemaDiff | None = None,
+        schema_hash: str | None = None,
     ) -> None:
         event_context = context.to_event_context()
         merge_event = BranchMergedEvent(
@@ -115,13 +115,13 @@ class PostMergeDispatcher:
         )
 
         events: list[InfrahubEvent] = [merge_event]
-        if schema_diff is not None:
+        if schema_diff is not None and schema_hash is not None:
             # Drive the display-label, HFID and computed-attribute backfills for destination-only nodes,
             # scoped to the elements the merge changed so the recompute stays narrow.
             events.append(
                 SchemaUpdatedEvent(
                     branch_name=self.default_branch.name,
-                    schema_hash=registry.schema.get_schema_branch(name=self.default_branch.name).get_hash(),
+                    schema_hash=schema_hash,
                     changed_elements=build_changed_elements_payload(schema_diff),
                     meta=EventMeta.from_parent(parent=merge_event, branch=self.default_branch),
                 )

--- a/backend/tests/component/core/merge/test_post_merge.py
+++ b/backend/tests/component/core/merge/test_post_merge.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core.initialization import create_branch
+from infrahub.core.merge.post_merge import PostMergeDispatcher
+from infrahub.core.merge.repository_merge_dispatcher import RepositoryMergeDispatcher
+from infrahub.core.registry import registry
+from infrahub.events.branch_action import BranchMergedEvent
+from infrahub.events.schema_action import SchemaUpdatedEvent
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from tests.adapters.event import MemoryInfrahubEvent
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestPostMergeSchemaEvent:
+    """A merge that applied schema changes emits a scoped SchemaUpdatedEvent for the destination branch.
+
+    The event drives the display-label, HFID and computed-attribute backfills so destination-only nodes
+    refresh their derived values; its changed_elements scope keeps that recompute limited to the schema
+    elements the merge actually changed.
+    """
+
+    def _build_dispatcher(
+        self,
+        db: InfrahubDatabase,
+        source_branch: Branch,
+        destination_branch: Branch,
+        event_service: MemoryInfrahubEvent,
+    ) -> PostMergeDispatcher:
+        workflow = WorkflowLocalExecution()
+        return PostMergeDispatcher(
+            repository_merge_dispatcher=RepositoryMergeDispatcher(
+                db=db, source_branch=source_branch, destination_branch=destination_branch, workflow=workflow
+            ),
+            workflow=workflow,
+            event_service=event_service,
+            default_branch=destination_branch,
+            global_branch=registry.get_global_branch(),
+        )
+
+    def _context(self, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext.init(
+            branch=default_branch,
+            account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+        )
+
+    async def test_emits_scoped_schema_updated_event_when_schema_changed(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+        car_person_schema: SchemaBranch,
+    ) -> None:
+        source_branch = await create_branch(branch_name="feature", db=db)
+        memory_event = MemoryInfrahubEvent()
+        dispatcher = self._build_dispatcher(db, source_branch, default_branch, memory_event)
+
+        # A schema change confined to a derived-value definition on the destination branch.
+        base_schema = registry.schema.get_schema_branch(name=default_branch.name)
+        candidate = base_schema.duplicate()
+        car = candidate.get(name="TestCar", duplicate=True)
+        car.display_labels = ["nbr_seats__value"]
+        candidate.set(name="TestCar", schema=car)
+        candidate.process()
+        schema_diff = base_schema.diff(other=candidate)
+
+        await dispatcher.dispatch_events(
+            branch=source_branch,
+            proposed_change_id=None,
+            node_events=[],
+            context=self._context(default_branch),
+            schema_diff=schema_diff,
+        )
+
+        schema_events = [event for event in memory_event.events if isinstance(event, SchemaUpdatedEvent)]
+        assert len(schema_events) == 1
+        event = schema_events[0]
+        assert event.branch_name == default_branch.name
+        assert event.changed_elements is not None
+        assert "display_labels" in event.changed_elements.changed_fields.get("TestCar", [])
+
+    async def test_no_schema_updated_event_when_no_schema_change(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+        car_person_schema: SchemaBranch,
+    ) -> None:
+        source_branch = await create_branch(branch_name="feature", db=db)
+        memory_event = MemoryInfrahubEvent()
+        dispatcher = self._build_dispatcher(db, source_branch, default_branch, memory_event)
+
+        await dispatcher.dispatch_events(
+            branch=source_branch,
+            proposed_change_id=None,
+            node_events=[],
+            context=self._context(default_branch),
+            schema_diff=None,
+        )
+
+        assert not [event for event in memory_event.events if isinstance(event, SchemaUpdatedEvent)]
+        assert [event for event in memory_event.events if isinstance(event, BranchMergedEvent)]

--- a/backend/tests/component/core/merge/test_post_merge.py
+++ b/backend/tests/component/core/merge/test_post_merge.py
@@ -79,12 +79,14 @@ class TestPostMergeSchemaEvent:
             node_events=[],
             context=self._context(default_branch),
             schema_diff=schema_diff,
+            schema_hash=candidate.get_hash(),
         )
 
         schema_events = [event for event in memory_event.events if isinstance(event, SchemaUpdatedEvent)]
         assert len(schema_events) == 1
         event = schema_events[0]
         assert event.branch_name == default_branch.name
+        assert event.schema_hash == candidate.get_hash()
         assert event.changed_elements is not None
         assert "display_labels" in event.changed_elements.changed_fields.get("TestCar", [])
 

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -418,16 +418,12 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         assert branch_after > branch_before
         assert main_after == main_before
 
-    async def test_merge_does_not_trigger_schema_scoped_recompute(
-        self, client: InfrahubClient, schema_computed_tshirt: dict
-    ) -> None:
-        """Merging a branch's schema change does not run this feature's schema-scoped recompute.
+    async def test_merge_triggers_scoped_recompute(self, client: InfrahubClient, schema_computed_tshirt: dict) -> None:
+        """Merging a branch's computed-attribute template change recomputes the affected attribute on main.
 
-        Merge and rebase emit branch and node events, not a schema-update event, so the
-        computed-attribute setup flow is not triggered on merge. A schema-only change applied by a
-        merge (no object-data change) therefore does not recompute on the target branch; merged
-        data changes are recomputed by the separate data-change path. This characterizes the
-        boundary and confirms a merge never broadens recompute onto the default branch.
+        The merge applies the new schema to the default branch and emits a scoped schema-update event, so
+        the computed-attribute setup refreshes the changed attribute on main-only nodes instead of leaving
+        them stale until their next mutation.
         """
         branch = await client.branch.create(branch_name="merge-scope")
 
@@ -447,11 +443,16 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         merged = await client.branch.merge(branch_name=branch.name)
         assert merged
 
-        # Give any merge-driven work time to surface, then confirm no schema-scoped recompute ran.
-        await sleep(2)
-        await wait_for_all_tasks_to_be_completed(client)
-        main_after = await client.task.count(
-            filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name], branch="main")
-        )
+        # The merge-driven backfill is asynchronous; poll until the scoped recompute surfaces on main.
+        main_after = main_before
+        deadline = time.monotonic() + PREFECT_EVENT_WAIT_SECONDS
+        while time.monotonic() < deadline:
+            await sleep(1)
+            await wait_for_all_tasks_to_be_completed(client)
+            main_after = await client.task.count(
+                filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name], branch="main")
+            )
+            if main_after > main_before:
+                break
 
-        assert main_after == main_before
+        assert main_after > main_before

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -423,8 +423,18 @@ class TestComputedAttributes(TestInfrahubDockerClient):
 
         The merge applies the new schema to the default branch and emits a scoped schema-update event, so
         the computed-attribute setup refreshes the changed attribute on main-only nodes instead of leaving
-        them stale until their next mutation.
+        them stale until their next mutation. The assertion pins the content of the dispatched recompute by
+        checking the refreshed value, not just that some recompute task ran.
         """
+        # A main-only TestingTShirt rendered by the computed-attribute template; it is absent from the
+        # merge data diff, so only the schema-scoped refresh can update its stored description.
+        color = await client.create(kind="TestingColor", data={"name": "Scoped", "description": "scoped"})
+        await color.save()
+        tshirt = await client.create(kind="TestingTShirt", data={"name": "ScopedMerge", "color": color})
+        await tshirt.save()
+        expected = "Merged template: ScopedMerge"
+        assert (await client.get(kind="TestingTShirt", id=tshirt.id)).description.value != expected
+
         branch = await client.branch.create(branch_name="merge-scope")
 
         # Schema-only change on the branch (a Jinja2 template edit); no object data is touched.
@@ -443,16 +453,19 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         merged = await client.branch.merge(branch_name=branch.name)
         assert merged
 
-        # The merge-driven backfill is asynchronous; poll until the scoped recompute surfaces on main.
-        main_after = main_before
+        # The merge-driven backfill is asynchronous; poll until the main-only node refreshes to the merged
+        # template's output, which pins both that a recompute was dispatched and the value it produced.
+        description = ""
         deadline = time.monotonic() + PREFECT_EVENT_WAIT_SECONDS
         while time.monotonic() < deadline:
             await sleep(1)
             await wait_for_all_tasks_to_be_completed(client)
-            main_after = await client.task.count(
-                filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name], branch="main")
-            )
-            if main_after > main_before:
+            description = (await client.get(kind="TestingTShirt", id=tshirt.id)).description.value
+            if description == expected:
                 break
 
+        assert description == expected
+        main_after = await client.task.count(
+            filters=TaskFilter(workflow=[COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE.name], branch="main")
+        )
         assert main_after > main_before

--- a/backend/tests/integration_docker/test_merge_derived_value_refresh.py
+++ b/backend/tests/integration_docker/test_merge_derived_value_refresh.py
@@ -1,0 +1,99 @@
+"""A branch merge that applies a computed-attribute schema change refreshes derived values on main-only nodes."""
+
+from __future__ import annotations
+
+from asyncio import sleep
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+from infrahub.core.constants import ComputedAttributeKind
+from infrahub.core.schema import AttributeSchema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
+from tests.helpers.schema import WIDGET
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+KIND = WIDGET.kind
+
+
+def _schema(template: str) -> dict:
+    widget = deepcopy(WIDGET)
+    widget.attributes.append(
+        AttributeSchema(
+            name="label",
+            kind="Text",
+            read_only=True,
+            optional=True,
+            computed_attribute=ComputedAttribute(kind=ComputedAttributeKind.JINJA2, jinja2_template=template),
+        )
+    )
+    return {"version": "1.0", "nodes": [widget.model_dump()]}
+
+
+async def _poll_label(client: InfrahubClient, node_id: str, expected: str, max_wait: int = 120) -> str:
+    """Poll up to ``max_wait`` seconds for the node's stored label to reach ``expected``.
+
+    The backfill is dispatched asynchronously (SchemaUpdatedEvent -> automation -> computed-attribute
+    setup -> per-node update); under Redis-backed scaleout messaging that chain has non-trivial latency,
+    so the budget is generous. Returns the last observed value so the caller can assert with a diagnostic.
+    """
+    last = ""
+    for _ in range(max_wait):
+        node = await client.get(kind=KIND, id=node_id)
+        last = node.label.value
+        if last == expected:
+            return last
+        await sleep(1)
+    return last
+
+
+class TestMergeDerivedValueRefresh(TestInfrahubDockerClient):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    async def test_merge_refreshes_main_only_computed_attribute(self, client: InfrahubClient) -> None:
+        # baseline: the v1 template renders the bare name
+        r1 = await client.schema.load(schemas=[_schema("{{ name__value }}")], wait_until_converged=True)
+        assert r1.schema_updated
+        assert await client.schema.in_sync()
+
+        alpha = await client.create(kind=KIND, data={"name": "alpha"})
+        await alpha.save()
+        alpha_initial = await client.get(kind=KIND, id=alpha.id)
+        assert alpha_initial.label.value == "alpha"
+
+        # sanity check: a schema-load applied directly to main (not via merge) refreshes the stored value
+        rc = await client.schema.load(schemas=[_schema("v2-{{ name__value }}")], wait_until_converged=True)
+        assert rc.schema_updated
+        alpha_v2 = await _poll_label(client, alpha.id, expected="v2-alpha")
+        assert alpha_v2 == "v2-alpha", (
+            f"direct schema-load on main did not refresh the value (got {alpha_v2!r}); "
+            f"without observable backfill the assertion below is inconclusive."
+        )
+
+        # load the v3 template on a branch, to be merged into main
+        branch = await client.branch.create(branch_name="tmpl-v3")
+        loaded = await client.schema.load(
+            schemas=[_schema("v3-{{ name__value }}")], branch=branch.name, wait_until_converged=True
+        )
+        assert loaded.schema_updated
+
+        # beta exists only on main (created after the branch forked), so the merge brings no data diff for it
+        beta = await client.create(kind=KIND, data={"name": "beta"})
+        await beta.save()
+        beta_initial = await client.get(kind=KIND, id=beta.id)
+        assert beta_initial.label.value == "v2-beta", f"expected main still at v2 (got {beta_initial.label.value!r})"
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+
+        # after the merge, main is on v3; the main-only node should refresh to "v3-beta"
+        beta_after = await _poll_label(client, beta.id, expected="v3-beta")
+        assert beta_after == "v3-beta", (
+            f"main-only node was not refreshed after the merge (got {beta_after!r}, expected 'v3-beta')."
+        )


### PR DESCRIPTION
# Why

On `develop`, a schema-changing merge updated the registry but did not emit a `SchemaUpdatedEvent`, so the display-label, HFID, and computed-attribute backfills never ran on the destination branch. Stored derived values on destination nodes that were absent from the merge diff stayed stale until the node was next mutated.

Goal: a merge that edits a derived-value definition (display label, human-friendly ID, or a Jinja2 computed-attribute template) refreshes the stored derived values of nodes that exist on the target branch but were absent from the source branch.

Non-goals: the rebase path. It has the same gap, but develop's scoped-recompute design only recomputes branches whose schema differs from the default branch, and a rebased branch's schema matches the default by definition (confirmed end to end: the post-rebase setup selects 0 attributes and deletes the branch trigger). Rebase recompute is left to the coalesced recompute work (IFC-2761). Tracked separately as IFC-2831.

Backport of IFC-2758 (resolved on stable, deferred from the stable-to-develop sync in #9712) as the scoped variant that fits develop's existing recompute machinery (#9415 / #9467). Tracked as IFC-2815.

## What changed

Behavioral:
- Merging a branch that changes a computed attribute, display label, or HFID template now refreshes those derived values on destination-only nodes.
- The refresh is scoped to the schema elements the merge changed, so unrelated attributes are not recomputed and a merge does not broaden recompute into a full sweep on the default branch.

Implementation:
- The merge orchestrator computes the destination schema diff (`pre_merge_schema.diff(candidate_schema)`) when a merge applies schema changes.
- The post-merge dispatcher emits a `SchemaUpdatedEvent` for the destination branch carrying the changed-element set, sent with the other post-merge events after the merge is committed so a send failure cannot roll back the merge.

What stayed the same:
- No database schema changes, no migration, no `GRAPH_VERSION` bump.
- The rebase path is unchanged.
- The scoped-recompute machinery is unchanged; this only feeds it a correctly scoped event on merge.
- No new changelog fragment. This backports a fix already on stable, whose `+merge-refresh-derived-values.fixed.md` fragment lands on develop via the stable-to-develop sync.

## How to review

- `backend/infrahub/core/merge/orchestrator.py` and `backend/infrahub/core/merge/post_merge.py` are the fix.
- `backend/tests/component/core/merge/test_post_merge.py` covers event emission and scope without a full stack.
- `backend/tests/integration_docker/test_merge_derived_value_refresh.py` is the end-to-end repro (a main-only node refreshes after a schema-changing merge).
- In `backend/tests/integration_docker/test_computed_attributes.py`, the former `test_merge_does_not_trigger_schema_scoped_recompute` is replaced by `test_merge_triggers_scoped_recompute`, which asserts the merge recomputes the changed attribute on the default branch.

## How to test

```bash
# Component (fast)
uv run pytest backend/tests/component/core/merge/test_post_merge.py --neo4j

# Integration (docker; builds the local image first)
uv run invoke dev.build
uv run pytest backend/tests/integration_docker/test_merge_derived_value_refresh.py
```

Verified locally against a freshly built image: the docker repro passes (a main-only node refreshes from `v2-beta` to `v3-beta` after the merge), and the component tests pass.

## Impact & rollout

- **Backward compatibility:** no breaking changes; no migration.
- **Performance:** recompute on merge is scoped to the changed schema elements, so it does not broaden into a full sweep.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry: not added here. This backports a stable fix whose changelog fragment already exists on stable and syncs to develop.
- [ ] External docs updated (no user-facing doc change)
- [ ] Internal .md docs updated (no internal doc made a stale claim about this path)
- [x] I have reviewed AI generated content