### PR TITLE
chore(tasks): build code-generation paths from REPO_BASE, not the escaped path

### DIFF
--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -10,7 +10,7 @@ from .shared import (
     PYTHON_PRIMITIVE_MAP,
     execute_command,
 )
-from .utils import ESCAPED_REPO_PATH
+from .utils import ESCAPED_REPO_PATH, REPO_BASE
 
 MAIN_DIRECTORY = "backend"
 NAMESPACE = "BACKEND"
@@ -351,8 +351,8 @@ def _generate_schemas(context: Context) -> None:
         relationship_schema,
     )
 
-    env = Environment(loader=FileSystemLoader(f"{ESCAPED_REPO_PATH}/backend/templates"), undefined=StrictUndefined)
-    generated = f"{ESCAPED_REPO_PATH}/backend/infrahub/core/schema/generated"
+    env = Environment(loader=FileSystemLoader(f"{REPO_BASE}/backend/templates"), undefined=StrictUndefined)
+    generated = f"{REPO_BASE}/backend/infrahub/core/schema/generated"
     template = env.get_template("generate_schema.j2")
 
     attributes_rendered = template.render(schema="AttributeSchema", node=attribute_schema, parent="HashableModel")
@@ -449,16 +449,16 @@ def _generate_protocols(context: Context) -> None:
     # We need to insert this folder in the search order to ensure
     # that it appears before the python_sdk folder since that folder also has
     # a 'tests' module and the sys.path seems to be random between runs.
-    sys.path.insert(0, f"{ESCAPED_REPO_PATH}/backend")
+    sys.path.insert(0, f"{REPO_BASE}/backend")
     from tests.helpers.schema import test_models
 
-    env = Environment(loader=FileSystemLoader(f"{ESCAPED_REPO_PATH}/backend/templates"), undefined=StrictUndefined)
+    env = Environment(loader=FileSystemLoader(f"{REPO_BASE}/backend/templates"), undefined=StrictUndefined)
     env.filters["inheritance"] = _jinja2_filter_inheritance
     env.filters["render_attribute"] = _jinja2_filter_render_attribute
     env.filters["render_relationship"] = _jinja2_filter_render_relationship
 
     # Export protocols for backend code use
-    generated = f"{ESCAPED_REPO_PATH}/backend/infrahub/core"
+    generated = f"{REPO_BASE}/backend/infrahub/core"
     template = env.get_template("generate_protocols.j2")
 
     protocols_rendered = template.render(
@@ -471,7 +471,7 @@ def _generate_protocols(context: Context) -> None:
     execute_command(context=context, command=f"ruff check --fix {protocols_output}")
 
     # Export test protocols for backend code use
-    generated = f"{ESCAPED_REPO_PATH}/backend/tests/"
+    generated = f"{REPO_BASE}/backend/tests/"
 
     test_models["nodes"].extend(core_models["nodes"])
     test_models["generics"].extend(core_models["generics"])
@@ -485,7 +485,7 @@ def _generate_protocols(context: Context) -> None:
     execute_command(context=context, command=f"ruff check --fix {protocols_output}")
 
     # Export protocols for Python SDK code use
-    generated = f"{ESCAPED_REPO_PATH}/python_sdk/infrahub_sdk"
+    generated = f"{REPO_BASE}/python_sdk/infrahub_sdk"
     template = env.get_template("generate_protocols_sdk.j2")
 
     protocols_rendered = template.render(


### PR DESCRIPTION
## Summary

The schema and protocol code-generation tasks built their filesystem paths from `ESCAPED_REPO_PATH`. That value is **shell-escaped** (`escape_path` backslash-escapes characters such as `-`), but the paths are consumed by Python file APIs — Jinja's `FileSystemLoader`, `sys.path`, and `open` — which expect the real path. When the repository path contains an escaped character (for example a worktree directory named `dazed-secure`), generation reads from and writes to a path that does not exist.

## Symptom & paths

Running `uv run invoke backend.generate` from a worktree whose path contains a character that `escape_path` rewrites (here the directory `dazed-secure`, and the `.superset` segment) fails while loading the generation templates:

```text
jinja2.exceptions.TemplateNotFound: 'generate_schema.j2' not found in search path:
'/Users/Pol/\.superset/worktrees/infrahub/dazed\-secure/backend/templates'
```

`escape_path` backslash-escapes shell-special characters (`.`, `-`, …). The result is correct as a shell argument but, when handed to Python's file APIs (`FileSystemLoader`, `sys.path`, `open`), it is a literal path that does not exist.

| | Path used | On disk |
|---|-----------|---------|
| Before — `ESCAPED_REPO_PATH` | `/Users/Pol/\.superset/worktrees/infrahub/dazed\-secure/backend/templates` | ❌ does not exist → `TemplateNotFound` |
| After — `REPO_BASE` | `/Users/Pol/.superset/worktrees/infrahub/dazed-secure/backend/templates` | ✅ resolves, template loads |

The same escaped-vs-real mismatch applies to the `sys.path` insertion and the generated-file output directories, so generation would also resolve those under the wrong, non-existent location.

## Change

Use the raw `REPO_BASE` instead of `ESCAPED_REPO_PATH` for the generation input/output paths in `tasks/backend.py` (schema templates, `sys.path` insertion, and the generated-file output directories).

## Testing

`uv run invoke backend.generate` resolves the template and output paths correctly from a worktree whose path contains a `-`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the real repo path (`REPO_BASE`) for schema and protocol code generation instead of the shell-escaped `ESCAPED_REPO_PATH`. This fixes broken Jinja `FileSystemLoader`, `sys.path`, and output paths when the repo path includes characters like `-`, so generation reads/writes to the correct directories.

<sup>Written for commit 856774aa78ee366b442c0355ca795a98cc127507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

