### PR TITLE
feat(webhook): log the delivery attempt, request headers, and payload

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -204,6 +204,9 @@ class EventContext(BaseModel):
         )
 
 
+MASKED_HEADER_VALUE = "***"
+
+
 class HeaderKind(StrEnum):
     STATIC = "static"
     ENVIRONMENT = "environment"
@@ -252,7 +255,7 @@ class Webhook(BaseModel):
         """Build and return the payload to deliver."""
         return {"data": data, **context.model_dump()}
 
-    def _build_headers(self, payload: Any, uuid: UUID | None = None, at: Timestamp | None = None) -> dict[str, Any]:
+    def build_headers(self, payload: Any, uuid: UUID | None = None, at: Timestamp | None = None) -> dict[str, Any]:
         """Build the request headers, resolving each configured custom header.
 
         A header whose value cannot be resolved (for example an environment-sourced header whose
@@ -298,6 +301,17 @@ class Webhook(BaseModel):
 
         return headers
 
+    def redact_headers(self, headers: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of the headers with secret-bearing values masked for logging.
+
+        Values resolved from the environment and the request signature are masked, while standard
+        and statically configured headers are kept verbatim so the log stays useful without
+        exposing credentials.
+        """
+        sensitive = {header.key for header in self.custom_headers if header.kind is HeaderKind.ENVIRONMENT}
+        sensitive.add("webhook-signature")
+        return {key: (MASKED_HEADER_VALUE if key in sensitive else value) for key, value in headers.items()}
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def webhook_type(self) -> str:
@@ -315,9 +329,16 @@ class Webhook(BaseModel):
             return self.shared_key
         raise ValueError("Shared key is not set for the webhook")
 
-    async def send_payload(self, payload: Any, http_service: InfrahubHTTP) -> Response:
-        """Assign the headers for the given payload and POST it to the webhook endpoint."""
-        headers = self._build_headers(payload=payload)
+    async def send_payload(
+        self, payload: Any, http_service: InfrahubHTTP, headers: dict[str, Any] | None = None
+    ) -> Response:
+        """POST the payload to the webhook endpoint, building the headers when not supplied.
+
+        A caller that needs to inspect or log the exact headers builds them once and passes them
+        in, so the request that is sent matches the one that was logged.
+        """
+        if headers is None:
+            headers = self.build_headers(payload=payload)
         return await http_service.post(url=self.url, json=payload, headers=headers, verify=self.validate_certificates)
 
     def to_cache(self) -> dict[str, Any]:

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -206,6 +206,7 @@ class EventContext(BaseModel):
 
 MASKED_HEADER_VALUE = "***"
 WEBHOOK_SIGNATURE_HEADER = "webhook-signature"
+SENSITIVE_HEADER_NAMES = frozenset({"authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key"})
 
 
 class HeaderKind(StrEnum):
@@ -305,13 +306,15 @@ class Webhook(BaseModel):
     def redact_headers(self, headers: dict[str, Any]) -> dict[str, Any]:
         """Return a copy of the headers with secret-bearing values masked for logging.
 
-        Values resolved from the environment and the request signature are masked, while standard
-        and statically configured headers are kept verbatim so the log stays useful without
-        exposing credentials.
+        Environment-sourced values, the request signature, and any well-known credential-bearing
+        header are masked, while standard and statically configured headers are kept verbatim so
+        the log stays useful without exposing credentials. Matching is case-insensitive because
+        HTTP header names are, so a secret cannot slip through under a different casing.
         """
-        sensitive = {header.key for header in self.custom_headers if header.kind is HeaderKind.ENVIRONMENT}
-        sensitive.add(WEBHOOK_SIGNATURE_HEADER)
-        return {key: (MASKED_HEADER_VALUE if key in sensitive else value) for key, value in headers.items()}
+        sensitive = {header.key.lower() for header in self.custom_headers if header.kind is HeaderKind.ENVIRONMENT}
+        sensitive.add(WEBHOOK_SIGNATURE_HEADER.lower())
+        sensitive |= SENSITIVE_HEADER_NAMES
+        return {key: (MASKED_HEADER_VALUE if key.lower() in sensitive else value) for key, value in headers.items()}
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -205,6 +205,7 @@ class EventContext(BaseModel):
 
 
 MASKED_HEADER_VALUE = "***"
+WEBHOOK_SIGNATURE_HEADER = "webhook-signature"
 
 
 class HeaderKind(StrEnum):
@@ -297,7 +298,7 @@ class Webhook(BaseModel):
             signature = self._sign(data=unsigned_data)
             headers["webhook-id"] = message_id
             headers["webhook-timestamp"] = timestamp
-            headers["webhook-signature"] = f"v1,{base64.b64encode(signature).decode('utf-8')}"
+            headers[WEBHOOK_SIGNATURE_HEADER] = f"v1,{base64.b64encode(signature).decode('utf-8')}"
 
         return headers
 
@@ -309,7 +310,7 @@ class Webhook(BaseModel):
         exposing credentials.
         """
         sensitive = {header.key for header in self.custom_headers if header.kind is HeaderKind.ENVIRONMENT}
-        sensitive.add("webhook-signature")
+        sensitive.add(WEBHOOK_SIGNATURE_HEADER)
         return {key: (MASKED_HEADER_VALUE if key in sensitive else value) for key, value in headers.items()}
 
     @computed_field  # type: ignore[prop-decorator]

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -206,7 +206,9 @@ class EventContext(BaseModel):
 
 MASKED_HEADER_VALUE = "***"
 WEBHOOK_SIGNATURE_HEADER = "webhook-signature"
-SENSITIVE_HEADER_NAMES = frozenset({"authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key"})
+SENSITIVE_HEADER_NAMES = frozenset(
+    name.lower() for name in ("Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie", "X-API-Key")
+)
 
 
 class HeaderKind(StrEnum):

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -46,21 +46,30 @@ def _truncate_for_log(text: str) -> str:
     return f"{text[:PAYLOAD_LOG_LIMIT]}… (+{remaining} characters; enable debug logging for the full payload)"
 
 
+def _attempt_phrase(attempt: int | None) -> str:
+    """Position this send within its retry sequence, or note that no flow run is driving retries."""
+    if attempt is None:
+        return "outside a flow run"
+    return f"attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}"
+
+
 def _log_outgoing_request(
-    *, webhook: Webhook, webhook_name: str, attempt: int, headers: dict[str, Any], payload: Any
+    *, webhook: Webhook, webhook_name: str, attempt: int | None, headers: dict[str, Any], payload: Any
 ) -> None:
     """Log the outgoing request: a redacted, truncated summary at info and the full payload at debug."""
     log = get_run_logger()
     payload_json = ujson.dumps(payload)
     log.info(
-        f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}: POST {webhook.url} "
+        f"Webhook '{webhook_name}' {_attempt_phrase(attempt)}: POST {webhook.url} "
         f"with headers {webhook.redact_headers(headers)} and payload {_truncate_for_log(payload_json)}"
     )
-    log.debug(f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS} full payload: {payload_json}")
+    log.debug(f"Webhook '{webhook_name}' {_attempt_phrase(attempt)} full payload: {payload_json}")
 
 
 @task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
-async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, attempt: int) -> Response:
+async def webhook_post(
+    webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, attempt: int | None
+) -> Response:
     """Resolve the webhook config, log the outgoing request, and POST the prepared payload."""
     http_service = get_http()
     webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
@@ -93,8 +102,9 @@ async def webhook_send(
     """
     log = get_run_logger()
     await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
