### PR TITLE
fix(task): resolve Cubic findings in flow-run queries and retention

### DIFF
--- a/backend/infrahub/graphql/queries/task.py
+++ b/backend/infrahub/graphql/queries/task.py
@@ -75,7 +75,7 @@ class FlowRunConnectionSerializer:
 
 def _build_fetch_options(fields: dict[str, Any], log_limit: int | None, log_offset: int | None) -> FlowRunFetchOptions:
     node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"]) or {}
-    log_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node", "logs", "edges", "node"])
+    log_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node", "logs"])
     return FlowRunFetchOptions(
         include_count="count" in fields,
         include_runs=bool(node_fields),

--- a/backend/infrahub/task_manager/flow_run/filters.py
+++ b/backend/infrahub/task_manager/flow_run/filters.py
@@ -11,6 +11,7 @@ from prefect.client.schemas.filters import (
     FlowRunFilterTags,
 )
 
+from infrahub.exceptions import ValidationError
 from infrahub.workflows.constants import TAG_NAMESPACE, WorkflowTag
 
 from .models import FlowRunQueryCriteria
@@ -39,10 +40,17 @@ class FlowRunFilterBuilder:
         flow_run_filter = FlowRunFilter(tags=FlowRunFilterTags(all_=filter_tags))
 
         if criteria.ids:
-            flow_run_filter.id = FlowRunFilterId(any_=[UUID(id) for id in criteria.ids])
+            flow_run_filter.id = FlowRunFilterId(any_=[self._to_uuid(id) for id in criteria.ids])
         if criteria.statuses:
             flow_run_filter.state = FlowRunFilterState(type=FlowRunFilterStateType(any_=criteria.statuses))
         if criteria.q:
             flow_run_filter.name = FlowRunFilterName(like_=criteria.q)
 
         return flow_run_filter
+
+    @staticmethod
+    def _to_uuid(value: str) -> UUID:
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            raise ValidationError(input_value=f"'{value}' is not a valid task id") from exc

--- a/backend/infrahub/task_manager/flow_run/reader.py
+++ b/backend/infrahub/task_manager/flow_run/reader.py
@@ -130,8 +130,12 @@ class FlowRunReader:
         return flow_progress
 
     async def read_flows(self, ids: list[UUID] | None = None, names: list[str] | None = None) -> list[Flow]:
-        if not names and not ids:
+        if names is None and ids is None:
             return await self.client.read_flows()
+
+        # An empty filter list means no flows can match; an unfiltered call would return every flow instead.
+        if not names and not ids:
+            return []
 
         flow_filter = FlowFilter()
         flow_filter.name = FlowFilterName(any_=names) if names else None

--- a/backend/infrahub/task_manager/flow_run/reader.py
+++ b/backend/infrahub/task_manager/flow_run/reader.py
@@ -80,6 +80,9 @@ class FlowRunReader:
         if log_limit > NB_LOGS_LIMIT:
             raise ValueError(f"log_limit cannot be greater than {NB_LOGS_LIMIT}")
 
+        if not flow_ids:
+            return logs_flow
+
         all_logs = []
 
         # Fetch the logs in batches of PREFECT_MAX_LOGS_PER_CALL, as prefect does not allow to fetch more logs at once.

--- a/backend/infrahub/task_manager/flow_run/reader.py
+++ b/backend/infrahub/task_manager/flow_run/reader.py
@@ -109,11 +109,15 @@ class FlowRunReader:
         return logs_flow
 
     async def read_progress(self, flow_ids: list[UUID]) -> FlowProgress:
+        flow_progress = FlowProgress()
+
+        if not flow_ids:
+            return flow_progress
+
         artifacts = await self.client.read_artifacts(
             artifact_filter=ArtifactFilter(type=ArtifactFilterType(any_=["progress"])),
             flow_run_filter=FlowRunFilter(id=FlowRunFilterId(any_=flow_ids)),
         )
-        flow_progress = FlowProgress()
         for artifact in artifacts:
             if artifact.flow_run_id in flow_progress.data:
                 log.warning(

--- a/backend/infrahub/task_manager/flow_run/retention.py
+++ b/backend/infrahub/task_manager/flow_run/retention.py
@@ -47,7 +47,7 @@ class FlowRunRetention:
             batch_deleted = 0
             failed_deletes = []
 
-            for flow_run in flow_runs:
+            for index, flow_run in enumerate(flow_runs, start=1):
                 try:
                     if delete:
                         await self.client.delete_flow_run(flow_run_id=flow_run.id)
@@ -63,8 +63,8 @@ class FlowRunRetention:
                     logger.warning(f"Failed to delete flow run {flow_run.id}: {e}")
                     failed_deletes.append(flow_run.id)
 
-                # Rate limiting
-                if batch_deleted % 10 == 0:
+                # Rate limiting, based on runs processed so failures throttle the same way as successes.
+                if index % 10 == 0:
                     await asyncio.sleep(0.5)
 
             logger.info(f"Delete {batch_deleted}/{len(flow_runs)} flow runs (total: {deleted_total})")

--- a/backend/infrahub/task_manager/flow_run/retention.py
+++ b/backend/infrahub/task_manager/flow_run/retention.py
@@ -31,6 +31,7 @@ class FlowRunRetention:
     ) -> None:
         states = states or [StateType.COMPLETED, StateType.FAILED, StateType.CANCELLED]
         logger = get_logger()
+        action = "delete" if delete else "mark as crashed"
 
         cutoff = DateTime.now(tz=UTC) - timedelta(days=days_to_keep)
 
@@ -41,11 +42,11 @@ class FlowRunRetention:
 
         flow_runs = await self.client.read_flow_runs(flow_run_filter=flow_run_filter, limit=batch_size)
 
-        deleted_total = 0
+        purged_total = 0
 
         while True:
-            batch_deleted = 0
-            failed_deletes = []
+            batch_purged = 0
+            failed_purges = []
 
             for index, flow_run in enumerate(flow_runs, start=1):
                 try:
@@ -57,30 +58,30 @@ class FlowRunRetention:
                             state=State(type=StateType.CRASHED),
                             force=True,
                         )
