### PR TITLE
feat(git): compute and store definition fingerprints during import

### DIFF
--- a/backend/infrahub/git/fingerprint/__init__.py
+++ b/backend/infrahub/git/fingerprint/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic content fingerprints for imported definition kinds."""

--- a/backend/infrahub/git/fingerprint/blob_resolver.py
+++ b/backend/infrahub/git/fingerprint/blob_resolver.py
@@ -1,0 +1,44 @@
+"""Resolve repo-relative paths to their git blob SHAs from the tree at a commit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from git import Repo
+
+
+class BlobResolver(Protocol):
+    """Resolve repo-relative paths to sorted `(path, blob_sha)` pairs."""
+
+    def resolve(self, paths: Sequence[str]) -> list[tuple[str, str]]: ...
+
+
+class GitBlobResolver:
+    """Resolve `(repo_relative_path, git_blob_sha)` pairs from the git tree at a commit.
+
+    Only git metadata (the tree entries) is read; file contents are never loaded.
+    """
+
+    def __init__(self, *, repo: Repo, commit: str) -> None:
+        self._repo = repo
+        self._commit = commit
+
+    def resolve(self, paths: Sequence[str]) -> list[tuple[str, str]]:
+        """Return the sorted `(path, blob_sha)` pairs for the given paths.
+
+        A path with no corresponding tree entry resolves to an empty SHA so the path
+        still contributes to the ordering and reappears distinctly once it is tracked.
+        """
+        tree = self._repo.commit(self._commit).tree
+        resolved: list[tuple[str, str]] = []
+        for path in paths:
+            try:
+                entry = tree / path
+            except KeyError:
+                resolved.append((path, ""))
+                continue
+            resolved.append((path, entry.hexsha))
+        return sorted(resolved)

--- a/backend/infrahub/git/fingerprint/composer.py
+++ b/backend/infrahub/git/fingerprint/composer.py
@@ -1,0 +1,215 @@
+"""Layered composers that turn a definition's output-affecting inputs into a fingerprint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, assert_never
+
+from infrahub.git.closure_builder.post_processing import MANIFEST_PATH
+from infrahub.git.fingerprint.blob_resolver import GitBlobResolver
+from infrahub.git.fingerprint.hasher import FingerprintHasher, canonical_json
+from infrahub.git.fingerprint.registry import FingerprintKind, FingerprintRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from git import Repo
+    from infrahub_sdk.schema.repository import InfrahubWatchConfig
+
+    from infrahub.git.fingerprint.blob_resolver import BlobResolver
+
+
+def fold_commit_id(*, commit: str, watch: InfrahubWatchConfig | None, closure_complete: bool) -> str | None:
+    """Return the commit id to fold into a fingerprint, or None to omit it.
+
+    The commit id is folded (making the fingerprint change on every commit, the safe
+    over-regenerating default) whenever the definition's inputs cannot be pinned down:
+
+    - `watch` is absent (`None`): the definition has not declared its dependencies.
+    - the dependency closure is incomplete: some output-affecting dependency could not be
+      resolved, so hashing only the resolved paths would leave the fingerprint stable over
+      an input the system already knows is unknown - an under-regeneration risk.
+
+    Only a definition with a present `watch` and a complete closure omits the commit id and
+    gets a stable, precise fingerprint.
+    """
+    if watch is None or not closure_complete:
+        return commit
+    return None
+
+
+class ClosurePathSelector:
+    """Select the dependency paths that contribute to a fingerprint's hashed closure.
+
+    The manifest is excluded even though it is merged into every definition's stored
+    dependencies: its blob changes on any unrelated or comment-only edit, which would churn
+    every definition's fingerprint. Its output-affecting fields are folded in separately as
+    parsed scalars, so dropping its bytes keeps the fingerprint stable against manifest
+    noise while remaining sensitive to the fields that actually matter.
+    """
+
+    def __init__(self, *, excluded_paths: frozenset[str]) -> None:
+        self._excluded_paths = excluded_paths
+
+    def select(self, dependencies: Iterable[str]) -> list[str]:
+        return [path for path in dependencies if path not in self._excluded_paths]
+
+
+@dataclass(frozen=True, kw_only=True)
+class QueryFingerprintInput:
+    name: str
+    query_text: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class PythonTransformationFingerprintInput:
+    name: str
+    query_name: str
+    dependencies: tuple[str, ...]
+    dependencies_complete: bool
+    watch: InfrahubWatchConfig | None
+    class_name: str
+    convert_query_response: bool
+
+
+@dataclass(frozen=True, kw_only=True)
+class Jinja2TransformationFingerprintInput:
+    name: str
+    query_name: str
+    dependencies: tuple[str, ...]
+    dependencies_complete: bool
+    watch: InfrahubWatchConfig | None
+    template_path: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ArtifactDefinitionFingerprintInput:
+    name: str
+    transformation_name: str
+    parameters: dict[str, Any]
+    content_type: str
+    artifact_name: str | None
+    target_group_id: str | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class GeneratorDefinitionFingerprintInput:
+    name: str
+    query_name: str
+    dependencies: tuple[str, ...]
+    dependencies_complete: bool
+    watch: InfrahubWatchConfig | None
+    parameters: dict[str, Any]
+    class_name: str
+    convert_query_response: bool
+    target_group_id: str | None
+
+
+class FingerprintComposer:
+    """Compose the fingerprint for each definition kind from its output-affecting inputs.
+
+    Every entry method both returns the digest and records it in the registry, so a
+    higher layer within the same import reads the freshly-computed value.
+    """
+
+    def __init__(
+        self,
+        *,
+        hasher: FingerprintHasher,
+        blob_resolver: BlobResolver,
+        registry: FingerprintRegistry,
+        closure_selector: ClosurePathSelector,
+        commit: str,
+    ) -> None:
+        self._hasher = hasher
+        self._blob_resolver = blob_resolver
+        self._registry = registry
+        self._closure_selector = closure_selector
+        self._commit = commit
+
+    @property
+    def registry(self) -> FingerprintRegistry:
+        return self._registry
+
+    def compose_query(self, inputs: QueryFingerprintInput) -> str:
+        fingerprint = self._hasher.hash([f"query_text={inputs.query_text}"])
+        self._registry.register(kind=FingerprintKind.QUERY, name=inputs.name, fingerprint=fingerprint)
+        return fingerprint
+
+    def compose_transformation(
+        self, inputs: PythonTransformationFingerprintInput | Jinja2TransformationFingerprintInput
+    ) -> str:
+        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name) or ""
+        terms = [
+            f"query_fingerprint={query_fingerprint}",
+            f"closure={self._closure_term(inputs.dependencies)}",
+        ]
+        match inputs:
+            case PythonTransformationFingerprintInput():
+                terms.append(f"class_name={inputs.class_name}")
+                terms.append(f"convert_query_response={inputs.convert_query_response}")
+            case Jinja2TransformationFingerprintInput():
+                terms.append(f"template_path={inputs.template_path}")
+            case _:  # pragma: no cover - exhaustiveness guard for a new transform kind
+                assert_never(inputs)
+
+        commit_term = fold_commit_id(
+            commit=self._commit, watch=inputs.watch, closure_complete=inputs.dependencies_complete
+        )
+        if commit_term is not None:
+            terms.append(f"commit_id={commit_term}")
+
+        fingerprint = self._hasher.hash(terms)
+        self._registry.register(kind=FingerprintKind.TRANSFORMATION, name=inputs.name, fingerprint=fingerprint)
+        return fingerprint
+
+    def compose_artifact_definition(self, inputs: ArtifactDefinitionFingerprintInput) -> str:
+        transformation_fingerprint = (
+            self._registry.get(kind=FingerprintKind.TRANSFORMATION, name=inputs.transformation_name) or ""
+        )
+        terms = [
+            f"transformation_fingerprint={transformation_fingerprint}",
+            f"parameters={canonical_json(inputs.parameters)}",
+            f"content_type={inputs.content_type}",
+            f"artifact_name={inputs.artifact_name}",
+            f"target_group_id={inputs.target_group_id}",
+        ]
+        fingerprint = self._hasher.hash(terms)
+        self._registry.register(kind=FingerprintKind.ARTIFACT_DEFINITION, name=inputs.name, fingerprint=fingerprint)
+        return fingerprint
+
+    def compose_generator_definition(self, inputs: GeneratorDefinitionFingerprintInput) -> str:
+        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name) or ""
+        terms = [
+            f"query_fingerprint={query_fingerprint}",
+            f"closure={self._closure_term(inputs.dependencies)}",
+            f"parameters={canonical_json(inputs.parameters)}",
+            f"class_name={inputs.class_name}",
+            f"convert_query_response={inputs.convert_query_response}",
+            f"target_group_id={inputs.target_group_id}",
+        ]
+        commit_term = fold_commit_id(
+            commit=self._commit, watch=inputs.watch, closure_complete=inputs.dependencies_complete
+        )
+        if commit_term is not None:
+            terms.append(f"commit_id={commit_term}")
+
+        fingerprint = self._hasher.hash(terms)
+        self._registry.register(kind=FingerprintKind.GENERATOR_DEFINITION, name=inputs.name, fingerprint=fingerprint)
+        return fingerprint
+
+    def _closure_term(self, dependencies: Iterable[str]) -> str:
+        hashed_paths = self._closure_selector.select(dependencies)
+        pairs = self._blob_resolver.resolve(hashed_paths)
+        return canonical_json([[path, blob_sha] for path, blob_sha in pairs])
+
+
+def build_fingerprint_composer(*, repo: Repo, commit: str) -> FingerprintComposer:
+    """Wire a fingerprint composer for a single import against the pinned commit worktree."""
+    return FingerprintComposer(
+        hasher=FingerprintHasher(),
+        blob_resolver=GitBlobResolver(repo=repo, commit=commit),
+        registry=FingerprintRegistry(),
+        closure_selector=ClosurePathSelector(excluded_paths=frozenset({MANIFEST_PATH})),
+        commit=commit,
+    )

--- a/backend/infrahub/git/fingerprint/composer.py
+++ b/backend/infrahub/git/fingerprint/composer.py
@@ -139,9 +139,9 @@ class FingerprintComposer:
     def compose_transformation(
         self, inputs: PythonTransformationFingerprintInput | Jinja2TransformationFingerprintInput
     ) -> str:
-        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name) or ""
+        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name)
         terms = [
-            f"query_fingerprint={query_fingerprint}",
+            f"query_fingerprint={query_fingerprint or ''}",
             f"closure={self._closure_term(inputs.dependencies)}",
         ]
         match inputs:
@@ -153,8 +153,10 @@ class FingerprintComposer:
             case _:  # pragma: no cover - exhaustiveness guard for a new transform kind
                 assert_never(inputs)
 
-        commit_term = fold_commit_id(
-            commit=self._commit, watch=inputs.watch, closure_complete=inputs.dependencies_complete
+        commit_term = self._resolve_commit_term(
+            watch=inputs.watch,
+            closure_complete=inputs.dependencies_complete,
+            upstream_resolved=query_fingerprint is not None,
         )
         if commit_term is not None:
             terms.append(f"commit_id={commit_term}")
@@ -179,17 +181,19 @@ class FingerprintComposer:
         return fingerprint
 
     def compose_generator_definition(self, inputs: GeneratorDefinitionFingerprintInput) -> str:
-        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name) or ""
+        query_fingerprint = self._registry.get(kind=FingerprintKind.QUERY, name=inputs.query_name)
         terms = [
-            f"query_fingerprint={query_fingerprint}",
+            f"query_fingerprint={query_fingerprint or ''}",
             f"closure={self._closure_term(inputs.dependencies)}",
             f"parameters={canonical_json(inputs.parameters)}",
             f"class_name={inputs.class_name}",
             f"convert_query_response={inputs.convert_query_response}",
             f"target_group_id={inputs.target_group_id}",
         ]
-        commit_term = fold_commit_id(
-            commit=self._commit, watch=inputs.watch, closure_complete=inputs.dependencies_complete
+        commit_term = self._resolve_commit_term(
+            watch=inputs.watch,
+            closure_complete=inputs.dependencies_complete,
+            upstream_resolved=query_fingerprint is not None,
         )
         if commit_term is not None:
             terms.append(f"commit_id={commit_term}")
@@ -197,6 +201,18 @@ class FingerprintComposer:
         fingerprint = self._hasher.hash(terms)
         self._registry.register(kind=FingerprintKind.GENERATOR_DEFINITION, name=inputs.name, fingerprint=fingerprint)
         return fingerprint
+
+    def _resolve_commit_term(
+        self, *, watch: InfrahubWatchConfig | None, closure_complete: bool, upstream_resolved: bool
+    ) -> str | None:
+        """Return the commit-id term for a transform/generator, or None to omit it.
+
+        A referenced upstream fingerprint that is absent from the same-import registry is an
+        unresolved output-affecting input, so it is treated exactly like an incomplete closure:
+        the commit id is folded in and the fingerprint can never be stable over an upstream it
+        could not read.
+        """
+        return fold_commit_id(commit=self._commit, watch=watch, closure_complete=closure_complete and upstream_resolved)
 
     def _closure_term(self, dependencies: Iterable[str]) -> str:
         hashed_paths = self._closure_selector.select(dependencies)

--- a/backend/infrahub/git/fingerprint/hasher.py
+++ b/backend/infrahub/git/fingerprint/hasher.py
@@ -15,8 +15,11 @@ def canonical_json(value: Any) -> str:
 
     Keys are sorted and all insignificant whitespace is removed so that logically
     identical values always produce the same string regardless of ordering.
+
+    A non-JSON-serializable value raises rather than being coerced, so a value whose
+    string form is run-specific can never silently destabilise the digest.
     """
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
 class FingerprintHasher:

