### PR TITLE
ci: remove customer3 repository dispatch

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -39,7 +39,6 @@ jobs:
           - "INFRAHUB_PACKER_REPOSITORY"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
-          - "INFRAHUB_CUSTOMER3_REPOSITORY"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
The customer3 repository has been archived, so the release workflow no longer needs to dispatch an Infrahub update event to it. This removes the now-dead target from the repository-dispatch matrix.

## Key Changes
- Releases no longer attempt a `trigger-infrahub-update` dispatch to the archived customer3 repository (`INFRAHUB_CUSTOMER3_REPOSITORY`), avoiding a pointless/failing matrix job on every release.

## Test Plan
- CI on this PR (workflow syntax validation).
- Verified `INFRAHUB_CUSTOMER3_REPOSITORY` no longer appears anywhere in `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the archived customer3 target from the repository-dispatch workflow to stop dispatching Infrahub updates and avoid failing matrix jobs on releases. Deletes `INFRAHUB_CUSTOMER3_REPOSITORY` from the workflow matrix.

<sup>Written for commit a9948d0fbf7cb08cbe8fc6c4497e3ccb848b6098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