-    # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one.
-    attempt = flow_run.run_count or 1
+    # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one, where
+    # there is no retry sequence to report.
+    attempt = flow_run.run_count
     started = time.monotonic()
     try:
         response = await webhook_post(
@@ -107,14 +117,22 @@ async def webhook_send(
     except EXPECTED_DELIVERY_ERRORS as cause:
         elapsed_ms = (time.monotonic() - started) * 1_000
         failure = WebhookFailureClassifier().classify(cause=cause)
+        # A retry is only scheduled when a flow run is driving the sequence and attempts remain.
+        retry_note = ""
+        if attempt is not None:
+            retry_note = (
+                f" Retrying in {WEBHOOK_SEND_RETRY_DELAY_SECONDS:.0f}s (attempt {attempt + 1}/{WEBHOOK_SEND_ATTEMPTS})."
+                if attempt < WEBHOOK_SEND_ATTEMPTS
+                else " No retries remaining."
+            )
         log.error(
-            f"Webhook delivery failed [{failure.status_class}] on attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS} "
-            f"after {elapsed_ms:.0f} ms: {failure.message.rstrip('.')}. {failure.remediation}"
+            f"Webhook delivery failed [{failure.status_class}] {_attempt_phrase(attempt)} "
+            f"after {elapsed_ms:.0f} ms: {failure.message.rstrip('.')}. {failure.remediation}{retry_note}"
         )
         raise WebhookDeliveryError(failure) from None
     elapsed_ms = (time.monotonic() - started) * 1_000
     log.info(
-        f"Webhook delivered to {response.url} on attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}, "
+        f"Webhook delivered to {response.url} {_attempt_phrase(attempt)}, "
         f"HTTP {response.status_code} in {elapsed_ms:.0f} ms"
     )
     return response

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -34,14 +34,30 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 
 WEBHOOK_SEND_RETRIES: int = 3
 WEBHOOK_SEND_RETRY_DELAY_SECONDS: float = 120  # fixed 2m delay between attempts
+PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
+
+
+def _truncate_for_log(text: str) -> str:
+    if len(text) <= PAYLOAD_LOG_LIMIT:
+        return text
+    remaining = len(text) - PAYLOAD_LOG_LIMIT
+    return f"{text[:PAYLOAD_LOG_LIMIT]}… (+{remaining} characters; enable debug logging for the full payload)"
 
 
 @task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
-async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:  # noqa: ARG001
-    """Resolve the webhook config, assign its headers, and POST the prepared payload."""
+async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:
+    """Resolve the webhook config, log the outgoing request, and POST the prepared payload."""
+    log = get_run_logger()
     http_service = get_http()
     webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
-    response = await webhook.send_payload(payload=payload, http_service=http_service)
+    headers = webhook.build_headers(payload=payload)
+    payload_json = ujson.dumps(payload)
+    log.info(
+        f"Webhook '{webhook_name}': POST {webhook.url} "
+        f"with headers {webhook.redact_headers(headers)} and payload {_truncate_for_log(payload_json)}"
+    )
+    log.debug(f"Webhook '{webhook_name}' full payload: {payload_json}")
+    response = await webhook.send_payload(payload=payload, http_service=http_service, headers=headers)
     response.raise_for_status()
     return response
 

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -93,7 +93,7 @@ async def webhook_send(
     """
     log = get_run_logger()
     await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
-    # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one (e.g. a test).
+    # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one.
     attempt = flow_run.run_count or 1
     started = time.monotonic()
     try:

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -46,19 +46,26 @@ def _truncate_for_log(text: str) -> str:
     return f"{text[:PAYLOAD_LOG_LIMIT]}… (+{remaining} characters; enable debug logging for the full payload)"
 
 
-@task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
-async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, attempt: int) -> Response:
-    """Resolve the webhook config, log the outgoing request, and POST the prepared payload."""
+def _log_outgoing_request(
+    *, webhook: Webhook, webhook_name: str, attempt: int, headers: dict[str, Any], payload: Any
+) -> None:
+    """Log the outgoing request: a redacted, truncated summary at info and the full payload at debug."""
     log = get_run_logger()
-    http_service = get_http()
-    webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
-    headers = webhook.build_headers(payload=payload)
     payload_json = ujson.dumps(payload)
     log.info(
         f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}: POST {webhook.url} "
         f"with headers {webhook.redact_headers(headers)} and payload {_truncate_for_log(payload_json)}"
     )
     log.debug(f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS} full payload: {payload_json}")
+
+
+@task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
+async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, attempt: int) -> Response:
+    """Resolve the webhook config, log the outgoing request, and POST the prepared payload."""
+    http_service = get_http()
+    webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
+    headers = webhook.build_headers(payload=payload)
+    _log_outgoing_request(webhook=webhook, webhook_name=webhook_name, attempt=attempt, headers=headers, payload=payload)
     response = await webhook.send_payload(payload=payload, http_service=http_service, headers=headers)
     response.raise_for_status()
     return response

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -9,6 +9,7 @@ from infrahub_sdk.protocols import CoreTransformPython, CoreWebhook
 from prefect import flow, task
 from prefect.cache_policies import NONE
 from prefect.logging import get_run_logger
+from prefect.runtime import flow_run
 from prefect.states import Failed
 
 from infrahub.core.constants import InfrahubKind
@@ -34,6 +35,7 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 
 WEBHOOK_SEND_RETRIES: int = 3
 WEBHOOK_SEND_RETRY_DELAY_SECONDS: float = 120  # fixed 2m delay between attempts
+WEBHOOK_SEND_ATTEMPTS: int = WEBHOOK_SEND_RETRIES + 1  # the initial try plus its retries
 PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
 
 
@@ -45,7 +47,7 @@ def _truncate_for_log(text: str) -> str:
 
 
 @task(name="webhook-post", task_run_name="Send webhook {webhook_name}", cache_policy=NONE)
-async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any) -> Response:
+async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, attempt: int) -> Response:
     """Resolve the webhook config, log the outgoing request, and POST the prepared payload."""
     log = get_run_logger()
     http_service = get_http()
@@ -53,10 +55,10 @@ async def webhook_post(webhook_id: str, webhook_kind: str, webhook_name: str, pa
     headers = webhook.build_headers(payload=payload)
     payload_json = ujson.dumps(payload)
     log.info(
-        f"Webhook '{webhook_name}': POST {webhook.url} "
+        f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}: POST {webhook.url} "
         f"with headers {webhook.redact_headers(headers)} and payload {_truncate_for_log(payload_json)}"
     )
-    log.debug(f"Webhook '{webhook_name}' full payload: {payload_json}")
+    log.debug(f"Webhook '{webhook_name}' attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS} full payload: {payload_json}")
     response = await webhook.send_payload(payload=payload, http_service=http_service, headers=headers)
     response.raise_for_status()
     return response
@@ -84,21 +86,30 @@ async def webhook_send(
     """
     log = get_run_logger()
     await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
+    # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one (e.g. a test).
+    attempt = flow_run.run_count or 1
     started = time.monotonic()
     try:
         response = await webhook_post(
-            webhook_id=webhook_id, webhook_kind=webhook_kind, webhook_name=webhook_name, payload=payload
+            webhook_id=webhook_id,
+            webhook_kind=webhook_kind,
+            webhook_name=webhook_name,
+            payload=payload,
+            attempt=attempt,
         )
     except EXPECTED_DELIVERY_ERRORS as cause:
         elapsed_ms = (time.monotonic() - started) * 1_000
         failure = WebhookFailureClassifier().classify(cause=cause)
         log.error(
-            f"Webhook delivery failed [{failure.status_class}] after {elapsed_ms:.0f} ms: "
-            f"{failure.message.rstrip('.')}. {failure.remediation}"
+            f"Webhook delivery failed [{failure.status_class}] on attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS} "
+            f"after {elapsed_ms:.0f} ms: {failure.message.rstrip('.')}. {failure.remediation}"
         )
         raise WebhookDeliveryError(failure) from None
     elapsed_ms = (time.monotonic() - started) * 1_000
-    log.info(f"Webhook delivered to {response.url}, HTTP {response.status_code} in {elapsed_ms:.0f} ms")
+    log.info(
+        f"Webhook delivered to {response.url} on attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}, "
+        f"HTTP {response.status_code} in {elapsed_ms:.0f} ms"
+    )
     return response
 
 

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -6,6 +6,7 @@ import pytest
 
 from infrahub.core.timestamp import Timestamp
 from infrahub.webhook.models import (
+    MASKED_HEADER_VALUE,
     CustomWebhook,
     HeaderKind,
     StandardWebhook,
@@ -40,7 +41,7 @@ def test_standard_webhook_header() -> None:
     )
     test_id = UUID("217b4ebc-b84f-4736-b1ee-222182aed371")
     time1 = Timestamp("2025-02-27T11:43:49.064807Z")
-    headers = webhook._build_headers(payload=None, uuid=test_id, at=time1)
+    headers = webhook.build_headers(payload=None, uuid=test_id, at=time1)
 
     assert headers == {
         "Accept": "application/json",
@@ -60,7 +61,7 @@ def test_build_headers_with_static_custom_header() -> None:
         validate_certificates=True,
         custom_headers=[WebhookHeader(key="Authorization", value="Bearer token", kind=HeaderKind.STATIC)],
     )
-    headers = webhook._build_headers(payload=None)
+    headers = webhook.build_headers(payload=None)
 
     assert headers["Authorization"] == "Bearer token"
     assert headers["Accept"] == "application/json"
@@ -76,7 +77,7 @@ def test_custom_header_overrides_default() -> None:
         validate_certificates=True,
         custom_headers=[WebhookHeader(key="Content-Type", value="text/plain", kind=HeaderKind.STATIC)],
     )
-    headers = webhook._build_headers(payload=None)
+    headers = webhook.build_headers(payload=None)
 
     assert headers["Content-Type"] == "text/plain"
 
@@ -116,7 +117,7 @@ def test_build_headers_resolves_environment_variable() -> None:
     )
 
     with patch.dict("os.environ", {"MY_API_KEY": "secret123"}):
-        headers = webhook._build_headers(payload=None)
+        headers = webhook.build_headers(payload=None)
 
     assert headers["X-API-Key"] == "secret123"
     assert headers["Accept"] == "application/json"
@@ -139,7 +140,7 @@ def test_build_headers_fails_on_missing_environment_variable(cleared_environment
         WebhookHeaderResolutionError,
         match=r"^Webhook 'test': could not resolve header 'X-API-Key': Environment variable 'MISSING_VAR' not found$",
     ):
-        webhook._build_headers(payload=None)
+        webhook.build_headers(payload=None)
 
 
 def test_build_headers_warns_on_duplicate_keys(caplog: pytest.LogCaptureFixture) -> None:
@@ -156,7 +157,7 @@ def test_build_headers_warns_on_duplicate_keys(caplog: pytest.LogCaptureFixture)
     )
 
     with caplog.at_level(logging.WARNING, logger="infrahub.webhook.models"):