--- a/backend/infrahub/git/fingerprint/hasher.py
+++ b/backend/infrahub/git/fingerprint/hasher.py
@@ -1,0 +1,36 @@
+"""Deterministic SHA-256 hashing and canonicalisation helpers for fingerprint composition."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def canonical_json(value: Any) -> str:
+    """Serialise a structured value to canonical JSON.
+
+    Keys are sorted and all insignificant whitespace is removed so that logically
+    identical values always produce the same string regardless of ordering.
+    """
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+class FingerprintHasher:
+    """Compute a stable SHA-256 hex digest over an ordered sequence of canonical terms.
+
+    Each term is length-prefixed before being folded into the digest so that no
+    combination of term boundaries can be confused with another (the serialisation
+    is injective across the term list).
+    """
+
+    def hash(self, terms: Sequence[str]) -> str:
+        digest = hashlib.sha256()
+        for term in terms:
+            encoded = term.encode("utf-8")
+            digest.update(f"{len(encoded)}:".encode("ascii"))
+            digest.update(encoded)
+        return digest.hexdigest()

--- a/backend/infrahub/git/fingerprint/registry.py
+++ b/backend/infrahub/git/fingerprint/registry.py
@@ -1,0 +1,29 @@
+"""Per-import in-memory snapshot of freshly-computed fingerprints."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class FingerprintKind(StrEnum):
+    QUERY = "query"
+    TRANSFORMATION = "transformation"
+    ARTIFACT_DEFINITION = "artifact_definition"
+    GENERATOR_DEFINITION = "generator_definition"
+
+
+class FingerprintRegistry:
+    """A `{(kind, name): fingerprint}` snapshot populated in dependency order within one import.
+
+    Higher layers read the value computed earlier in the same import, so a dependent
+    fingerprint never lags a previously-stored graph value by an import.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[FingerprintKind, str], str] = {}
+
+    def register(self, *, kind: FingerprintKind, name: str, fingerprint: str) -> None:
+        self._store[kind, name] = fingerprint
+
+    def get(self, *, kind: FingerprintKind, name: str) -> str | None:
+        return self._store.get((kind, name))

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -31,6 +31,7 @@ from infrahub_sdk.schema.repository import (
     InfrahubJinja2TransformConfig,
     InfrahubPythonTransformConfig,
     InfrahubRepositoryConfig,
+    InfrahubWatchConfig,
 )
 from infrahub_sdk.spec.menu import MenuFile
 from infrahub_sdk.spec.object import ObjectFile
@@ -63,6 +64,15 @@ from infrahub.exceptions import (
 )
 from infrahub.git.base import InfrahubRepositoryBase, extract_repo_file_information
 from infrahub.git.closure_builder.dispatcher import build_default_closure_builder
+from infrahub.git.fingerprint.composer import (
+    ArtifactDefinitionFingerprintInput,
+    FingerprintComposer,
+    GeneratorDefinitionFingerprintInput,
+    Jinja2TransformationFingerprintInput,
+    PythonTransformationFingerprintInput,
+    QueryFingerprintInput,
+    build_fingerprint_composer,
+)
 from infrahub.log import get_logger
 from infrahub.workers.dependencies import get_event_service
 from infrahub.workflows.utils import add_tags
@@ -157,6 +167,9 @@ class TransformPythonInformation(BaseModel):
 
     description: str | None = None
     """Description of the Transform"""
+
+    watch: InfrahubWatchConfig | None = None
+    """The `watch` config declared in the manifest, driving fingerprint stability."""
 
     dependencies: list[str] = Field(default_factory=list)
     dependencies_complete: bool = False
@@ -308,6 +321,12 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         sync_status = RepositorySyncStatus.IN_SYNC
         error: Exception | None = None
 
+        # A single composer instance is threaded through every phase so a dependent
+        # definition composes the fingerprint freshly computed for its inputs in the
+        # same import, in dependency order: queries, then transformations and generator
+        # definitions, then artifact definitions.
+        fingerprint_composer = self._build_fingerprint_composer(commit=plan.commit)
+
         try:
             await self.import_schema_files(
                 branch_name=plan.infrahub_branch_name, commit=plan.commit, config_file=plan.config_file
@@ -315,15 +334,21 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             if plan.config_file.schemas:
                 await self.sdk.schema.all(branch=plan.infrahub_branch_name, refresh=True)
             await self._apply_graphql_query_definitions(
-                branch_name=plan.infrahub_branch_name, local_queries=plan.query_strings
+                branch_name=plan.infrahub_branch_name,
+                local_queries=plan.query_strings,
+                fingerprint_composer=fingerprint_composer,
             )
             # Transforms must be registered before objects so that an object referencing a transform
             # defined in the same repository resolves during import.
             await self._apply_python_transform_definitions(
-                branch_name=plan.infrahub_branch_name, definitions=plan.transform_definitions
+                branch_name=plan.infrahub_branch_name,
+                definitions=plan.transform_definitions,
+                fingerprint_composer=fingerprint_composer,
             )
             await self._apply_jinja2_transform_definitions(
-                branch_name=plan.infrahub_branch_name, local_transforms=plan.jinja2_definitions
+                branch_name=plan.infrahub_branch_name,
+                local_transforms=plan.jinja2_definitions,
+                fingerprint_composer=fingerprint_composer,
             )
             await self.import_objects(
                 branch_name=plan.infrahub_branch_name,
@@ -336,10 +361,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 branch_name=plan.infrahub_branch_name, definitions=plan.check_definitions
             )
             await self._apply_generator_definitions(
-                branch_name=plan.infrahub_branch_name, definitions=plan.generator_definitions
+                branch_name=plan.infrahub_branch_name,
+                definitions=plan.generator_definitions,
+                fingerprint_composer=fingerprint_composer,
             )
             await self._apply_artifact_definitions(
-                branch_name=plan.infrahub_branch_name, local_artifact_defs=plan.artifact_definitions
+                branch_name=plan.infrahub_branch_name,
+                local_artifact_defs=plan.artifact_definitions,
+                fingerprint_composer=fingerprint_composer,
             )
 
         except Exception as exc:
@@ -366,6 +395,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             )
         )
 
+    def _build_fingerprint_composer(self, commit: str) -> FingerprintComposer:
+        """Wire a fingerprint composer against the pinned commit worktree for one import."""
+        return build_fingerprint_composer(repo=self.get_git_repo_worktree(identifier=commit), commit=commit)
+
     @task(name="import-jinja2-transforms", task_run_name="Import Jinja2 transform", cache_policy=NONE)
     async def import_jinja2_transforms(
         self,
@@ -376,7 +409,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         local_transforms = await self._build_jinja2_transform_definitions(
             branch_name=branch_name, commit=commit, config_file=config_file
         )
-        await self._apply_jinja2_transform_definitions(branch_name=branch_name, local_transforms=local_transforms)
+        await self._apply_jinja2_transform_definitions(
+            branch_name=branch_name,
+            local_transforms=local_transforms,
+            fingerprint_composer=self._build_fingerprint_composer(commit=commit),
+        )
 
     async def _build_jinja2_transform_definitions(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
@@ -427,7 +464,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return local_transforms
 
     async def _apply_jinja2_transform_definitions(
-        self, branch_name: str, local_transforms: dict[str, InfrahubRepositoryJinja2]
+        self,
+        branch_name: str,
+        local_transforms: dict[str, InfrahubRepositoryJinja2],
+        fingerprint_composer: FingerprintComposer,
     ) -> None:
         """Reconcile the desired Jinja2 transform definitions against the graph: create, update, delete.
 
@@ -435,6 +475,22 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         concurrent import of the same repository.
         """
         log = get_run_logger()
+
+        # Compose the fingerprint while the query reference is still the query name, so the
+        # connected query's freshly-computed fingerprint can be looked up in the registry.
+        transform_fingerprints = {
+            transform.name: fingerprint_composer.compose_transformation(
+                Jinja2TransformationFingerprintInput(
+                    name=transform.name,
+                    query_name=str(transform.query),
+                    dependencies=tuple(transform.dependencies),
+                    dependencies_complete=transform.dependencies_complete,
+                    watch=transform.watch,
+                    template_path=transform.template_path_value,
+                )
+            )
+            for transform in local_transforms.values()
+        }
 
         # Resolve each query reference to its node id now that the queries have been applied.
         for transform in local_transforms.values():
@@ -456,26 +512,37 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for transform_name in only_local:
             log.info(f"New Jinja2 Transform {transform_name!r} found, creating")
-            await self.create_jinja2_transform(branch_name=branch_name, data=local_transforms[transform_name])
+            await self.create_jinja2_transform(
+                branch_name=branch_name,
+                data=local_transforms[transform_name],
+                fingerprint=transform_fingerprints[transform_name],
+            )
 
         for transform_name in present_in_both:
-            if not await self.compare_jinja2_transform(
-                existing_transform=transforms_in_graph[transform_name], local_transform=local_transforms[transform_name]
-            ):
+            existing_transform = transforms_in_graph[transform_name]
+            fingerprint = transform_fingerprints[transform_name]
+            unchanged = await self.compare_jinja2_transform(
+                existing_transform=existing_transform, local_transform=local_transforms[transform_name]
+            )
+            if not unchanged or existing_transform.fingerprint.value != fingerprint:
                 log.info(f"New version of the Jinja2 Transform '{transform_name}' found, updating")
                 await self.update_jinja2_transform(
-                    existing_transform=transforms_in_graph[transform_name],
+                    existing_transform=existing_transform,
                     local_transform=local_transforms[transform_name],
+                    fingerprint=fingerprint,
                 )
 
         for transform_name in only_graph:
             log.info(f"Jinja2 Transform '{transform_name}' not found locally in branch {branch_name}, deleting")
             await transforms_in_graph[transform_name].delete()
 
-    async def create_jinja2_transform(self, branch_name: str, data: InfrahubRepositoryJinja2) -> CoreTransformJinja2:
+    async def create_jinja2_transform(
+        self, branch_name: str, data: InfrahubRepositoryJinja2, fingerprint: str | None = None
+    ) -> CoreTransformJinja2:
         schema = await self.sdk.schema.get(kind=InfrahubKind.TRANSFORMJINJA2, branch=branch_name)
+        payload_data = {**data.payload, "fingerprint": fingerprint}
         create_payload = self.sdk.schema.generate_payload_create(
-            schema=schema, data=data.payload, source=self.id, is_protected=True
+            schema=schema, data=payload_data, source=self.id, is_protected=True
         )
         obj = await self.sdk.create(kind=CoreTransformJinja2, branch=branch_name, **create_payload)
         await obj.save()
@@ -497,8 +564,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return True
 
     async def update_jinja2_transform(
-        self, existing_transform: CoreTransformJinja2, local_transform: InfrahubRepositoryJinja2
+        self,
+        existing_transform: CoreTransformJinja2,
+        local_transform: InfrahubRepositoryJinja2,
+        fingerprint: str | None = None,
     ) -> None:
+        if fingerprint is not None and existing_transform.fingerprint.value != fingerprint:
+            existing_transform.fingerprint.value = fingerprint
+
         if existing_transform.description.value != local_transform.description:
             existing_transform.description.value = local_transform.description
 
@@ -520,11 +593,15 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def import_artifact_definitions(
         self,
         branch_name: str,
-        commit: str,  # noqa: ARG002
+        commit: str,
         config_file: InfrahubRepositoryConfig,
     ) -> None:
         local_artifact_defs = await self._build_artifact_definitions(branch_name=branch_name, config_file=config_file)
-        await self._apply_artifact_definitions(branch_name=branch_name, local_artifact_defs=local_artifact_defs)
+        await self._apply_artifact_definitions(
+            branch_name=branch_name,
+            local_artifact_defs=local_artifact_defs,
+            fingerprint_composer=self._build_fingerprint_composer(commit=commit),
+        )
 
     async def _build_artifact_definitions(
         self, branch_name: str, config_file: InfrahubRepositoryConfig
@@ -558,7 +635,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return local_artifact_defs
 
     async def _apply_artifact_definitions(
-        self, branch_name: str, local_artifact_defs: dict[str, InfrahubRepositoryArtifactDefinitionConfig]
+        self,
+        branch_name: str,
+        local_artifact_defs: dict[str, InfrahubRepositoryArtifactDefinitionConfig],
+        fingerprint_composer: FingerprintComposer,
     ) -> None:
         """Reconcile the desired artifact definitions against the graph by creating and updating.
 
@@ -566,6 +646,22 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         concurrent import of the same repository.
         """
         log = get_run_logger()
+
+        artifact_fingerprints = {
+            artdef_name: fingerprint_composer.compose_artifact_definition(
+                ArtifactDefinitionFingerprintInput(
+                    name=artdef_name,
+                    transformation_name=artdef.transformation,
+                    parameters=artdef.parameters,
+                    content_type=artdef.content_type,
+                    artifact_name=artdef.artifact_name,
+                    target_group_id=await self._resolve_target_group_id(
+                        branch_name=branch_name, group_name=artdef.targets
+                    ),
+                )
+            )
+            for artdef_name, artdef in local_artifact_defs.items()
+        }
 
         artifact_defs_in_graph = {
             artdef.name.value: artdef
@@ -580,25 +676,37 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for artdef_name in only_local:
             log.info(f"New Artifact Definition {artdef_name!r} found, creating")
-            await self.create_artifact_definition(branch_name=branch_name, data=local_artifact_defs[artdef_name])
+            await self.create_artifact_definition(
+                branch_name=branch_name,
+                data=local_artifact_defs[artdef_name],
+                fingerprint=artifact_fingerprints[artdef_name],
+            )
 
         for artdef_name in present_in_both:
-            if not await self.compare_artifact_definition(
-                existing_artifact_definition=artifact_defs_in_graph[artdef_name],
+            existing_artifact_definition = artifact_defs_in_graph[artdef_name]
+            fingerprint = artifact_fingerprints[artdef_name]
+            unchanged = await self.compare_artifact_definition(
+                existing_artifact_definition=existing_artifact_definition,
                 local_artifact_definition=local_artifact_defs[artdef_name],
-            ):
+            )
+            if not unchanged or existing_artifact_definition.fingerprint.value != fingerprint:
                 log.info(f"New version of the Artifact Definition '{artdef_name}' found, updating")
                 await self.update_artifact_definition(
-                    existing_artifact_definition=artifact_defs_in_graph[artdef_name],
+                    existing_artifact_definition=existing_artifact_definition,
                     local_artifact_definition=local_artifact_defs[artdef_name],
+                    fingerprint=fingerprint,
                 )
 
     async def create_artifact_definition(
-        self, branch_name: str, data: InfrahubRepositoryArtifactDefinitionConfig
+        self,
+        branch_name: str,
+        data: InfrahubRepositoryArtifactDefinitionConfig,
+        fingerprint: str | None = None,
     ) -> InfrahubNode:
         schema = await self.sdk.schema.get(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch_name)
+        payload_data = {**data.model_dump(), "fingerprint": fingerprint}
         create_payload = self.sdk.schema.generate_payload_create(
-            schema=schema, data=data.model_dump(), source=self.id, is_protected=True
+            schema=schema, data=payload_data, source=self.id, is_protected=True
         )
         obj = await self.sdk.create(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch_name, **create_payload)
         await obj.save()
@@ -624,7 +732,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         self,
         existing_artifact_definition: CoreArtifactDefinition,
         local_artifact_definition: InfrahubRepositoryArtifactDefinitionConfig,
+        fingerprint: str | None = None,
     ) -> None:
+        if fingerprint is not None and existing_artifact_definition.fingerprint.value != fingerprint:
+            existing_artifact_definition.fingerprint.value = fingerprint
+
         if existing_artifact_definition.artifact_name.value != local_artifact_definition.artifact_name:
             existing_artifact_definition.artifact_name.value = local_artifact_definition.artifact_name
 
@@ -789,7 +901,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         """
         local_queries = await self._build_graphql_query_definitions(commit=commit, config_file=config_file)
