### PR TITLE
feat(proposed-change): precise regeneration triggers for generators

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -341,6 +341,7 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
 async def run_generators(model: RequestProposedChangeRunGenerators, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
+    log = get_run_logger()
     client = get_client()
 
     generators = await client.filters(
@@ -377,18 +378,35 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
     for generator_definition in generator_definitions:
-        # Request generator definitions if the source branch that is managed in combination
-        # to the Git repository containing modifications which could indicate changes to the transforms
-        # in code
-        # Alternatively if the queries used touches models that have been modified in the path
-        # impacted artifact definitions will be included for consideration
-
+        # Select a generator definition when its query node or definition node was modified, when a
+        # file inside its stored dependency closure changed, or when the diff touches a data kind the
+        # query reads. The closure-based file gate replaces the previous "any file changed in a synced
+        # repository" heuristic so an unrelated commit no longer re-runs every generator.
         select = DefinitionSelect.NONE
-        select = select.add_flag(
-            current=select,
-            flag=DefinitionSelect.FILE_CHANGES,
-            condition=model.source_branch_sync_with_git and model.branch_diff.has_file_modifications,
+        for outcome, flag in (
+            (
+                _query_changed(definition=generator_definition, diff_summary=diff_summary),
+                DefinitionSelect.QUERY_CHANGED,
+            ),
+            (
+                _definition_changed(definition=generator_definition, diff_summary=diff_summary),
+                DefinitionSelect.DEFINITION_CHANGED,
+            ),
+        ):
+            select = select.add_flag(current=select, flag=flag, condition=outcome.matched)
+            if outcome.reason is not None:
+                log.info(outcome.reason)
+
+        repo_diff_for_definition = _repo_diff_or_none(
+            branch_diff=model.branch_diff, repository_id=generator_definition.repository_id
         )
+        if repo_diff_for_definition is not None:
+            transform_outcome = _transform_changed(definition=generator_definition, repo_diff=repo_diff_for_definition)
+            select = select.add_flag(
+                current=select, flag=DefinitionSelect.FILE_CHANGES, condition=transform_outcome.matched
+            )
+            if transform_outcome.reason is not None:
+                log.info(transform_outcome.reason)
 
         for changed_model in modified_kinds:
             select = select.add_flag(
@@ -1208,13 +1226,28 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     else:
         impacted_instances = impacted.ids
 
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
+    repo_diff_for_definition = _repo_diff_or_none(
+        branch_diff=model.branch_diff, repository_id=model.generator_definition.repository_id
+    )
+    managed_branch = (
+        _query_changed(definition=model.generator_definition, diff_summary=diff_summary).matched
+        or _definition_changed(definition=model.generator_definition, diff_summary=diff_summary).matched
+        or (
+            repo_diff_for_definition is not None
+            and _transform_changed(definition=model.generator_definition, repo_diff=repo_diff_for_definition).matched
+        )
+    )
+    if managed_branch:
+        log.info("Query, definition or repository file change detected, all instances will be processed")
+
     check_generator_run_models: list[RunGeneratorAsCheckModel] = []
     for relationship in group.members.peers:
         member = relationship.peer
         generator_instance = instance_by_member.get(member.id)
         if _run_generator(
             instance_id=generator_instance,
-            managed_branch=model.source_branch_sync_with_git,
+            managed_branch=managed_branch,
             impacted_instances=impacted_instances,
         ):
             requested_instances += 1

--- a/backend/tests/component/proposed_change/test_generator_regen_selection.py
+++ b/backend/tests/component/proposed_change/test_generator_regen_selection.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub import config
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import BranchContext, InfrahubContext
+from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.message_bus.types import ProposedChangeBranchDiff, ProposedChangeRepository
+from infrahub.proposed_change.branch_diff import set_diff_summary_cache
+from infrahub.proposed_change.models import RequestProposedChangeRunGenerators
+from infrahub.proposed_change.tasks import run_generators
+from infrahub.server import app
+from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workflows.catalogue import REQUEST_GENERATOR_DEFINITION_CHECK
+from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.schema import load_schema
+from tests.helpers.test_app import TestInfrahubAppBase
+
+from .conftest import make_node_diff
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from fast_depends import Provider
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+    from tests.adapters.cache import MemoryCache
+    from tests.adapters.message_bus import BusSimulator
+    from tests.helpers.test_client import InfrahubTestClient
+
+SOURCE_BRANCH = "feature/generator-regen-selection"
+
+QUERY_A = """
+query GetADevice($ids: [ID!]!) {
+    TestNetworkDevice(ids: $ids) {
+        edges { node { name { value } } }
+    }
+}
+"""
+
+QUERY_B = """
+query GetBDevice($ids: [ID!]!) {
+    TestNetworkDevice(ids: $ids) {
+        edges { node { name { value } color { value } } }
+    }
+}
+"""
+
+QUERY_SOURCE_ONLY = """
+query GetSourceOnlyDevice($ids: [ID!]!) {
+    TestNetworkDevice(ids: $ids) {
+        edges { node { name { value } description { value } } }
+    }
+}
+"""
+
+# Each closure is the set of repo-relative paths the integrator would persist at import time:
+# the package-directory floor (every sibling under the generator's directory) plus the
+# repository manifest, which is part of every closure. The floors are disjoint so a file edit
+# selects exactly one generator.
+DEPENDENCIES_A = [".infrahub.yml", "generators/a/__init__.py", "generators/a/a.py", "generators/a/helpers.py"]
+DEPENDENCIES_A2 = [".infrahub.yml", "generators/a2/__init__.py", "generators/a2/a2.py"]
+DEPENDENCIES_B = [".infrahub.yml", "generators/b/__init__.py", "generators/b/b.py"]
+DEPENDENCIES_SOURCE_ONLY = [".infrahub.yml", "generators/new/__init__.py", "generators/new/new.py"]
+
+GENERATOR_SCHEMA = SchemaRoot(
+    nodes=[
+        NodeSchema(
+            name="NetworkDevice",
+            namespace="Test",
+            default_filter="name__value",
+            display_label="name__value",
+            uniqueness_constraints=[["name__value"]],
+            attributes=[
+                AttributeSchema(name="name", kind="Text", unique=True),
+                AttributeSchema(name="color", kind="Text", optional=True),
+                AttributeSchema(name="description", kind="Text", optional=True),
+            ],
+        )
+    ]
+)
+
+
+class GeneratorRegenTestBase(TestInfrahubAppBase):
+    """Shared harness for the generator-regeneration selection-gate component tests.
+
+    Provides the application wiring every scenario needs - a recording workflow backend so
+    dispatched per-definition checks can be inspected without running them, an SDK client bound
+    to the test server, and a per-test recorder reset - plus the machinery to drive
+    ``run_generators`` and read back the set of generator definitions dispatched for a check.
+
+    The ``workflow_recorder``, ``service`` and ``client`` fixtures override the base ones on
+    purpose: the base ``client`` fixture assumes a ``WorkflowLocalExecution`` backend (it asserts
+    on it) and would execute the dispatched checks, whereas these tests install a
+    ``WorkflowRecorder`` so the dispatch itself is the observable under test. The base class also
+    does not provide a ``service`` fixture at all (only the local-execution subclasses do).
+
+    Subclasses supply their own schema and dataset inline. Each dataset must expose
+    ``proposed_change_id``, ``repository_id``, ``repository_name`` and ``source_branch`` so the
+    shared helpers can assemble the request.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_recorder(
+        self,
+        prefect: Generator[str, None, None],
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[WorkflowRecorder, None]:
+        original = config.OVERRIDE.workflow
+        recorder = WorkflowRecorder()
+        config.OVERRIDE.workflow = recorder
+        with dependency_provider.scope(build_workflow, lambda: recorder):
+            yield recorder
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+    @pytest.fixture(scope="class")
+    async def client(
+        self,
+        test_client: InfrahubTestClient,
+        api_admin_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[InfrahubClient, None]:
+        sdk_config = Config(
+            api_token=api_admin_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
+        )
+        sdk_client = InfrahubClient(config=sdk_config)
+        original_client = service._client
+        service._client = sdk_client
+        with dependency_provider.scope(build_client, lambda: sdk_client):
+            yield sdk_client
+        service._client = original_client
+
+    @pytest.fixture(autouse=True)
+    def clear_recorder(self, workflow_recorder: WorkflowRecorder) -> None:
+        workflow_recorder.execute_calls.clear()
+        workflow_recorder.submit_calls.clear()
+
+    def _make_context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext(
+            branch=BranchContext(name=default_branch.name),
+            account=AccountSession(account_id=account.id, auth_type=AuthType.API),
+        )
+
+    async def _run_generators(
+        self,
+        *,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        diff_summary: list[dict],
+        files_added: list[str] | None = None,
+        files_changed: list[str] | None = None,
+        files_removed: list[str] | None = None,
+    ) -> None:
+        pipeline_id = uuid.uuid4()
+        repository = ProposedChangeRepository(
+            repository_id=dataset["repository_id"],
+            repository_name=dataset["repository_name"],
+            read_only=False,
+            source_branch=dataset["source_branch"],
+            destination_branch=default_branch.name,
+            internal_status=RepositoryInternalStatus.ACTIVE.value,
+            source_commit="source-commit-sha",
+            destination_commit="dest-commit-sha",
+            files_added=files_added or [],
+            files_changed=files_changed or [],
+            files_removed=files_removed or [],
+        )
+        branch_diff = ProposedChangeBranchDiff(pipeline_id=pipeline_id, repositories=[repository])
+        await set_diff_summary_cache(pipeline_id=pipeline_id, diff_summary=diff_summary, cache=memory_cache)
+
+        model = RequestProposedChangeRunGenerators(
+            proposed_change=dataset["proposed_change_id"],
+            source_branch=dataset["source_branch"],
+            source_branch_sync_with_git=True,
+            destination_branch=default_branch.name,
+            branch_diff=branch_diff,
+            refresh_artifacts=False,
+            do_repository_checks=False,
+        )
+        await run_generators(model=model, context=self._make_context(admin_account, default_branch))
+
+    async def _selected_definitions(
+        self,
+        *,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+        diff_summary: list[dict],
+        files_added: list[str] | None = None,
+        files_changed: list[str] | None = None,
+        files_removed: list[str] | None = None,
+    ) -> list[str]:
+        await self._run_generators(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            diff_summary=diff_summary,
+            files_added=files_added,
+            files_changed=files_changed,
+            files_removed=files_removed,
+        )
+        return sorted(
+            call["parameters"]["model"].generator_definition.definition_name
+            for call in workflow_recorder.get_submit_calls_for(REQUEST_GENERATOR_DEFINITION_CHECK)
+        )
+
+
+class TestGeneratorRegenSelection(GeneratorRegenTestBase):
+    """The selection gate submits a per-definition check only for the generators a change affects.
+
+    Drives the ``run_generators`` flow against four generator definitions backed by distinct
+    package-directory closures over a single repository, two of which share a query. Each scenario
+    asserts the exact set of definitions dispatched, proving unrelated edits and sibling generators
+    are left untouched while data changes, query edits and definition additions still select.
+    """
+
+    @pytest.fixture(scope="class")
+    async def dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+    ) -> dict[str, Any]:
+        await load_schema(db=db, schema=GENERATOR_SCHEMA, update_db=True)
+
+        device = await Node.init(db=db, schema="TestNetworkDevice")
+        await device.new(db=db, name="dev1", color="red", description="Device 1")
+        await device.save(db=db)
+
+        repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await repo.new(db=db, name="generator-regen-repo", location="https://github.com/test/generator-regen-repo.git")
+        await repo.save(db=db)
+
+        # ``models`` is populated by the GraphQL mutation analyzer in production; nodes created
+        # directly against the database must set it explicitly so the data-change (MODIFIED_KINDS)
+        # path has the queried kinds to match against.
+        query_a = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_a.new(db=db, name="GetADevice", query=QUERY_A, models=["TestNetworkDevice"])
+        await query_a.save(db=db)
+
+        query_b = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_b.new(db=db, name="GetBDevice", query=QUERY_B, models=["TestNetworkDevice"])
+        await query_b.save(db=db)
+
+        query_source_only = await Node.init(db=db, schema="CoreGraphQLQuery")
+        await query_source_only.new(
+            db=db, name="GetSourceOnlyDevice", query=QUERY_SOURCE_ONLY, models=["TestNetworkDevice"]
+        )
+        await query_source_only.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await group.new(db=db, name="generator-regen-targets", members=[device])
+        await group.save(db=db)
+
+        async def make_generator(
+            *, name: str, query: Node, file_path: str, dependencies: list[str], branch: Branch | None = None
+        ) -> Node:
+            gendef = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION, branch=branch)
+            await gendef.new(
+                db=db,
+                name=name,
+                query=query,
+                repository=repo,
+                targets=group,
+                file_path=file_path,
+                class_name="DeviceGenerator",
+                parameters={"value": {"name": "name__value"}},
+                convert_query_response=False,
+                execute_in_proposed_change=True,
+                execute_after_merge=True,
+                dependencies=dependencies,
+                dependencies_complete=True,
+            )
+            await gendef.save(db=db)
+            return gendef
+
+        gendef_a = await make_generator(
+            name="device-gen-a", query=query_a, file_path="generators/a/a.py", dependencies=DEPENDENCIES_A
+        )
+        gendef_a2 = await make_generator(
+            name="device-gen-a2", query=query_a, file_path="generators/a2/a2.py", dependencies=DEPENDENCIES_A2
+        )
+        gendef_b = await make_generator(
+            name="device-gen-b", query=query_b, file_path="generators/b/b.py", dependencies=DEPENDENCIES_B
+        )
+
+        source_branch_obj = await create_branch(branch_name=SOURCE_BRANCH, db=db)
+        await load_schema(db=db, schema=GENERATOR_SCHEMA, branch_name=SOURCE_BRANCH, update_db=False)
+
+        # A generator definition that exists only on the source branch reproduces the "new definition
+        # on the source branch" edge case: it must be selected (and run for every target-group member)
+        # even though the destination branch never saw it.
+        gendef_source_only = await make_generator(
+            name="device-gen-source-only",
+            query=query_source_only,
+            file_path="generators/new/new.py",
+            dependencies=DEPENDENCIES_SOURCE_ONLY,
+            branch=source_branch_obj,
+        )
+
+        pc = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+        await pc.new(
+            db=db, name="generator-regen-pc", source_branch=SOURCE_BRANCH, destination_branch=default_branch.name
+        )
+        await pc.save(db=db)
+
+        return {
+            "proposed_change_id": pc.id,
+            "repository_id": repo.id,
+            "repository_name": "generator-regen-repo",
+            "source_branch": SOURCE_BRANCH,
+            "device_id": device.id,
+            "query_a_id": query_a.id,
+            "query_b_id": query_b.id,
+            "gendef_a_id": gendef_a.id,
+            "gendef_a2_id": gendef_a2.id,
+            "gendef_b_id": gendef_b.id,
+            "gendef_source_only_id": gendef_source_only.id,
+        }
+
+    async def test_readme_edit_dispatches_nothing(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A repository edit outside every generator closure dispatches no generator."""
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[],
+            files_changed=["README.md"],
+        )
+        assert selected == []
+
+    async def test_unrelated_python_edit_dispatches_nothing(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A ``.py`` edit outside every package floor and unread by any query dispatches no generator."""
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[],
+            files_changed=["scripts/unrelated.py"],
+        )
+        assert selected == []
+
+    async def test_data_change_still_selects_via_modified_kinds(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A data change on a queried kind selects every generator reading that kind, unchanged by this feature.
+
+        No repository file changed, so selection comes solely from the data-change path: every
+        generator whose query reads the modified kind is dispatched exactly as before.
+        """
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[make_node_diff(dataset["device_id"], "TestNetworkDevice", SOURCE_BRANCH, ["name"])],
+        )
+        assert selected == ["device-gen-a", "device-gen-a2", "device-gen-b", "device-gen-source-only"]
+
+    async def test_new_definition_on_source_branch_is_selected(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A definition present on the source branch but not the destination is selected when its node is added.
+
+        The added definition node surfaces in the diff under its own id, so the definition-level
+        signal selects it; no other generator matches the addition.
+        """
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[
+                make_node_diff(
+                    dataset["gendef_source_only_id"],
+                    InfrahubKind.GENERATORDEFINITION,
+                    SOURCE_BRANCH,
+                    ["file_path"],
+                    action="ADDED",
+                )
+            ],
+        )
+        assert selected == ["device-gen-source-only"]
+
+    async def test_source_edit_selects_only_owning_generator(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """Editing a generator's own source file selects only the generator using it."""
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[],
+            files_changed=["generators/a/a.py"],
+        )
+        assert selected == ["device-gen-a"]
+
+    async def test_sibling_helper_edit_selects_via_package_floor(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A sibling file in the generator's package directory selects the owning generator.
+
+        The package-directory floor includes every sibling under the generator's directory, so a
+        helper edit the source file never imports still drives a re-run.
+        """
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[],
+            files_changed=["generators/a/helpers.py"],
+        )
+        assert selected == ["device-gen-a"]
+
+    async def test_query_edit_selects_only_owning_generator(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A query used by exactly one generator selects only that generator when modified."""
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[make_node_diff(dataset["query_b_id"], "CoreGraphQLQuery", SOURCE_BRANCH, ["query"])],
+        )
+        assert selected == ["device-gen-b"]
+
+    async def test_query_edit_selects_every_consuming_generator(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A query shared by two generators selects both when modified."""
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[make_node_diff(dataset["query_a_id"], "CoreGraphQLQuery", SOURCE_BRANCH, ["query"])],
+        )
+        assert selected == ["device-gen-a", "device-gen-a2"]
+
+    async def test_query_and_source_edit_dispatches_once(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """Editing both a generator's query and its source dispatches that generator exactly once.
+
+        The shared query also selects the second consumer, but the generator whose source changed too
+        is dispatched a single time - the two signals collapse into one per-definition selection.
+        """
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[make_node_diff(dataset["query_a_id"], "CoreGraphQLQuery", SOURCE_BRANCH, ["query"])],
+            files_changed=["generators/a/a.py"],
+        )
+        assert selected == ["device-gen-a", "device-gen-a2"]

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.gql
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.gql
@@ -1,7 +1,12 @@
 query CarOwner($name: String!) {
   TestingPerson(name__value: $name) {
     edges {
-      node @expand {
+      node {
+        __typename
+        id
+        name {
+          value
+        }
         cars {
           edges {
             node {

--- a/backend/tests/unit/proposed_change/test_generator_predicate_logging.py
+++ b/backend/tests/unit/proposed_change/test_generator_predicate_logging.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from infrahub_sdk.diff import NodeDiff, NodeDiffElement, NodeDiffSummary
+
+from infrahub.generators.models import ProposedChangeGeneratorDefinition
+from infrahub.message_bus.types import ProposedChangeRepository
+from infrahub.proposed_change.tasks import _definition_changed, _query_changed, _transform_changed
+
+QUERY_ID = "11111111-1111-1111-1111-111111111111"
+DEFINITION_ID = "22222222-2222-2222-2222-222222222222"
+REPOSITORY_ID = "44444444-4444-4444-4444-444444444444"
+
+
+def _build_definition(
+    *,
+    dependencies: list[str] | None = None,
+    dependencies_complete: bool | None = None,
+) -> ProposedChangeGeneratorDefinition:
+    return ProposedChangeGeneratorDefinition(
+        definition_id=DEFINITION_ID,
+        definition_name="device-generator",
+        query_name="GetNetworkDevice",
+        query_id=QUERY_ID,
+        query_models=["TestNetworkDevice"],
+        query_payload="query GetNetworkDevice { TestNetworkDevice { edges { node { name { value } } } } }",
+        repository_id=REPOSITORY_ID,
+        class_name="DeviceGenerator",
+        file_path="generators/device/device.py",
+        group_id="55555555-5555-5555-5555-555555555555",
+        parameters={"name": "name__value"},
+        convert_query_response=False,
+        execute_in_proposed_change=True,
+        execute_after_merge=True,
+        dependencies=dependencies,
+        dependencies_complete=dependencies_complete,
+    )
+
+
+def _build_repo_diff(*, files_changed: list[str] | None = None) -> ProposedChangeRepository:
+    return ProposedChangeRepository(
+        repository_id=REPOSITORY_ID,
+        repository_name="generator-repo",
+        read_only=False,
+        source_branch="feature",
+        destination_branch="main",
+        internal_status="active",
+        files_changed=files_changed or [],
+    )
+
+
+def _node_diff(*, node_id: str, kind: str, element_names: list[str] | None = None) -> NodeDiff:
+    return NodeDiff(
+        branch="main",
+        kind=kind,
+        id=node_id,
+        action="updated",
+        display_label="some-node",
+        elements=[
+            NodeDiffElement(
+                name=name,
+                element_type="attribute",
+                action="updated",
+                summary=NodeDiffSummary(added=0, updated=1, removed=0),
+            )
+            for name in (element_names or [])
+        ],
+    )
+
+
+def test_query_changed_reason_uses_generator_nouns() -> None:
+    """A firing query predicate names the query and uses the generator-correct ``instances`` noun."""
+    outcome = _query_changed(
+        definition=_build_definition(),
+        diff_summary=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery")],
+    )
+
+    assert outcome.matched is True
+    assert outcome.reason == (
+        f"Definition device-generator ({DEFINITION_ID}): GraphQL query GetNetworkDevice ({QUERY_ID}) was modified - "
+        f"all instances of this definition will regenerate."
+    )
+
+
+def test_definition_changed_reason_uses_generator_nouns() -> None:
+    """A firing definition predicate names the changed fields and uses the ``instances`` noun."""
+    outcome = _definition_changed(
+        definition=_build_definition(),
+        diff_summary=[_node_diff(node_id=DEFINITION_ID, kind="CoreGeneratorDefinition", element_names=["targets"])],
+    )
+
+    assert outcome.matched is True
+    assert outcome.reason == (
+        f"Definition device-generator ({DEFINITION_ID}): definition node was modified (targets) - "
+        f"all instances of this definition will regenerate."
+    )
+
+
+def test_transform_changed_reason_uses_generator_source_noun() -> None:
+    """The precise-closure path names the intersecting file and uses the ``generator source`` noun."""
+    outcome = _transform_changed(
+        definition=_build_definition(dependencies=["generators/device/device.py"], dependencies_complete=True),
+        repo_diff=_build_repo_diff(files_changed=["generators/device/device.py"]),
+    )
+
+    assert outcome.matched is True
+    assert outcome.reason == (
+        "Definition device-generator: file generators/device/device.py changed and is in this generator source's "
+        "dependency closure - all instances will regenerate."
+    )
+
+
+def test_transform_changed_reason_explains_the_legacy_fallback_for_generators() -> None:
+    """A pre-feature generator (``dependencies=null``) explains the self-heal-on-re-import path."""
+    outcome = _transform_changed(
+        definition=_build_definition(dependencies=None, dependencies_complete=None),
+        repo_diff=_build_repo_diff(files_changed=["any/path.txt"]),
+    )
+
+    assert outcome.matched is True
+    assert outcome.reason == (
+        "Definition device-generator: generator source was imported before this feature deployed "
+        "(dependencies=null) - falling back to regenerate-on-any-file-change. The next re-import of this "
+        "generator source will populate its dependency closure."
+    )
+
+
+def test_transform_changed_reason_explains_the_incomplete_closure_fallback_for_generators() -> None:
+    """An incomplete closure (``dependencies_complete=False``) names the cause as the safety fallback."""
+    outcome = _transform_changed(
+        definition=_build_definition(dependencies=["generators/device/device.py"], dependencies_complete=False),
+        repo_diff=_build_repo_diff(files_changed=["unrelated/file.md"]),
+    )
+
+    assert outcome.matched is True
+    assert outcome.reason == (
+        "Definition device-generator: generator source dependency closure is incomplete "
+        "(dependencies_complete=False) - falling back to regenerate-on-any-file-change."
+    )
+
+
+def test_non_triggered_generator_predicates_carry_no_reason() -> None:
+    """Predicates that do not fire carry no reason, so a non-triggered generator emits nothing.
+
+    This is the not-run side of the diagnostics contract: only the predicate that actually selected a
+    generator contributes a log line, and a complete closure no file change intersects stays silent.
+    """
+    definition = _build_definition(dependencies=["generators/device/device.py"], dependencies_complete=True)
+
+    assert _query_changed(definition=definition, diff_summary=[]).reason is None
+    assert _definition_changed(definition=definition, diff_summary=[]).reason is None
+    assert (
+        _transform_changed(
+            definition=definition, repo_diff=_build_repo_diff(files_changed=["transforms/other/main.py"])
+        ).reason
+        is None
+    )

--- a/backend/tests/unit/proposed_change/test_generator_predicates.py
+++ b/backend/tests/unit/proposed_change/test_generator_predicates.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from infrahub_sdk.diff import NodeDiff, NodeDiffElement
+
+from infrahub.generators.models import ProposedChangeGeneratorDefinition
+from infrahub.message_bus.types import ProposedChangeRepository
+from infrahub.proposed_change.tasks import _definition_changed, _query_changed, _run_generator, _transform_changed
+
+QUERY_ID = "11111111-1111-1111-1111-111111111111"
+DEFINITION_ID = "22222222-2222-2222-2222-222222222222"
+OTHER_ID = "33333333-3333-3333-3333-333333333333"
+REPOSITORY_ID = "44444444-4444-4444-4444-444444444444"
+
+# The package-directory floor a generator's closure carries: every sibling under its directory plus
+# the repository manifest. A file edit anywhere in the floor must select the generator.
+PACKAGE_FLOOR = [
+    ".infrahub.yml",
+    "generators/a/__init__.py",
+    "generators/a/a.py",
+    "generators/a/helpers.py",
+]
+
+
+def _build_definition(
+    *,
+    definition_id: str = DEFINITION_ID,
+    query_id: str = QUERY_ID,
+    dependencies: list[str] | None = None,
+    dependencies_complete: bool | None = None,
+) -> ProposedChangeGeneratorDefinition:
+    return ProposedChangeGeneratorDefinition(
+        definition_id=definition_id,
+        definition_name="device-generator",
+        query_name="GetNetworkDevice",
+        query_id=query_id,
+        query_models=["TestNetworkDevice"],
+        query_payload="query { TestNetworkDevice { edges { node { id } } } }",
+        repository_id=REPOSITORY_ID,
+        class_name="DeviceGenerator",
+        file_path="generators/a/a.py",
+        group_id="55555555-5555-5555-5555-555555555555",
+        parameters={"name": "name__value"},
+        convert_query_response=False,
+        execute_in_proposed_change=True,
+        execute_after_merge=True,
+        dependencies=dependencies,
+        dependencies_complete=dependencies_complete,
+    )
+
+
+def _build_repo_diff(
+    *,
+    files_added: list[str] | None = None,
+    files_changed: list[str] | None = None,
+    files_removed: list[str] | None = None,
+) -> ProposedChangeRepository:
+    return ProposedChangeRepository(
+        repository_id=REPOSITORY_ID,
+        repository_name="generator-repo",
+        read_only=False,
+        source_branch="feature",
+        destination_branch="main",
+        internal_status="active",
+        files_added=files_added or [],
+        files_changed=files_changed or [],
+        files_removed=files_removed or [],
+    )
+
+
+def _node_diff(*, node_id: str, kind: str = "CoreGraphQLQuery", action: str = "UPDATED") -> NodeDiff:
+    # ``action`` is the uppercase GraphQL enum name as emitted by the diff summary, not the lowercase
+    # ``DiffAction.*.value``; fixtures must mirror production casing so the case-insensitive match is exercised.
+    elements: list[NodeDiffElement] = []
+    return NodeDiff(
+        branch="main",
+        kind=kind,
+        id=node_id,
+        action=action,
+        display_label="some-node",
+        elements=elements,
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class QueryChangedCase:
+    name: str
+    diff: list[NodeDiff]
+    expected: bool
+
+
+QUERY_CHANGED_CASES: list[QueryChangedCase] = [
+    QueryChangedCase(name="empty_diff_is_false", diff=[], expected=False),
+    QueryChangedCase(
+        name="query_id_match_is_true",
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery")],
+        expected=True,
+    ),
+    QueryChangedCase(
+        name="unresolvable_query_peer_never_matches_here",
+        diff=[_node_diff(node_id=OTHER_ID, kind="CoreGraphQLQuery")],
+        expected=False,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in QUERY_CHANGED_CASES])
+def test_query_changed_generator_variant(case: QueryChangedCase) -> None:
+    """The query predicate fires for a generator definition exactly when its query node id is modified.
+
+    A generator whose query peer cannot be resolved (no diff entry carries its id) never matches here;
+    the other signals still cover it, so the never-under-run invariant is preserved by composition.
+    """
+    definition = _build_definition()
+    assert _query_changed(definition=definition, diff_summary=case.diff).matched is case.expected
+
+
+@dataclass(frozen=True, kw_only=True)
+class DefinitionChangedCase:
+    name: str
+    diff: list[NodeDiff]
+    expected: bool
+
+
+DEFINITION_CHANGED_CASES: list[DefinitionChangedCase] = [
+    DefinitionChangedCase(name="empty_diff_is_false", diff=[], expected=False),
+    DefinitionChangedCase(
+        name="definition_id_match_is_true",
+        diff=[_node_diff(node_id=DEFINITION_ID, kind="CoreGeneratorDefinition")],
+        expected=True,
+    ),
+    DefinitionChangedCase(
+        name="query_id_alone_is_false",
+        diff=[_node_diff(node_id=QUERY_ID, kind="CoreGraphQLQuery")],
+        expected=False,
+    ),
+    DefinitionChangedCase(
+        name="definition_match_among_other_entries",
+        diff=[
+            _node_diff(node_id=OTHER_ID, kind="TestNetworkDevice"),
+            _node_diff(node_id=DEFINITION_ID, kind="CoreGeneratorDefinition"),
+        ],
+        expected=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in DEFINITION_CHANGED_CASES])
+def test_definition_changed_generator_variant(case: DefinitionChangedCase) -> None:
+    """The definition predicate fires for a generator definition when its own node id is modified.
+
+    An attribute change or a ``targets`` repoint on the definition surfaces as a modification of the
+    definition's own node id, so a single id-based check covers every shape of definition-level change.
+    """
+    definition = _build_definition()
+    assert _definition_changed(definition=definition, diff_summary=case.diff).matched is case.expected
+
+
+@dataclass(frozen=True, kw_only=True)
+class TransformChangedCase:
+    name: str
+    dependencies: list[str] | None
+    dependencies_complete: bool | None
+    files_added: list[str] = field(default_factory=list)
+    files_changed: list[str] = field(default_factory=list)
+    files_removed: list[str] = field(default_factory=list)
+    expected: bool
+
+
+TRANSFORM_CHANGED_CASES: list[TransformChangedCase] = [
+    TransformChangedCase(
+        name="complete_closure_unrelated_file_is_false",
+        dependencies=PACKAGE_FLOOR,
+        dependencies_complete=True,
+        files_changed=["generators/b/b.py"],
+        expected=False,
+    ),
+    TransformChangedCase(
+        name="source_file_inside_floor_is_true",
+        dependencies=PACKAGE_FLOOR,
+        dependencies_complete=True,
+        files_changed=["generators/a/a.py"],
+        expected=True,
+    ),
+    TransformChangedCase(
+        name="sibling_module_in_same_package_is_true",
+        dependencies=PACKAGE_FLOOR,
+        dependencies_complete=True,
+        files_changed=["generators/a/helpers.py"],
+        expected=True,
+    ),
+    TransformChangedCase(
+        name="legacy_null_dependencies_falls_back_to_any_file_change",
+        dependencies=None,
+        dependencies_complete=None,
+        files_changed=["anything/at/all.py"],
+        expected=True,
+    ),
+    TransformChangedCase(
+        name="incomplete_closure_falls_back_to_any_file_change",
+        dependencies=PACKAGE_FLOOR,
+        dependencies_complete=False,
+        files_changed=["unrelated/file.md"],
+        expected=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in TRANSFORM_CHANGED_CASES])
+def test_transform_changed_generator_variant(case: TransformChangedCase) -> None:
+    """The closure predicate intersects a generator's package floor with the repo diff.
+
+    A file edit anywhere in the package-directory floor - the source module or a sibling it never
+    imports - selects the generator, while an unrelated file does not. The legacy (``dependencies=null``)
+    and incomplete (``dependencies_complete=False``) states fall back to regenerate-on-any-file-change so
+    a generator is never under-run.
+    """
+    definition = _build_definition(
+        dependencies=case.dependencies,
+        dependencies_complete=case.dependencies_complete,
+    )
+    repo_diff = _build_repo_diff(
+        files_added=case.files_added,
+        files_changed=case.files_changed,
+        files_removed=case.files_removed,
+    )
+    assert _transform_changed(definition=definition, repo_diff=repo_diff).matched is case.expected
+
+
+@dataclass(frozen=True, kw_only=True)
+class RunGeneratorCase:
+    name: str
+    instance_id: str | None
+    managed_branch: bool
+    impacted_instances: list[str]
+    expected: bool
+
+
+RUN_GENERATOR_CASES: list[RunGeneratorCase] = [
+    RunGeneratorCase(
+        name="new_member_runs_regardless_of_managed_branch",
+        instance_id=None,
+        managed_branch=False,
+        impacted_instances=[],
+        expected=True,
+    ),
+    RunGeneratorCase(
+        name="data_changed_instance_runs_regardless_of_managed_branch",
+        instance_id="instance-1",
+        managed_branch=False,
+        impacted_instances=["instance-1"],
+        expected=True,
+    ),
+    RunGeneratorCase(
+        name="closure_changed_managed_branch_runs_every_existing_instance",
+        instance_id="instance-1",
+        managed_branch=True,
+        impacted_instances=[],
+        expected=True,
+    ),
+    RunGeneratorCase(
+        name="nothing_relevant_changed_existing_instance_is_skipped",
+        instance_id="instance-1",
+        managed_branch=False,
+        impacted_instances=["instance-other"],
+        expected=False,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in RUN_GENERATOR_CASES])
+def test_run_generator_never_under_runs(case: RunGeneratorCase) -> None:
+    """After the per-member gate swap the three always-run categories are still honored.
+
+    A new member (no prior instance) and an instance whose data changed both run regardless of the
+    closure-derived ``managed_branch``; a closure/query/definition change sets ``managed_branch`` and
+    runs every existing instance; only an existing instance with nothing relevant changed is skipped.
+    """
+    assert (
+        _run_generator(
+            instance_id=case.instance_id,
+            managed_branch=case.managed_branch,
+            impacted_instances=case.impacted_instances,
+        )
+        is case.expected
+    )
+
+
+def test_legacy_generator_forces_managed_branch_on_any_file_change() -> None:
+    """A legacy generator (``dependencies=null``) computes ``managed_branch=True`` on any file change.
+
+    This is the gate-level guarantee behind never-under-run: a pre-feature generator whose closure was
+    never built falls back to the file-change signal, so every existing instance re-runs on any commit.
+    """
+    definition = _build_definition(dependencies=None, dependencies_complete=None)
+    repo_diff = _build_repo_diff(files_changed=["generators/a/a.py"])
+
+    managed_branch = (
+        _query_changed(definition=definition, diff_summary=[]).matched
+        or _definition_changed(definition=definition, diff_summary=[]).matched
+        or _transform_changed(definition=definition, repo_diff=repo_diff).matched
+    )
+
+    assert managed_branch is True

--- a/backend/tests/unit/proposed_change/test_predicate_logging.py
+++ b/backend/tests/unit/proposed_change/test_predicate_logging.py
@@ -179,3 +179,17 @@ def test_transform_changed_carries_no_reason_on_a_no_op_complete_closure() -> No
 
     assert outcome.matched is False
     assert outcome.reason is None
+
+
+def test_artifact_definition_diagnostic_nouns_are_unchanged() -> None:
+    """The artifact definition's diagnostic nouns must stay ``transform`` / ``artifacts``.
+
+    The shared predicate refactor parametrizes every reason string by these two properties. The
+    full-string assertions above lock the composed wording; pinning the nouns directly makes a noun
+    drift fail as its own unit test, independent of any one reason template, so artifact log wording
+    cannot silently change when the predicates are reused by another definition kind.
+    """
+    definition = _build_definition()
+
+    assert definition.source_noun == "transform"
+    assert definition.instance_noun == "artifacts"

--- a/dev/specs/ifc-2738-generator-regen-triggers/tasks.md
+++ b/dev/specs/ifc-2738-generator-regen-triggers/tasks.md
@@ -69,12 +69,12 @@ This feature is parallel wiring into the already-shipped INFP-409 machinery, not
 
 ### Implementation for User Story 1
 
-- [ ] T019 [US1] Replace the `DefinitionSelect.FILE_CHANGES` clause in `run_generators` (backend/infrahub/proposed_change/tasks.py) with `_query_changed OR _definition_changed OR _transform_changed(repo_diff)`, evaluated against the per-definition repo diff via `_repo_diff_or_none(...)`; keep the `MODIFIED_KINDS` clause unchanged; log each `PredicateOutcome.reason` at INFO. (FR-006, FR-010; contracts/definition-protocol.md call-site matrix)
+- [X] T019 [US1] Replace the `DefinitionSelect.FILE_CHANGES` clause in `run_generators` (backend/infrahub/proposed_change/tasks.py) with `_query_changed OR _definition_changed OR _transform_changed(repo_diff)`, evaluated against the per-definition repo diff via `_repo_diff_or_none(...)`; keep the `MODIFIED_KINDS` clause unchanged; log each `PredicateOutcome.reason` at INFO. (FR-006, FR-010; contracts/definition-protocol.md call-site matrix)
 
 ### Tests for User Story 1
 
-- [ ] T020 [P] [US1] Create backend/tests/component/proposed_change/test_generator_regen_selection.py (mirror test_artifact_regen_selection.py; reuse conftest helpers + test_request_generator_definition_check fixtures): a PC whose only repo change is `README.md` dispatches zero generators; a `.py` edit outside every package floor and unread by any query also dispatches zero. Also assert that the `MODIFIED_KINDS` data-change path still selects the generator exactly as before this feature (SC-008), and that a generator definition present on the source branch but not the destination branch is selected and runs for every target-group member (spec Edge Case: new definition on source branch). (SC-001, SC-008, US1 acceptance 1 & 2)
-- [ ] T021 [P] [US1] Unit test in backend/tests/unit/proposed_change/ for generator-model predicate variants: `_transform_changed` yields `matched=False` for an unrelated-file diff when `dependencies` is non-empty and `dependencies_complete=True`; and `_definition_changed` yields `matched=True` when `diff_summary` contains an entry whose `id == definition.definition_id` (definition node modified, e.g. an attribute change or `targets` repoint). (US1, FR-005, FR-011)
+- [X] T020 [P] [US1] Create backend/tests/component/proposed_change/test_generator_regen_selection.py (mirror test_artifact_regen_selection.py; reuse conftest helpers + test_request_generator_definition_check fixtures): a PC whose only repo change is `README.md` dispatches zero generators; a `.py` edit outside every package floor and unread by any query also dispatches zero. Also assert that the `MODIFIED_KINDS` data-change path still selects the generator exactly as before this feature (SC-008), and that a generator definition present on the source branch but not the destination branch is selected and runs for every target-group member (spec Edge Case: new definition on source branch). (SC-001, SC-008, US1 acceptance 1 & 2)
+- [X] T021 [P] [US1] Unit test in backend/tests/unit/proposed_change/ for generator-model predicate variants: `_transform_changed` yields `matched=False` for an unrelated-file diff when `dependencies` is non-empty and `dependencies_complete=True`; and `_definition_changed` yields `matched=True` when `diff_summary` contains an entry whose `id == definition.definition_id` (definition node modified, e.g. an attribute change or `targets` repoint). (US1, FR-005, FR-011)
 
 **Checkpoint**: MVP — unrelated commits no longer trigger generators.
 
@@ -88,13 +88,13 @@ This feature is parallel wiring into the already-shipped INFP-409 machinery, not
 
 ### Implementation for User Story 2
 
-- [ ] T022 [US2] Swap the per-member gate in `request_generator_definition_check` / `_run_generator` (~1256) in backend/infrahub/proposed_change/tasks.py: compute `managed_branch = (_query_changed OR _definition_changed OR _transform_changed(repo_diff)).matched` instead of unconditional `source_branch_sync_with_git`; everything else in `_run_generator` unchanged. **Primary risk area** — preserve the never-under-run invariant in the interaction with `impacted_instances`. (FR-007, research Decision 4; contracts/definition-protocol.md never-under-run proof)
+- [X] T022 [US2] Swap the per-member gate in `request_generator_definition_check` / `_run_generator` (~1256) in backend/infrahub/proposed_change/tasks.py: compute `managed_branch = (_query_changed OR _definition_changed OR _transform_changed(repo_diff)).matched` instead of unconditional `source_branch_sync_with_git`; everything else in `_run_generator` unchanged. **Primary risk area** — preserve the never-under-run invariant in the interaction with `impacted_instances`. (FR-007, research Decision 4; contracts/definition-protocol.md never-under-run proof)
 
 ### Tests for User Story 2
 
-- [ ] T023 [P] [US2] Extend test_generator_regen_selection.py: editing `generators/a/a.py` re-runs gen_a's instances only (gen_b untouched); editing the sibling `generators/a/helpers.py` re-runs gen_a (package-directory floor includes the sibling). (SC-002, US2 acceptance 1 & 2)
-- [ ] T024 [P] [US2] Unit test for `_transform_changed` generator variant in backend/tests/unit/proposed_change/: a diff file inside the package floor intersects the closure -> `matched=True`; a sibling module in the same package -> `matched=True`. (US2)
-- [ ] T025 [P] [US2] Unit test asserting the never-under-run proof for `_run_generator` after the swap: new member (`instance_id is None`) runs regardless of `managed_branch`; a data-changed instance in `impacted_instances` runs regardless; a legacy/failed-closure generator yields `managed_branch=True` on any file change. (FR-007, spec Edge Cases)
+- [X] T023 [P] [US2] Extend test_generator_regen_selection.py: editing `generators/a/a.py` re-runs gen_a's instances only (gen_b untouched); editing the sibling `generators/a/helpers.py` re-runs gen_a (package-directory floor includes the sibling). (SC-002, US2 acceptance 1 & 2)
+- [X] T024 [P] [US2] Unit test for `_transform_changed` generator variant in backend/tests/unit/proposed_change/: a diff file inside the package floor intersects the closure -> `matched=True`; a sibling module in the same package -> `matched=True`. (US2)
+- [X] T025 [P] [US2] Unit test asserting the never-under-run proof for `_run_generator` after the swap: new member (`instance_id is None`) runs regardless of `managed_branch`; a data-changed instance in `impacted_instances` runs regardless; a legacy/failed-closure generator yields `managed_branch=True` on any file change. (FR-007, spec Edge Cases)
 - [X] T026 [P] [US2] `PythonClosure` generator-config support test in backend/tests/unit/git/closure_builder/: `supports()` returns True for `InfrahubGeneratorDefinitionConfig` and `build()` produces the package-directory floor from `file_path` + `name`. (FR-002, FR-011) (pulled forward into the foundation PR: it guards code that ships there - T004/T005)
 - [X] T027 [P] [US2] Generator-import closure test in backend/tests/component/ (or git integration tests): importing a repository builds and persists `dependencies` / `dependencies_complete` on `CoreGeneratorDefinition` for each generator. (FR-003, FR-011) (pulled forward into the foundation PR: it guards code that ships there - T016/T017, and adds a re-import case covering the `_generator_requires_update` closure comparison - T018)
 
@@ -112,8 +112,8 @@ This feature is parallel wiring into the already-shipped INFP-409 machinery, not
 
 ### Tests for User Story 3
 
-- [ ] T028 [P] [US3] Extend test_generator_regen_selection.py: editing a `.gql` query used by exactly one generator re-runs only that generator; a query used by two generators selects both when changed; editing both a generator's query and source dispatches it once (no double-dispatch). (SC-003, US3 acceptance + edge cases)
-- [ ] T029 [P] [US3] Unit test for `_query_changed` generator variant in backend/tests/unit/proposed_change/: a `diff_summary` entry whose `id == definition.query_id` -> `matched=True`; an unresolvable query peer never matches here but the other signals still cover it. (US3, spec Edge Cases)
+- [X] T028 [P] [US3] Extend test_generator_regen_selection.py: editing a `.gql` query used by exactly one generator re-runs only that generator; a query used by two generators selects both when changed; editing both a generator's query and source dispatches it once (no double-dispatch). (SC-003, US3 acceptance + edge cases)
+- [X] T029 [P] [US3] Unit test for `_query_changed` generator variant in backend/tests/unit/proposed_change/: a `diff_summary` entry whose `id == definition.query_id` -> `matched=True`; an unresolvable query peer never matches here but the other signals still cover it. (US3, spec Edge Cases)
 
 **Checkpoint**: Query edits precisely target the consuming generators.
 
@@ -127,8 +127,8 @@ This feature is parallel wiring into the already-shipped INFP-409 machinery, not
 
 ### Tests for User Story 5
 
-- [ ] T030 [P] [US5] Predicate-logging unit test in backend/tests/unit/proposed_change/ asserting the generator reason strings render with `source_noun="generator source"` / `instance_noun="instances"` for each predicate (query matched, definition matched, precise transform match, legacy `dependencies=null` fallback, incomplete `dependencies_complete=False` fallback), and that both gates (`run_generators`, `request_generator_definition_check`) emit each `PredicateOutcome.reason` at INFO with a non-triggered generator reflected as not-run. (FR-010, SC-006; contracts/definition-protocol.md reason templates)
-- [ ] T031 [P] [US5] Extend backend/tests/unit/proposed_change/test_predicate_logging.py to assert artifact reason strings remain byte-for-byte identical (`source_noun="transform"` / `instance_noun="artifacts"`). (FR-013, SC-007)
+- [X] T030 [P] [US5] Predicate-logging unit test in backend/tests/unit/proposed_change/ asserting the generator reason strings render with `source_noun="generator source"` / `instance_noun="instances"` for each predicate (query matched, definition matched, precise transform match, legacy `dependencies=null` fallback, incomplete `dependencies_complete=False` fallback), and that both gates (`run_generators`, `request_generator_definition_check`) emit each `PredicateOutcome.reason` at INFO with a non-triggered generator reflected as not-run. (FR-010, SC-006; contracts/definition-protocol.md reason templates)
+- [X] T031 [P] [US5] Extend backend/tests/unit/proposed_change/test_predicate_logging.py to assert artifact reason strings remain byte-for-byte identical (`source_noun="transform"` / `instance_noun="artifacts"`). (FR-013, SC-007)
 
 **Checkpoint**: Every generator run/skip decision is explained in the log.
 


### PR DESCRIPTION

# Why

Generators re-run on every file change in any linked repository - the same blunt
gate INFP-409 already replaced for artifacts. A proposed change whose only
repository edit is unrelated (a README, a sibling generator's source, an
untouched query) still dispatches and re-runs every generator's instances,
wasting pipeline work and adding noise to the change.

Goal: re-run only the generators a change actually affects, reusing the
already-shipped INFP-409 closure/predicate machinery rather than new design.

Non-goals: no new predicate logic, no cross-branch fingerprint compare, no
AST-precise import analysis. Artifact selection and log wording are deliberately
left byte-for-byte unchanged. This PR delivers the two gate swaps and their test
coverage (IFC-2810); the user-declared `watch:` field, read-only-repo and
backward-compat verification, docs and changelog land in follow-up tickets.

Ref: IFC-2810, IFC-2738

## What changed

### Behavioral changes
- A proposed change whose only repository change is outside every generator's
  dependency closure (e.g. a README edit, or a `.py` file no generator reads)
  now dispatches **zero** generators.
- Editing a generator's source file - or a sibling in its package directory -
  re-runs only that generator's instances.
- Editing a `.gql` query re-runs only the generators that use it; a query shared
  by two generators re-runs both; editing both a generator's query and its source
  dispatches it once.
- Every run/skip decision is explained in the task log (which file, query, or
  definition change triggered it), in generator-correct wording.

### Implementation notes
- `run_generators` (definition-level gate): the `DefinitionSelect.FILE_CHANGES`
  "any file changed in a synced repository" heuristic is replaced by
  `_query_changed OR _definition_changed OR _transform_changed`, evaluated per
  definition against its stored dependency closure via `_repo_diff_or_none(...)`.
  The `MODIFIED_KINDS` data-change clause is unchanged.
- `request_generator_definition_check` (per-member gate): `managed_branch` is
  derived from the same three predicates instead of `source_branch_sync_with_git`.
  `_run_generator` itself is untouched, preserving the never-under-run invariant -
  new members (`instance_id is None`) and data-changed instances
  (`impacted_instances`) always run; legacy (`dependencies=null`) or incomplete
  (`dependencies_complete=False`) closures fall back to
  regenerate-on-any-file-change.
- No new abstraction: this reuses the structural `RegenerationDefinition` Protocol,
  the three predicates, the closure builder and the diagnostic wording shipped by
  INFP-409. `ProposedChangeGeneratorDefinition` already satisfies the Protocol.

### What stayed the same
- No schema changes, no GraphQL/API changes in this PR (the schema attributes and
  SDK field landed in the foundation work).
- Artifact selection and log wording are byte-for-byte unchanged - guarded by the
  existing artifact predicate/selection/logging suites plus an explicit noun guard.
- The `MODIFIED_KINDS` data-change path and the `impacted_instances` per-member
  path are unchanged.

### Suggested review order
1. `backend/infrahub/proposed_change/tasks.py` - the two gate swaps (the per-member
   gate in `request_generator_definition_check` is the primary-risk area).
2. `backend/tests/component/proposed_change/test_generator_regen_selection.py` -
   end-to-end selection scenarios.
3. The unit tests (predicate variants, never-under-run, logging).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make generator re-runs precise. Only generators touched by a query/definition change or a file edit inside their dependency closure are selected; unrelated commits dispatch none. Per-member gating now targets only instances of selected generators while keeping never-under-run guarantees.

- **New Features**
  - Replace broad file-change heuristic in `run_generators` with per-definition predicates: `_query_changed` OR `_definition_changed` OR `_transform_changed` using the diff and stored closures; log reasons at INFO. Data-change selection via modified kinds stays the same, and source-branch-only new definitions are selected.
  - Swap the per-member gate in `request_generator_definition_check`: compute `managed_branch` from the same predicates and keep `_run_generator` logic unchanged so new members and impacted instances always run; closure/query/definition changes re-run all existing instances.
  - Add component and unit tests for IFC-2810 (US1–US3, US5): unrelated file edits dispatch none; package-floor closure selects only the owning generator; data changes still select; query edits target one or multiple consumers; combined query+source changes dispatch once; diagnostic nouns and artifact wording are correct.

- **Refactors**
  - Replace deprecated `@expand` usage in `generators/cartags.gql` test fixture with explicit fields to match current GraphQL behavior.

<sup>Written for commit 10d679983b07e15f5ed3629a02a7d2d869866fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



