### PR TITLE
feat(cache): NATS per-key TTL + init lock TTL on NATS

### DIFF
--- a/backend/infrahub/lock.py
+++ b/backend/infrahub/lock.py
@@ -90,10 +90,12 @@ class InfrahubMultiLock:
 class NATSLock:
     """Context manager to lock using NATS."""
 
-    def __init__(self, service: InfrahubServices, name: str) -> None:
+    def __init__(self, service: InfrahubServices, name: str, ttl: int | None = None) -> None:
         self.name = name
-        self.token = None
+        self.token: str | None = None
         self.service = service
+        # Maximum lifetime in seconds for the lock.
+        self.ttl = ttl
 
     async def __aenter__(self) -> None:
         await self.acquire()
@@ -106,8 +108,8 @@ class NATSLock:
     ) -> None:
         await self.release()
 
-    async def acquire(self) -> None:
-        token = f"{current_timestamp()}::{WORKER_IDENTITY}"
+    async def acquire(self, token: str | None = None) -> None:
+        token = token or f"{current_timestamp()}::{WORKER_IDENTITY}"
         while True:
             if await self.do_acquire(token):
                 self.token = token
@@ -115,10 +117,16 @@ class NATSLock:
             await sleep(0.1)  # default Redis GlobalLock value
 
     async def do_acquire(self, token: str) -> bool | None:
-        return await self.service.cache.set(key=self.name, value=token, not_exists=True)
+        return await self.service.cache.set(key=self.name, value=token, not_exists=True, expires=self.ttl)
 
     async def release(self) -> None:
+        if self.ttl is not None and await self.service.cache.get(key=self.name) != self.token:
+            # The TTL elapsed and the lock may have been re-acquired by another worker; nothing of ours
+            # to release.
+            self.token = None
+            return
         await self.service.cache.delete(key=self.name)
+        self.token = None
 
     async def locked(self) -> bool:
         return await self.service.cache.get(key=self.name) is not None
@@ -160,7 +168,7 @@ class InfrahubLock:
         elif config.SETTINGS.cache.driver == config.CacheDriver.Redis:
             self.remote = GlobalLock(redis=self.connection, name=f"{LOCK_PREFIX}.{self.name}", timeout=ttl)
         else:
-            self.remote = NATSLock(service=self.connection, name=f"{LOCK_PREFIX}.{self.name}")
+            self.remote = NATSLock(service=self.connection, name=f"{LOCK_PREFIX}.{self.name}", ttl=ttl)
 
     @property
     def acquire_time(self) -> int:

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -33,8 +33,10 @@ class InfrahubCache(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def set(self, key: str, value: str, expires: KVTTL | None = None, not_exists: bool = False) -> bool | None:
-        """Set a value in the cache."""
+    async def set(
+        self, key: str, value: str, expires: KVTTL | int | None = None, not_exists: bool = False
+    ) -> bool | None:
+        """Set a value in the cache, with an optional time-to-live in seconds."""
         raise NotImplementedError()
 
     @classmethod

--- a/backend/infrahub/services/adapters/cache/nats.py
+++ b/backend/infrahub/services/adapters/cache/nats.py
@@ -1,45 +1,40 @@
 from __future__ import annotations
 
+import contextlib
 import ssl
+from typing import TYPE_CHECKING
 
 import nats
+import nats.js.api
+import nats.js.errors
 
 from infrahub import config
-from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache import InfrahubCache
 
-# Inherit from BaseModel to avoid implementing a `__init__` otherwise `cls(...)` fails.
+if TYPE_CHECKING:
+    from infrahub.message_bus.types import KVTTL
 
 
 class NATSCache(InfrahubCache):
     connection: nats.NATS
     jetstream: nats.js.JetStreamContext
-    kv: dict[int, nats.js.kv.KeyValue]
-    kv_buckets: dict[str, KVTTL]
+    kv: nats.js.kv.KeyValue
+    bucket: str
 
     def __init__(
         self,
         connection: nats.NATS,
         jetstream: nats.js.JetStreamContext,
-        kv: dict[int, nats.js.kv.KeyValue],
-        kv_buckets: dict[str, KVTTL],
+        kv: nats.js.kv.KeyValue,
+        bucket: str,
     ) -> None:
         self.connection = connection
         self.jetstream = jetstream
         self.kv = kv
-        self.kv_buckets = kv_buckets
+        self.bucket = bucket
 
     @classmethod
     async def new(cls) -> NATSCache:
-        # FIXME: remove once NATS supports TTL for keys (2.11)
-        kv_buckets = {
-            NATSCache._tokenize_key_name("validator_execution_id:"): KVTTL.TWO_HOURS,
-            NATSCache._tokenize_key_name("workers:primary:"): KVTTL.FIFTEEN,
-            NATSCache._tokenize_key_name("workers:schema_hash:branch:"): KVTTL.TWO_HOURS,
-            NATSCache._tokenize_key_name("workers:active:"): KVTTL.FIFTEEN,
-            NATSCache._tokenize_key_name("workers:worker:"): KVTTL.TWO_HOURS,
-        }
-
         tls_context = None
         if config.SETTINGS.cache.tls_enabled:
             tls_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
@@ -57,36 +52,40 @@ class NATSCache(InfrahubCache):
         )
         jetstream = connection.jetstream()
 