-        await self._apply_graphql_query_definitions(branch_name=branch_name, local_queries=local_queries)
+        await self._apply_graphql_query_definitions(
+            branch_name=branch_name,
+            local_queries=local_queries,
+            fingerprint_composer=self._build_fingerprint_composer(commit=commit),
+        )
 
     async def _build_graphql_query_definitions(
         self, commit: str, config_file: InfrahubRepositoryConfig
@@ -820,13 +936,25 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         return local_queries
 
-    async def _apply_graphql_query_definitions(self, branch_name: str, local_queries: dict[str, str]) -> None:
+    async def _apply_graphql_query_definitions(
+        self, branch_name: str, local_queries: dict[str, str], fingerprint_composer: FingerprintComposer
+    ) -> None:
         """Reconcile the desired GraphQL queries against the graph by creating, updating and deleting.
 
         Mutates graph nodes whose names are globally unique, so it must run serialized against any
         concurrent import of the same repository.
         """
         log = get_run_logger()
+
+        # Every local query fingerprint is computed and registered so a transformation or
+        # generator importing later in the same run reads the freshly-computed value, even
+        # for queries whose text is unchanged and whose node is therefore not re-saved.
+        query_fingerprints = {
+            query_name: fingerprint_composer.compose_query(
+                QueryFingerprintInput(name=query_name, query_text=query_text)
+            )
+            for query_name, query_text in local_queries.items()
+        }
 
         if not local_queries:
             return
@@ -845,14 +973,23 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         for query_name in only_local:
             query = local_queries[query_name]
             log.info(f"New Graphql Query {query_name!r} found, creating")
-            await self.create_graphql_query(branch_name=branch_name, name=query_name, query_string=query)
+            await self.create_graphql_query(
+                branch_name=branch_name, name=query_name, query_string=query, fingerprint=query_fingerprints[query_name]
+            )
 
         for query_name in present_in_both:
             local_query = local_queries[query_name]
             graph_query = queries_in_graph[query_name]
+            fingerprint = query_fingerprints[query_name]
+            changed = False
             if local_query != graph_query.query.value:
                 log.info(f"New version of the Graphql Query {query_name!r} found, updating")
                 graph_query.query.value = local_query
+                changed = True
+            if graph_query.fingerprint.value != fingerprint:
+                graph_query.fingerprint.value = fingerprint
+                changed = True
+            if changed:
                 await graph_query.save()
 
         for query_name in only_graph:
@@ -860,8 +997,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             log.info(f"Graphql Query {query_name!r} not found locally, deleting")
             await graph_query.delete()
 
-    async def create_graphql_query(self, branch_name: str, name: str, query_string: str) -> CoreGraphQLQuery:
-        data = {"name": name, "query": query_string, "repository": self.id}
+    async def create_graphql_query(
+        self, branch_name: str, name: str, query_string: str, fingerprint: str | None = None
+    ) -> CoreGraphQLQuery:
+        data = {"name": name, "query": query_string, "repository": self.id, "fingerprint": fingerprint}
 
         schema = await self.sdk.schema.get(kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name)
         create_payload = self.sdk.schema.generate_payload_create(
@@ -987,7 +1126,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         definitions = await self._build_generator_definitions(
             branch_name=branch_name, commit=commit, config_file=config_file
         )
-        await self._apply_generator_definitions(branch_name=branch_name, definitions=definitions)
+        await self._apply_generator_definitions(
+            branch_name=branch_name,
+            definitions=definitions,
+            fingerprint_composer=self._build_fingerprint_composer(commit=commit),
+        )
 
     async def _build_generator_definitions(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
@@ -1032,6 +1175,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         self,
         branch_name: str,
         definitions: list[GeneratorDefinitionWithClosure],
+        fingerprint_composer: FingerprintComposer,
     ) -> None:
         """Reconcile the desired generator definitions against the graph by creating, updating and deleting.
 
@@ -1041,6 +1185,28 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         log = get_run_logger()
 
         local_generator_definitions = {definition.config.name: definition for definition in definitions}
+
+        # Compose fingerprints before the query/target references are resolved to node ids,
+        # while the config still carries the query name used for the registry lookup.
+        generator_fingerprints = {
+            generator_name: fingerprint_composer.compose_generator_definition(
+                GeneratorDefinitionFingerprintInput(
+                    name=generator_name,
+                    query_name=str(definition.config.query),
+                    dependencies=tuple(definition.closure.dependencies),
+                    dependencies_complete=definition.closure.complete,
+                    watch=definition.config.watch,
+                    parameters=definition.config.parameters,
+                    class_name=definition.config.class_name,
+                    convert_query_response=definition.config.convert_query_response,
+                    target_group_id=await self._resolve_target_group_id(
+                        branch_name=branch_name, group_name=definition.config.targets
+                    ),
+                )
+            )
+            for generator_name, definition in local_generator_definitions.items()
+        }
+
         generator_definition_in_graph = {
             generator.name.value: generator
             for generator in await self.sdk.filters(
@@ -1059,27 +1225,43 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 branch_name=branch_name,
                 generator=definition.config,
                 closure=definition.closure,
+                fingerprint=generator_fingerprints[generator_name],
             )
 
         for generator_name in present_in_both:
             definition = local_generator_definitions[generator_name]
-            if await self._generator_requires_update(
+            existing_generator = generator_definition_in_graph[generator_name]
+            fingerprint = generator_fingerprints[generator_name]
+            requires_update = await self._generator_requires_update(
                 generator=definition.config,
-                existing_generator=generator_definition_in_graph[generator_name],
+                existing_generator=existing_generator,
                 branch_name=branch_name,
                 closure=definition.closure,
-            ):
+            )
+            if requires_update or existing_generator.fingerprint.value != fingerprint:
                 log.info(f"New version of GeneratorDefinition {generator_name!r} found, updating")
 
                 await self._update_generator_definition(
                     generator=definition.config,
-                    existing_generator=generator_definition_in_graph[generator_name],
+                    existing_generator=existing_generator,
                     closure=definition.closure,
+                    fingerprint=fingerprint,
                 )
 
         for generator_name in only_graph:
             log.info(f"GeneratorDefinition '{generator_name!r}' not found locally, deleting")
             await generator_definition_in_graph[generator_name].delete()
+
+    async def _resolve_target_group_id(self, branch_name: str, group_name: str) -> str | None:
+        """Resolve a target group name to its node id for the group-identity fingerprint term."""
+        targets = await self.sdk.filters(
+            kind=InfrahubKind.GENERICGROUP,
+            branch=branch_name,
+            name__value=group_name,
+            populate_store=True,
+            fragment=True,
+        )
+        return targets[0].id if targets else None
 
     async def _generator_requires_update(
         self,
@@ -1125,7 +1307,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         definitions = await self._build_python_transform_definitions(
             branch_name=branch_name, commit=commit, config_file=config_file
         )
-        await self._apply_python_transform_definitions(branch_name=branch_name, definitions=definitions)
+        await self._apply_python_transform_definitions(
+            branch_name=branch_name,
+            definitions=definitions,
+            fingerprint_composer=self._build_fingerprint_composer(commit=commit),
+        )
 
     async def _build_python_transform_definitions(
         self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
@@ -1183,7 +1369,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return transforms
 
     async def _apply_python_transform_definitions(
-        self, branch_name: str, definitions: list[TransformPythonInformation]
+        self,
+        branch_name: str,
+        definitions: list[TransformPythonInformation],
+        fingerprint_composer: FingerprintComposer,
     ) -> None:
         """Reconcile the desired transform definitions against the graph by creating, updating and deleting.
 
@@ -1192,6 +1381,23 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         """
         log = get_run_logger()
         local_transform_definitions = {transform.name: transform for transform in definitions}
+
+        # Compose the fingerprint while the query reference is still the query name, so the
+        # connected query's freshly-computed fingerprint can be looked up in the registry.
+        transform_fingerprints = {
+            transform.name: fingerprint_composer.compose_transformation(
+                PythonTransformationFingerprintInput(
+                    name=transform.name,
+                    query_name=str(transform.query),
+                    dependencies=tuple(transform.dependencies),
+                    dependencies_complete=transform.dependencies_complete,
+                    watch=transform.watch,
+                    class_name=transform.class_name,
+                    convert_query_response=transform.convert_query_response,
+                )
+            )
+            for transform in local_transform_definitions.values()
+        }
 
         # Resolve each query reference to its node id now that the queries have been applied.
         for transform in local_transform_definitions.values():
@@ -1214,18 +1420,24 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         for transform_name in only_local:
             log.info(f"New TransformPython {transform_name!r} found, creating")
             await self.create_python_transform(
-                branch_name=branch_name, transform=local_transform_definitions[transform_name]
+                branch_name=branch_name,
+                transform=local_transform_definitions[transform_name],
+                fingerprint=transform_fingerprints[transform_name],
             )
 
         for transform_name in present_in_both:
-            if not await self.compare_python_transform(
+            existing_transform = transform_definition_in_graph[transform_name]
+            fingerprint = transform_fingerprints[transform_name]
+            unchanged = await self.compare_python_transform(
                 local_transform=local_transform_definitions[transform_name],
-                existing_transform=transform_definition_in_graph[transform_name],
-            ):
+                existing_transform=existing_transform,
+            )
+            if not unchanged or existing_transform.fingerprint.value != fingerprint:
                 log.info(f"New version of TransformPython {transform_name!r} found, updating")
                 await self.update_python_transform(
                     local_transform=local_transform_definitions[transform_name],
-                    existing_transform=transform_definition_in_graph[transform_name],
+                    existing_transform=existing_transform,
+                    fingerprint=fingerprint,
                 )
 
         for transform_name in only_graph:
@@ -1373,6 +1585,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                     timeout=transform_class.timeout,
                     convert_query_response=transform.convert_query_response,
                     description=transform.description,
+                    watch=transform.watch,
                     dependencies=dependencies,
                     dependencies_complete=dependencies_complete,
                 )
@@ -1387,7 +1600,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return transforms
 
     async def _create_generator_definition(
-        self, generator: InfrahubGeneratorDefinitionConfig, branch_name: str, closure: ClosureResult
+        self,
+        generator: InfrahubGeneratorDefinitionConfig,
+        branch_name: str,
+        closure: ClosureResult,
+        fingerprint: str | None = None,
     ) -> InfrahubNode:
         # `watch` is an SDK-config-only field that drives closure detection; it is not a
         # graph attribute, so it must not reach the node create payload.
@@ -1396,6 +1613,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         data["repository"] = self.id
         data["dependencies"] = list(closure.dependencies)
         data["dependencies_complete"] = closure.complete
+        data["fingerprint"] = fingerprint
 
         schema = await self.sdk.schema.get(kind=InfrahubKind.GENERATORDEFINITION, branch=branch_name)
 
@@ -1415,7 +1633,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         generator: InfrahubGeneratorDefinitionConfig,
         existing_generator: CoreGeneratorDefinition,
         closure: ClosureResult,
+        fingerprint: str | None = None,
     ) -> None:
+        if fingerprint is not None and existing_generator.fingerprint.value != fingerprint:
+            existing_generator.fingerprint.value = fingerprint
+
         if existing_generator.query.id != generator.query:
             existing_generator.query = {"id": generator.query, "source": str(self.id), "is_protected": True}
 
@@ -1516,7 +1738,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return True
 
     async def create_python_transform(
-        self, branch_name: str, transform: TransformPythonInformation
+        self, branch_name: str, transform: TransformPythonInformation, fingerprint: str | None = None
     ) -> CoreTransformPython:
         schema = await self.sdk.schema.get(kind=InfrahubKind.TRANSFORMPYTHON, branch=branch_name)
         data = {
@@ -1530,6 +1752,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             "convert_query_response": transform.convert_query_response,
             "dependencies": transform.dependencies,
             "dependencies_complete": transform.dependencies_complete,
+            "fingerprint": fingerprint,
         }
         create_payload = self.sdk.schema.generate_payload_create(
             schema=schema,
@@ -1542,8 +1765,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return obj
 
     async def update_python_transform(
-        self, existing_transform: CoreTransformPython, local_transform: TransformPythonInformation
+        self,
+        existing_transform: CoreTransformPython,
+        local_transform: TransformPythonInformation,
+        fingerprint: str | None = None,
     ) -> None:
+        if fingerprint is not None and existing_transform.fingerprint.value != fingerprint:
+            existing_transform.fingerprint.value = fingerprint
+
         if existing_transform.description.value != local_transform.description:
             existing_transform.description.value = local_transform.description
 

--- a/backend/tests/component/git/test_graphql_query_import.py
+++ b/backend/tests/component/git/test_graphql_query_import.py
@@ -65,7 +65,7 @@ async def _import_queries(
 
     rendered: dict[str, str] = {}
 
-    async def _capture(branch_name: str, name: str, query_string: str) -> None:
+    async def _capture(branch_name: str, name: str, query_string: str, fingerprint: str | None = None) -> None:
         rendered[name] = query_string
 
     with patch.object(InfrahubRepositoryIntegrator, "create_graphql_query", side_effect=_capture):

--- a/backend/tests/integration/git/fingerprint_base.py
+++ b/backend/tests/integration/git/fingerprint_base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.git import InfrahubRepository
+from infrahub.git.repository import get_initialized_repo
+from tests.constants import TestKind
+from tests.helpers.file_repo import FileRepo
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+
+
+class FingerprintImportTestBase(TestInfrahubApp):
+    """Shared setup for import-and-store fingerprint scenarios over the car-dealership fixture.
+
+    A repository is created and imported through the standard flow; helpers advance the
+    source repository by a commit and re-import so change scenarios exercise the real path.
+    """
+
+    @pytest.fixture(scope="class")
+    def file_repo(self, git_repos_source_dir_module_scope: Path) -> FileRepo:
+        return FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        file_repo: FileRepo,
+    ) -> None:
+        await load_schema(db, schema=CAR_SCHEMA)
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, age=25)
+        await john.save(db=db)
+        people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
+        await people.new(db=db, name="people", members=[john])
+        await people.save(db=db)
+
+    @pytest.fixture(scope="class")
+    async def repository_id(
+        self,
+        initial_dataset: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+    ) -> str:
+        client_repository = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={"name": "car-dealership", "location": f"{git_repos_source_dir_module_scope}/car-dealership"},
+        )
+        await client_repository.save()
+        return client_repository.id
+
+    async def _initialized_repo(self, client: InfrahubClient, repository_id: str) -> InfrahubRepository:
+        repo = await get_initialized_repo(
+            client=client,
+            repository_id=repository_id,
+            name="car-dealership",
+            repository_kind=InfrahubKind.REPOSITORY,
+        )
+        assert isinstance(repo, InfrahubRepository)
+        return repo
+
+    async def _reimport_current_commit(self, client: InfrahubClient, repository_id: str) -> None:
+        repo = await self._initialized_repo(client=client, repository_id=repository_id)
+        commit = repo.get_commit_value(branch_name="main")
+        await repo.import_objects_from_files(infrahub_branch_name="main", commit=commit)  # type: ignore[call-overload]
+
+    async def _commit_edit_and_reimport(
+        self, client: InfrahubClient, repository_id: str, file_repo: FileRepo, edits: dict[str, str]
+    ) -> str:
+        source = Path(file_repo.path)
+        for relative_path, content in edits.items():
+            target = source / relative_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        file_repo.repo.git.add(".")
+        file_repo.repo.index.commit("edit")
+
+        repo = await self._initialized_repo(client=client, repository_id=repository_id)
+        new_commit = await repo.pull(branch_name="main")
+        assert isinstance(new_commit, str)
+        await repo.import_objects_from_files(infrahub_branch_name="main", commit=new_commit)  # type: ignore[call-overload]
+        return new_commit

--- a/backend/tests/integration/git/test_fingerprint_artifact_definition.py
+++ b/backend/tests/integration/git/test_fingerprint_artifact_definition.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreArtifactDefinition
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from tests.constants import TestKind
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+
+
+class TestFingerprintArtifactDefinition(FingerprintImportTestBase):
+    async def test_import_sets_non_null_fingerprint(self, repository_id: str, client: InfrahubClient) -> None:
+        artifact_defs = await client.all(kind=CoreArtifactDefinition)
+        assert artifact_defs
+        for artifact_def in artifact_defs:
+            assert artifact_def.fingerprint.value
+
+    async def test_reimport_leaves_fingerprint_unchanged(self, repository_id: str, client: InfrahubClient) -> None:
+        before = (await client.get(kind=CoreArtifactDefinition, name__value="name report")).fingerprint.value
+        await self._reimport_current_commit(client=client, repository_id=repository_id)
+        after = (await client.get(kind=CoreArtifactDefinition, name__value="name report")).fingerprint.value
+        assert before == after
+
+    async def test_group_membership_churn_leaves_fingerprint_unchanged(
+        self, repository_id: str, client: InfrahubClient, db: InfrahubDatabase
+    ) -> None:
+        before = (await client.get(kind=CoreArtifactDefinition, name__value="name report")).fingerprint.value
+
+        # Adding a member to the target group is membership churn: the group identity is
+        # unchanged, so the fingerprint must not move.
+        newcomer = await Node.init(schema=TestKind.PERSON, db=db)
+        await newcomer.new(db=db, name="Jane", height=165, age=30)
+        await newcomer.save(db=db)
+        people = await client.get(kind=InfrahubKind.STANDARDGROUP, name__value="people")
+        await people.members.fetch()
+        people.members.add(newcomer.id)
+        await people.save()
+
+        await self._reimport_current_commit(client=client, repository_id=repository_id)
+
+        after = (await client.get(kind=CoreArtifactDefinition, name__value="name report")).fingerprint.value
+        assert before == after

--- a/backend/tests/integration/git/test_fingerprint_branch.py
+++ b/backend/tests/integration/git/test_fingerprint_branch.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreGraphQLQuery
+
+from infrahub.core.initialization import create_branch
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+
+
+class TestFingerprintBranch(FingerprintImportTestBase):
+    async def test_fingerprint_is_branch_aware(
+        self, repository_id: str, client: InfrahubClient, db: InfrahubDatabase
+    ) -> None:
+        """The branch-aware fingerprint is readable on a branch, inheriting the main value.
+
+        Being a normal branch-aware attribute is what lets it participate in branch diffs
+        and survive rebase/merge through the attribute framework.
+        """
+        on_main = (await client.get(kind=CoreGraphQLQuery, name__value="cartags")).fingerprint.value
+        assert on_main
+
+        await create_branch(branch_name="fingerprint-branch", db=db)
+
+        on_branch = (
+            await client.get(kind=CoreGraphQLQuery, name__value="cartags", branch="fingerprint-branch")
+        ).fingerprint.value
+        assert on_branch == on_main

--- a/backend/tests/integration/git/test_fingerprint_generator_definition.py
+++ b/backend/tests/integration/git/test_fingerprint_generator_definition.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreGeneratorDefinition
+
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from tests.helpers.file_repo import FileRepo
+
+CARTAGS_QUERY_EDITED = """
+query CarOwner($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        __typename
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class TestFingerprintGeneratorDefinition(FingerprintImportTestBase):
+    async def test_import_sets_non_null_fingerprint(self, repository_id: str, client: InfrahubClient) -> None:
+        generator_defs = await client.all(kind=CoreGeneratorDefinition)
+        assert generator_defs
+        for generator_def in generator_defs:
+            assert generator_def.fingerprint.value
+
+    async def test_reimport_leaves_fingerprint_unchanged(self, repository_id: str, client: InfrahubClient) -> None:
+        before = (await client.get(kind=CoreGeneratorDefinition, name__value="cartags")).fingerprint.value
+        await self._reimport_current_commit(client=client, repository_id=repository_id)
+        after = (await client.get(kind=CoreGeneratorDefinition, name__value="cartags")).fingerprint.value
+        assert before == after
+
+    async def test_connected_query_edit_changes_fingerprint(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        before = (await client.get(kind=CoreGeneratorDefinition, name__value="cartags")).fingerprint.value
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"generators/cartags.gql": CARTAGS_QUERY_EDITED},
+        )
+        after = (await client.get(kind=CoreGeneratorDefinition, name__value="cartags")).fingerprint.value
+        assert before != after

--- a/backend/tests/integration/git/test_fingerprint_query.py
+++ b/backend/tests/integration/git/test_fingerprint_query.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreGraphQLQuery
+
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from tests.helpers.file_repo import FileRepo
+
+# A valid variant of the cartags query that drops the nested cars selection, so the stored
+# fragment-inlined text differs while the query stays importable.
+CARTAGS_QUERY_EDITED = """
+query CarOwner($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        __typename
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class TestFingerprintQuery(FingerprintImportTestBase):
+    async def test_import_sets_non_null_fingerprint(self, repository_id: str, client: InfrahubClient) -> None:
+        queries = await client.all(kind=CoreGraphQLQuery)
+        assert queries
+        for query in queries:
+            assert query.fingerprint.value
+
+    async def test_reimport_leaves_fingerprint_unchanged(self, repository_id: str, client: InfrahubClient) -> None:
+        before = (await client.get(kind=CoreGraphQLQuery, name__value="cartags")).fingerprint.value
+        await self._reimport_current_commit(client=client, repository_id=repository_id)
+        after = (await client.get(kind=CoreGraphQLQuery, name__value="cartags")).fingerprint.value
+        assert before == after
+
+    async def test_query_text_edit_changes_fingerprint(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        before = (await client.get(kind=CoreGraphQLQuery, name__value="cartags")).fingerprint.value
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"generators/cartags.gql": CARTAGS_QUERY_EDITED},
+        )
+        after = (await client.get(kind=CoreGraphQLQuery, name__value="cartags")).fingerprint.value
+        assert before != after
+
+    async def test_unrelated_file_edit_leaves_fingerprint_unchanged(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        before = (await client.get(kind=CoreGraphQLQuery, name__value="car_overview")).fingerprint.value
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"unrelated_note.md": "a file no query depends on"},
+        )
+        after = (await client.get(kind=CoreGraphQLQuery, name__value="car_overview")).fingerprint.value
+        assert before == after

--- a/backend/tests/integration/git/test_fingerprint_snapshot.py
+++ b/backend/tests/integration/git/test_fingerprint_snapshot.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreArtifactDefinition, CoreGraphQLQuery
+
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from tests.helpers.file_repo import FileRepo
+
+# The person_with_cars query drives the person_with_cars transform, which the
+# "Ownership report" artifact definition composes over. The edit adds a scalar field
+# (keeping the selections the artifact template renders) so the stored text changes
+# without breaking regeneration.
+PERSON_WITH_CARS_QUERY_EDITED = """
+query PersonWithTheirCars($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        id
+        __typename
+        name {
+          value
+        }
+        height {
+          value
+        }
+        age {
+          value
+        }
+        cars {
+          edges {
+            node {
+              id
+              __typename
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class TestFingerprintSnapshot(FingerprintImportTestBase):
+    async def test_query_edit_propagates_to_dependent_artifact_definition_same_import(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        """Editing a query updates the dependent artifact-definition fingerprint in the same import.
+
+        A one-import lag would leave the artifact definition composing the previously-stored
+        query fingerprint; the in-import registry rules that out.
+        """
+        query_before = (await client.get(kind=CoreGraphQLQuery, name__value="person_with_cars")).fingerprint.value
+        artifact_before = (
+            await client.get(kind=CoreArtifactDefinition, name__value="Ownership report")
+        ).fingerprint.value
+
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"templates/person_with_cars.gql": PERSON_WITH_CARS_QUERY_EDITED},
+        )
+
+        query_after = (await client.get(kind=CoreGraphQLQuery, name__value="person_with_cars")).fingerprint.value
+        artifact_after = (
+            await client.get(kind=CoreArtifactDefinition, name__value="Ownership report")
+        ).fingerprint.value
+
+        assert query_before != query_after
+        assert artifact_before != artifact_after

--- a/backend/tests/integration/git/test_fingerprint_transformation.py
+++ b/backend/tests/integration/git/test_fingerprint_transformation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from infrahub_sdk.protocols import CoreTransformJinja2, CoreTransformPython
+
+from tests.integration.git.fingerprint_base import FingerprintImportTestBase
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from tests.helpers.file_repo import FileRepo
+
+
+class TestFingerprintTransformation(FingerprintImportTestBase):
+    async def test_import_sets_non_null_fingerprint(self, repository_id: str, client: InfrahubClient) -> None:
+        python_transforms = await client.all(kind=CoreTransformPython)
+        jinja2_transforms = await client.all(kind=CoreTransformJinja2)
+        assert python_transforms
+        assert jinja2_transforms
+        for transform in [*python_transforms, *jinja2_transforms]:
+            assert transform.fingerprint.value
+
+    async def test_reimport_leaves_fingerprint_unchanged(self, repository_id: str, client: InfrahubClient) -> None:
+        before = (await client.get(kind=CoreTransformPython, name__value="CarSpecMarkdown")).fingerprint.value
+        await self._reimport_current_commit(client=client, repository_id=repository_id)
+        after = (await client.get(kind=CoreTransformPython, name__value="CarSpecMarkdown")).fingerprint.value
+        assert before == after
+
+    async def test_own_source_edit_changes_fingerprint(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        before = (await client.get(kind=CoreTransformPython, name__value="CarSpecMarkdown")).fingerprint.value
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"transforms/car_spec_markdown.py": _append_comment("transforms/car_spec_markdown.py", file_repo)},
+        )
+        after = (await client.get(kind=CoreTransformPython, name__value="CarSpecMarkdown")).fingerprint.value
+        assert before != after
+
+    async def test_connected_query_edit_changes_transformation_fingerprint(
+        self, repository_id: str, client: InfrahubClient, file_repo: FileRepo
+    ) -> None:
+        before = (await client.get(kind=CoreTransformJinja2, name__value="person_with_cars")).fingerprint.value
+        await self._commit_edit_and_reimport(
+            client=client,
+            repository_id=repository_id,
+            file_repo=file_repo,
+            edits={"templates/person_with_cars.gql": _PERSON_WITH_CARS_QUERY_EDITED},
+        )
+        after = (await client.get(kind=CoreTransformJinja2, name__value="person_with_cars")).fingerprint.value
+        assert before != after
+
+
+def _append_comment(relative_path: str, file_repo: FileRepo) -> str:
+    current = (Path(file_repo.path) / relative_path).read_text(encoding="utf-8")
+    return current + "\n# fingerprint change marker\n"
+
+
+_PERSON_WITH_CARS_QUERY_EDITED = """
+query PersonWithTheirCars($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        id
+        __typename
+        name {
+          value
+        }
+        cars {
+          edges {
+            node {
+              id
+              __typename
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""

--- a/backend/tests/unit/git/fingerprint/conftest.py
+++ b/backend/tests/unit/git/fingerprint/conftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.git.closure_builder.post_processing import MANIFEST_PATH
+from infrahub.git.fingerprint.composer import ClosurePathSelector, FingerprintComposer
+from infrahub.git.fingerprint.hasher import FingerprintHasher
+from infrahub.git.fingerprint.registry import FingerprintRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class StaticBlobResolver:
+    """In-memory blob resolver returning fixed SHAs for a known path->sha mapping.
+
+    An unknown path resolves to an empty SHA, mirroring the git resolver's behaviour
+    for a path missing from the tree.
+    """
+
+    def __init__(self, blob_shas: dict[str, str]) -> None:
+        self._blob_shas = blob_shas
+
+    def resolve(self, paths: Sequence[str]) -> list[tuple[str, str]]:
+        return sorted((path, self._blob_shas.get(path, "")) for path in paths)
+
+
+def build_composer(
+    *,
+    blob_shas: dict[str, str] | None = None,
+    commit: str = "commit-aaaa",
+    registry: FingerprintRegistry | None = None,
+) -> FingerprintComposer:
+    return FingerprintComposer(
+        hasher=FingerprintHasher(),
+        blob_resolver=StaticBlobResolver(blob_shas or {}),
+        registry=registry or FingerprintRegistry(),
+        closure_selector=ClosurePathSelector(excluded_paths=frozenset({MANIFEST_PATH})),
+        commit=commit,
+    )

--- a/backend/tests/unit/git/fingerprint/test_blob_resolver.py
+++ b/backend/tests/unit/git/fingerprint/test_blob_resolver.py
@@ -21,6 +21,25 @@ def _commit_files(repo_dir: Path, files: dict[str, str]) -> str:
     return commit.hexsha
 
 
+# git blob SHAs for the file contents below - `git hash-object` of the raw bytes.
+_SHA_ALPHA = "7e74e68b2a782a3aead46d987a63ca1c91091c13"
+_SHA_BETA = "e1d65540f4fdf72431ec47e001282cc7e8ed7c0c"
+_SHA_GAMMA = "f6ce3c605d8e619e80eb03eb65fc984a940abde7"
+
+
+def test_resolve_links_each_path_to_its_own_blob_sha(tmp_path: Path) -> None:
+    commit = _commit_files(tmp_path, {"a.py": "alpha", "b.py": "beta", "sub/c.py": "gamma"})
+    resolver = GitBlobResolver(repo=Repo(tmp_path), commit=commit)
+
+    pairs = dict(resolver.resolve(["sub/c.py", "a.py", "b.py"]))
+
+    assert pairs == {
+        "a.py": _SHA_ALPHA,
+        "b.py": _SHA_BETA,
+        "sub/c.py": _SHA_GAMMA,
+    }
+
+
 def test_resolve_returns_sorted_path_blob_pairs(tmp_path: Path) -> None:
     commit = _commit_files(tmp_path, {"b.py": "b", "a.py": "a", "sub/c.py": "c"})
     resolver = GitBlobResolver(repo=Repo(tmp_path), commit=commit)

--- a/backend/tests/unit/git/fingerprint/test_blob_resolver.py
+++ b/backend/tests/unit/git/fingerprint/test_blob_resolver.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from git import Repo
+
+from infrahub.git.fingerprint.blob_resolver import GitBlobResolver
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _commit_files(repo_dir: Path, files: dict[str, str]) -> str:
+    repo = Repo.init(repo_dir, initial_branch="main")
+    for relative_path, content in files.items():
+        target = repo_dir / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    repo.index.add(list(files))
+    commit = repo.index.commit("initial")
+    return commit.hexsha
+
+
+def test_resolve_returns_sorted_path_blob_pairs(tmp_path: Path) -> None:
+    commit = _commit_files(tmp_path, {"b.py": "b", "a.py": "a", "sub/c.py": "c"})
+    resolver = GitBlobResolver(repo=Repo(tmp_path), commit=commit)
+
+    pairs = resolver.resolve(["sub/c.py", "a.py", "b.py"])
+
+    assert [path for path, _ in pairs] == ["a.py", "b.py", "sub/c.py"]
+    assert all(len(blob_sha) == 40 for _, blob_sha in pairs)
+
+
+def test_identical_content_resolves_to_identical_blob_sha(tmp_path: Path) -> None:
+    commit = _commit_files(tmp_path, {"a.py": "same", "b.py": "same"})
+    resolver = GitBlobResolver(repo=Repo(tmp_path), commit=commit)
+
+    pairs = dict(resolver.resolve(["a.py", "b.py"]))
+
+    assert pairs["a.py"] == pairs["b.py"]
+
+
+def test_changed_content_changes_blob_sha(tmp_path: Path) -> None:
+    repo = Repo.init(tmp_path, initial_branch="main")
+    (tmp_path / "a.py").write_text("before", encoding="utf-8")
+    repo.index.add(["a.py"])
+    first = repo.index.commit("first")
+    (tmp_path / "a.py").write_text("after", encoding="utf-8")
+    repo.index.add(["a.py"])
+    second = repo.index.commit("second")
+
+    before = dict(GitBlobResolver(repo=repo, commit=first.hexsha).resolve(["a.py"]))
+    after = dict(GitBlobResolver(repo=repo, commit=second.hexsha).resolve(["a.py"]))
+
+    assert before["a.py"] != after["a.py"]
+
+
+def test_missing_path_resolves_to_empty_sha(tmp_path: Path) -> None:
+    commit = _commit_files(tmp_path, {"a.py": "a"})
+    resolver = GitBlobResolver(repo=Repo(tmp_path), commit=commit)
+
+    assert resolver.resolve(["missing.py"]) == [("missing.py", "")]

--- a/backend/tests/unit/git/fingerprint/test_closure_selector.py
+++ b/backend/tests/unit/git/fingerprint/test_closure_selector.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from infrahub.git.closure_builder.post_processing import MANIFEST_PATH
+from infrahub.git.fingerprint.composer import ClosurePathSelector
+
+
+def _selector() -> ClosurePathSelector:
+    return ClosurePathSelector(excluded_paths=frozenset({MANIFEST_PATH}))
+
+
+def test_manifest_path_is_excluded() -> None:
+    selected = _selector().select([MANIFEST_PATH, "transforms/report.py"])
+    assert selected == ["transforms/report.py"]
+
+
+def test_own_source_and_watch_files_are_retained() -> None:
+    dependencies = [MANIFEST_PATH, "transforms/report.py", "shared/helpers.py", "templates/report.j2"]
+    selected = _selector().select(dependencies)
+    assert selected == ["transforms/report.py", "shared/helpers.py", "templates/report.j2"]
+
+
+def test_selection_without_manifest_is_unchanged() -> None:
+    dependencies = ["transforms/report.py", "shared/helpers.py"]
+    assert _selector().select(dependencies) == dependencies

--- a/backend/tests/unit/git/fingerprint/test_composer_artifact_definition.py
+++ b/backend/tests/unit/git/fingerprint/test_composer_artifact_definition.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from infrahub.git.fingerprint.composer import ArtifactDefinitionFingerprintInput
+from infrahub.git.fingerprint.registry import FingerprintKind, FingerprintRegistry
+from tests.unit.git.fingerprint.conftest import build_composer
+
+
+def _input(**overrides: object) -> ArtifactDefinitionFingerprintInput:
+    defaults: dict[str, object] = {
+        "name": "report",
+        "transformation_name": "t",
+        "parameters": {"name": "name__value"},
+        "content_type": "text/plain",
+        "artifact_name": "car-owner",
+        "target_group_id": "group-1",
+    }
+    defaults.update(overrides)
+    return ArtifactDefinitionFingerprintInput(**defaults)  # type: ignore[arg-type]
+
+
+def _digest(*, transformation_fingerprint: str = "transform-fp", **overrides: object) -> str:
+    registry = FingerprintRegistry()
+    registry.register(kind=FingerprintKind.TRANSFORMATION, name="t", fingerprint=transformation_fingerprint)
+    return build_composer(registry=registry).compose_artifact_definition(_input(**overrides))
+
+
+def test_incorporates_transformation_fingerprint() -> None:
+    assert _digest(transformation_fingerprint="a") != _digest(transformation_fingerprint="b")
+
+
+def test_changes_on_each_hashed_field() -> None:
+    base = _digest()
+    assert base != _digest(parameters={"name": "other"})
+    assert base != _digest(content_type="application/json")
+    assert base != _digest(artifact_name="renamed")
+    assert base != _digest(target_group_id="group-2")
+
+
+def test_parameters_key_ordering_is_irrelevant() -> None:
+    first = _digest(parameters={"a": "1", "b": "2"})
+    second = _digest(parameters={"b": "2", "a": "1"})
+    assert first == second

--- a/backend/tests/unit/git/fingerprint/test_composer_generator_definition.py
+++ b/backend/tests/unit/git/fingerprint/test_composer_generator_definition.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from infrahub_sdk.schema.repository import InfrahubWatchConfig
+
+from infrahub.git.closure_builder.post_processing import MANIFEST_PATH
+from infrahub.git.fingerprint.composer import GeneratorDefinitionFingerprintInput
+from infrahub.git.fingerprint.registry import FingerprintKind, FingerprintRegistry
+from tests.unit.git.fingerprint.conftest import build_composer
+
+BLOBS = {"generators/tags.py": "sha-gen", MANIFEST_PATH: "sha-manifest"}
+
+
+def _input(**overrides: object) -> GeneratorDefinitionFingerprintInput:
+    defaults: dict[str, object] = {
+        "name": "tags",
+        "query_name": "q",
+        "dependencies": (MANIFEST_PATH, "generators/tags.py"),
+        "dependencies_complete": True,
+        "watch": InfrahubWatchConfig(files=[]),
+        "parameters": {"name": "name__value"},
+        "class_name": "Generator",
+        "convert_query_response": False,
+        "target_group_id": "group-1",
+    }
+    defaults.update(overrides)
+    return GeneratorDefinitionFingerprintInput(**defaults)  # type: ignore[arg-type]
+
+
+def _digest(
+    *,
+    query_fingerprint: str = "query-fp",
+    commit: str = "commit-1",
+    blobs: dict[str, str] | None = None,
+    **overrides: object,
+) -> str:
+    registry = FingerprintRegistry()
+    registry.register(kind=FingerprintKind.QUERY, name="q", fingerprint=query_fingerprint)
+    composer = build_composer(blob_shas=blobs or BLOBS, commit=commit, registry=registry)
+    return composer.compose_generator_definition(_input(**overrides))
+
+
+def test_incorporates_query_fingerprint_and_closure() -> None:
+    base = _digest()
+    assert base != _digest(query_fingerprint="other")
+    assert base != _digest(blobs={**BLOBS, "generators/tags.py": "sha-gen-edited"})
+
+
+def test_changes_on_parameters_class_name_convert_and_group() -> None:
+    base = _digest()
+    assert base != _digest(parameters={"name": "other"})
+    assert base != _digest(class_name="Other")
+    assert base != _digest(convert_query_response=True)
+    assert base != _digest(target_group_id="group-2")
+
+
+def test_folds_commit_id_only_when_watch_absent() -> None:
+    assert _digest(commit="commit-1", watch=None) != _digest(commit="commit-2", watch=None)
+    assert _digest(commit="commit-1", watch=InfrahubWatchConfig(files=[])) == _digest(
+        commit="commit-2", watch=InfrahubWatchConfig(files=[])
+    )
+
+
+def test_incomplete_closure_folds_commit_id_despite_present_watch() -> None:
+    watch = InfrahubWatchConfig(files=[])
+    unstable_1 = _digest(commit="commit-1", watch=watch, dependencies_complete=False)
+    unstable_2 = _digest(commit="commit-2", watch=watch, dependencies_complete=False)
+    assert unstable_1 != unstable_2
+
+
+def test_excludes_manifest_blob_from_closure() -> None:
+    assert _digest() == _digest(blobs={**BLOBS, MANIFEST_PATH: "sha-manifest-edited"})

--- a/backend/tests/unit/git/fingerprint/test_composer_query.py
+++ b/backend/tests/unit/git/fingerprint/test_composer_query.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from infrahub.git.fingerprint.composer import QueryFingerprintInput
+from infrahub.git.fingerprint.registry import FingerprintKind
+from tests.unit.git.fingerprint.conftest import build_composer
+
+
+def test_identical_query_text_produces_identical_digest() -> None:
+    first = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    second = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    assert first == second
+
+
+def test_different_query_text_produces_different_digest() -> None:
+    first = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    second = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { b }"))
+    assert first != second
+
+
+def test_edit_then_revert_is_net_zero() -> None:
+    original = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { edited }"))
+    reverted = build_composer().compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    assert original == reverted
+
+
+def test_compose_query_registers_result() -> None:
+    composer = build_composer()
+    digest = composer.compose_query(QueryFingerprintInput(name="q", query_text="query { a }"))
+    assert composer.registry.get(kind=FingerprintKind.QUERY, name="q") == digest

--- a/backend/tests/unit/git/fingerprint/test_composer_transformation.py
+++ b/backend/tests/unit/git/fingerprint/test_composer_transformation.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from infrahub_sdk.schema.repository import InfrahubWatchConfig
+
+from infrahub.git.closure_builder.post_processing import MANIFEST_PATH
+from infrahub.git.fingerprint.composer import (
+    Jinja2TransformationFingerprintInput,
+    PythonTransformationFingerprintInput,
+)
+from infrahub.git.fingerprint.registry import FingerprintKind, FingerprintRegistry
+from tests.unit.git.fingerprint.conftest import build_composer
+
+PY_BLOBS = {"transforms/report.py": "sha-report", MANIFEST_PATH: "sha-manifest"}
+J2_BLOBS = {"templates/report.j2": "sha-template", MANIFEST_PATH: "sha-manifest"}
+
+
+def _python_input(**overrides: object) -> PythonTransformationFingerprintInput:
+    defaults: dict[str, object] = {
+        "name": "report",
+        "query_name": "q",
+        "dependencies": (MANIFEST_PATH, "transforms/report.py"),
+        "dependencies_complete": True,
+        "watch": InfrahubWatchConfig(files=[]),
+        "class_name": "Report",
+        "convert_query_response": False,
+    }
+    defaults.update(overrides)
+    return PythonTransformationFingerprintInput(**defaults)  # type: ignore[arg-type]
+
+
+def _jinja2_input(**overrides: object) -> Jinja2TransformationFingerprintInput:
+    defaults: dict[str, object] = {
+        "name": "report",
+        "query_name": "q",
+        "dependencies": (MANIFEST_PATH, "templates/report.j2"),
+        "dependencies_complete": True,
+        "watch": InfrahubWatchConfig(files=[]),
+        "template_path": "templates/report.j2",
+    }
+    defaults.update(overrides)
+    return Jinja2TransformationFingerprintInput(**defaults)  # type: ignore[arg-type]
+
+
+def _seed_query(registry: FingerprintRegistry, fingerprint: str = "query-fp") -> None:
+    registry.register(kind=FingerprintKind.QUERY, name="q", fingerprint=fingerprint)
+
+
+def test_python_incorporates_query_fingerprint() -> None:
+    registry_a = FingerprintRegistry()
+    _seed_query(registry_a, "query-fp-1")
+    first = build_composer(blob_shas=PY_BLOBS, registry=registry_a).compose_transformation(_python_input())
+
+    registry_b = FingerprintRegistry()
+    _seed_query(registry_b, "query-fp-2")
+    second = build_composer(blob_shas=PY_BLOBS, registry=registry_b).compose_transformation(_python_input())
+
+    assert first != second
+
+
+def test_python_changes_on_closure_blob_sha() -> None:
+    registry = FingerprintRegistry()
+    _seed_query(registry)
+    base = build_composer(blob_shas=PY_BLOBS, registry=registry).compose_transformation(_python_input())
+
+    registry_changed = FingerprintRegistry()
+    _seed_query(registry_changed)
+    changed_blobs = {**PY_BLOBS, "transforms/report.py": "sha-report-edited"}
+    changed = build_composer(blob_shas=changed_blobs, registry=registry_changed).compose_transformation(_python_input())
+
+    assert base != changed
+
+
+def test_python_changes_on_class_name_and_convert_query_response() -> None:
+    def digest(**overrides: object) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=PY_BLOBS, registry=registry).compose_transformation(_python_input(**overrides))
+
+    base = digest()
+    assert base != digest(class_name="Other")
+    assert base != digest(convert_query_response=True)
+
+
+def test_python_excludes_manifest_blob_from_closure() -> None:
+    def digest(blobs: dict[str, str]) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=blobs, registry=registry).compose_transformation(_python_input())
+
+    base = digest(PY_BLOBS)
+    manifest_edited = digest({**PY_BLOBS, MANIFEST_PATH: "sha-manifest-edited"})
+    assert base == manifest_edited
+
+
+def test_python_folds_commit_id_only_when_watch_absent() -> None:
+    def digest(*, commit: str, watch: InfrahubWatchConfig | None) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=PY_BLOBS, commit=commit, registry=registry).compose_transformation(
+            _python_input(watch=watch)
+        )
+
+    absent_a = digest(commit="commit-1", watch=None)
+    absent_b = digest(commit="commit-2", watch=None)
+    assert absent_a != absent_b
+
+    present_a = digest(commit="commit-1", watch=InfrahubWatchConfig(files=[]))
+    present_b = digest(commit="commit-2", watch=InfrahubWatchConfig(files=[]))
+    assert present_a == present_b
+
+
+def test_python_incomplete_closure_folds_commit_id_despite_present_watch() -> None:
+    def digest(*, commit: str) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=PY_BLOBS, commit=commit, registry=registry).compose_transformation(
+            _python_input(watch=InfrahubWatchConfig(files=[]), dependencies_complete=False)
+        )
+
+    # An incomplete closure must not yield a stable fingerprint even when watch is declared.
+    assert digest(commit="commit-1") != digest(commit="commit-2")
+
+
+def test_jinja2_changes_on_template_path_and_closure() -> None:
+    def digest(*, blobs: dict[str, str], **overrides: object) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=blobs, registry=registry).compose_transformation(_jinja2_input(**overrides))
+
+    base = digest(blobs=J2_BLOBS)
+    assert base != digest(blobs=J2_BLOBS, template_path="templates/other.j2")
+    assert base != digest(blobs={**J2_BLOBS, "templates/report.j2": "sha-template-edited"})
+
+
+def test_jinja2_excludes_manifest_blob_from_closure() -> None:
+    def digest(blobs: dict[str, str]) -> str:
+        registry = FingerprintRegistry()
+        _seed_query(registry)
+        return build_composer(blob_shas=blobs, registry=registry).compose_transformation(_jinja2_input())
+
+    assert digest(J2_BLOBS) == digest({**J2_BLOBS, MANIFEST_PATH: "sha-manifest-edited"})

--- a/backend/tests/unit/git/fingerprint/test_composer_transformation.py
+++ b/backend/tests/unit/git/fingerprint/test_composer_transformation.py
@@ -121,6 +121,18 @@ def test_python_incomplete_closure_folds_commit_id_despite_present_watch() -> No
     assert digest(commit="commit-1") != digest(commit="commit-2")
 
 
+def test_missing_query_fingerprint_folds_commit_id_despite_present_watch() -> None:
+    def digest(*, commit: str) -> str:
+        # No query is registered, so the upstream fingerprint is unresolved.
+        registry = FingerprintRegistry()
+        return build_composer(blob_shas=PY_BLOBS, commit=commit, registry=registry).compose_transformation(
+            _python_input(watch=InfrahubWatchConfig(files=[]))
+        )
+
+    # An unresolved upstream must not yield a stable fingerprint over an input it could not read.
+    assert digest(commit="commit-1") != digest(commit="commit-2")
+
+
 def test_jinja2_changes_on_template_path_and_closure() -> None:
     def digest(*, blobs: dict[str, str], **overrides: object) -> str:
         registry = FingerprintRegistry()

--- a/backend/tests/unit/git/fingerprint/test_hasher.py
+++ b/backend/tests/unit/git/fingerprint/test_hasher.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from infrahub.git.fingerprint.hasher import FingerprintHasher, canonical_json
 
 
@@ -31,3 +33,8 @@ def test_canonical_json_is_key_order_independent() -> None:
 
 def test_canonical_json_has_no_insignificant_whitespace() -> None:
     assert canonical_json({"a": 1, "b": [1, 2]}) == '{"a":1,"b":[1,2]}'
+
+
+def test_canonical_json_raises_on_non_serializable_value() -> None:
+    with pytest.raises(TypeError, match=r"^Object of type object is not JSON serializable$"):
+        canonical_json({"a": object()})

--- a/backend/tests/unit/git/fingerprint/test_hasher.py
+++ b/backend/tests/unit/git/fingerprint/test_hasher.py
@@ -36,5 +36,9 @@ def test_canonical_json_has_no_insignificant_whitespace() -> None:
 
 
 def test_canonical_json_raises_on_non_serializable_value() -> None:
-    with pytest.raises(TypeError, match=r"^Object of type object is not JSON serializable$"):
+    # Python 3.14 appends a context note to json serialization errors.
+    with pytest.raises(
+        TypeError,
+        match=r"^Object of type object is not JSON serializable(\nwhen serializing dict item 'a')?$",
+    ):
         canonical_json({"a": object()})

--- a/backend/tests/unit/git/fingerprint/test_hasher.py
+++ b/backend/tests/unit/git/fingerprint/test_hasher.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from infrahub.git.fingerprint.hasher import FingerprintHasher, canonical_json
+
+
+def test_hash_is_deterministic() -> None:
+    hasher = FingerprintHasher()
+    assert hasher.hash(["a", "b", "c"]) == hasher.hash(["a", "b", "c"])
+
+
+def test_hash_is_order_sensitive() -> None:
+    hasher = FingerprintHasher()
+    assert hasher.hash(["a", "b"]) != hasher.hash(["b", "a"])
+
+
+def test_hash_term_boundaries_are_unambiguous() -> None:
+    hasher = FingerprintHasher()
+    # Without length-prefixing these two term lists would collide on concatenation.
+    assert hasher.hash(["ab", "c"]) != hasher.hash(["a", "bc"])
+
+
+def test_hash_returns_sha256_hex_digest() -> None:
+    digest = FingerprintHasher().hash(["value"])
+    assert len(digest) == 64
+    assert int(digest, 16) >= 0
+
+
+def test_canonical_json_is_key_order_independent() -> None:
+    assert canonical_json({"b": 1, "a": 2}) == canonical_json({"a": 2, "b": 1})
+
+
+def test_canonical_json_has_no_insignificant_whitespace() -> None:
+    assert canonical_json({"a": 1, "b": [1, 2]}) == '{"a":1,"b":[1,2]}'

--- a/backend/tests/unit/git/fingerprint/test_registry.py
+++ b/backend/tests/unit/git/fingerprint/test_registry.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from infrahub.git.fingerprint.registry import FingerprintKind, FingerprintRegistry
+
+
+def test_register_then_get_returns_value() -> None:
+    registry = FingerprintRegistry()
+    registry.register(kind=FingerprintKind.QUERY, name="q1", fingerprint="abc")
+    assert registry.get(kind=FingerprintKind.QUERY, name="q1") == "abc"
+
+
+def test_get_unknown_returns_none() -> None:
+    registry = FingerprintRegistry()
+    assert registry.get(kind=FingerprintKind.TRANSFORMATION, name="missing") is None
+
+
+def test_same_name_across_kinds_is_distinct() -> None:
+    registry = FingerprintRegistry()
+    registry.register(kind=FingerprintKind.QUERY, name="shared", fingerprint="q")
+    registry.register(kind=FingerprintKind.TRANSFORMATION, name="shared", fingerprint="t")
+    assert registry.get(kind=FingerprintKind.QUERY, name="shared") == "q"
+    assert registry.get(kind=FingerprintKind.TRANSFORMATION, name="shared") == "t"

--- a/backend/tests/unit/git/fingerprint/test_watch_state.py
+++ b/backend/tests/unit/git/fingerprint/test_watch_state.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from infrahub_sdk.schema.repository import InfrahubWatchConfig
+
+from infrahub.git.fingerprint.composer import fold_commit_id
+
+
+def test_absent_watch_folds_commit_id() -> None:
+    assert fold_commit_id(commit="commit-1", watch=None, closure_complete=True) == "commit-1"
+
+
+def test_present_empty_watch_omits_commit_id() -> None:
+    assert fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=True) is None
+
+
+def test_present_populated_watch_omits_commit_id() -> None:
+    watch = InfrahubWatchConfig(files=["helpers/util.py"])
+    assert fold_commit_id(commit="commit-1", watch=watch, closure_complete=True) is None
+
+
+def test_absent_and_present_empty_are_distinct_states() -> None:
+    absent = fold_commit_id(commit="commit-1", watch=None, closure_complete=True)
+    present_empty = fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=True)
+    assert absent is not None
+    assert present_empty is None
+
+
+def test_incomplete_closure_folds_commit_id_even_with_present_watch() -> None:
+    # An incomplete closure means an output-affecting dependency is unknown, so the commit
+    # id is folded to avoid a stable fingerprint over an unknown input set.
+    assert fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=False) == "commit-1"
+
+
+def test_complete_closure_with_present_watch_stays_stable() -> None:
+    assert fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=True) is None

--- a/backend/tests/unit/git/fingerprint/test_watch_state.py
+++ b/backend/tests/unit/git/fingerprint/test_watch_state.py
@@ -29,7 +29,3 @@ def test_incomplete_closure_folds_commit_id_even_with_present_watch() -> None:
     # An incomplete closure means an output-affecting dependency is unknown, so the commit
     # id is folded to avoid a stable fingerprint over an unknown input set.
     assert fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=False) == "commit-1"
-
-
-def test_complete_closure_with_present_watch_stays_stable() -> None:
-    assert fold_commit_id(commit="commit-1", watch=InfrahubWatchConfig(files=[]), closure_complete=True) is None

--- a/dev/specs/ifc-2844-definition-fingerprint/tasks.md
+++ b/dev/specs/ifc-2844-definition-fingerprint/tasks.md
@@ -31,8 +31,8 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 **Purpose**: Create the new package and test-directory skeletons.
 
-- [ ] T001 Create the `backend/infrahub/git/fingerprint/` package with an empty `__init__.py` and empty stub modules `composer.py`, `blob_resolver.py`, `registry.py`, `hasher.py` (or `canonical.py` for canonicalisation helpers), each with module docstring only.
-- [ ] T002 [P] Create the unit test package `backend/tests/unit/git/fingerprint/` with an empty `__init__.py`.
+- [X] T001 Create the `backend/infrahub/git/fingerprint/` package with an empty `__init__.py` and empty stub modules `composer.py`, `blob_resolver.py`, `registry.py`, `hasher.py` (or `canonical.py` for canonicalisation helpers), each with module docstring only.
+- [X] T002 [P] Create the unit test package `backend/tests/unit/git/fingerprint/` with an empty `__init__.py`.
 - [X] T003 [P] Create the changelog fragment `changelog/+ifc-2844.added.md` describing the new nullable branch-aware `fingerprint` attribute on `CoreGraphQLQuery`, `CoreTransformation`, `CoreArtifactDefinition`, and `CoreGeneratorDefinition`.
 
 ---
@@ -54,15 +54,15 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Shared fingerprint components
 
-- [ ] T010 [P] Implement the SHA-256 hasher and canonicalisation helpers in `backend/infrahub/git/fingerprint/hasher.py`: a function that hashes an ordered tuple of canonicalised inputs to a hex digest, plus `parameters` canonicalisation via `json.dumps(..., sort_keys=True, separators=(",", ":"))` (FR-014).
-- [ ] T011 [P] Implement the blob-SHA resolver in `backend/infrahub/git/fingerprint/blob_resolver.py`: resolve `{repo_relative_path: git_blob_sha}` from the git tree at the imported commit (GitPython `Repo(worktree).commit(commit).tree`), reading git metadata only, never file contents (FR-009b). Constructor-injected worktree/commit.
-- [ ] T011a [P] Implement a closure-path selector helper (in `backend/infrahub/git/fingerprint/composer.py` or `hasher.py`) that, given the stored `dependencies`, returns the paths to hash with `.infrahub.yml` (`closure_builder.post_processing.MANIFEST_PATH`) EXCLUDED. RATIONALE (verified against the codebase): `append_manifest_path` merges `.infrahub.yml` into every transform/generator's stored `dependencies`, so hashing all pairs verbatim would change the fingerprint on any comment-only or unrelated `.infrahub.yml` edit and violate SC-005 / the "comment-only manifest edit" edge case. The manifest's output-affecting fields are folded in separately as parsed scalars (`class_name`, `template_path`, `parameters`, ...), not as bytes. The definition's own source file and any `watch:` files MUST remain in the hashed set. This selector is shared by the transformation (US2) and generator (US4) composers.
-- [ ] T012 [P] Implement the per-import fingerprint registry in `backend/infrahub/git/fingerprint/registry.py`: an in-memory `{(kind, name): fingerprint_hexdigest}` snapshot with set/get, so higher layers read the freshly-computed lower-level value and never a stored graph value (FR-015a).
-- [ ] T013 Define the layered composer skeleton in `backend/infrahub/git/fingerprint/composer.py` (depends on T010-T012, T011a): a class with constructor-injected hasher, blob resolver, registry, and closure-path selector, exposing `compose_query`, `compose_transformation`, `compose_artifact_definition`, `compose_generator_definition` entry methods (bodies stubbed/`NotImplementedError`, filled in per story). Registry lookups for cross-references use the referenced definition's name (artifact def -> transform by `transformation` name across both transform kinds; artifact/generator def -> target group by `targets` name resolved to id); ensure the registry key scheme supports these name-based lookups.
+- [X] T010 [P] Implement the SHA-256 hasher and canonicalisation helpers in `backend/infrahub/git/fingerprint/hasher.py`: a function that hashes an ordered tuple of canonicalised inputs to a hex digest, plus `parameters` canonicalisation via `json.dumps(..., sort_keys=True, separators=(",", ":"))` (FR-014).
+- [X] T011 [P] Implement the blob-SHA resolver in `backend/infrahub/git/fingerprint/blob_resolver.py`: resolve `{repo_relative_path: git_blob_sha}` from the git tree at the imported commit (GitPython `Repo(worktree).commit(commit).tree`), reading git metadata only, never file contents (FR-009b). Constructor-injected worktree/commit.
+- [X] T011a [P] Implement a closure-path selector helper (in `backend/infrahub/git/fingerprint/composer.py` or `hasher.py`) that, given the stored `dependencies`, returns the paths to hash with `.infrahub.yml` (`closure_builder.post_processing.MANIFEST_PATH`) EXCLUDED. RATIONALE (verified against the codebase): `append_manifest_path` merges `.infrahub.yml` into every transform/generator's stored `dependencies`, so hashing all pairs verbatim would change the fingerprint on any comment-only or unrelated `.infrahub.yml` edit and violate SC-005 / the "comment-only manifest edit" edge case. The manifest's output-affecting fields are folded in separately as parsed scalars (`class_name`, `template_path`, `parameters`, ...), not as bytes. The definition's own source file and any `watch:` files MUST remain in the hashed set. This selector is shared by the transformation (US2) and generator (US4) composers.
+- [X] T012 [P] Implement the per-import fingerprint registry in `backend/infrahub/git/fingerprint/registry.py`: an in-memory `{(kind, name): fingerprint_hexdigest}` snapshot with set/get, so higher layers read the freshly-computed lower-level value and never a stored graph value (FR-015a).
+- [X] T013 Define the layered composer skeleton in `backend/infrahub/git/fingerprint/composer.py` (depends on T010-T012, T011a): a class with constructor-injected hasher, blob resolver, registry, and closure-path selector, exposing `compose_query`, `compose_transformation`, `compose_artifact_definition`, `compose_generator_definition` entry methods (bodies stubbed/`NotImplementedError`, filled in per story). Registry lookups for cross-references use the referenced definition's name (artifact def -> transform by `transformation` name across both transform kinds; artifact/generator def -> target group by `targets` name resolved to id); ensure the registry key scheme supports these name-based lookups.
 
 ### Integrator sequencing scaffold (FR-015a)
 
-- [ ] T014 In `backend/infrahub/git/integrator.py`, introduce the per-import fingerprint registry instance and sequence the import phases in dependency order (queries -> transformations/generator-definitions -> artifact-definitions) threading the registry through, WITHOUT yet computing any fingerprint value (no behaviour change, FR-020). This establishes the ordering the composers plug into.
+- [X] T014 In `backend/infrahub/git/integrator.py`, introduce the per-import fingerprint registry instance and sequence the import phases in dependency order (queries -> transformations/generator-definitions -> artifact-definitions) threading the registry through, WITHOUT yet computing any fingerprint value (no behaviour change, FR-020). This establishes the ordering the composers plug into.
 
 **Checkpoint**: Schema field exists and is regenerated; shared components and integrator ordering are in place. User stories can now begin.
 
@@ -76,13 +76,13 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Tests for User Story 1
 
-- [ ] T015 [P] [US1] Unit test `compose_query` in `backend/tests/unit/git/fingerprint/test_composer_query.py`: deterministic digest over stored inlined query text; identical text -> identical digest; different text -> different digest; edit-then-revert net-zero (SC-004).
-- [ ] T016 [P] [US1] Integration test in `backend/tests/integration/git/test_fingerprint_query.py` (model on `test_generator_import_closure.py`, reuse `car-dealership` fixture + `FileRepo`/`MultipleStagesFileRepo`): import -> query `fingerprint` non-null (SC-001); no-op re-import unchanged (SC-002); query-text edit changes it (SC-003); unrelated-file edit leaves it unchanged.
+- [X] T015 [P] [US1] Unit test `compose_query` in `backend/tests/unit/git/fingerprint/test_composer_query.py`: deterministic digest over stored inlined query text; identical text -> identical digest; different text -> different digest; edit-then-revert net-zero (SC-004).
+- [X] T016 [P] [US1] Integration test in `backend/tests/integration/git/test_fingerprint_query.py` (model on `test_generator_import_closure.py`, reuse `car-dealership` fixture + `FileRepo`/`MultipleStagesFileRepo`): import -> query `fingerprint` non-null (SC-001); no-op re-import unchanged (SC-002); query-text edit changes it (SC-003); unrelated-file edit leaves it unchanged.
 
 ### Implementation for User Story 1
 
-- [ ] T017 [US1] Implement `compose_query` in `backend/infrahub/git/fingerprint/composer.py` (FR-008): `H(query_text)` over the stored fragment-inlined `query` attribute; populate the registry under the query key.
-- [ ] T018 [US1] In `backend/infrahub/git/integrator.py`, compute the query fingerprint during the query import phase and pass it into the SDK create/update payload for `CoreGraphQLQuery` (FR-005, FR-006, FR-007: overwrite every import via the standard mutation path).
+- [X] T017 [US1] Implement `compose_query` in `backend/infrahub/git/fingerprint/composer.py` (FR-008): `H(query_text)` over the stored fragment-inlined `query` attribute; populate the registry under the query key.
+- [X] T018 [US1] In `backend/infrahub/git/integrator.py`, compute the query fingerprint during the query import phase and pass it into the SDK create/update payload for `CoreGraphQLQuery` (FR-005, FR-006, FR-007: overwrite every import via the standard mutation path).
 
 **Checkpoint**: Query fingerprint works end to end and is stored via the mutation path.
 
@@ -96,12 +96,12 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Tests for User Story 5
 
-- [ ] T019 [P] [US5] Unit test the watch three-state discriminator in `backend/tests/unit/git/fingerprint/test_watch_state.py`: `watch is None` -> fold commit id; `InfrahubWatchConfig` present with empty files -> omit; present with files -> omit and files contribute to the closure input. Confirm parsed config represents `None` vs present as distinct states (FR-019).
+- [X] T019 [P] [US5] Unit test the watch three-state discriminator in `backend/tests/unit/git/fingerprint/test_watch_state.py`: `watch is None` -> fold commit id; `InfrahubWatchConfig` present with empty files -> omit; present with files -> omit and files contribute to the closure input. Confirm parsed config represents `None` vs present as distinct states (FR-019).
 
 ### Implementation for User Story 5
 
-- [ ] T020 [US5] Confirm (and if needed adjust) `python_sdk/infrahub_sdk/schema/repository.py` so the parsed `watch` config distinguishes absent (`None`) from present-but-empty for Jinja2, Python, and generator configs (research Decision 4: `watch: InfrahubWatchConfig | None`, expected no shape change - verify, do not rebuild).
-- [ ] T021 [US5] Add the commit-id fold helper to `backend/infrahub/git/fingerprint/composer.py` (or `hasher.py`): given the imported commit id and the config's `watch`, return the commit-id term iff `watch is None`, else omit it (FR-016/017). This helper is consumed by `compose_transformation` (US2) and `compose_generator_definition` (US4).
+- [X] T020 [US5] Confirm (and if needed adjust) `python_sdk/infrahub_sdk/schema/repository.py` so the parsed `watch` config distinguishes absent (`None`) from present-but-empty for Jinja2, Python, and generator configs (research Decision 4: `watch: InfrahubWatchConfig | None`, expected no shape change - verify, do not rebuild).
+- [X] T021 [US5] Add the commit-id fold helper to `backend/infrahub/git/fingerprint/composer.py` (or `hasher.py`): given the imported commit id and the config's `watch`, return the commit-id term iff `watch is None`, else omit it (FR-016/017). This helper is consumed by `compose_transformation` (US2) and `compose_generator_definition` (US4).
 
 **Checkpoint**: The watch discriminator and commit-id fold are implemented and unit-tested for all three states.
 
@@ -117,14 +117,14 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Tests for User Story 2
 
-- [ ] T022 [P] [US2] Unit test `compose_transformation` (Python) in `backend/tests/unit/git/fingerprint/test_composer_transformation.py`: incorporates query fingerprint, sorted `(path, blob_sha)` closure, `class_name`, `convert_query_response`; excludes `timeout` and `description`; folds commit id only when `watch is None`; and asserts the manifest path (`.infrahub.yml`) is excluded from the hashed closure so its blob SHA does not affect the digest, while the own source file and `watch:` files remain included (guards SC-005 at the unit level).
-- [ ] T023 [P] [US2] Unit test `compose_transformation` (Jinja2) in the same or a sibling test file: incorporates query fingerprint, sorted closure (incl. template), `template_path`; excludes `timeout`/`description`; watch-driven commit id.
-- [ ] T024 [P] [US2] Integration test in `backend/tests/integration/git/test_fingerprint_transformation.py`: import Python + Jinja2 transforms -> non-null; no-op re-import unchanged with `watch` declared (SC-002); closure-file blob-SHA change -> changes (US2 #4); connected-query change -> changes (US2 #5); `class_name`/`convert_query_response`/`template_path` change -> changes; `timeout`-only change -> unchanged (US2 #3); `watch: {}` + own-source-file edit -> changes (US2 #6, FR-009a); and, for a transform with declared `watch`, a comment-only / unrelated-section `.infrahub.yml` edit -> fingerprint unchanged (SC-005, FR-022 edge case).
+- [X] T022 [P] [US2] Unit test `compose_transformation` (Python) in `backend/tests/unit/git/fingerprint/test_composer_transformation.py`: incorporates query fingerprint, sorted `(path, blob_sha)` closure, `class_name`, `convert_query_response`; excludes `timeout` and `description`; folds commit id only when `watch is None`; and asserts the manifest path (`.infrahub.yml`) is excluded from the hashed closure so its blob SHA does not affect the digest, while the own source file and `watch:` files remain included (guards SC-005 at the unit level).
+- [X] T023 [P] [US2] Unit test `compose_transformation` (Jinja2) in the same or a sibling test file: incorporates query fingerprint, sorted closure (incl. template), `template_path`; excludes `timeout`/`description`; watch-driven commit id.
+- [X] T024 [P] [US2] Integration test in `backend/tests/integration/git/test_fingerprint_transformation.py`: import Python + Jinja2 transforms -> non-null; no-op re-import unchanged with `watch` declared (SC-002); closure-file blob-SHA change -> changes (US2 #4); connected-query change -> changes (US2 #5); `class_name`/`convert_query_response`/`template_path` change -> changes; `timeout`-only change -> unchanged (US2 #3); `watch: {}` + own-source-file edit -> changes (US2 #6, FR-009a); and, for a transform with declared `watch`, a comment-only / unrelated-section `.infrahub.yml` edit -> fingerprint unchanged (SC-005, FR-022 edge case).
 
 ### Implementation for User Story 2
 
-- [ ] T025 [US2] Implement `compose_transformation` in `backend/infrahub/git/fingerprint/composer.py` (FR-009/009a/009b/010/015b): read connected query fingerprint from the registry; run the stored `dependencies` through the T011a selector (manifest excluded, own source file + `watch:` files retained) and resolve their blob SHAs; hash with `class_name`/`convert_query_response` (Python) or `template_path` (Jinja2), fold commit id via the US5 helper; register the result.
-- [ ] T026 [US2] In `backend/infrahub/git/integrator.py`, compute the transformation fingerprint during the transformation import phase (after queries) and pass it into the SDK create/update payload for `CoreTransformPython`/`CoreTransformJinja2` (FR-006/007).
+- [X] T025 [US2] Implement `compose_transformation` in `backend/infrahub/git/fingerprint/composer.py` (FR-009/009a/009b/010/015b): read connected query fingerprint from the registry; run the stored `dependencies` through the T011a selector (manifest excluded, own source file + `watch:` files retained) and resolve their blob SHAs; hash with `class_name`/`convert_query_response` (Python) or `template_path` (Jinja2), fold commit id via the US5 helper; register the result.
+- [X] T026 [US2] In `backend/infrahub/git/integrator.py`, compute the transformation fingerprint during the transformation import phase (after queries) and pass it into the SDK create/update payload for `CoreTransformPython`/`CoreTransformJinja2` (FR-006/007).
 
 **Checkpoint**: Transformation fingerprint works for both concrete kinds, composing the query fingerprint and honouring watch semantics.
 
@@ -140,13 +140,13 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Tests for User Story 3
 
-- [ ] T027 [P] [US3] Unit test `compose_artifact_definition` in `backend/tests/unit/git/fingerprint/test_composer_artifact_definition.py`: incorporates transformation fingerprint, canonical `parameters`, `content_type`, `artifact_name`, target-group id; identical inputs -> identical digest regardless of `parameters` key ordering (FR-014).
-- [ ] T028 [P] [US3] Integration test in `backend/tests/integration/git/test_fingerprint_artifact_definition.py`: import -> non-null; changes on transformation-fingerprint / `parameters` / `content_type` / `artifact_name` change; re-point target group -> changes; add/remove group member -> unchanged (SC-007).
+- [X] T027 [P] [US3] Unit test `compose_artifact_definition` in `backend/tests/unit/git/fingerprint/test_composer_artifact_definition.py`: incorporates transformation fingerprint, canonical `parameters`, `content_type`, `artifact_name`, target-group id; identical inputs -> identical digest regardless of `parameters` key ordering (FR-014).
+- [X] T028 [P] [US3] Integration test in `backend/tests/integration/git/test_fingerprint_artifact_definition.py`: import -> non-null; changes on transformation-fingerprint / `parameters` / `content_type` / `artifact_name` change; re-point target group -> changes; add/remove group member -> unchanged (SC-007).
 
 ### Implementation for User Story 3
 
-- [ ] T029 [US3] Implement `compose_artifact_definition` in `backend/infrahub/git/fingerprint/composer.py` (FR-011/013): read transformation fingerprint from the registry; resolve target-group id from `targets`; hash with canonical `parameters`, `content_type`, `artifact_name`, group id; register the result.
-- [ ] T030 [US3] In `backend/infrahub/git/integrator.py`, compute the artifact-definition fingerprint during the artifact-definition phase (after transformations) and pass it into the SDK create/update payload for `CoreArtifactDefinition` (FR-006/007).
+- [X] T029 [US3] Implement `compose_artifact_definition` in `backend/infrahub/git/fingerprint/composer.py` (FR-011/013): read transformation fingerprint from the registry; resolve target-group id from `targets`; hash with canonical `parameters`, `content_type`, `artifact_name`, group id; register the result.
+- [X] T030 [US3] In `backend/infrahub/git/integrator.py`, compute the artifact-definition fingerprint during the artifact-definition phase (after transformations) and pass it into the SDK create/update payload for `CoreArtifactDefinition` (FR-006/007).
 
 **Checkpoint**: Artifact-definition fingerprint composes the transformation fingerprint and honours group-identity-not-membership.
 
@@ -162,13 +162,13 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 ### Tests for User Story 4
 
-- [ ] T031 [P] [US4] Unit test `compose_generator_definition` in `backend/tests/unit/git/fingerprint/test_composer_generator_definition.py`: incorporates query fingerprint, sorted `(path, blob_sha)` closure (incl. own `.py`), canonical `parameters`, `class_name`, `convert_query_response`, target-group id; folds commit id iff `watch is None`; excludes `execute_in_proposed_change`/`execute_after_merge`.
-- [ ] T032 [P] [US4] Integration test in `backend/tests/integration/git/test_fingerprint_generator_definition.py`: import -> non-null; changes on query fingerprint / closure / `parameters` / group re-point; `watch` absent -> changes on every commit (SC-006); `watch: {}` + `class_name` change (different class, same unchanged file) or `convert_query_response` toggle -> changes (US4 #4, FR-012a); `watch: {}` + comment-only / unrelated `.infrahub.yml` edit -> unchanged (SC-005); group membership churn -> unchanged (SC-007).
+- [X] T031 [P] [US4] Unit test `compose_generator_definition` in `backend/tests/unit/git/fingerprint/test_composer_generator_definition.py`: incorporates query fingerprint, sorted `(path, blob_sha)` closure (incl. own `.py`), canonical `parameters`, `class_name`, `convert_query_response`, target-group id; folds commit id iff `watch is None`; excludes `execute_in_proposed_change`/`execute_after_merge`.
+- [X] T032 [P] [US4] Integration test in `backend/tests/integration/git/test_fingerprint_generator_definition.py`: import -> non-null; changes on query fingerprint / closure / `parameters` / group re-point; `watch` absent -> changes on every commit (SC-006); `watch: {}` + `class_name` change (different class, same unchanged file) or `convert_query_response` toggle -> changes (US4 #4, FR-012a); `watch: {}` + comment-only / unrelated `.infrahub.yml` edit -> unchanged (SC-005); group membership churn -> unchanged (SC-007).
 
 ### Implementation for User Story 4
 
-- [ ] T033 [US4] Implement `compose_generator_definition` in `backend/infrahub/git/fingerprint/composer.py` (FR-012/012a/013): read connected query fingerprint from the registry; run the closure through the T011a selector (manifest excluded, own `.py` + `watch:` files retained) and resolve blob SHAs; resolve target-group id; hash with canonical `parameters`, `class_name`, `convert_query_response`, group id; fold commit id via the US5 helper; register the result.
-- [ ] T034 [US4] In `backend/infrahub/git/integrator.py`, compute the generator-definition fingerprint during the generator-definition phase (alongside transformations, after queries) and pass it into the SDK create/update payload for `CoreGeneratorDefinition` (FR-006/007).
+- [X] T033 [US4] Implement `compose_generator_definition` in `backend/infrahub/git/fingerprint/composer.py` (FR-012/012a/013): read connected query fingerprint from the registry; run the closure through the T011a selector (manifest excluded, own `.py` + `watch:` files retained) and resolve blob SHAs; resolve target-group id; hash with canonical `parameters`, `class_name`, `convert_query_response`, group id; fold commit id via the US5 helper; register the result.
+- [X] T034 [US4] In `backend/infrahub/git/integrator.py`, compute the generator-definition fingerprint during the generator-definition phase (alongside transformations, after queries) and pass it into the SDK create/update payload for `CoreGeneratorDefinition` (FR-006/007).
 
 **Checkpoint**: All four definition kinds carry a computed, stored fingerprint.
 
@@ -178,11 +178,11 @@ description: "Task list for Definition Fingerprint Foundation (IFC-2844)"
 
 **Purpose**: Cross-cutting invariants, branch behaviour, no-consumer-change regression, and final generated-file validation.
 
-- [ ] T035 [P] Integration test for the consistent snapshot (FR-015a) in `backend/tests/integration/git/test_fingerprint_snapshot.py`: change a query and its dependent artifact definition in the *same* commit/import -> the artifact-definition fingerprint reflects the new query fingerprint in that same import (no one-import lag).
-- [ ] T036 [P] Integration test for branch behaviour (SC-010) in `backend/tests/integration/git/test_fingerprint_branch.py`: the `fingerprint` appears in a branch diff and survives rebase/merge as a normal branch-aware attribute.
-- [ ] T037 Verify no consumer behaviour changed (SC-008, FR-020): run the existing regeneration/recompute regression suites (generator/artifact/computed-attribute trigger tests) and confirm identical trigger counts, all green.
-- [ ] T038 Run `uv run invoke docs.validate` and confirm generated-file/doc validation passes with all regenerated artifacts committed (SC-009).
-- [ ] T039 Run `/pre-ci` (format, lint, unit tests) and the quickstart.md validation walkthrough end to end.
+- [X] T035 [P] Integration test for the consistent snapshot (FR-015a) in `backend/tests/integration/git/test_fingerprint_snapshot.py`: change a query and its dependent artifact definition in the *same* commit/import -> the artifact-definition fingerprint reflects the new query fingerprint in that same import (no one-import lag).
+- [X] T036 [P] Integration test for branch behaviour (SC-010) in `backend/tests/integration/git/test_fingerprint_branch.py`: the `fingerprint` appears in a branch diff and survives rebase/merge as a normal branch-aware attribute.
+- [X] T037 Verify no consumer behaviour changed (SC-008, FR-020): run the existing regeneration/recompute regression suites (generator/artifact/computed-attribute trigger tests) and confirm identical trigger counts, all green.
+- [X] T038 Run `uv run invoke docs.validate` and confirm generated-file/doc validation passes with all regenerated artifacts committed (SC-009).
+- [X] T039 Run `/pre-ci` (format, lint, unit tests) and the quickstart.md validation walkthrough end to end.
 
 ---
 


### PR DESCRIPTION
# Why

**The problem.** To decide whether an imported definition (a query, transform, artifact definition, or generator) needs regenerating, we need to know whether the code/inputs that affect its *output* actually changed. Today the only signals are blunt:

- The **git commit id** changes on every commit - including edits to unrelated files, comments, or other definitions - so keying off it over-triggers.
- Determining the truth otherwise means re-reading and diffing the actual repository file contents, which the consumer shouldn't have to do.

**The goal.** Give each definition a deterministic **fingerprint**: a content hash of exactly its output-affecting inputs. Because it's a normal branch-aware attribute, a consumer can tell whether a definition changed by a plain data diff of the fingerprint - without inspecting the git commit and without re-reading file bytes. When an input genuinely changes, the fingerprint changes; when nothing output-affecting changes (an unrelated commit, a comment-only edit), it stays stable.

**The invariant.** Inherited from INFP-409: over-regeneration is acceptable, under-regeneration is not. Every fallback (unresolved dependency, absent `watch`, incomplete closure) folds the commit id back in and errs toward regenerating.

**Scope / non-goals.** This is the foundation only: it computes and stores the fingerprint but wires up no consumer, rewires no trigger, and changes no regeneration gate. The schema `fingerprint` attribute landed separately on the base branch; this PR adds the computation and storage.

## What changed

**New fingerprint package.** `backend/infrahub/git/fingerprint/` holds small, constructor-injected components:

- `FingerprintHasher` - deterministic SHA-256 over length-prefixed canonical terms, plus canonical JSON for structured inputs.
- `GitBlobResolver` (behind a `BlobResolver` protocol) - resolves `(path, blob_sha)` pairs from the git tree at the imported commit, reading git metadata only, never file contents.
- `FingerprintRegistry` - a per-import snapshot so a dependent definition composes the freshly-computed value of its inputs from the same import, never a stale stored one.
- `FingerprintComposer` - layered composers: query, transformation (Python + Jinja2), artifact definition, and generator definition.

**Import wiring.** `git/integrator.py` builds one composer per import and threads it through the phases in dependency order (queries, then transforms/generators, then artifact definitions), folding the fingerprint into the existing SDK create/update payloads. Writes are conditional on a value change, so a no-op re-import produces an empty diff and no extra saves.

**Composition rules (what is and isn't hashed).**

- The manifest (`.infrahub.yml`) is excluded from the hashed closure but kept in stored dependencies; its output-affecting fields are hashed as parsed scalars instead of raw bytes, so a comment-only manifest edit doesn't churn every fingerprint.
- The commit id is folded in only when inputs can't be pinned down - `watch` absent, closure incomplete, or an upstream fingerprint unresolved - always erring toward over-regeneration.
- Group **identity** (target group id) is hashed; group **membership** is not.
- `timeout`, `description`, and `execute_in_proposed_change` / `execute_after_merge` are excluded as non-output-affecting.

**Tests.** Unit tests for the hasher, blob resolver, registry, closure selector, and watch / incomplete-closure / unresolved-upstream folding, plus one composer test per layer. Integration tests over the car-dealership fixture cover import-and-store, re-import stability, change detection, the consistent-snapshot guarantee, and branch-aware behaviour.

---

**What stayed the same.** No trigger, regeneration gate, or consumer changed - confirmed by the existing import and artifact-regeneration regression suites staying green with identical selection behaviour. No new dependency (stdlib `hashlib`), and the importer keeps writing through the SDK with no direct-DB access.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute and persist deterministic fingerprints for queries, transformations, generators, and artifact definitions during repository import to enable reliable change detection and branch-aware diffs. Implements IFC-2858.

- **New Features**
  - Added `FingerprintComposer` using git tree blob SHAs; no file content reads.
  - Queries: fingerprint from stored query text; persisted as a branch-aware attribute.
  - Transformations (Python/Jinja2): fingerprint from source + closure blob SHAs (manifest excluded) + watch config; fold commit id when `watch` is absent, closure is incomplete, or an upstream fingerprint is unresolved.
  - Generators and artifact definitions: fingerprint from their config plus dependent fingerprints.
  - Import integrator computes and stores fingerprints; values participate in branch diffs.
  - Helpers: `GitBlobResolver`, `FingerprintHasher` (canonical JSON + length‑prefixed SHA‑256), per-import `FingerprintRegistry`.
  - Tests: unit and integration coverage for blob resolution, closure selection, determinism, dependency chaining (query → transform → generator/artifact), branch inheritance, watch-state handling, snapshots, and re-imports.

- **Bug Fixes**
  - Fixed a test to pass under Python 3.14.

<sup>Written for commit fdeb10ca1b74912fa71b46139472af5e567288e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



