### PR TITLE
Fix merge and diff failing when a relationship peer is missing

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -273,6 +273,8 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
             relm: RelationshipManager = getattr(self, schema_path.relationship_schema.name)
             await relm.resolve(db=db)
             node = await relm.get_peer(db=db)
+            if node is None:
+                return None
             attr = getattr(node, schema_path.attribute_schema.name)
             return getattr(attr, schema_path.attribute_property_name)
 

--- a/backend/tests/integration_docker/test_merge_recompute_delete_peer.py
+++ b/backend/tests/integration_docker/test_merge_recompute_delete_peer.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from asyncio import sleep, timeout
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+from tests.helpers.schema.color import COLOR
+from tests.helpers.schema.tshirt import TSHIRT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from infrahub_sdk import InfrahubClient
+
+COLOR_KIND = "TestingColor"
+TSHIRT_KIND = "TestingTShirt"
+
+
+def _schema_dict() -> dict:
+    """Reuse the TShirt and Color helpers, dropping the transform-python attribute (it needs a transform repo) and making color optional."""
+    tshirt = TSHIRT.duplicate()
+    tshirt.generate_template = False
+    tshirt.attributes = [attribute for attribute in tshirt.attributes if attribute.name != "pitch"]
+    for relationship in tshirt.relationships:
+        if relationship.name == "color":
+            relationship.optional = True
+    return {"version": "1.0", "nodes": [COLOR.model_dump(), tshirt.model_dump()]}
+
+
+async def _wait_until(predicate: Callable[[], Awaitable[bool]], *, seconds: int = 120) -> None:
+    async with timeout(seconds):
+        while not await predicate():  # noqa: ASYNC110
+            await sleep(2)
+
+
+class TestMergeDeletePeerRecompute(TestInfrahubDockerClient):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    @pytest.fixture(scope="class")
+    def delete_peer_schema(self) -> dict:
+        return _schema_dict()
+
+    async def test_merge_survives_deleting_a_read_peer(self, client: InfrahubClient, delete_peer_schema: dict) -> None:
+        """Merging a branch that deleted a read peer completes instead of erroring on the missing peer."""
+        loaded = await client.schema.load(schemas=[delete_peer_schema], wait_until_converged=True)
+        assert loaded.schema_updated
+
+        color = await client.create(kind=COLOR_KIND, data={"name": "red", "description": "the red one"})
+        await color.save()
+        tshirt = await client.create(kind=TSHIRT_KIND, data={"name": "tee", "color": color})
+        await tshirt.save()
+
+        async def _reader_initial() -> bool:
+            refreshed = await client.get(kind=TSHIRT_KIND, id=tshirt.id)
+            return refreshed.display_label == "tee red"
+
+        await _wait_until(_reader_initial)
+
+        branch = await client.branch.create(branch_name="delete-peer-survives")
+        color_on_branch = await client.get(kind=COLOR_KIND, id=color.id, branch=branch.name)
+        await color_on_branch.delete()
+
+        await client.branch.merge(branch_name=branch.name)
+
+        refreshed = await client.get(kind=TSHIRT_KIND, id=tshirt.id)
+        assert refreshed.name.value == "tee"

--- a/changelog/+display-label-missing-relationship-peer.fixed.md
+++ b/changelog/+display-label-missing-relationship-peer.fixed.md
@@ -1,0 +1,1 @@
+Display labels, human-friendly IDs, and computed attributes that read across a relationship no longer error when the related peer is missing, such as after the peer has been deleted. The missing value now resolves as empty. This previously caused branch merge, rebase, and diff calculation to fail.


### PR DESCRIPTION
# Why

Merging a branch, rebasing a branch, or viewing a diff could fail with an error. This happened when a node's display label, human friendly ID, or computed attribute read a value from a related node that was no longer there. The usual way to hit it is to delete a peer that another node still points to through an optional relationship.

The goal is to keep merge, rebase, and diff working in this case instead of failing.

This does not change the value the reader keeps once the peer is gone. That remaining gap is tracked in IFC-2852.

## What changed

- Merge, rebase, and diff no longer fail when a reader points at a missing peer through its display label, human friendly ID, or computed attribute.
- When the relationship has no peer, the value it points to is treated as empty instead of raising an error.
- No schema changes. No API changes.

## How to test

```bash
uv run pytest backend/tests/integration_docker/test_merge_recompute_delete_peer.py
```

The test creates a node that reads a peer, deletes the peer on a branch, merges the branch, and checks that the merge completes.

## Impact & rollout

- Backward compatibility: no breaking changes.
- Performance: no impact.
- Config or env changes: none.
- Deployment notes: safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated (not needed)
- [ ] Internal .md docs updated (not needed)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes merge, rebase, and diff failures by treating missing relationship peers as empty when resolving derived values. Aligns with IFC-2852 so display labels, human-friendly IDs, and computed attributes render empty instead of throwing when the related node is gone.

- **Bug Fixes**
  - `get_path_value` now returns `None` when the relationship has no peer, so templates render empty instead of erroring.
  - Added an integration test that deletes a related node on a branch and verifies the merge completes and the reader node stays valid.

<sup>Written for commit 1e502e3c63e1e3eeb3a51b9c5709cc144286bf13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