-        kv_config = nats.js.api.KeyValueConfig(bucket=f"kv_{config.SETTINGS.cache.database}")
-        kv = {0: await jetstream.create_key_value(config=kv_config)}
+        bucket = f"kv_{config.SETTINGS.cache.database}"
+        kv = await cls._ensure_kv(jetstream=jetstream, bucket=bucket)
 
-        # FIXME: remove once NATS supports TTL for keys (2.11)
-        for ttl in KVTTL.variations():
-            kv_config.bucket = f"kv_{config.SETTINGS.cache.database}_ttl_{ttl.name.lower()}"
-            kv_config.ttl = ttl.value
-            kv[ttl.value] = await jetstream.create_key_value(config=kv_config)
+        return cls(connection=connection, jetstream=jetstream, kv=kv, bucket=bucket)
 
-        return cls(kv_buckets=kv_buckets, kv=kv, connection=connection, jetstream=jetstream)
+    @staticmethod
+    async def _ensure_kv(jetstream: nats.js.JetStreamContext, bucket: str) -> nats.js.kv.KeyValue:
+        """Return the KV bucket, ensuring per-message TTL is enabled on it.
+
+        Per-message TTL (NATS server 2.11+) lets each key carry its own expiry, replacing the
+        previous approach of routing keys to separate buckets configured with a fixed bucket-wide TTL.
+        """
+        try:
+            return await jetstream.create_key_value(config=nats.js.api.KeyValueConfig(bucket=bucket))
+        except nats.js.errors.BadRequestError:
+            # A bucket created by a release without per-message TTL already exists; enable it in place.
+            stream = await jetstream.stream_info(f"KV_{bucket}")
+            stream.config.allow_msg_ttl = True
+            await jetstream.update_stream(config=stream.config)
+            return await jetstream.key_value(bucket)
 
     @staticmethod
     def _tokenize_key_name(key: str) -> str:
         return key.replace(":", ".")
 
-    # FIXME: remove once NATS supports TTL for keys (2.11)
-    def _get_kv(self, key: str) -> nats.js.kv.KeyValue:
-        for bucket, ttl in self.kv_buckets.items():
-            if key.startswith(bucket):
-                return self.kv[ttl.value]
-        return self.kv[0]
-
     async def delete(self, key: str) -> None:
         key = self._tokenize_key_name(key)
-        await self._get_kv(key).delete(key)
+        with contextlib.suppress(nats.js.errors.KeyNotFoundError):
+            await self.kv.delete(key)
 
     async def get(self, key: str) -> str | None:
         key = self._tokenize_key_name(key)
         try:
-            entry = await self._get_kv(key).get(key=key)
+            entry = await self.kv.get(key=key)
             if entry.value:
                 return entry.value.decode()
         except nats.js.errors.KeyNotFoundError:
@@ -96,9 +95,9 @@ class NATSCache(InfrahubCache):
     async def get_values(self, keys: list[str]) -> list[str | None]:
         return [await self.get(key) for key in keys]
 
-    async def _keys(self, kv: nats.js.kv.KeyValue, filter_pattern: str) -> list[str]:
+    async def _keys(self, filter_pattern: str) -> list[str]:
         # code borrowed from py-nats keys()