-                    deleted_total += 1
-                    batch_deleted += 1
+                    purged_total += 1
+                    batch_purged += 1
                 except Exception as e:
-                    logger.warning(f"Failed to delete flow run {flow_run.id}: {e}")
-                    failed_deletes.append(flow_run.id)
+                    logger.warning(f"Failed to {action} flow run {flow_run.id}: {e}")
+                    failed_purges.append(flow_run.id)
 
                 # Rate limiting, based on runs processed so failures throttle the same way as successes.
                 if index % 10 == 0:
                     await asyncio.sleep(0.5)
 
-            logger.info(f"Delete {batch_deleted}/{len(flow_runs)} flow runs (total: {deleted_total})")
+            logger.info(f"Purged ({action}) {batch_purged}/{len(flow_runs)} flow runs (total: {purged_total})")
 
             previous_flow_run_ids = [fr.id for fr in flow_runs]
             flow_runs = await self.client.read_flow_runs(flow_run_filter=flow_run_filter, limit=batch_size)
 
             if not flow_runs:
-                logger.info("No more flow runs to delete")
+                logger.info("No more flow runs to purge")
                 break
 
             if previous_flow_run_ids == [fr.id for fr in flow_runs]:
-                logger.info("Found same flow runs to delete, aborting")
+                logger.info("Found same flow runs to purge, aborting")
                 break
 
             # Delay between batches to avoid overwhelming the API
             await asyncio.sleep(1.0)
 