-        headers = webhook._build_headers(payload=None)
+        headers = webhook.build_headers(payload=None)
 
     assert headers["X-Token"] == "second"
     assert "duplicate header key 'X-Token'" in caplog.text
@@ -182,7 +183,7 @@ def test_webhook_signature_with_payload() -> None:
     }
     test_id = UUID("217b4ebc-b84f-4736-b1ee-222182aed371")
     time1 = Timestamp("2025-02-27T11:43:49.064807Z")
-    headers = webhook._build_headers(payload=payload, uuid=test_id, at=time1)
+    headers = webhook.build_headers(payload=payload, uuid=test_id, at=time1)
 
     assert headers == {
         "Accept": "application/json",
@@ -191,3 +192,54 @@ def test_webhook_signature_with_payload() -> None:
         "webhook-timestamp": "1740656629",
         "webhook-signature": "v1,5JQxZW3lMNdaSnofcSV0Y3krxQ7aZI7EyThUqHVDGc4=",
     }
+
+
+def test_redact_headers_masks_environment_value_and_signature() -> None:
+    """Environment-sourced values and the signature are masked; everything else stays verbatim."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[
+            WebhookHeader(key="X-Static", value="plain", kind=HeaderKind.STATIC),
+            WebhookHeader(key="Authorization", value="SECRET_TOKEN", kind=HeaderKind.ENVIRONMENT),
+        ],
+    )
+    headers = {
+        "Accept": "application/json",
+        "X-Static": "plain",
+        "Authorization": "resolved-secret-value",
+        "webhook-id": "msg_1",
+        "webhook-timestamp": "1740656629",
+        "webhook-signature": "v1,c2lnbmF0dXJl",
+    }
+
+    redacted = webhook.redact_headers(headers)
+
+    assert redacted == {
+        "Accept": "application/json",
+        "X-Static": "plain",
+        "Authorization": MASKED_HEADER_VALUE,
+        "webhook-id": "msg_1",
+        "webhook-timestamp": "1740656629",
+        "webhook-signature": MASKED_HEADER_VALUE,
+    }
+    assert headers["Authorization"] == "resolved-secret-value"  # the source mapping is left untouched
+
+
+def test_redact_headers_without_sensitive_headers_returns_equal_copy() -> None:
+    """With no environment header and no signature, nothing is masked."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[WebhookHeader(key="X-Static", value="plain", kind=HeaderKind.STATIC)],
+    )
+    headers = {"Accept": "application/json", "X-Static": "plain"}
+
+    redacted = webhook.redact_headers(headers)
+
+    assert redacted == headers
+    assert redacted is not headers

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -228,6 +228,38 @@ def test_redact_headers_masks_environment_value_and_signature() -> None:
     assert headers["Authorization"] == "resolved-secret-value"  # the source mapping is left untouched
 
 
