### PR TITLE
fix(ci): scope per-platform digest artifacts per workflow invocation

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -35,6 +35,15 @@ on:
         required: false
         description: Comma separated platform list to build the image for
         default: "linux/amd64,linux/arm64"
+      artifact_prefix:
+        type: string
+        required: false
+        description: >
+          Prefix used to namespace the per-platform digest artifacts. Must be unique per
+          invocation when this reusable workflow is called more than once within the same
+          caller run (artifacts are scoped to the run, not the invocation), otherwise the
+          merge step mixes digests across invocations.
+        default: digests
 
 permissions:
   contents: read
@@ -121,7 +130,7 @@ jobs:
         if: steps.check.outputs.skip == 'false' && inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: ${{ inputs.artifact_prefix }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -137,7 +146,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: ${{ inputs.artifact_prefix }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/schedule-publish-docker-image.yml
+++ b/.github/workflows/schedule-publish-docker-image.yml
@@ -60,6 +60,7 @@ jobs:
       ref: ${{ needs.meta_data.outputs.ref }}
       tags: ${{needs.meta_data.outputs.tags}}
       labels: ${{needs.meta_data.outputs.labels}}
+      artifact_prefix: digests-develop
 
   meta_data_stable:
     runs-on: ubuntu-24.04
@@ -109,3 +110,4 @@ jobs:
       ref: ${{ needs.meta_data_stable.outputs.ref }}
       tags: ${{needs.meta_data_stable.outputs.tags}}
       labels: ${{needs.meta_data_stable.outputs.labels}}
+      artifact_prefix: digests-stable


### PR DESCRIPTION
## Problem

The scheduled "publish development and stable docker image" job has been producing a **mixed develop/stable image**: the `develop` and `stable` tags end up pointing at manifest lists assembled from *both* branches' per-platform digests.

## Root cause

`schedule-publish-docker-image.yml` calls the reusable `ci-docker-image.yml` **twice in the same workflow run** — once for `develop`, once for `stable`. (The other three callers — `release.yml`, `publish-dev-docker-image.yml`, `publish-preview-dev-docker-image.yml` — call it only once, so they were unaffected.)

`ci-docker-image.yml` builds each platform untagged (`push-by-digest=true`), uploads each platform's digest as an artifact, then a `merge` job collects the digests and builds the tagged manifest list:

- Upload used **fixed names** `digests-amd64` / `digests-arm64`.
- `merge` downloaded with `pattern: digests-*` + `merge-multiple: true`, then assembled the manifest from **every** matching digest.

GitHub Actions artifacts are scoped to the **workflow run**, not to a reusable-workflow invocation. So the two invocations shared one artifact namespace, and each `merge` job pulled **both** develop and stable digests into a single pool — tagging the resulting mixed manifest as `develop` *and* `stable`. (The identical upload names also collide outright under the immutable-artifact semantics of the pinned action versions.)

## Fix

Namespace the digest artifacts per invocation, contained in the reusable workflow with a backward-compatible default:

- `ci-docker-image.yml`: new `artifact_prefix` input (default `digests`), used in the upload `name` and the download `pattern`. Single-invocation callers stay byte-identical (`digests-amd64`/`digests-arm64`).
- `schedule-publish-docker-image.yml`: develop invocation passes `artifact_prefix: digests-develop`; stable passes `artifact_prefix: digests-stable`.

Each `merge` job now only sees its own branch's two digests, so `develop` and `stable` get correctly separate manifest lists.

The `sbom` artifact (`sbom-${{ inputs.version }}`) was already invocation-unique (`dev-…` vs `stable-…`), so it needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mixed develop/stable Docker images by scoping per-platform digest artifacts per reusable workflow invocation. Adds an `artifact_prefix` input so each merge builds a manifest from only its own branch digests.

- **Bug Fixes**
  - Add `artifact_prefix` input to `ci-docker-image.yml` (default `digests`) and use it in upload names and download patterns.
  - Update `schedule-publish-docker-image.yml` to pass `digests-develop` and `digests-stable`.
  - Single-invocation callers remain unchanged; SBOM artifacts were already unique.

<sup>Written for commit c71daa908ce613f316a6e2e970cc8c57f9eb95d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

