### PR TITLE
fix: normalize IPv6 host-bits input in search-anywhere object lookup

### DIFF
--- a/backend/infrahub/graphql/queries/search.py
+++ b/backend/infrahub/graphql/queries/search.py
@@ -50,7 +50,7 @@ def _collapse_ipv6(s: str) -> str:
         pass
 
     try:
-        return ipaddress.IPv6Network(s).with_prefixlen
+        return ipaddress.IPv6Interface(s).with_prefixlen
     except ipaddress.AddressValueError:
         pass
 

--- a/backend/tests/component/graphql/queries/test_search.py
+++ b/backend/tests/component/graphql/queries/test_search.py
@@ -7,6 +7,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.registry import registry
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import GraphqlParams, prepare_graphql_params
@@ -220,6 +221,48 @@ async def test_search_ipv6_network_extended_format(
     )
 
 
+async def test_search_ipv6_address_with_prefix_extended_format(
+    db: InfrahubDatabase,
+    ip_dataset_01: dict[str, Any],
+    default_branch: Branch,
+) -> None:
+    """An IPv6 address stored with a prefix length (host bits set) is found regardless of input compression."""
+    address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
+    address = await Node.init(db=db, schema=address_schema)
+    await address.new(
+        db=db, address="2001:db8::1/64", ip_prefix=ip_dataset_01["net162"], ip_namespace=ip_dataset_01["ns1"]
+    )
+    await address.save(db=db)
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+
+    res_collapsed = await graphql(
+        schema=gql_params.schema,
+        source=SEARCH_QUERY,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"search": "2001:db8::1/64"},
+    )
+
+    res_extended = await graphql(
+        schema=gql_params.schema,
+        source=SEARCH_QUERY,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"search": "2001:0db8:0000:0000:0000:0000:0000:0001/64"},
+    )
+
+    assert res_collapsed.data
+    assert res_extended.data
+
+    collapsed_ids = {e["node"]["id"] for e in res_collapsed.data["InfrahubSearchAnywhere"]["edges"]}
+    extended_ids = {e["node"]["id"] for e in res_extended.data["InfrahubSearchAnywhere"]["edges"]}
+
+    assert address.id in collapsed_ids
+    assert collapsed_ids == extended_ids
+
+
 async def test_search_ipv6_partial_address(
     db: InfrahubDatabase,
     ip_dataset_01: dict[str, Any],
@@ -322,6 +365,9 @@ async def test_search_ipv4(
         ("2001:0db8:0000:0001:00", "2001:db8:0:1"),
         ("2001:0db8:0001:0002:00", "2001:db8:1:2"),
         ("2001:0db8:0001:0000:0002:0000:0003", "2001:db8:1:0:2:0:3"),
+        ("2a0b:2081:0001:00d3:0000:0000:0000:0001/127", "2a0b:2081:1:d3::1/127"),
+        ("2a0b:2081:1:d3::1/127", "2a0b:2081:1:d3::1/127"),
+        ("2001:0db8:0000:0000:0000:0000:0000:0001/64", "2001:db8::1/64"),
     ],
 )
 def test_collapse_ipv6_address_or_network(query: str, expected: str) -> None:

--- a/changelog/9788.fixed.md
+++ b/changelog/9788.fixed.md
@@ -1,0 +1,1 @@
+The search bar now finds an IPv6 address or prefix entered with a prefix length regardless of how it is written. Previously, typing an IPv6 value with host bits set (for example `2a0b:2081:1:d3::1/127`), or its non-collapsed extended form, returned no matching object even when one existed, because the value was not normalized before the lookup.


### PR DESCRIPTION
# Why

IPAM search-anywhere failed to return a matching object when an IPv6 value was typed with host bits set and a prefix length (e.g. `2a0b:2081:1:d3::1/127`), or in non-collapsed extended form. The canonical network form (`2a0b:2081:1:d3::/127`) worked, so the two results looked like they should be equivalent but the object match silently disappeared — while the Parent Prefixes section stayed correct in both cases.

Goal: object lookup normalizes IPv6 input the same way regardless of host bits or compression, so compressed and expanded forms of the same address-with-mask return the same result.

Non-goals: no change to the parent-prefix lookup (already correct); IPv4 address-with-mask normalization is out of scope.

Closes #9788

## What changed

- **Behavioral:** searching an IPv6 address stored with a prefix length now finds it whether typed compressed, expanded, or with host bits set.
- **Implementation:** `_collapse_ipv6` now collapses via `ipaddress.IPv6Interface(s).with_prefixlen` instead of `IPv6Network(s).with_prefixlen`. `IPv6Network` raises a plain `ValueError` (not the caught `AddressValueError`) when host bits are set, so the value was left un-normalized and the raw string was used for the object filter. `IPv6Interface` collapses networks and addresses-with-prefix alike while **preserving host bits**. Dropping host bits via `ip_network(strict=False)` was intentionally avoided — it would make IP Address objects unfindable.
- **What stayed the same:** no schema, GraphQL-schema, or API changes. Parent-prefix lookup untouched. All existing `_collapse_ipv6` and search behavior preserved.

## How to review

The change is a one-line swap in `backend/infrahub/graphql/queries/search.py` plus docstring/comment. Focus there; the rest is test coverage.

## How to test

```bash
cd backend
uv run pytest tests/component/graphql/queries/test_search.py -q
```

Added coverage: 3 new `_collapse_ipv6` cases (host-bits, compressed + expanded) and `test_search_ipv6_address_with_prefix_extended_format` (compressed/expanded parity for an IPv6 address stored with a mask, mirroring the existing extended-format test). Verified the new tests fail without the source fix and pass with it; full file = 45 passed, no regressions.

## Impact & rollout

- **Backward compatibility:** no breaking changes; strictly widens which inputs resolve to a match.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/9788.fixed.md`)
- [ ] External docs updated (no user-facing doc change needed)
- [ ] Internal .md docs updated (n/a)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize IPv6 input in search-anywhere object lookup so addresses with a prefix (including host bits) match regardless of compression or extended form. Aligns Objects with Parent Prefixes and the behavior required in IFC-2860.

- **Bug Fixes**
  - Collapse via `ipaddress.IPv6Interface(s).with_prefixlen` (replacing `IPv6Network`) to preserve host bits and normalize equally.
  - Added tests for host-bits and extended-form; no API/schema changes; parent-prefix lookup unchanged.

<sup>Written for commit 8acf5fbcb9aeed6eb75ef968a91ec6a95a6f26e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