+def test_redact_headers_masks_well_known_secret_headers_regardless_of_kind() -> None:
+    """Credential-bearing headers are masked even when statically configured, matched case-insensitively."""
+    webhook = CustomWebhook(
+        name="test",
+        url="http://test.com",
+        event_type="test",
+        validate_certificates=True,
+        custom_headers=[
+            WebhookHeader(key="Authorization", value="Bearer static-token", kind=HeaderKind.STATIC),
+            WebhookHeader(key="x-api-key", value="static-key", kind=HeaderKind.STATIC),
+            WebhookHeader(key="X-Safe", value="plain", kind=HeaderKind.STATIC),
+        ],
+    )
+    headers = {
+        "Accept": "application/json",
+        "Authorization": "Bearer static-token",
+        "x-api-key": "static-key",
+        "Cookie": "session=abc",
+        "X-Safe": "plain",
+    }
+
+    redacted = webhook.redact_headers(headers)
+
+    assert redacted == {
+        "Accept": "application/json",
+        "Authorization": MASKED_HEADER_VALUE,
+        "x-api-key": MASKED_HEADER_VALUE,
+        "Cookie": MASKED_HEADER_VALUE,
+        "X-Safe": "plain",
+    }
+
+
 def test_redact_headers_without_sensitive_headers_returns_equal_copy() -> None:
     """With no environment header and no signature, nothing is masked."""
     webhook = CustomWebhook(

--- a/backend/tests/unit/webhook/test_process.py
+++ b/backend/tests/unit/webhook/test_process.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import httpx
+import pytest
+import ujson
+
+from infrahub.exceptions import HTTPServerError
+from infrahub.webhook.classifier import WebhookDeliveryError
+from infrahub.webhook.models import CustomWebhook, HeaderKind, WebhookHeader
+from infrahub.webhook.tasks import process
+from infrahub.webhook.tasks.process import PAYLOAD_LOG_LIMIT, webhook_post, webhook_send
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+LOGGER_NAME = "infrahub.webhook.tasks.process"
+
+
+class _RecordingHTTP:
+    """A minimal InfrahubHTTP stand-in that returns a fixed response and records the POST."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self.posted: dict[str, object] = {}
+
+    async def post(
+        self, url: str, json: object = None, headers: dict[str, str] | None = None, verify: bool | None = None
+    ) -> httpx.Response:
+        self.posted = {"url": url, "json": json, "headers": headers, "verify": verify}
+        return self._response
+
+
+@pytest.fixture(autouse=True)
+def _patch_prefect_logger() -> Iterator[None]:
+    """Replace Prefect's get_run_logger with a standard logger so caplog captures output."""
+    with patch("infrahub.webhook.tasks.process.get_run_logger", return_value=logging.getLogger(LOGGER_NAME)):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _silence_add_tags() -> Iterator[None]:
+    """add_tags only talks to the Prefect runtime; it is irrelevant to these logging tests."""
+
+    async def _noop(**_kwargs: object) -> None:
+        return None
+
+    with patch.object(process, "add_tags", _noop):
+        yield
+
+
+@pytest.fixture
+def recording_http() -> Iterator[_RecordingHTTP]:
+    """Stand in for the HTTP service: returns a 200 response and records the POST it received."""
+    recorder = _RecordingHTTP(httpx.Response(200, request=httpx.Request("POST", "https://target.example/hook")))
+    with patch.object(process, "get_http", return_value=recorder):
+        yield recorder
+
+
+@pytest.fixture
+def webhook_token_env() -> Iterator[str]:
+    """Set the environment variable that the env-sourced header resolves from, and clear it afterwards."""
+    os.environ["WEBHOOK_TOKEN_ENV"] = "super-secret-token"
+    yield "super-secret-token"
+    os.environ.pop("WEBHOOK_TOKEN_ENV", None)
+
+
+async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
+    caplog: pytest.LogCaptureFixture, recording_http: _RecordingHTTP, webhook_token_env: str
+) -> None:
+    # No shared_key: avoids the random webhook-id/timestamp/signature so the logged line is fully fixed.
+    webhook = CustomWebhook(
+        name="hook",
+        url="https://target.example/hook",
+        event_type="infrahub.branch.created",
+        validate_certificates=False,
+        custom_headers=[
+            WebhookHeader(key="X-Static", value="plain", kind=HeaderKind.STATIC),
+            WebhookHeader(key="X-Token", value="WEBHOOK_TOKEN_ENV", kind=HeaderKind.ENVIRONMENT),
+        ],
+    )
+
+    async def _resolve(webhook_id: str, webhook_kind: str) -> CustomWebhook:
+        return webhook
+
+    payload = {"event": "branch.created"}
+    payload_json = ujson.dumps(payload)
+    expected_headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Static": "plain",
+        "X-Token": "***",
+    }
+
+    with patch.object(process, "_resolve_webhook", _resolve), caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        await webhook_post.fn(
+            webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload=payload, attempt=2
+        )
+
+    info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
+    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+
+    assert info_messages == [
+        "Webhook 'hook' attempt 2/4: POST https://target.example/hook "
+        f"with headers {expected_headers} and payload {payload_json}"
+    ]
+    assert debug_messages == [f"Webhook 'hook' attempt 2/4 full payload: {payload_json}"]
+
+
+async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_at_debug(
+    caplog: pytest.LogCaptureFixture, recording_http: _RecordingHTTP
+) -> None:
+    webhook = CustomWebhook(
+        name="hook",
+        url="https://target.example/hook",
+        event_type="infrahub.branch.created",
+        validate_certificates=False,
+    )
+
+    async def _resolve(webhook_id: str, webhook_kind: str) -> CustomWebhook:
+        return webhook
+
+    payload = {"blob": "x" * (PAYLOAD_LOG_LIMIT * 2)}
+    payload_json = ujson.dumps(payload)
+    overflow = len(payload_json) - PAYLOAD_LOG_LIMIT
+    truncated = (
+        payload_json[:PAYLOAD_LOG_LIMIT] + f"… (+{overflow} characters; enable debug logging for the full payload)"
+    )
+    expected_headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    with patch.object(process, "_resolve_webhook", _resolve), caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        await webhook_post.fn(
+            webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload=payload, attempt=1
+        )
+
+    info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
+    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+
+    assert info_messages == [
+        "Webhook 'hook' attempt 1/4: POST https://target.example/hook "
+        f"with headers {expected_headers} and payload {truncated}"
+    ]
+    assert debug_messages == [f"Webhook 'hook' attempt 1/4 full payload: {payload_json}"]
+
+
+async def test_webhook_send_logs_and_raises_the_classified_failure(caplog: pytest.LogCaptureFixture) -> None:
+    async def _failing_post(**_kwargs: object) -> httpx.Response:
+        raise HTTPServerError(message="Connection to https://target.example failed")
+
+    with (
+        patch.object(process, "webhook_post", _failing_post),
+        caplog.at_level(logging.ERROR, logger=LOGGER_NAME),
+        pytest.raises(WebhookDeliveryError, match=r"^Connection to https://target\.example failed$"),
+    ):
+        await webhook_send.fn(
+            webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload={"event": "branch.created"}
+        )
+
+    error_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(error_messages) == 1
+    # The elapsed milliseconds are the only variable part of the line.
+    assert re.fullmatch(
+        r"Webhook delivery failed \[CONNECTION\] on attempt 1/4 after \d+ ms: "
+        r"Connection to https://target\.example failed\. "
+        r"Verify the target endpoint is reachable from Infrahub\.",
+        error_messages[0],
+    )

