### PR TITLE
fix(backend): resolve diff relationship peer when schema removed

### DIFF
--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -568,9 +568,12 @@ class DiffQueryParser:
         return diff_node
 
     def _get_relationship_schema(self, database_path: DatabasePath) -> RelationshipSchema | None:
+        # Prefer the schema on the path's own branch, then fall back to the other branches
+        # in case the schema was deleted on this branch
         branches_to_check = [database_path.deepest_branch]
-        if database_path.deepest_branch == self.diff_branch_name:
-            branches_to_check.append(self.base_branch_name)
+        for fallback_branch in (self.diff_branch_name, self.base_branch_name):
+            if fallback_branch not in branches_to_check:
+                branches_to_check.append(fallback_branch)
         for schema_branch_name in branches_to_check:
             try:
                 node_schema = self.schema_manager.get(

--- a/backend/tests/component/core/diff/diff_calculator/test_relationships.py
+++ b/backend/tests/component/core/diff/diff_calculator/test_relationships.py
@@ -1,6 +1,6 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.diff.model.field_specifiers_map import NodeFieldSpecifierMap
@@ -1285,3 +1285,79 @@ async def test_diff_relationship_property_update_on_main(
     assert diff_rel.name == "owner"
     assert diff_rel.action is DiffAction.UPDATED
     assert {elem.action for elem in diff_rel.relationships} == {DiffAction.ADDED, DiffAction.REMOVED}
+
+
+async def test_relationship_property_change_after_relationship_removed_from_base_schema(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main: Node,
+    person_john_main: Node,
+    person_alfred_main: Node,
+) -> None:
+    """Diff must resolve the peer when the relationship was removed from the base branch schema.
+
+    Removing a relationship from the schema runs a no-op migration, so existing Relationship
+    vertices keep their identifier while the base schema no longer knows it. When the diff branch
+    then changes a non-peer property (source) of that relationship, the peer-side path resolves
+    only against the diff branch schema; the diff must still identify the peer.
+    """
+    branch = await create_branch(db=db, branch_name="branch-rel-removed-base")
+    from_time = Timestamp(branch.created_at)
+
+    # On the diff branch (still has the owner relationship): set owner.source = alfred.
+    branch_car = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await branch_car.get_relationship("owner").update(
+        db=db, data={"id": person_john_main.id, "_relation__source": person_alfred_main.id}
+    )
+    await branch_car.save(db=db)
+
+    # On the base branch: remove the owner/cars relationship from the schema. The migration is a
+    # no-op, so the Relationship vertices and their edges remain in the graph.
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate = schema.duplicate()
+    car_schema = candidate.get_node(name="TestCar")
+    car_schema.relationships = [r for r in car_schema.relationships if r.name != "owner"]
+    person_schema = candidate.get_node(name="TestPerson")
+    person_schema.relationships = [r for r in person_schema.relationships if r.name != "cars"]
+    registry.schema.set(name="TestCar", schema=car_schema, branch=default_branch.name)
+    registry.schema.set(name="TestPerson", schema=person_schema, branch=default_branch.name)
+
+    diff_calculator = DiffCalculator(db=db)
+    # Must not raise DiffNoPeerIdError.
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+        include_unchanged=False,
+    )
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    nodes_by_uuid = {n.uuid: n for n in branch_diff.nodes}
+    car_node = nodes_by_uuid[car_accord_main.id]
+    assert car_node.action is DiffAction.UPDATED
+
+    rels_by_name = {r.name: r for r in car_node.relationships}
+    assert set(rels_by_name) == {"owner"}
+    owner_rel = rels_by_name["owner"]
+    assert owner_rel.identifier == "testcar__testperson"
+    assert owner_rel.cardinality is RelationshipCardinality.ONE
+    assert owner_rel.action is DiffAction.UPDATED
+    assert len(owner_rel.relationships) == 1
+
+    element = owner_rel.relationships[0]
+    assert element.peer_id == person_john_main.id
+    assert element.action is DiffAction.UPDATED
+
+    props_by_type = {p.property_type: p for p in element.properties}
+    assert set(props_by_type) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.HAS_SOURCE}
+
+    is_related = props_by_type[DatabaseEdgeType.IS_RELATED]
+    assert is_related.action is DiffAction.UNCHANGED
+    assert is_related.previous_value == person_john_main.id
+    assert is_related.new_value == person_john_main.id
+
+    has_source = props_by_type[DatabaseEdgeType.HAS_SOURCE]
+    assert has_source.action is DiffAction.ADDED
+    assert has_source.previous_value is None
+    assert has_source.new_value == person_alfred_main.id

--- a/changelog/+diff-relationship-peer-schema-change.fixed.md
+++ b/changelog/+diff-relationship-peer-schema-change.fixed.md
@@ -1,0 +1,1 @@
+Fix diff calculation to correctly handle the case when a relationship was removed from a branch's schema while the other branch changed a non-peer property (source, owner, or protected flag) of that relationship. This issue would have previously appeared as a `DiffNoPeerIdError`.


### PR DESCRIPTION

`DiffQueryParser._get_relationship_schema()` only checked the base branch schema as a fallback for diff-branch paths. When a relationship was removed from (or its identifier changed in) one branch's schema, the peer-side path of that relationship is rooted on the branch that no longer knows the identifier, so its schema lookup failed and the peer was dropped from the diff, raising `DiffNoPeerIdError` during diff/rebase.

Fall back to both the diff and base branch schemas so the peer resolves against whichever branch still defines the relationship.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix peer resolution in diffs when a relationship is removed or its identifier changes on one branch. We now check both branches’ schemas so peers are not dropped and `DiffNoPeerIdError` is avoided during diff/rebase.

- **Bug Fixes**
  - Update `DiffQueryParser._get_relationship_schema()` to prefer the path’s branch and fall back to both the diff and base schemas.
  - Add test covering schema removal on base with a non-peer property update on diff; add changelog entry.

<sup>Written for commit 02c6780209e50383e0d30bfb2dcce3ffa43b6403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