-        watcher = await kv.watch(
+        watcher = await self.kv.watch(
             filter_pattern,
             ignore_deletes=True,
             meta_only=True,
@@ -112,42 +111,30 @@ class NATSCache(InfrahubCache):
             keys.append(key.key)
         await watcher.stop()
 
-        if not keys:
-            return []
-
         return keys
 
     async def list_keys(self, filter_pattern: str) -> list[str]:
-        # return await self.kv[None].keys() # does not support filtering
         filter_pattern = self._tokenize_key_name(filter_pattern)
         filter_pattern = filter_pattern.replace("*", ">")  # NATS uses * as token wildcard and > as full wildcard
-        # FIXME: remove once NATS supports TTL for keys (2.11)
-        if filter_pattern.startswith("workers."):
-            keys = await self._keys(self.kv[KVTTL.FIFTEEN.value], filter_pattern) + await self._keys(
-                self.kv[KVTTL.TWO_HOURS.value], filter_pattern
-            )
-        elif filter_pattern.startswith("validator_execution_id."):
-            keys = await self._keys(self.kv[KVTTL.TWO_HOURS.value], filter_pattern)
-        else:
-            keys = await self._keys(self.kv[0], filter_pattern)
-
+        keys = await self._keys(filter_pattern)
         return [key.replace(".", ":") for key in keys]
 
     async def set(
-        self,
-        key: str,
-        value: str,
-        expires: KVTTL | None = None,  # noqa: ARG002
-        not_exists: bool = False,
+        self, key: str, value: str, expires: KVTTL | int | None = None, not_exists: bool = False
     ) -> bool | None:
         key = self._tokenize_key_name(key)
+        msg_ttl = float(expires) if expires else None
         if not_exists:
             try:
-                await self._get_kv(key).create(key=key, value=value.encode())
+                await self.kv.create(key=key, value=value.encode(), msg_ttl=msg_ttl)
                 return True
             except nats.js.errors.KeyWrongLastSequenceError:
                 return False
-        await self._get_kv(key).put(key=key, value=value.encode())
+        if msg_ttl is None:
+            await self.kv.put(key=key, value=value.encode())
+        else:
+            # KeyValue.put() does not support per-message TTL; publish to the bucket subject directly.
+            await self.jetstream.publish(f"$KV.{self.bucket}.{key}", value.encode(), msg_ttl=msg_ttl)
         return True
 
     async def close_connection(self) -> None: ...

--- a/backend/infrahub/services/adapters/cache/redis.py
+++ b/backend/infrahub/services/adapters/cache/redis.py
@@ -55,8 +55,12 @@ class RedisCache(InfrahubCache):
 
         return [key.decode() for key in keys]
 
-    async def set(self, key: str, value: str, expires: KVTTL | None = None, not_exists: bool = False) -> bool | None:
-        return await self.connection.set(name=key, value=value, ex=expires.value if expires else None, nx=not_exists)
+    async def set(
+        self, key: str, value: str, expires: KVTTL | int | None = None, not_exists: bool = False
+    ) -> bool | None:
+        # redis-py cannot encode an IntEnum (e.g. KVTTL) directly, so coerce the TTL to a plain int.
+        ex = int(expires) if expires else None
+        return await self.connection.set(name=key, value=value, ex=ex, nx=not_exists)
 
     @classmethod
     async def new(cls) -> RedisCache:

--- a/backend/tests/component/services/adapters/nats/test_lock_ttl.py
+++ b/backend/tests/component/services/adapters/nats/test_lock_ttl.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import pytest
+
+from infrahub import config
+from infrahub.lock import LOCK_PREFIX, InfrahubLockRegistry
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.cache.nats import NATSCache
+
+
+async def _registry() -> tuple[InfrahubLockRegistry, InfrahubServices]:
+    cache = await NATSCache.new()
+    service = await InfrahubServices.new(cache=cache)
+    return InfrahubLockRegistry(local_only=False, service=service), service
+
+
+async def test_init_lock_auto_expires(nats: dict[int, int] | None) -> None:
+    """A global init lock with a TTL is dropped by NATS on its own, even if it is never released."""
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    registry, service = await _registry()
+    lock_obj = registry.get(name="global.init.test", ttl=2)
+    key = f"{LOCK_PREFIX}.global.init.test"
+
+    await lock_obj.acquire()
+    assert await service.cache.get(key) is not None
+
+    await asyncio.sleep(3)
+    # NATS expired the key without anyone releasing the lock, so a crashed holder cannot deadlock startup.
+    assert await service.cache.get(key) is None
+
+    # Releasing a lock that already expired must not raise back to the caller.
+    await lock_obj.release()
+    await service.cache.close_connection()
+
+
+async def test_lock_acquire_release_cycle(nats: dict[int, int] | None) -> None:
+    """A lock with no TTL is held until released and then frees the key."""
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    registry, service = await _registry()
+    lock_obj = registry.get(name="repository.repo-cycle")
+    key = f"{LOCK_PREFIX}.repository.repo-cycle"
+
+    await lock_obj.acquire()
+    assert await service.cache.get(key) is not None
+    await lock_obj.release()
+    assert await service.cache.get(key) is None
+
+    await service.cache.close_connection()

--- a/backend/tests/component/services/adapters/nats/test_nats.py
+++ b/backend/tests/component/services/adapters/nats/test_nats.py
@@ -1,0 +1,90 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from infrahub import config
+from infrahub.services.adapters.cache.nats import NATSCache
+
+
+async def test_set_and_get(nats: dict[int, int] | None) -> None:
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    cache = await NATSCache.new()
+    key = f"ci_testing:{uuid4()}"
+    value = "I exist"
+    initial = await cache.get(key)
+    await cache.set(key=key, value=value)
+    after_set = await cache.get(key)
+
+    assert initial is None
+    assert after_set == value
+    await cache.close_connection()
+
+
+async def test_per_key_ttl_expires(nats: dict[int, int] | None) -> None:
+    """A key written with an expiry is dropped by NATS once its per-key TTL elapses."""
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    cache = await NATSCache.new()
+    key = f"ci_testing:{uuid4()}"
+    await cache.set(key=key, value="temporary", expires=2)
+    after_set = await cache.get(key)
+    await asyncio.sleep(3)
+    after_expiry = await cache.get(key)
+
+    assert after_set == "temporary"
+    assert after_expiry is None
+    await cache.close_connection()
+
+
+async def test_per_key_ttl_on_create(nats: dict[int, int] | None) -> None:
+    """not_exists writes (create) also honor a per-key TTL and reject a second create."""
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    cache = await NATSCache.new()
+    key = f"ci_testing:{uuid4()}"
+    first = await cache.set(key=key, value="held", expires=2, not_exists=True)
+    second = await cache.set(key=key, value="other", expires=2, not_exists=True)
+    await asyncio.sleep(3)
+    after_expiry = await cache.get(key)
+
+    assert first is True
+    assert second is False  # key already exists
+    assert after_expiry is None  # the per-key TTL released it
+    await cache.close_connection()
+
+
+async def test_set_without_ttl_persists(nats: dict[int, int] | None) -> None:
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    cache = await NATSCache.new()
+    key = f"ci_testing:{uuid4()}"
+    await cache.set(key=key, value="permanent")
+    await asyncio.sleep(2)
+    after_wait = await cache.get(key)
+
+    assert after_wait == "permanent"
+    await cache.close_connection()
+
+
+async def test_list_keys(nats: dict[int, int] | None) -> None:
+    if config.SETTINGS.cache.driver != config.CacheDriver.NATS:
+        pytest.skip("Must use NATS to run this test")
+
+    cache = await NATSCache.new()
+    base_key = f"ci_testing:{uuid4()}"
+    iterations = 5
+    for i in range(iterations):
+        await cache.set(key=f"{base_key}:{i + 1}", value="value set")
+
+    keys = await cache.list_keys(filter_pattern=f"{base_key}:*")
+
+    assert len(keys) == iterations
+    assert f"{base_key}:1" in keys
+    assert f"{base_key}:5" in keys
+    await cache.close_connection()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -484,7 +484,8 @@ def nats_container(request: pytest.FixtureRequest, load_settings_before_session:
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver != config.CacheDriver.NATS:
         return None
 
-    container = DockerContainer(image="nats:alpine").with_command("--jetstream").with_exposed_ports(PORT_NATS)
+    # Per-message (per-key) TTL in KV buckets requires NATS 2.11 or later; pinned to a recent release.
+    container = DockerContainer(image="nats:2.14.3-alpine").with_command("--jetstream").with_exposed_ports(PORT_NATS)
 
     container.start()
     wait_for_logs(container, "Server is ready")  # wait_container_is_ready does not seem to be enough

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi==0.60b0",
     "opentelemetry-exporter-otlp-proto-grpc==1.39.0",
     "opentelemetry-exporter-otlp-proto-http==1.39.0",
-    "nats-py==2.7.2",
+    "nats-py==2.15.0",
     "netaddr==1.3.0",
     "authlib==1.6.12",
     "aiodataloader==0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1549,7 +1549,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3,<4" },
     { name = "lunr", specifier = ">=0.7.0.post1,<0.8" },
-    { name = "nats-py", specifier = "==2.7.2" },
+    { name = "nats-py", specifier = "==2.15.0" },
     { name = "neo4j", specifier = "==6.0.3" },
     { name = "neo4j-rust-ext", specifier = "==6.0.3.0" },
     { name = "netaddr", specifier = "==1.3.0" },
@@ -2163,9 +2163,12 @@ wheels = [
 
 [[package]]
 name = "nats-py"
-version = "2.7.2"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/30/16d3c830715d5b6e48e323a53db6796525a725bcf71a83b97991f8cc6866/nats-py-2.7.2.tar.gz", hash = "sha256:0c97b4a57bed0ef1ff9ae6c19bc115ec7ca8ede5ab3e001fd00a377056a547cf", size = 98698, upload-time = "2024-02-27T17:22:23.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
+]
 
 [[package]]
 name = "neo4j"


### PR DESCRIPTION
## Summary

Builds on the Redis init-lock TTL work (this PR targets that branch). It modernizes the NATS cache backend and brings the global initialization-lock TTL safety net to NATS as well, so a worker that dies mid-initialization can no longer deadlock startup regardless of cache driver.

## Key Changes

**Commit 1 — `feat(cache): switch NATS cache to per-key TTL`**
- Bumps `nats-py` 2.7.2 → 2.15.0.
- Replaces the per-bucket TTL workaround (one KV bucket per supported TTL, keys routed by prefix) with real per-message (per-key) TTL, available since NATS server 2.11.
- A single KV bucket now applies the caller-supplied expiry directly via `msg_ttl`, so NATS finally honors the same per-key expiry Redis already did. Existing buckets are upgraded in place to enable per-message TTL.
- The cache `set(expires=…)` value is now seconds (`KVTTL` members remain valid as they are integers). `RedisCache` aligned accordingly.
- Test NATS image pinned to `nats:2.11-alpine`.

**Commit 2 — `fix(lock): enforce init lock TTL on the NATS backend`**
- Fixes NATS-backed distributed locks: `NATSLock.acquire()` did not accept the `token` `InfrahubLock` passes, so acquiring any NATS lock raised a `TypeError`.
- Global initialization locks acquired through NATS now carry the configurable TTL via the per-key cache expiry, matching the Redis behavior. A TTL'd lock is released only if we still own it, so an expired-and-reacquired lock is not clobbered.

## Related Context

Follow-up to the Redis global-init-lock TTL (issue #9277). The TTL value/config (`INFRAHUB_CACHE_INIT_LOCK_TTL_MINS`, default 20 min) is defined on the base branch and reused here.

## Test Plan

Validated against a real NATS server (`nats:2.11-alpine`, server v2.11.17) with the NATS cache driver:

- `INFRAHUB_CACHE_DRIVER=nats uv run pytest backend/tests/component/services/adapters/nats` — cache per-key TTL (create + put paths), no-TTL persistence, list_keys; init lock auto-expiry, configured-TTL wiring, acquire/release cycle.
- `uv run pytest backend/tests/component/services/adapters/redis/test_redis.py` and `.../redis/test_lock_ttl.py` — Redis path unchanged.
- `uv run pytest backend/tests/unit/test_lock.py backend/tests/unit/adapters/test_lock.py` — local/Redis lock units.
- `ruff`, `ty` clean on changed files.

## Notes

- NATS message-bus adapter API usage was checked for compatibility with the `nats-py` bump (publish/subscribe/add_stream/add_consumer signatures unchanged; `publish` gains an optional `msg_ttl`).
- These NATS tests run in CI only when the suite is exercised with the NATS cache driver.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the NATS cache to real per-key TTL and adds a configurable TTL to all global initialization locks so a crashed worker can’t block startup. Follow-up to #9277, aligning NATS with Redis behavior and defaulting TTL to 20 minutes via `INFRAHUB_CACHE_INIT_LOCK_TTL_MINS`.

- New Features
  - NATS uses per-message (per-key) TTL in a single KV bucket; existing buckets auto-upgrade to enable per-message TTL.
  - Global init locks (`global.init`, `global.taskmgr.init`, `global.worker.taskmgr.init`) now auto-expire on both Redis and NATS; TTL is passed in seconds across caches.
  - `cache.set(expires=...)` now takes seconds; `KVTTL` values still work since they’re ints. `RedisCache` and NATS both accept int seconds.
  - Requires NATS server 2.11+; bumped `nats-py` to `2.15.0`; tests pin `nats:2.14.3-alpine`.

- Bug Fixes
  - Fixed NATS lock acquire TypeError: `NATSLock.acquire()` now accepts an optional token to match `InfrahubLock` and keeps the `timestamp::worker_id` value.
  - Releasing TTL’d locks is safe: no-op if the lock already expired or we no longer own it (Redis handles `LockNotOwnedError`; NATS checks the token).

<sup>Written for commit 36d09628d8e4ab092bdbe222839e1acc00bf6834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