--- a/backend/tests/unit/webhook/test_process.py
+++ b/backend/tests/unit/webhook/test_process.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -63,11 +62,10 @@ def recording_http() -> Iterator[_RecordingHTTP]:
 
 
 @pytest.fixture
-def webhook_token_env() -> Iterator[str]:
-    """Set the environment variable that the env-sourced header resolves from, and clear it afterwards."""
-    os.environ["WEBHOOK_TOKEN_ENV"] = "super-secret-token"
-    yield "super-secret-token"
-    os.environ.pop("WEBHOOK_TOKEN_ENV", None)
+def webhook_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set the environment variable that the env-sourced header resolves from; auto-restored afterwards."""
+    monkeypatch.setenv("WEBHOOK_TOKEN_ENV", "super-secret-token")
+    return "super-secret-token"
 
 
 async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(

--- a/backend/tests/unit/webhook/test_process.py
+++ b/backend/tests/unit/webhook/test_process.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import httpx
 import pytest
@@ -11,12 +10,17 @@ import ujson
 
 from infrahub.exceptions import HTTPServerError
 from infrahub.webhook.classifier import WebhookDeliveryError
-from infrahub.webhook.models import CustomWebhook, HeaderKind, WebhookHeader
+from infrahub.webhook.models import CustomWebhook, HeaderKind, Webhook, WebhookHeader
 from infrahub.webhook.tasks import process
-from infrahub.webhook.tasks.process import PAYLOAD_LOG_LIMIT, webhook_post, webhook_send
+from infrahub.webhook.tasks.process import (
+    PAYLOAD_LOG_LIMIT,
+    WEBHOOK_SEND_ATTEMPTS,
+    webhook_post,
+    webhook_send,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
 
 LOGGER_NAME = "infrahub.webhook.tasks.process"
 
@@ -36,29 +40,40 @@ class _RecordingHTTP:
 
 
 @pytest.fixture(autouse=True)
-def _patch_prefect_logger() -> Iterator[None]:
+def _patch_prefect_logger(monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace Prefect's get_run_logger with a standard logger so caplog captures output."""
-    with patch("infrahub.webhook.tasks.process.get_run_logger", return_value=logging.getLogger(LOGGER_NAME)):
-        yield
+    monkeypatch.setattr(process, "get_run_logger", lambda: logging.getLogger(LOGGER_NAME))
 
 
 @pytest.fixture(autouse=True)