-        logger.info(f"Retention complete. Total deleted tasks: {deleted_total}")
+        logger.info(f"Retention complete. Total purged tasks: {purged_total}")

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -162,6 +162,11 @@ FETCH_OPTIONS_CASES = [
         expected=FlowRunFetchOptions(include_runs=True, include_logs=True),
     ),
     FetchOptionsCase(
+        name="logs_count_alone_enables_logs",
+        fields={"edges": {"node": {"logs": {"count": {}}}}},
+        expected=FlowRunFetchOptions(include_runs=True, include_logs=True),
+    ),
+    FetchOptionsCase(
         name="progress_enables_progress",
         fields={"edges": {"node": {"progress": {}}}},
         expected=FlowRunFetchOptions(include_runs=True, include_progress=True),

--- a/backend/tests/unit/task_manager/flow_run/test_filters.py
+++ b/backend/tests/unit/task_manager/flow_run/test_filters.py
@@ -1,7 +1,9 @@
 from uuid import UUID
 
+import pytest
 from prefect.client.schemas.objects import StateType
 
+from infrahub.exceptions import ValidationError
 from infrahub.task_manager.flow_run.filters import FlowRunFilterBuilder
 from infrahub.task_manager.flow_run.models import FlowRunQueryCriteria
 from infrahub.workflows.constants import TAG_NAMESPACE
@@ -60,6 +62,10 @@ class TestBuildFlowRunFilter:
 
         assert flow_run_filter.id is not None
         assert flow_run_filter.id.any_ == [UUID(id_a), UUID(id_b)]
+
+    def test_invalid_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError, match=r"^'not-a-uuid' is not a valid task id$"):
+            FlowRunFilterBuilder().build_flow_run_filter(criteria=FlowRunQueryCriteria(ids=["not-a-uuid"]))
 
     def test_statuses_set_state_type_any(self) -> None:
         flow_run_filter = FlowRunFilterBuilder().build_flow_run_filter(

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -152,6 +152,22 @@ class TestReadFlows:
         assert result == flows
         assert client.read_flows_calls == [None]
 
+    async def test_empty_ids_return_no_flows_without_remote_call(self) -> None:
+        client = FakeReaderClient(flows=[Flow(id=uuid4(), name="wf", labels={})])
+
+        result = await FlowRunReader(client=client).read_flows(ids=[])
+
+        assert result == []
+        assert client.read_flows_calls == []
+
+    async def test_empty_names_return_no_flows_without_remote_call(self) -> None:
+        client = FakeReaderClient(flows=[Flow(id=uuid4(), name="wf", labels={})])
+
+        result = await FlowRunReader(client=client).read_flows(names=[])
+
+        assert result == []
+        assert client.read_flows_calls == []
+
     async def test_filters_by_names(self) -> None:
         client = FakeReaderClient()
 

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -21,6 +21,7 @@ class FakeReaderClient:
         self._artifacts = artifacts or []
         self._flows = flows or []
         self._log_fetches: list[tuple[int, int]] = []
+        self.read_artifacts_calls: list[FlowRunFilter] = []
         self.read_flows_calls: list[FlowFilter | None] = []
 
     async def read_flow_runs(
@@ -42,6 +43,7 @@ class FakeReaderClient:
         assert self._log_fetches == pages
 
     async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
+        self.read_artifacts_calls.append(flow_run_filter)
         return self._artifacts
 
     async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
@@ -130,6 +132,14 @@ class TestReadProgress:
         result = await FlowRunReader(client=client).read_progress(flow_ids=[flow_id])
 
         assert result.data == {}
+
+    async def test_no_flow_ids_returns_empty_without_remote_call(self) -> None:
+        client = FakeReaderClient(artifacts=[make_artifact(uuid4(), 0.5)])
+
+        result = await FlowRunReader(client=client).read_progress(flow_ids=[])
+
+        assert result.data == {}
+        assert client.read_artifacts_calls == []
 
 
 class TestReadFlows:

--- a/backend/tests/unit/task_manager/flow_run/test_reader.py
+++ b/backend/tests/unit/task_manager/flow_run/test_reader.py
@@ -91,6 +91,14 @@ class TestReadLogs:
 
         assert [entry.message for entry in result.logs[flow_id]] == ["real work"]
 
+    async def test_no_flow_ids_returns_empty_without_remote_call(self) -> None:
+        client = FakeReaderClient(logs=[make_log(uuid4())])
+
+        result = await FlowRunReader(client=client).read_logs(flow_ids=[], log_limit=None, log_offset=None)
+
+        assert result.logs == {}
+        client.assert_log_pages_fetched([])
+
     async def test_rejects_log_limit_above_max(self) -> None:
         with pytest.raises(ValueError, match=rf"^log_limit cannot be greater than {NB_LOGS_LIMIT}$"):
             await FlowRunReader(client=FakeReaderClient()).read_logs(

--- a/changelog/+task-filter-invalid-id.fixed.md
+++ b/changelog/+task-filter-invalid-id.fixed.md
@@ -1,0 +1,1 @@
+Filtering tasks by an id that is not a valid UUID now returns a validation error instead of an internal server error.

--- a/changelog/+task-logs-count-selection.fixed.md
+++ b/changelog/+task-logs-count-selection.fixed.md
@@ -1,0 +1,1 @@
+The task GraphQL query now returns the correct log count when only `logs { count }` is selected, without requesting the log entries themselves.


### PR DESCRIPTION
# Why

Cubic flagged 7 pre-existing issues in the flow-run task manager while reviewing #9599 (tracked in Jira [IFC-2756](https://opsmill.atlassian.net/browse/IFC-2756)): two user-visible bugs (wrong log count, HTTP 500 on malformed task ids) and several wasted Prefect calls plus misleading retention throttling/logging. This PR resolves all 7.

## What changed

Behavioral changes:

- The tasks GraphQL query returns the correct log count when only `logs { count }` is selected.
- Filtering tasks by an id that is not a valid UUID returns a 422 validation error instead of a 500.

Internal changes (no visible output change):

- A task query matching zero runs no longer calls Prefect for logs, progress artifacts, or an unfiltered read of every flow.
- Flow-run retention throttles on runs processed instead of successes only, and its log messages reflect the configured action (delete vs mark as crashed).

One commit per finding:

| Commit | Cubic feedback |
|---|---|
| 8b64a1f7a `fix(task): fetch logs when only the log count is selected` | [r3426681429](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681429) |
| f9bc26ae6 `fix(task): report invalid task id filters as validation errors` | [r3426681416](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681416) |
| 5a240845d `perf(task): skip the log fetch when no flow runs are selected` | [r3426681458](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681458) |
| 3a85633f5 `perf(task): skip the progress artifact query when no flow runs are selected` | [r3426681451](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681451) |
| ea0de551f `perf(task): treat an empty flow filter as matching no flows` | [r3426681463](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681463) |
| 18ef19f62 `fix(task): throttle flow-run retention on runs processed rather than successes` | [r3426681424](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681424) |
| 142e18b25 `fix(task): make retention log messages reflect the purge action` | [r3426681465](https://github.com/opsmill/infrahub/pull/9599/changes#r3426681465) |

## How to test

```bash
uv run pytest backend/tests/unit/task_manager/flow_run backend/tests/unit/graphql/queries/test_task.py
```

## Impact & rollout

- **Backward compatibility:** no schema or API contract changes; malformed task id filters now return 422 instead of 500.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (two fragments, for the two user-visible fixes)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IFC-2756]: https://opsmill.atlassian.net/browse/IFC-2756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cubic findings in the flow-run task manager: correct log counts, 422 on invalid task ID filters, and clearer retention with proper throttling, while avoiding unnecessary Prefect calls (IFC-2756).

- **Bug Fixes**
  - Task GraphQL returns the correct `logs { count }`.
  - Invalid task ID filters now return 422 instead of 500.
  - Retention: throttle on runs processed and log the actual action (delete vs mark as crashed).

- **Performance**
  - Avoid unnecessary Prefect calls by skipping log/progress fetches when no runs are selected and treating empty flow/name filters as matching none.

<sup>Written for commit 142e18b251d18340f3de25286ba8be6a8d9ecfd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