-def _silence_add_tags() -> Iterator[None]:
+def _silence_add_tags(monkeypatch: pytest.MonkeyPatch) -> None:
     """add_tags only talks to the Prefect runtime; it is irrelevant to these logging tests."""
 
     async def _noop(**_kwargs: object) -> None:
         return None
 
-    with patch.object(process, "add_tags", _noop):
-        yield
+    monkeypatch.setattr(process, "add_tags", _noop)
 
 
 @pytest.fixture
-def recording_http() -> Iterator[_RecordingHTTP]:
+def recording_http(monkeypatch: pytest.MonkeyPatch) -> _RecordingHTTP:
     """Stand in for the HTTP service: returns a 200 response and records the POST it received."""
     recorder = _RecordingHTTP(httpx.Response(200, request=httpx.Request("POST", "https://target.example/hook")))
-    with patch.object(process, "get_http", return_value=recorder):
-        yield recorder
+    monkeypatch.setattr(process, "get_http", lambda: recorder)
+    return recorder
+
+
+@pytest.fixture
+def resolve_webhook_to(monkeypatch: pytest.MonkeyPatch) -> Callable[[Webhook], None]:
+    """Resolve any webhook id to the given webhook, bypassing the cache and the client."""
+
+    def _install(webhook: Webhook) -> None:
+        async def _resolve(webhook_id: str, webhook_kind: str) -> Webhook:
+            return webhook
+
+        monkeypatch.setattr(process, "_resolve_webhook", _resolve)
+
+    return _install
 
 
 @pytest.fixture
@@ -69,7 +84,10 @@ def webhook_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
 
 
 async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
-    caplog: pytest.LogCaptureFixture, recording_http: _RecordingHTTP, webhook_token_env: str
+    caplog: pytest.LogCaptureFixture,
+    recording_http: _RecordingHTTP,
+    webhook_token_env: str,
+    resolve_webhook_to: Callable[[Webhook], None],
 ) -> None:
     # No shared_key: avoids the random webhook-id/timestamp/signature so the logged line is fully fixed.
     webhook = CustomWebhook(
@@ -82,9 +100,7 @@ async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
             WebhookHeader(key="X-Token", value="WEBHOOK_TOKEN_ENV", kind=HeaderKind.ENVIRONMENT),
         ],
     )
-
-    async def _resolve(webhook_id: str, webhook_kind: str) -> CustomWebhook:
-        return webhook
+    resolve_webhook_to(webhook)
 
     payload = {"event": "branch.created"}
     payload_json = ujson.dumps(payload)
@@ -95,7 +111,7 @@ async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
         "X-Token": "***",
     }
 
-    with patch.object(process, "_resolve_webhook", _resolve), caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
         await webhook_post.fn(
             webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload=payload, attempt=2
         )
@@ -111,7 +127,9 @@ async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
 
 
 async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_at_debug(
-    caplog: pytest.LogCaptureFixture, recording_http: _RecordingHTTP
+    caplog: pytest.LogCaptureFixture,
+    recording_http: _RecordingHTTP,
+    resolve_webhook_to: Callable[[Webhook], None],
 ) -> None:
     webhook = CustomWebhook(
         name="hook",
@@ -119,9 +137,7 @@ async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_a
         event_type="infrahub.branch.created",
         validate_certificates=False,
     )
-
-    async def _resolve(webhook_id: str, webhook_kind: str) -> CustomWebhook:
-        return webhook
+    resolve_webhook_to(webhook)
 
     payload = {"blob": "x" * (PAYLOAD_LOG_LIMIT * 2)}
     payload_json = ujson.dumps(payload)
@@ -131,7 +147,7 @@ async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_a
     )
     expected_headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
-    with patch.object(process, "_resolve_webhook", _resolve), caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
         await webhook_post.fn(
             webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload=payload, attempt=1
         )
@@ -146,12 +162,51 @@ async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_a
     assert debug_messages == [f"Webhook 'hook' attempt 1/4 full payload: {payload_json}"]
 
 
-async def test_webhook_send_logs_and_raises_the_classified_failure(caplog: pytest.LogCaptureFixture) -> None:
+@dataclass
+class FailureLogCase:
+    name: str
+    run_count: int | None
+    location: str  # the attempt phrase in the log line
+    retry_note: str  # the trailing retry note, empty when none is expected
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        FailureLogCase(
+            name="mid_run_attempt_announces_next_retry",
+            run_count=1,
+            location="attempt 1/4",
+            retry_note=" Retrying in 120s (attempt 2/4).",
+        ),
+        FailureLogCase(
+            name="last_attempt_reports_no_retries_remaining",
+            run_count=WEBHOOK_SEND_ATTEMPTS,
+            location=f"attempt {WEBHOOK_SEND_ATTEMPTS}/4",
+            retry_note=" No retries remaining.",
+        ),
+        FailureLogCase(
+            name="outside_flow_run_omits_attempt_and_retry_note",
+            run_count=None,
+            location="outside a flow run",
+            retry_note="",
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+async def test_webhook_send_logs_and_raises_the_classified_failure(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, case: FailureLogCase
+) -> None:
+    monkeypatch.setattr(process.flow_run, "run_count", case.run_count)
+    # Pin the clock so the logged elapsed time is a fixed "0 ms" and the line can be matched exactly.
+    monkeypatch.setattr(process.time, "monotonic", lambda: 0.0)
+
     async def _failing_post(**_kwargs: object) -> httpx.Response:
         raise HTTPServerError(message="Connection to https://target.example failed")
 
+    monkeypatch.setattr(process, "webhook_post", _failing_post)
+
     with (
-        patch.object(process, "webhook_post", _failing_post),
         caplog.at_level(logging.ERROR, logger=LOGGER_NAME),
         pytest.raises(WebhookDeliveryError, match=r"^Connection to https://target\.example failed$"),
     ):
@@ -160,11 +215,8 @@ async def test_webhook_send_logs_and_raises_the_classified_failure(caplog: pytes
         )
 
     error_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.ERROR]
-    assert len(error_messages) == 1
-    # The elapsed milliseconds are the only variable part of the line.
-    assert re.fullmatch(
-        r"Webhook delivery failed \[CONNECTION\] on attempt 1/4 after \d+ ms: "
-        r"Connection to https://target\.example failed\. "
-        r"Verify the target endpoint is reachable from Infrahub\.",
-        error_messages[0],
-    )
+    assert error_messages == [
+        f"Webhook delivery failed [CONNECTION] {case.location} after 0 ms: "
+        "Connection to https://target.example failed. "
+        f"Verify the target endpoint is reachable from Infrahub.{case.retry_note}"
+    ]

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -222,6 +222,8 @@ The `available_actions` field on the task query reports each action with whether
 
 Each send attempt logs one line before the request is sent: the attempt number (`n/N`), the target URL, the request headers, and the payload. The payload is truncated inline (2048 characters) with the full body emitted only at debug level. Secret-bearing header values are masked in this log — see [Log redaction](#log-redaction) for the rule.
 
+When an attempt fails, `webhook_send` logs one error line carrying the failure class, the attempt number (`n/N`), the elapsed time, the reason, and its remediation. While the flow run has attempts left it also states when the next one fires (`Retrying in 120s (attempt n+1/N).`); on the final attempt it states `No retries remaining.`. Outside a flow run, where no retry sequence drives the send, the line reads `outside a flow run` in place of the attempt number and carries no retry note.
+
 ## Security
 
 HMAC-SHA256 signing is performed when a `shared_key` is set:

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -103,11 +103,12 @@ Pydantic model for a custom HTTP header: `key` (str), `value` (str), `kind` (Lit
 The base class handles:
 
 - Payload computation (`compute_payload`)
-- Header construction with custom headers and optional HMAC signing (`_build_headers`)
-- HTTP delivery of a precomputed payload via `send_payload()`
+- Header construction with custom headers and optional HMAC signing (`build_headers`)
+- Redaction of secret-bearing header values for logging (`redact_headers`)
+- HTTP delivery of a precomputed payload via `send_payload()`, which builds the headers itself unless a caller passes a set already built for logging
 - Cache serialization (`to_cache` / `from_cache`)
 
-The `custom_headers: list[WebhookHeader]` field on the base `Webhook` class holds headers loaded from the `CoreWebhook.headers` relationship. During `_build_headers()`, custom headers are applied after system defaults (Accept, Content-Type) but before HMAC signature headers. Static headers use the value directly; environment headers resolve from `os.environ` at send time. A missing variable fails the delivery with a configuration error (the `CONFIG` failure class) rather than being skipped.
+The `custom_headers: list[WebhookHeader]` field on the base `Webhook` class holds headers loaded from the `CoreWebhook.headers` relationship. During `build_headers()`, custom headers are applied after system defaults (Accept, Content-Type) but before HMAC signature headers. Static headers use the value directly; environment headers resolve from `os.environ` at send time. A missing variable fails the delivery with a configuration error (the `CONFIG` failure class) rather than being skipped.
 
 ## Schema (GraphQL)
 
@@ -217,6 +218,10 @@ The `available_actions` field on the task query reports each action with whether
 
 `InfrahubTaskRetry` and `InfrahubTaskCancel` carry out the actions. Each loads the delivery through a query-only Prefect client (`DeliveryReader`), then authorizes it (`DeliveryActionAuthorizer`): the action must apply to the run's current state, and the caller must hold the `UPDATE` permission on the webhook's node kind. Loading is kept separate from authorization so the read uses the narrowest client capability it needs.
 
+### Delivery logging
+
+Each send attempt logs one line before the request is sent: the attempt number (`n/N`), the target URL, the request headers, and the payload. The payload is truncated inline (2048 characters) with the full body emitted only at debug level. Secret-bearing header values are masked in this log — see [Log redaction](#log-redaction) for the rule.
+
 ## Security
 
 HMAC-SHA256 signing is performed when a `shared_key` is set:
@@ -234,6 +239,10 @@ Three headers are added to signed requests:
 | `webhook-id` | `msg_<uuid_hex>` |
 | `webhook-timestamp` | Unix timestamp |
 | `webhook-signature` | `v1,<base64_signature>` |
+
+### Log redaction
+
+When a delivery request is logged, secret-bearing header values are masked as `***`. A header value is masked when the header is environment-sourced, is the signature header, or matches a well-known credential header name (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`). Matching is case-insensitive, since HTTP header names are, so a secret cannot slip through under a different casing. Standard and statically configured non-credential headers are logged verbatim so the record stays useful; the payload is logged in full only at debug level.
 
 ## Caching
 

--- a/dev/specs/ifc-2755-webhook-delivery-operability/quickstart.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/quickstart.md
@@ -21,7 +21,7 @@ Set up a target you control to observe deliveries — a request bin, a local ech
 
 1. Click a delivery to open its detail.
 2. Verify the **payload** (from run parameters), **request** (URL + headers), **response** (status, body, latency) are shown.
-3. Verify redaction: the ENVIRONMENT-sourced header and `webhook-signature` are masked; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and STATIC custom headers are verbatim.
+3. Verify redaction: the ENVIRONMENT-sourced header, `webhook-signature`, and well-known credential headers (`Authorization`, `Cookie`, `X-API-Key`) are masked regardless of kind; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and non-credential STATIC custom headers are verbatim.
 4. Point the webhook at an endpoint that returns an error; trigger again; confirm the captured request/response are still present and reflect the **last attempt**.
 
 Backend check: the run carries one `http` artifact (key `infrahub-webhook-http`); no raw secret appears in the artifact.

--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -276,6 +276,8 @@ Authentication header values must include the full value including any type pref
 
 Every delivery attempt is logged with the target URL, the request headers, and the payload, so you can see what was sent from the delivery's task logs. Secret-bearing header values are masked as `***` in that log: environment-sourced values, the `webhook-signature`, and well-known credential headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`) — matched case-insensitively, regardless of whether the header was configured as static or environment-sourced. The payload is truncated in the log, with the full body available only at debug level.
 
+When a delivery attempt fails, the log records why it failed and, while retries remain, when the next attempt will run, so you can tell from the logs whether to wait for an automatic retry or step in.
+
 ## Custom webhook transformation
 
 The `data` object from the payloads above is passed to the `transform` method of your custom Transformation. For the full setup walkthrough, see [Webhook with custom Transformation](./custom-transformation.mdx).

--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -266,11 +266,15 @@ When a webhook fires, headers are merged in this order:
 For environment-variable-based headers, the value is resolved from `os.environ` on the Prefect worker at send time:
 
 - If the environment variable exists, its value is used as the header value.
-- If the environment variable is **not found**, the header is skipped, a warning is logged, and all remaining headers are still sent.
+- If the environment variable is **not found**, the delivery fails with a configuration error that names the webhook and the header, rather than sending the request without that header.
 
 :::note
 Authentication header values must include the full value including any type prefix. For example, for Bearer token authentication, set the value to `Bearer eyJhbGci...` (not only the token).
 :::
+
+### Header and payload logging
+
+Every delivery attempt is logged with the target URL, the request headers, and the payload, so you can see what was sent from the delivery's task logs. Secret-bearing header values are masked as `***` in that log: environment-sourced values, the `webhook-signature`, and well-known credential headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`) — matched case-insensitively, regardless of whether the header was configured as static or environment-sourced. The payload is truncated in the log, with the full body available only at debug level.
 
 ## Custom webhook transformation
 


### PR DESCRIPTION
## Summary

Enrich the webhook delivery run logs so an operator can see, for every attempt:

- the attempt number (`attempt N/4`) on the request, success, and failure log lines
- the outgoing request: target URL, the headers with secret values masked, and the payload (truncated inline, logged in full at debug level)

Environment-sourced header values, the request signature, and well-known credential headers (`Authorization`, `Cookie`, `X-API-Key`, …) are masked regardless of how the header was configured, matched case-insensitively; other standard and static headers, and the payload, are kept verbatim.

The attempt number is read once from the flow run and passed into the send task, rather than read from the Prefect runtime inside the task.

Resolves [IFC-2832](https://opsmill.atlassian.net/browse/IFC-2832) and [IFC-2833](https://opsmill.atlassian.net/browse/IFC-2833).

## Example log output

Take a signed `StandardWebhook` named `notify-slack`, pointing at `https://hooks.example.com/services/T000`, configured with a static header `X-Custom-Source: infrahub` and an environment-sourced header `X-Api-Token` (reading `SLACK_TOKEN`). The signature and the env-sourced token are masked; the static header and the standard headers are kept.

**Attempt succeeds on the first try:**

```
INFO  Webhook 'notify-slack' attempt 1/4: POST https://hooks.example.com/services/T000 with headers {'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Custom-Source': 'infrahub', 'X-Api-Token': '***', 'webhook-id': 'msg_1f0a…', 'webhook-timestamp': '1751459200', 'webhook-signature': '***'} and payload {"data": {"name": "device-01"}, "event_id": "…", "event_type": "infrahub.node.updated", …}
INFO  Webhook delivered to https://hooks.example.com/services/T000 attempt 1/4, HTTP 200 in 143 ms
```

**Target returns a 5xx, so the attempt fails and a retry is scheduled** (`status_class` drives the remediation hint; the retry note is appended because attempts remain):

```
INFO   Webhook 'notify-slack' attempt 2/4: POST https://hooks.example.com/services/T000 with headers {…} and payload {…}
ERROR  Webhook delivery failed [HTTP_SERVER_ERROR] attempt 2/4 after 88 ms: The target responded with HTTP 503. The target returned a server error; retry, or check the target. Retrying in 120s (attempt 3/4).
```

**Last attempt fails on a connection error** (no retry note beyond the "no retries remaining" tail):

```
ERROR  Webhook delivery failed [CONNECTION] attempt 4/4 after 30015 ms: All connection attempts failed. Verify the target endpoint is reachable from Infrahub. No retries remaining.
```

**Misconfigured header** — the env var backing `X-Api-Token` is unset, so the request never leaves Infrahub and the failure is classified as configuration:

```
ERROR  Webhook delivery failed [CONFIG] attempt 1/4 after 2 ms: Webhook 'notify-slack': could not resolve header 'X-Api-Token': Environment variable 'SLACK_TOKEN' not found. Check the webhook's headers; a configured header value could not be resolved. Retrying in 120s (attempt 2/4).
```

A payload longer than 2048 characters is truncated inline with a `… (+N characters; enable debug logging for the full payload)` marker; the full payload is emitted on a separate `DEBUG` line.

## UI Screenshot

### Headers & payload
<img width="3332" height="724" alt="image" src="https://github.com/user-attachments/assets/eb1d497e-d8f6-4ada-93ec-6c796307cca4" />

### Attempts and execution time
<img width="3238" height="112" alt="image" src="https://github.com/user-attachments/assets/3502aef4-9149-495f-981a-62d841997174" />



## Checklist

- [x] Tests added/updated
- [ ] Changelog entry — intentionally omitted for this operability logging change
- [x] External docs updated (`docs/docs/webhooks/overview.mdx`)
- [x] Internal .md docs updated (`dev/knowledge/backend/webhooks.md`, delivery-operability spec quickstart)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IFC-2832]: https://opsmill.atlassian.net/browse/IFC-2832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IFC-2833]: https://opsmill.atlassian.net/browse/IFC-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-attempt webhook delivery logging with redacted headers and a truncated payload, plus retry notes, so operators can see what was sent without exposing secrets. Full payload is logged at debug. Addresses IFC-2832 and IFC-2833.

- **New Features**
  - Show attempt n/N on request, success, and failure logs; add retry notes with the next attempt and delay, or “No retries remaining.” Outside a flow run, logs read “outside a flow run.”
  - Log POST details before sending: target URL, headers with secrets masked (env-sourced values, `webhook-signature`, and credential headers like `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, case-insensitive), and payload truncated to 2048 chars; full payload at debug.

- **Refactors**
  - Exposed `build_headers` and added `redact_headers`; `send_payload` accepts prebuilt headers so logged and sent headers match.
  - Centralized the signature header name and normalized sensitive header names to lowercase for consistent redaction.

<sup>Written for commit acc653e6da15ddbfc29525a20b467a7e6194f425. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

