### PR TITLE
Add sort picker

### DIFF
--- a/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
@@ -7,11 +7,13 @@ import {
   type AddAttributesToRequestOptions,
   addAttributesToRequest,
   addFiltersToRequest,
+  addOrderByToRequest,
   addRelationshipsToRequest,
 } from "@/shared/api/graphql/utils";
 import type { ContextParams, PaginationParams } from "@/shared/api/types";
 import type { Filter } from "@/shared/hooks/useFilters";
 
+import type { Sort } from "@/entities/nodes/object/domain/sort";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
 interface GetObjectsQueryParams {
@@ -21,6 +23,7 @@ interface GetObjectsQueryParams {
   limit?: number;
   offset?: number;
   filters?: Array<Filter>;
+  sort?: Sort[] | null;
   attributesOptions?: AddAttributesToRequestOptions;
   relationshipsOptions?: AddAttributesToRequestOptions;
 }
@@ -32,6 +35,7 @@ const getObjectsQuery = ({
   limit,
   offset,
   filters,
+  sort,
   attributesOptions,
   relationshipsOptions,
 }: GetObjectsQueryParams) => {
@@ -43,7 +47,8 @@ const getObjectsQuery = ({
           __args: {
             limit,
             offset,
-            ...(filters ? addFiltersToRequest(filters) : {}),
+            ...(filters?.length ? addFiltersToRequest(filters) : {}),
+            ...(sort?.length ? addOrderByToRequest(sort) : {}),
           },
           edges: {
             node: {
@@ -72,6 +77,7 @@ export async function getObjectsFromApi({
   branchName,
   atDate,
   filters,
+  sort,
   attributesOptions,
   relationshipsOptions,
 }: GetObjectsFromApiParams) {
@@ -83,6 +89,7 @@ export async function getObjectsFromApi({
       limit,
       offset,
       filters,
+      sort,
       attributesOptions,
       relationshipsOptions,
     }),

--- a/frontend/app/src/entities/nodes/object/domain/get-objects.ts
+++ b/frontend/app/src/entities/nodes/object/domain/get-objects.ts
@@ -4,6 +4,7 @@ import type { Filter } from "@/shared/hooks/useFilters";
 import { DEFAULT_PAGE_SIZE } from "@/shared/utils/pagination";
 
 import { getObjectsFromApi } from "@/entities/nodes/object/api/get-objects-from-api";
+import type { Sort } from "@/entities/nodes/object/domain/sort";
 import { getAttributesVisibleInListView } from "@/entities/nodes/object/utils/get-attributes-visible-in-list-view";
 import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/utils/get-relationships-visible-in-list-view";
 import type { NodeObject } from "@/entities/nodes/types";
@@ -13,6 +14,7 @@ export type GetObjectsParams = ContextParams &
   PaginationParams & {
     schema: ModelSchema;
     filters?: Array<Filter>;
+    sort?: Sort[] | null;
     getAttributesVisible?: (attributes: AttributeSchema[]) => AttributeSchema[];
     getRelationshipsVisible?: (relationships: RelationshipSchema[]) => RelationshipSchema[];
     attributesOptions?: AddAttributesToRequestOptions;
@@ -28,6 +30,7 @@ export const getObjects: GetObjects = async ({
   branchName,
   atDate,
   filters,
+  sort,
   getAttributesVisible = getAttributesVisibleInListView,
   getRelationshipsVisible = getRelationshipsVisibleInListView,
   attributesOptions,
@@ -47,6 +50,7 @@ export const getObjects: GetObjects = async ({
     branchName,
     atDate,
     filters,
+    sort,
     attributesOptions,
     relationshipsOptions,
   });

--- a/frontend/app/src/entities/nodes/object/domain/sort.test.ts
+++ b/frontend/app/src/entities/nodes/object/domain/sort.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  formatSort,
+  getSortDirection,
+  getSortField,
+  getValidSort,
+  parseSort,
+  type Sort,
+} from "@/entities/nodes/object/domain/sort";
+import type { SortFieldKey } from "@/entities/nodes/object/domain/sortable-field";
+
+const SORTABLE = new Set<SortFieldKey>([
+  "name__value",
+  "owner__name__value",
+  "node_metadata__created_at",
+  "node_metadata__updated_at",
+]);
+
+describe("getSortField", () => {
+  test("strips a trailing direction suffix", () => {
+    // GIVEN / WHEN / THEN
+    expect(getSortField("name__value__asc")).toBe("name__value");
+    expect(getSortField("node_metadata__updated_at__desc")).toBe("node_metadata__updated_at");
+  });
+});
+
+describe("getSortDirection", () => {
+  test("reads the uppercase direction from the lowercase suffix", () => {
+    // GIVEN / WHEN / THEN
+    expect(getSortDirection("name__value__desc")).toBe("DESC");
+    expect(getSortDirection("name__value__asc")).toBe("ASC");
+  });
+
+  test("defaults to ASC when the suffix is absent", () => {
+    // GIVEN / WHEN / THEN
+    expect(getSortDirection("owner__name__value")).toBe("ASC");
+  });
+});
+
+describe("parseSort", () => {
+  test("splits a token into its field key and uppercase direction", () => {
+    // GIVEN / WHEN / THEN
+    expect(parseSort("owner__name__value__desc")).toEqual({
+      field: "owner__name__value",
+      direction: "DESC",
+    });
+  });
+
+  test("round-trips with formatSort", () => {
+    // GIVEN
+    const sort = parseSort("name__value__asc");
+    // WHEN / THEN
+    expect(formatSort(sort.field, sort.direction)).toBe("name__value__asc");
+  });
+});
+
+describe("formatSort", () => {
+  test("joins a field and uppercase direction into a lowercase token", () => {
+    // GIVEN / WHEN / THEN
+    expect(formatSort("name__value", "DESC")).toBe("name__value__desc");
+  });
+
+  test("round-trips with getSortField and getSortDirection", () => {
+    // GIVEN
+    const sort = formatSort("owner__name__value", "ASC");
+    // WHEN / THEN
+    expect(getSortField(sort)).toBe("owner__name__value");
+    expect(getSortDirection(sort)).toBe("ASC");
+  });
+});
+
+describe("getValidSort", () => {
+  const nameAsc: Sort = { field: "name__value", direction: "ASC" };
+  const ownerDesc: Sort = { field: "owner__name__value", direction: "DESC" };
+  const createdAsc: Sort = { field: "node_metadata__created_at", direction: "ASC" };
+
+  test("returns null when there is no sort", () => {
+    // GIVEN / WHEN / THEN
+    expect(getValidSort(null, SORTABLE)).toBeNull();
+    expect(getValidSort([], SORTABLE)).toBeNull();
+  });
+
+  test("keeps schema-compatible entries in order", () => {
+    // GIVEN / WHEN
+    const result = getValidSort([ownerDesc, nameAsc], SORTABLE);
+    // THEN
+    expect(result).toEqual([ownerDesc, nameAsc]);
+  });
+
+  test("excludes entries whose field is not sortable in the schema", () => {
+    // GIVEN
+    const sorts: Sort[] = [nameAsc, { field: "gone__value", direction: "DESC" }, createdAsc];
+    // WHEN
+    const result = getValidSort(sorts, SORTABLE);
+    // THEN
+    expect(result).toEqual([nameAsc, createdAsc]);
+  });
+
+  test("returns null when every entry is invalid", () => {
+    // GIVEN
+    const sorts: Sort[] = [
+      { field: "gone__value", direction: "ASC" },
+      { field: "also_gone__value", direction: "DESC" },
+    ];
+    // WHEN / THEN
+    expect(getValidSort(sorts, SORTABLE)).toBeNull();
+  });
+
+  test("drops duplicate fields, keeping the first", () => {
+    // GIVEN
+    const sorts: Sort[] = [nameAsc, { field: "name__value", direction: "DESC" }];
+    // WHEN
+    const result = getValidSort(sorts, SORTABLE);
+    // THEN
+    expect(result).toEqual([nameAsc]);
+  });
+
+  test("includes an entry once its field becomes sortable again", () => {
+    // GIVEN
+    const teamDesc: Sort = { field: "team__name__value", direction: "DESC" };
+    expect(getValidSort([teamDesc, nameAsc], SORTABLE)).toEqual([nameAsc]);
+
+    // WHEN
+    const widened = new Set<SortFieldKey>([...SORTABLE, "team__name__value"]);
+
+    // THEN
+    expect(getValidSort([teamDesc, nameAsc], widened)).toEqual([teamDesc, nameAsc]);
+  });
+});

--- a/frontend/app/src/entities/nodes/object/domain/sort.ts
+++ b/frontend/app/src/entities/nodes/object/domain/sort.ts
@@ -1,0 +1,61 @@
+import * as R from "remeda";
+
+import {
+  getSortableFields,
+  type SortDirection,
+  type SortFieldKey,
+} from "@/entities/nodes/object/domain/sortable-field";
+import type { ModelSchema } from "@/entities/schema/types";
+
+/** Lowercase `field__direction` token, e.g. `name__value__asc`; the URL and REST `order_by` form. */
+export type SortToken = `${SortFieldKey}__${Lowercase<SortDirection>}`;
+
+export interface Sort {
+  field: SortFieldKey;
+  direction: SortDirection;
+}
+
+const DIRECTION_SUFFIX = /__(asc|desc)$/;
+
+export function getSortField(sort: string): SortFieldKey {
+  return sort.replace(DIRECTION_SUFFIX, "") as SortFieldKey;
+}
+
+export function getSortDirection(sort: string): SortDirection {
+  return sort.endsWith("__desc") ? "DESC" : "ASC";
+}
+
+export function formatSort(field: SortFieldKey, direction: SortDirection): SortToken {
+  return `${field}__${direction.toLowerCase() as Lowercase<SortDirection>}`;
+}
+
+export function parseSort(token: string): Sort {
+  return { field: getSortField(token), direction: getSortDirection(token) };
+}
+
+/** Sortable, field-deduplicated entries (first wins), or `null` when none remain. */
+export function getValidSort(
+  sorts: Sort[] | null | undefined,
+  sortableKeys: ReadonlySet<SortFieldKey>
+): Sort[] | null {
+  const valid = R.pipe(
+    sorts ?? [],
+    R.filter((sort) => sortableKeys.has(sort.field)),
+    R.uniqueBy((sort) => sort.field)
+  );
+
+  return valid.length > 0 ? valid : null;
+}
+
+export function getSchemaDefaultSort(schema: ModelSchema): Sort[] | null {
+  const sortableKeys = new Set(getSortableFields(schema).map((field) => field.field));
+  return getValidSort(schema.order_by?.map(parseSort), sortableKeys);
+}
+
+/** Order-sensitive: position encodes primary → secondary precedence. */
+export function sortsEqual(a: Sort[], b: Sort[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((sort, i) => sort.field === b[i]?.field && sort.direction === b[i]?.direction)
+  );
+}

--- a/frontend/app/src/entities/nodes/object/domain/sortable-field.ts
+++ b/frontend/app/src/entities/nodes/object/domain/sortable-field.ts
@@ -1,0 +1,82 @@
+import { sortByOrderWeight } from "@/shared/utils/common";
+
+import { ATTRIBUTE_KIND } from "@/entities/schema/constants";
+import { getSchema } from "@/entities/schema/domain/get-schema";
+import type { AttributeKind, AttributeSchema, ModelSchema } from "@/entities/schema/types";
+
+/** An `order_by` field key, e.g. `name__value`, `tags__name__value`, `node_metadata__created_at`. */
+export type SortFieldKey = `${string}__${string}`;
+export type SortDirection = "ASC" | "DESC";
+
+export interface SortableField {
+  field: SortFieldKey;
+  label: string;
+}
+
+const SORTABLE_ATTRIBUTE_KINDS = new Set<AttributeKind>([
+  ATTRIBUTE_KIND.TEXT,
+  ATTRIBUTE_KIND.TEXTAREA,
+  ATTRIBUTE_KIND.EMAIL,
+  ATTRIBUTE_KIND.URL,
+  ATTRIBUTE_KIND.DATETIME,
+  ATTRIBUTE_KIND.NUMBER,
+  ATTRIBUTE_KIND.BANDWIDTH,
+  ATTRIBUTE_KIND.DROPDOWN,
+  ATTRIBUTE_KIND.COLOR,
+  ATTRIBUTE_KIND.CHECKBOX,
+  ATTRIBUTE_KIND.BOOLEAN,
+  ATTRIBUTE_KIND.MAC_ADDRESS,
+  ATTRIBUTE_KIND.IP_HOST,
+  ATTRIBUTE_KIND.IP_NETWORK,
+  ATTRIBUTE_KIND.ID,
+]);
+
+const NODE_METADATA_SORTABLE_FIELDS: SortableField[] = [
+  { field: "node_metadata__created_at", label: "Created at" },
+  { field: "node_metadata__updated_at", label: "Updated at" },
+];
+
+// "Peer › Attribute" separator. En-spaces ( ) around the chevron keep it from looking cramped.
+const PEER_LABEL_SEPARATOR = " › ";
+
+const attributeLabel = (attribute: AttributeSchema) => attribute.label ?? attribute.name;
+
+function isSortableAttribute(attribute: AttributeSchema): boolean {
+  return SORTABLE_ATTRIBUTE_KINDS.has(attribute.kind as AttributeKind);
+}
+
+function getAttributeSortableFields(schema: ModelSchema): SortableField[] {
+  const sortableAttributes = (schema.attributes ?? []).filter(isSortableAttribute);
+
+  return sortByOrderWeight(sortableAttributes).map((attribute) => ({
+    field: `${attribute.name}__value`,
+    label: attributeLabel(attribute),
+  }));
+}
+
+function getRelationshipSortableFields(schema: ModelSchema): SortableField[] {
+  const cardinalityOneRelationships = (schema.relationships ?? []).filter(
+    (relationship) => relationship.cardinality === "one"
+  );
+
+  return sortByOrderWeight(cardinalityOneRelationships).flatMap((relationship) => {
+    const peerSchema = getSchema(relationship.peer).schema;
+    if (!peerSchema) return [];
+
+    const relationshipLabel = relationship.label ?? relationship.name;
+    const sortablePeerAttributes = (peerSchema.attributes ?? []).filter(isSortableAttribute);
+
+    return sortByOrderWeight(sortablePeerAttributes).map((attribute) => ({
+      field: `${relationship.name}__${attribute.name}__value`,
+      label: `${relationshipLabel}${PEER_LABEL_SEPARATOR}${attributeLabel(attribute)}`,
+    }));
+  });
+}
+
+export function getSortableFields(schema: ModelSchema): SortableField[] {
+  return [
+    ...getAttributeSortableFields(schema),
+    ...getRelationshipSortableFields(schema),
+    ...NODE_METADATA_SORTABLE_FIELDS,
+  ];
+}

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { useRef, useState } from "react";
 import type { Key } from "react-aria-components";
 
+import { CountBadge } from "@/shared/components/count-badge";
 import { isFieldFiltered } from "@/shared/hooks/is-field-filtered";
 import type { Filter } from "@/shared/hooks/useFilters";
 import { classNames } from "@/shared/utils/common";
@@ -59,10 +60,10 @@ export function FilterPicker({ schema, filters }: FilterPickerProps) {
           if (!isOpen) setSelectedField(null);
         }}
       >
-        <Button variant="ghost" size="sm" className="rounded-xl border-gray-300">
+        <Button variant="outline" size="sm" className="rounded-xl">
           <Icon icon="mdi:filter-variant" className="text-base" />
           Filter
-          {filterCount > 0 && <FilterCountBadge count={filterCount} />}
+          {filterCount > 0 && <CountBadge count={filterCount} />}
         </Button>
 
         <Popover
@@ -135,14 +136,6 @@ function FilterPickerItem({ definition, hasActiveFilter, ref }: FilterPickerItem
       {hasActiveFilter && <ActiveFilterIndicator />}
       <ChevronRightIcon className={classNames("size-3.5")} />
     </ListBoxItem>
-  );
-}
-
-function FilterCountBadge({ count }: { count: number }) {
-  return (
-    <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-stone-200 px-1 text-stone-600 text-xs">
-      {count}
-    </span>
   );
 }
 

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -8,9 +8,11 @@ import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/
 import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/utils/get-object-table-columns";
 import { useObjects } from "@/entities/nodes/object/ui/queries/get-objects.query";
 import { useObjectsCount } from "@/entities/nodes/object/ui/queries/get-objects-count.query";
+import { useSort } from "@/entities/nodes/object/ui/sort/use-sort";
 
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
+  const [sort] = useSort(selectedSchema);
 
   const { data: count } = useObjectsCount({
     objectKind: selectedSchema.kind!,
@@ -20,6 +22,7 @@ export const ObjectTable = () => {
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
     schema: selectedSchema,
     filters,
+    sort,
   });
 
   if (error) {

--- a/frontend/app/src/entities/nodes/object/ui/objects-manager-toolbar.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/objects-manager-toolbar.tsx
@@ -8,6 +8,7 @@ import { FilterSearchInput } from "@/entities/nodes/object/ui/filters/filter-sea
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
 import { ObjectTableSchemaSelector } from "@/entities/nodes/object/ui/object-table/object-table-schema-selector";
 import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
+import { SortPicker } from "@/entities/nodes/object/ui/sort/sort-picker";
 import { isGenericSchema } from "@/entities/schema/utils/is-generic-schema";
 
 export function ObjectsManagerToolbar() {
@@ -21,6 +22,8 @@ export function ObjectsManagerToolbar() {
         )}
 
         <FilterSearchInput schema={selectedSchema} />
+
+        <SortPicker schema={selectedSchema} />
 
         <FilterPicker schema={selectedSchema} filters={filters} />
 

--- a/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.test.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import type { Filter } from "@/shared/hooks/useFilters";
 
+import type { Sort } from "@/entities/nodes/object/domain/sort";
+
 import { objectQueryKeys } from "./object.query-keys";
 
 describe("objectQueryKeys", () => {
@@ -42,31 +44,35 @@ describe("objectQueryKeys", () => {
     expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind"]);
   });
 
-  it("returns query key for list", () => {
+  it("returns query key for list including filters and sort", () => {
     // GIVEN
     const filters: Filter[] = [{ name: "include_available", value: "true" }];
+    const sort: Sort[] = [{ field: "name__value", direction: "ASC" }];
     const params = {
       branchName: "branchName",
       atDate: new Date("2024-01-01"),
       objectKind: "RandomKind",
       filters,
+      sort,
     };
 
     // WHEN
     const result = objectQueryKeys.list(params);
 
     // THEN
-    expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind", filters]);
+    expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind", filters, sort]);
   });
 
-  it("returns query key for count", () => {
+  it("returns query key for count without sort, since sort never changes the row count", () => {
     // GIVEN
     const filters: Filter[] = [{ name: "include_available", value: "true" }];
+    const sort: Sort[] = [{ field: "name__value", direction: "ASC" }];
     const params = {
       branchName: "branchName",
       atDate: new Date("2024-01-01"),
       objectKind: "RandomKind",
       filters,
+      sort,
     };
 
     // WHEN

--- a/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.ts
@@ -1,6 +1,7 @@
 import type { ContextParams } from "@/shared/api/types";
 import type { Filter } from "@/shared/hooks/useFilters";
 
+import type { Sort } from "@/entities/nodes/object/domain/sort";
 import { getAttributesVisibleInDetailedView } from "@/entities/nodes/object/utils/get-attributes-visible-in-detailed-view";
 import { getRelationshipsVisibleInDetailedView } from "@/entities/nodes/object/utils/get-relationships-visible-in-detailed-view";
 import type { AttributeSchema, ModelSchema, RelationshipSchema } from "@/entities/schema/types";
@@ -11,6 +12,7 @@ export interface ObjectKeysBaseParams extends ContextParams {
 
 export interface ObjectListKeysParams extends ObjectKeysBaseParams {
   filters?: Filter[];
+  sort?: Sort[] | null;
 }
 
 export interface ObjectDetailKeysParams extends ObjectKeysBaseParams {
@@ -44,7 +46,7 @@ export const objectQueryKeys = {
   count: (params: ObjectListKeysParams) =>
     [...objectQueryKeys.lists(params), "count", params.filters] as const,
   list: (params: ObjectListKeysParams) =>
-    [...objectQueryKeys.lists(params), params.filters] as const,
+    [...objectQueryKeys.lists(params), params.filters, params.sort] as const,
   profiles: (params: ObjectKeysBaseParams) =>
     [...objectQueryKeys.lists(params), "profiles"] as const,
   detail: (params: ObjectDetailKeysParams) =>

--- a/frontend/app/src/entities/nodes/object/ui/sort/add-sort.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/add-sort.tsx
@@ -1,0 +1,81 @@
+import {
+  Autocomplete,
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  SubmenuTrigger,
+  Tooltip,
+} from "@infrahub/ui";
+import { PlusIcon } from "lucide-react";
+
+import type { Sort } from "@/entities/nodes/object/domain/sort";
+import type { SortableField, SortDirection } from "@/entities/nodes/object/domain/sortable-field";
+
+interface AddSortProps {
+  fields: SortableField[];
+  onAdd: (sort: Sort) => void;
+}
+
+export function AddSort({ fields, onAdd }: AddSortProps) {
+  const noFieldsLeft = fields.length === 0;
+
+  return (
+    <MenuTrigger>
+      <Tooltip message={noFieldsLeft ? "All fields are already in use." : undefined}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="justify-start text-stone-600"
+          isDisabledAndFocusable={noFieldsLeft}
+        >
+          <PlusIcon />
+          Add sort
+        </Button>
+      </Tooltip>
+
+      <Popover placement="bottom start">
+        <AddSortPicker fields={fields} onSelect={onAdd} />
+      </Popover>
+    </MenuTrigger>
+  );
+}
+
+export const DIRECTION_OPTIONS: { id: SortDirection; label: string }[] = [
+  { id: "ASC", label: "Ascending" },
+  { id: "DESC", label: "Descending" },
+];
+
+interface AddSortPickerProps {
+  fields: SortableField[];
+  onSelect: (sort: Sort) => void;
+}
+
+export function AddSortPicker({ fields, onSelect }: AddSortPickerProps) {
+  return (
+    <Autocomplete>
+      <Menu variant="picker" aria-label="Add sort field" className="max-h-72" items={fields}>
+        {(field) => (
+          <SubmenuTrigger>
+            <MenuItem textValue={field.label}>{field.label}</MenuItem>
+
+            <Popover>
+              <Menu
+                aria-label={`Sort direction for ${field.label}`}
+                items={DIRECTION_OPTIONS}
+                onAction={(_, value) => onSelect({ field: field.field, direction: value.id })}
+              >
+                {(direction) => (
+                  <MenuItem id={direction.id} textValue={direction.label}>
+                    {direction.label}
+                  </MenuItem>
+                )}
+              </Menu>
+            </Popover>
+          </SubmenuTrigger>
+        )}
+      </Menu>
+    </Autocomplete>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
@@ -1,0 +1,188 @@
+import {
+  Autocomplete,
+  Button,
+  ListBox,
+  ListBoxItem,
+  Popover,
+  Select,
+  SelectTrigger,
+  SortableItem,
+  SortableList,
+  Tooltip,
+} from "@infrahub/ui";
+import { InfoIcon, RotateCcwIcon, XIcon } from "lucide-react";
+
+import { Col } from "@/shared/components/container";
+
+import { getSchemaDefaultSort, type Sort } from "@/entities/nodes/object/domain/sort";
+import {
+  getSortableFields,
+  type SortDirection,
+  type SortFieldKey,
+} from "@/entities/nodes/object/domain/sortable-field";
+import {
+  AddSort,
+  AddSortPicker,
+  DIRECTION_OPTIONS,
+} from "@/entities/nodes/object/ui/sort/add-sort";
+import { useSort } from "@/entities/nodes/object/ui/sort/use-sort";
+import type { ModelSchema } from "@/entities/schema/types";
+
+interface SortEditorProps {
+  schema: ModelSchema;
+}
+
+export function SortEditor({ schema }: SortEditorProps) {
+  const [sort, setSort] = useSort(schema);
+
+  const sortableFields = getSortableFields(schema);
+  const currentSort: Sort[] = sort ?? getSchemaDefaultSort(schema) ?? [];
+
+  const addSort = (newSort: Sort) => setSort([...currentSort, newSort]);
+
+  if (currentSort.length === 0) {
+    return <AddSortPicker fields={sortableFields} onSelect={addSort} />;
+  }
+
+  const usedFields = new Set(currentSort.map((entry) => entry.field));
+  const unusedFields = sortableFields.filter((field) => !usedFields.has(field.field));
+
+  return (
+    <>
+      <Col className="items-start gap-1 p-1">
+        <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
+          {(entry) => (
+            <SortableItem id={entry.field} textValue={entry.field}>
+              <SortRow schema={schema} sort={entry} />
+            </SortableItem>
+          )}
+        </SortableList>
+
+        <AddSort fields={unusedFields} onAdd={addSort} />
+      </Col>
+
+      <SortEditorFooter schema={schema} />
+    </>
+  );
+}
+
+interface SortEditorFooterProps {
+  schema: ModelSchema;
+}
+
+function SortEditorFooter({ schema }: SortEditorFooterProps) {
+  const [sort, setSort] = useSort(schema);
+  const resetSort = () => setSort([]);
+
+  return (
+    <div className="border-neutral-300 border-t p-1 text-center">
+      {sort === null ? (
+        <div className="p-1 text-stone-400 text-xs">
+          Default order · edit or add a field to customize
+        </div>
+      ) : (
+        <Button variant="outline" size="xs" className="w-full text-stone-600" onPress={resetSort}>
+          {getSchemaDefaultSort(schema) ? (
+            <>
+              <RotateCcwIcon />
+              Reset to default
+            </>
+          ) : (
+            <>
+              <XIcon />
+              Clear sort
+            </>
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface SortRowProps {
+  schema: ModelSchema;
+  sort: Sort;
+}
+
+function SortRow({ schema, sort }: SortRowProps) {
+  const [userSort, setSort] = useSort(schema);
+  const currentSort = userSort ?? getSchemaDefaultSort(schema) ?? [];
+
+  const fieldsUsedByOtherRows = new Set(
+    currentSort.filter((entry) => entry.field !== sort.field).map((entry) => entry.field)
+  );
+  const availableFields = getSortableFields(schema).filter(
+    (field) => !fieldsUsedByOtherRows.has(field.field)
+  );
+
+  const replaceField = (field: SortFieldKey) =>
+    setSort(currentSort.map((entry) => (entry.field === sort.field ? { ...entry, field } : entry)));
+
+  const replaceDirection = (direction: SortDirection) =>
+    setSort(
+      currentSort.map((entry) => (entry.field === sort.field ? { ...entry, direction } : entry))
+    );
+
+  const remove = () => setSort(currentSort.filter((entry) => entry.field !== sort.field));
+
+  // Removing the only row while on the schema default is a no-op (it snaps back), so hide it.
+  const canRemove = !(userSort === null && currentSort.length === 1);
+
+  return (
+    <>
+      <Select
+        aria-label="Sort field"
+        value={sort.field}
+        onChange={(value) => replaceField(String(value) as SortFieldKey)}
+        className="min-w-0 flex-1"
+      >
+        <SelectTrigger size="sm" />
+        <Popover>
+          <Autocomplete>
+            <ListBox items={availableFields} selectionMode="single">
+              {(field) => (
+                <ListBoxItem id={field.field} textValue={field.label}>
+                  {field.label}
+                </ListBoxItem>
+              )}
+            </ListBox>
+          </Autocomplete>
+        </Popover>
+      </Select>
+
+      <Select
+        aria-label="Sort direction"
+        value={sort.direction}
+        onChange={(value) => replaceDirection(value as SortDirection)}
+        className="w-32 shrink-0"
+      >
+        <SelectTrigger size="sm" />
+
+        <Popover>
+          <ListBox items={DIRECTION_OPTIONS} selectionMode="single">
+            {(direction) => (
+              <ListBoxItem textValue={direction.label}>{direction.label}</ListBoxItem>
+            )}
+          </ListBox>
+        </Popover>
+      </Select>
+
+      {canRemove ? (
+        <Button variant="ghost" size="sm" shape="square" aria-label="Remove sort" onPress={remove}>
+          <XIcon />
+        </Button>
+      ) : (
+        <Tooltip message="This is the default order. Edit it or add a sort to customize.">
+          <Button
+            variant="ghost"
+            size="sm"
+            shape="square"
+            aria-label="Why this sort can't be removed"
+          >
+            <InfoIcon />
+          </Button>
+        </Tooltip>
+      )}
+    </>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
@@ -62,7 +62,7 @@ export function SortEditor({ schema }: SortEditorProps) {
   return (
     <Col className="items-start gap-1 p-1">
       {isDefaultOrder ? (
-        <div className="rounded-lg border border-stone-300 bg-stone-200/50">
+        <div className="inset-shadow-[0_1px_2px_rgb(255,255,255),0_1px_4px_rgba(0,0,0,0.1)] rounded-lg border border-stone-200 bg-stone-200/50 shadow-[0_1px_1px_rgba(0,0,0,0.02)]">
           <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
             <CheckIcon className="size-3.5 text-cyan-600" />
             Default order · applied now

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
@@ -10,9 +10,9 @@ import {
   SortableList,
   Tooltip,
 } from "@infrahub/ui";
-import { InfoIcon, RotateCcwIcon, XIcon } from "lucide-react";
+import { CheckIcon, InfoIcon, RotateCcwIcon, SlidersHorizontalIcon, XIcon } from "lucide-react";
 
-import { Col } from "@/shared/components/container";
+import { Row } from "@/shared/components/container";
 
 import { getSchemaDefaultSort, type Sort } from "@/entities/nodes/object/domain/sort";
 import {
@@ -47,55 +47,60 @@ export function SortEditor({ schema }: SortEditorProps) {
   const usedFields = new Set(currentSort.map((entry) => entry.field));
   const unusedFields = sortableFields.filter((field) => !usedFields.has(field.field));
 
+  const isDefaultOrder = sort === null;
+
+  const sortList = (
+    <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
+      {(entry) => (
+        <SortableItem id={entry.field} textValue={entry.field}>
+          <SortRow schema={schema} sort={entry} />
+        </SortableItem>
+      )}
+    </SortableList>
+  );
+
   return (
     <>
-      <Col className="items-start gap-1 p-1">
-        <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
-          {(entry) => (
-            <SortableItem id={entry.field} textValue={entry.field}>
-              <SortRow schema={schema} sort={entry} />
-            </SortableItem>
-          )}
-        </SortableList>
-
-        <AddSort fields={unusedFields} onAdd={addSort} />
-      </Col>
-
-      <SortEditorFooter schema={schema} />
-    </>
-  );
-}
-
-interface SortEditorFooterProps {
-  schema: ModelSchema;
-}
-
-function SortEditorFooter({ schema }: SortEditorFooterProps) {
-  const [sort, setSort] = useSort(schema);
-  const resetSort = () => setSort([]);
-
-  return (
-    <div className="border-neutral-300 border-t p-1 text-center">
-      {sort === null ? (
-        <div className="p-1 text-stone-400 text-xs">
-          Default order · edit or add a field to customize
+      {isDefaultOrder ? (
+        <div className="rounded-t-xl bg-stone-200/60 p-1">
+          <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
+            <CheckIcon className="size-3.5 text-cyan-600" />
+            Default order · applied now
+          </Row>
+          {sortList}
         </div>
       ) : (
-        <Button variant="outline" size="xs" className="w-full text-stone-600" onPress={resetSort}>
-          {getSchemaDefaultSort(schema) ? (
-            <>
-              <RotateCcwIcon />
-              Reset to default
-            </>
-          ) : (
-            <>
-              <XIcon />
-              Clear sort
-            </>
-          )}
-        </Button>
+        <div className="p-1 pb-0">
+          <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
+            <SlidersHorizontalIcon className="size-3.5" />
+            Custom order
+            <Button
+              variant="ghost"
+              size="xxs"
+              className="ml-auto text-xxs"
+              onPress={() => setSort([])}
+            >
+              {getSchemaDefaultSort(schema) ? (
+                <>
+                  <RotateCcwIcon />
+                  Reset to default
+                </>
+              ) : (
+                <>
+                  <XIcon />
+                  Clear sort
+                </>
+              )}
+            </Button>
+          </Row>
+          {sortList}
+        </div>
       )}
-    </div>
+
+      <div className="p-1">
+        <AddSort fields={unusedFields} onAdd={addSort} />
+      </div>
+    </>
   );
 }
 

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
@@ -12,7 +12,7 @@ import {
 } from "@infrahub/ui";
 import { CheckIcon, InfoIcon, RotateCcwIcon, SlidersHorizontalIcon, XIcon } from "lucide-react";
 
-import { Row } from "@/shared/components/container";
+import { Col, Row } from "@/shared/components/container";
 
 import { getSchemaDefaultSort, type Sort } from "@/entities/nodes/object/domain/sort";
 import {
@@ -60,9 +60,9 @@ export function SortEditor({ schema }: SortEditorProps) {
   );
 
   return (
-    <>
+    <Col className="items-start gap-1 p-1">
       {isDefaultOrder ? (
-        <div className="rounded-t-xl bg-stone-200/60 p-1">
+        <div className="rounded-lg border border-stone-300 bg-stone-200/50">
           <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
             <CheckIcon className="size-3.5 text-cyan-600" />
             Default order · applied now
@@ -70,7 +70,7 @@ export function SortEditor({ schema }: SortEditorProps) {
           {sortList}
         </div>
       ) : (
-        <div className="p-1 pb-0">
+        <div className="border border-transparent">
           <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
             <SlidersHorizontalIcon className="size-3.5" />
             Custom order
@@ -97,10 +97,8 @@ export function SortEditor({ schema }: SortEditorProps) {
         </div>
       )}
 
-      <div className="p-1">
-        <AddSort fields={unusedFields} onAdd={addSort} />
-      </div>
-    </>
+      <AddSort fields={unusedFields} onAdd={addSort} />
+    </Col>
   );
 }
 

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-editor.tsx
@@ -128,6 +128,10 @@ function SortRow({ schema, sort }: SortRowProps) {
   // Removing the only row while on the schema default is a no-op (it snaps back), so hide it.
   const canRemove = !(userSort === null && currentSort.length === 1);
 
+  // Deleting the last remaining row reverts to the schema default, so frame it as a reset.
+  const removeResetsToDefault =
+    canRemove && currentSort.length === 1 && (getSchemaDefaultSort(schema)?.length ?? 0) > 0;
+
   return (
     <>
       <Select
@@ -167,11 +171,7 @@ function SortRow({ schema, sort }: SortRowProps) {
         </Popover>
       </Select>
 
-      {canRemove ? (
-        <Button variant="ghost" size="sm" shape="square" aria-label="Remove sort" onPress={remove}>
-          <XIcon />
-        </Button>
-      ) : (
+      {!canRemove ? (
         <Tooltip message="This is the default order. Edit it or add a sort to customize.">
           <Button
             variant="ghost"
@@ -182,6 +182,22 @@ function SortRow({ schema, sort }: SortRowProps) {
             <InfoIcon />
           </Button>
         </Tooltip>
+      ) : removeResetsToDefault ? (
+        <Tooltip message="Reset to the default order">
+          <Button
+            variant="ghost"
+            size="sm"
+            shape="square"
+            aria-label="Reset to default"
+            onPress={remove}
+          >
+            <RotateCcwIcon />
+          </Button>
+        </Tooltip>
+      ) : (
+        <Button variant="ghost" size="sm" shape="square" aria-label="Remove sort" onPress={remove}>
+          <XIcon />
+        </Button>
       )}
     </>
   );

--- a/frontend/app/src/entities/nodes/object/ui/sort/sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/sort-picker.tsx
@@ -1,0 +1,29 @@
+import { Button, Popover, PopoverTrigger } from "@infrahub/ui";
+import { ArrowUpDownIcon } from "lucide-react";
+
+import { CountBadge } from "@/shared/components/count-badge";
+
+import { SortEditor } from "@/entities/nodes/object/ui/sort/sort-editor";
+import { useSort } from "@/entities/nodes/object/ui/sort/use-sort";
+import type { ModelSchema } from "@/entities/schema/types";
+
+interface SortPickerProps {
+  schema: ModelSchema;
+}
+
+export function SortPicker({ schema }: SortPickerProps) {
+  const [sort] = useSort(schema);
+
+  return (
+    <PopoverTrigger>
+      <Button variant="outline" size="sm" className="rounded-xl">
+        <ArrowUpDownIcon /> Sort
+        {sort !== null && sort.length > 0 && <CountBadge count={sort.length} />}
+      </Button>
+
+      <Popover placement="bottom start">
+        <SortEditor schema={schema} />
+      </Popover>
+    </PopoverTrigger>
+  );
+}

--- a/frontend/app/src/entities/nodes/object/ui/sort/use-sort.test.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/sort/use-sort.test.tsx
@@ -1,0 +1,92 @@
+import { type OnUrlUpdateFunction, withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import type { ModelSchema } from "@/entities/schema/types";
+
+import { useSort } from "./use-sort";
+
+vi.mock("@/entities/nodes/object/domain/sortable-field", () => ({
+  getSortableFields: () => [
+    { field: "name__value", label: "Name" },
+    { field: "owner__name__value", label: "Owner › Name" },
+    { field: "node_metadata__updated_at", label: "Updated at" },
+  ],
+}));
+
+const schema = { kind: "TestNode", order_by: ["name__value"] } as ModelSchema;
+
+function render(searchParams: string, onUrlUpdate?: OnUrlUpdateFunction) {
+  return renderHook(() => useSort(schema), {
+    wrapper: withNuqsTestingAdapter({ searchParams, onUrlUpdate }),
+  });
+}
+
+describe("useSort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns null and leaves the URL clean when there is no sort param", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn();
+    // WHEN
+    const { result } = await render("", onUrlUpdate);
+    // THEN
+    expect(result.current[0]).toBeNull();
+    expect(onUrlUpdate).not.toHaveBeenCalled();
+  });
+
+  test("reads a valid sort param, excluding unknown fields without rewriting the URL", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn();
+    // WHEN
+    const { result } = await render("?sort=owner__name__value__desc,gone__value__asc", onUrlUpdate);
+    // THEN
+    expect(result.current[0]).toEqual([{ field: "owner__name__value", direction: "DESC" }]);
+    expect(onUrlUpdate).not.toHaveBeenCalled();
+  });
+
+  test("writes the full array to the sort param", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn();
+    const hook = await render("", onUrlUpdate);
+    // WHEN
+    await hook.act(() => {
+      hook.result.current[1]([
+        { field: "name__value", direction: "ASC" },
+        { field: "owner__name__value", direction: "DESC" },
+      ]);
+    });
+    // THEN
+    expect(onUrlUpdate.mock.lastCall?.[0].searchParams.get("sort")).toBe(
+      "name__value__asc,owner__name__value__desc"
+    );
+  });
+
+  test("normalizes a sort equal to the schema default to null, removing the param", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn();
+    const hook = await render("?sort=owner__name__value__desc", onUrlUpdate);
+    // WHEN
+    await hook.act(() => {
+      hook.result.current[1]([{ field: "name__value", direction: "ASC" }]);
+    });
+    // THEN — the param is dropped so we fall back onto the live default
+    expect(onUrlUpdate.mock.lastCall?.[0].searchParams.get("sort")).toBeNull();
+    expect(hook.result.current[0]).toBeNull();
+  });
+
+  test("removes the sort param when cleared", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn();
+    const hook = await render("?sort=name__value__desc", onUrlUpdate);
+    // WHEN
+    await hook.act(() => {
+      hook.result.current[1]([]);
+    });
+    // THEN
+    expect(onUrlUpdate.mock.lastCall?.[0].searchParams.get("sort")).toBeNull();
+    expect(hook.result.current[0]).toBeNull();
+  });
+});

--- a/frontend/app/src/entities/nodes/object/ui/sort/use-sort.ts
+++ b/frontend/app/src/entities/nodes/object/ui/sort/use-sort.ts
@@ -1,0 +1,40 @@
+import { createParser, parseAsArrayOf, useQueryState } from "nuqs";
+
+import { QSP } from "@/shared/config/qsp";
+
+import {
+  formatSort,
+  getSchemaDefaultSort,
+  getValidSort,
+  parseSort,
+  type Sort,
+  sortsEqual,
+} from "@/entities/nodes/object/domain/sort";
+import { getSortableFields } from "@/entities/nodes/object/domain/sortable-field";
+import type { ModelSchema } from "@/entities/schema/types";
+
+const sortParser = createParser({
+  parse: (token: string): Sort => parseSort(token),
+  serialize: (sort: Sort): string => formatSort(sort.field, sort.direction),
+});
+
+/**
+ * `?sort` as structured {@link Sort} entries. `null` means "on the schema default": unsortable
+ * entries drop from the result but stay in the URL (so they revive on a schema change), and
+ * `setSort` removes the param when given the default or an empty list, re-tracking the live default.
+ */
+export function useSort(schema: ModelSchema): [Sort[] | null, (next: Sort[]) => void] {
+  const [rawSort, setRawSort] = useQueryState(
+    QSP.SORT,
+    parseAsArrayOf(sortParser).withOptions({ history: "push" })
+  );
+
+  const sortableKeys = new Set(getSortableFields(schema).map((field) => field.field));
+  const schemaDefault = getSchemaDefaultSort(schema) ?? [];
+
+  const sort = getValidSort(rawSort, sortableKeys);
+  const setSort = (next: Sort[]) =>
+    setRawSort(next.length > 0 && !sortsEqual(next, schemaDefault) ? next : null);
+
+  return [sort, setSort];
+}

--- a/frontend/app/src/shared/api/graphql/utils.test.ts
+++ b/frontend/app/src/shared/api/graphql/utils.test.ts
@@ -1,11 +1,18 @@
+import { EnumType, jsonToGraphQLQuery } from "json-to-graphql-query";
 import { describe, expect, it } from "vitest";
 
 import type { Filter } from "@/shared/hooks/useFilters";
 
+import type { Sort } from "@/entities/nodes/object/domain/sort";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
 import { generateAttributeSchema, generateRelationshipSchema } from "../../../../tests/fake/schema";
-import { addAttributesToRequest, addFiltersToRequest, addRelationshipsToRequest } from "./utils";
+import {
+  addAttributesToRequest,
+  addFiltersToRequest,
+  addOrderByToRequest,
+  addRelationshipsToRequest,
+} from "./utils";
 
 describe("addAttributesToRequest", () => {
   it("should return base fragment for simple attribute", () => {
@@ -387,5 +394,42 @@ describe("addFiltersToRequest", () => {
 
     // THEN
     expect(result).toEqual({});
+  });
+});
+
+describe("addOrderByToRequest", () => {
+  it("serializes direction as an unquoted enum the server accepts, not a quoted string", () => {
+    // GIVEN
+    const sort: Sort[] = [
+      { field: "name__value", direction: "ASC" },
+      { field: "owner__name__value", direction: "DESC" },
+    ];
+
+    // WHEN
+    const query = jsonToGraphQLQuery({ q: { __args: addOrderByToRequest(sort) } });
+
+    // THEN
+    expect(query).toContain("direction: ASC");
+    expect(query).toContain("direction: DESC");
+    expect(query).not.toContain('direction: "ASC"');
+    expect(query).not.toContain('direction: "DESC"');
+  });
+
+  it("passes relationship and node-metadata field keys through verbatim, wrapping only direction", () => {
+    // GIVEN
+    const sort: Sort[] = [
+      { field: "owner__name__value", direction: "ASC" },
+      { field: "node_metadata__updated_at", direction: "DESC" },
+    ];
+
+    // WHEN
+    const { order } = addOrderByToRequest(sort);
+
+    // THEN
+    expect(order.by.map((entry) => entry.field)).toEqual([
+      "owner__name__value",
+      "node_metadata__updated_at",
+    ]);
+    expect(order.by.every((entry) => entry.direction instanceof EnumType)).toBe(true);
   });
 });

--- a/frontend/app/src/shared/api/graphql/utils.ts
+++ b/frontend/app/src/shared/api/graphql/utils.ts
@@ -1,6 +1,9 @@
+import { EnumType } from "json-to-graphql-query";
+
 import type { Filter } from "@/shared/hooks/useFilters";
 
 import { AVAILABLE_IP_FILTER_NAME } from "@/entities/ipam/constants";
+import type { Sort } from "@/entities/nodes/object/domain/sort";
 import { ATTRIBUTE_KIND } from "@/entities/schema/constants";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/types";
 
@@ -162,6 +165,14 @@ export const addFiltersToRequest = (filters: Array<Filter>) => {
     },
     {} as Record<string, string | number | boolean | string[]>
   );
+};
+
+export const addOrderByToRequest = (sort: Sort[]) => {
+  return {
+    order: {
+      by: sort.map(({ field, direction }) => ({ field, direction: new EnumType(direction) })),
+    },
+  };
 };
 
 export const dropIncludeAvailableWhenFalse = (filters?: Filter[]) =>

--- a/frontend/app/src/shared/components/count-badge.tsx
+++ b/frontend/app/src/shared/components/count-badge.tsx
@@ -1,0 +1,11 @@
+interface CountBadgeProps {
+  count: number;
+}
+
+export function CountBadge({ count }: CountBadgeProps) {
+  return (
+    <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-stone-200 px-1 text-stone-600 text-xs">
+      {count}
+    </span>
+  );
+}

--- a/frontend/app/src/shared/config/qsp.ts
+++ b/frontend/app/src/shared/config/qsp.ts
@@ -8,6 +8,7 @@ export const QSP = {
   PROPOSED_CHANGES_STATE: "pr_state",
   QUERY: "query",
   SEARCH: "search",
+  SORT: "sort",
   STATUS: "status",
   HIGHLIGHT: "highlight",
 } as const;

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type React from "react";
 
 import { CopyIcon, GroupIcon, PencilLineIcon, Trash2Icon } from "lucide-react";
+import React, { useState } from "react";
+import { Popover as AriaPopover } from "react-aria-components";
 
-import { Menu, MenuItem, MenuSection } from "./menu";
+import { Autocomplete } from "../autocomplete/autocomplete";
+import { Button } from "../button/button";
+import { Menu, MenuItem, MenuSection, MenuTrigger, SubmenuTrigger } from "./menu";
 
 const meta: Meta<typeof Menu> = {
   title: "Components/Menu",
@@ -30,70 +33,157 @@ const MenuSurface = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-export const Default: Story = {
+// Item sets shared across both variants, so each scenario renders identically as action and picker.
+const simpleItems = () => [
+  <MenuItem key="edit">
+    <PencilLineIcon />
+    <span>Edit</span>
+  </MenuItem>,
+  <MenuItem key="duplicate">
+    <CopyIcon />
+    <span>Duplicate</span>
+  </MenuItem>,
+  <MenuItem key="delete" className="text-red-500">
+    <Trash2Icon />
+    <span>Delete</span>
+  </MenuItem>,
+];
+
+const sectionItems = () => [
+  <MenuSection key="actions" title="Actions">
+    <MenuItem>Copy ID</MenuItem>
+    <MenuItem>Copy HFID</MenuItem>
+  </MenuSection>,
+  <MenuSection key="manage" title="Manage">
+    <MenuItem>
+      <PencilLineIcon />
+      <span>Edit</span>
+    </MenuItem>
+    <MenuItem>
+      <GroupIcon />
+      <span>Groups</span>
+    </MenuItem>
+  </MenuSection>,
+];
+
+const disabledItems = () => [
+  <MenuItem key="edit">
+    <PencilLineIcon />
+    <span>Edit</span>
+  </MenuItem>,
+  <MenuItem
+    key="delete"
+    isDisabled
+    tooltip="You don't have permission to delete this object"
+    className="text-red-500"
+  >
+    <Trash2Icon />
+    <span>Delete</span>
+  </MenuItem>,
+];
+
+export const AllVariants: Story = {
   render: () => (
-    <div className="grid grid-cols-[8rem_auto]  items-start gap-x-6 gap-y-6">
+    <div className="grid grid-cols-[8rem_max-content_max-content] items-start gap-x-6 gap-y-6">
+      <div />
+      <ColumnLabel>action (default)</ColumnLabel>
+      <ColumnLabel>picker</ColumnLabel>
+
       <ColumnLabel>Simple</ColumnLabel>
       <MenuSurface>
-        <Menu aria-label="Simple menu">
-          <MenuItem>
-            <PencilLineIcon />
-            <span>Edit</span>
-          </MenuItem>
-          <MenuItem>
-            <CopyIcon />
-            <span>Duplicate</span>
-          </MenuItem>
-          <MenuItem className="text-red-500">
-            <Trash2Icon />
-            <span>Delete</span>
-          </MenuItem>
+        <Menu aria-label="Simple action menu" variant="action">
+          {simpleItems()}
+        </Menu>
+      </MenuSurface>
+      <MenuSurface>
+        <Menu aria-label="Simple picker menu" variant="picker">
+          {simpleItems()}
         </Menu>
       </MenuSurface>
 
       <ColumnLabel>With sections</ColumnLabel>
       <MenuSurface>
-        <Menu aria-label="Menu with sections">
-          <MenuSection title="Actions">
-            <MenuItem>Copy ID</MenuItem>
-            <MenuItem>Copy HFID</MenuItem>
-          </MenuSection>
-          <MenuSection title="Manage">
-            <MenuItem>
-              <PencilLineIcon />
-              <span>Edit</span>
-            </MenuItem>
-            <MenuItem>
-              <GroupIcon />
-              <span>Groups</span>
-            </MenuItem>
-          </MenuSection>
+        <Menu aria-label="Action menu with sections" variant="action">
+          {sectionItems()}
+        </Menu>
+      </MenuSurface>
+      <MenuSurface>
+        <Menu aria-label="Picker menu with sections" variant="picker">
+          {sectionItems()}
         </Menu>
       </MenuSurface>
 
       <ColumnLabel>Disabled + tooltip</ColumnLabel>
       <div className="space-y-1">
         <MenuSurface>
-          <Menu aria-label="Menu with a disabled item">
-            <MenuItem>
-              <PencilLineIcon />
-              <span>Edit</span>
-            </MenuItem>
-            <MenuItem
-              isDisabled
-              tooltip="You don't have permission to delete this object"
-              className="text-red-500"
-            >
-              <Trash2Icon />
-              <span>Delete</span>
-            </MenuItem>
+          <Menu aria-label="Action menu with a disabled item" variant="action">
+            {disabledItems()}
           </Menu>
         </MenuSurface>
         <p className="text-[10px] text-neutral-400">Hover the disabled item to see the tooltip.</p>
       </div>
+      <MenuSurface>
+        <Menu aria-label="Picker menu with a disabled item" variant="picker">
+          {disabledItems()}
+        </Menu>
+      </MenuSurface>
     </div>
   ),
   parameters: {
     layout: "padded",
   },
+};
+
+/*
+ * The picker pattern that drives AddSort: a filtered field list whose items each open an
+ * asc/desc submenu. The submenu inherits variant="picker" from its parent — no prop needed.
+ */
+const SORT_FIELDS = ["Name", "Description", "Created at", "Site › Name", "Device › Role"];
+const DIRECTIONS = [
+  { id: "asc", label: "Ascending" },
+  { id: "desc", label: "Descending" },
+];
+
+function PickerWithSubmenuRender() {
+  const [picked, setPicked] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <MenuTrigger>
+        <Button variant="outline" size="sm">
+          Add sort
+        </Button>
+        <AriaPopover
+          placement="bottom start"
+          className="w-56 rounded-lg border border-neutral-300 bg-white shadow-md"
+        >
+          <Autocomplete>
+            <Menu variant="picker" aria-label="Sort field" className="max-h-72">
+              {SORT_FIELDS.map((field) => (
+                <SubmenuTrigger key={field}>
+                  <MenuItem textValue={field}>{field}</MenuItem>
+                  <AriaPopover className="rounded-lg border border-neutral-300 bg-white shadow-md">
+                    <Menu
+                      aria-label={`Direction for ${field}`}
+                      onAction={(key) => setPicked(`${field} · ${key}`)}
+                    >
+                      {DIRECTIONS.map((d) => (
+                        <MenuItem key={d.id} id={d.id} textValue={d.label}>
+                          {d.label}
+                        </MenuItem>
+                      ))}
+                    </Menu>
+                  </AriaPopover>
+                </SubmenuTrigger>
+              ))}
+            </Menu>
+          </Autocomplete>
+        </AriaPopover>
+      </MenuTrigger>
+      <p className="text-neutral-500 text-xs">Picked: {picked ?? "—"}</p>
+    </div>
+  );
+}
+
+export const PickerWithSubmenu: Story = {
+  render: () => <PickerWithSubmenuRender />,
 };

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -1,5 +1,5 @@
-import type React from "react";
-
+import { ChevronRightIcon } from "lucide-react";
+import React from "react";
 import {
   Header as AriaHeader,
   Menu as AriaMenu,
@@ -9,28 +9,57 @@ import {
   MenuSection as AriaMenuSection,
   type MenuSectionProps as AriaMenuSectionProps,
   MenuTrigger as AriaMenuTrigger,
+  SubmenuTrigger as AriaSubmenuTrigger,
   Collection,
 } from "react-aria-components";
-import { cn } from "tailwind-variants";
+import { type VariantProps, cn, tv } from "tailwind-variants";
 
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
 
 export const MenuTrigger = AriaMenuTrigger;
+export const SubmenuTrigger = AriaSubmenuTrigger;
 
-export interface MenuProps<T> extends AriaMenuProps<T> {}
-export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) => {
+const menuItemStyles = tv({
+  base: [
+    "flex min-w-40 cursor-pointer select-none items-center gap-2 border border-transparent rounded-lg px-2 py-1 text-sm text-stone-600 outline-hidden",
+    "data-disabled:pointer-events-none data-disabled:opacity-50",
+    "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  ],
+  variants: {
+    variant: {
+      action: [
+        "[&:not(:last-child)]:mb-0.5 bg-white shadow-sm transition-colors",
+        "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
+      ],
+      picker: ["rounded-lg", "data-focused:bg-stone-700/10 data-focused:text-stone-800"],
+    },
+  },
+  defaultVariants: { variant: "action" },
+});
+
+type MenuVariants = VariantProps<typeof menuItemStyles>;
+
+const MenuVariantContext = React.createContext<MenuVariants["variant"]>("action");
+
+export interface MenuProps<T> extends AriaMenuProps<T>, MenuVariants {}
+
+export const Menu = <T extends object>({ className, variant, ...props }: MenuProps<T>) => {
+  const resolvedVariant = variant ?? React.use(MenuVariantContext);
+
   return (
-    <AriaMenu
-      className={composeAriaClassName(className, (resolvedClassName) =>
-        cn(
-          "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
-          "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
-          resolvedClassName,
-        ),
-      )}
-      {...props}
-    />
+    <MenuVariantContext.Provider value={resolvedVariant}>
+      <AriaMenu
+        className={composeAriaClassName(
+          className,
+          cn(
+            "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
+            "*:[[role='group']:not(:last-child)]:mb-2",
+          ),
+        )}
+        {...props}
+      />
+    </MenuVariantContext.Provider>
   );
 };
 
@@ -61,21 +90,20 @@ export const MenuItem = ({
     );
   }
 
+  const variant = React.use(MenuVariantContext);
+
   return (
     <AriaMenuItem
       textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={composeAriaClassName(className, (resolvedClassName) =>
-        cn(
-          "data-disabled:pointer-events-none data-disabled:opacity-50",
-          "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-md border border-transparent bg-white px-2 py-1 text-sm text-stone-600 shadow-sm outline-hidden transition-colors",
-          "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-          "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
-          resolvedClassName,
-        ),
-      )}
+      className={composeAriaClassName(className, menuItemStyles({ variant }))}
       {...props}
     >
-      {children}
+      {(renderProps) => (
+        <>
+          {typeof children === "function" ? children(renderProps) : children}
+          {renderProps.hasSubmenu && <ChevronRightIcon className="ml-auto" />}
+        </>
+      )}
     </AriaMenuItem>
   );
 };
@@ -90,8 +118,8 @@ export const MenuSection = <T extends object>({
   ...props
 }: MenuSectionProps<T>) => {
   return (
-    <AriaMenuSection className={cn("flex flex-col gap-0.5", className)} {...props}>
-      {title && <AriaHeader className="px-1 text-stone-500 text-xs">{title}</AriaHeader>}
+    <AriaMenuSection className={cn("flex flex-col", className)} {...props}>
+      {title && <AriaHeader className="px-1 text-stone-500 text-xs mb-0.5">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -5,7 +5,7 @@ import {
   type ListBoxProps as AriaListBoxProps,
   SelectValue as AriaSelectValue,
 } from "react-aria-components";
-import { tv } from "tailwind-variants";
+import { tv, type VariantProps } from "tailwind-variants";
 export { Select } from "react-aria-components";
 
 import { focusVisibleStyle } from "../../styles/focus-visible";
@@ -15,16 +15,28 @@ import { Popover } from "../popover/popover";
 
 const triggerStyles = tv({
   base: [
-    "flex min-h-10 w-full items-center gap-2 rounded-lg border border-neutral-300 outline-none",
-    "bg-white p-2 text-sm placeholder:text-neutral-400",
-    "disabled:cursor-not-allowed disabled:bg-neutral-100",
+    "min-h-10 flex items-center gap-1 w-full rounded-xl shadow-[0_2px_4px_rgba(0,0,0,0.04)] bg-white p-2 pr-1.5 text-sm border border-neutral-200",
+    "data-disabled:cursor-not-allowed data-disabled:bg-neutral-100 data-disabled:shadow-none",
     focusVisibleStyle,
   ],
+  // Heights mirror the Button size scale so a trigger can line up with adjacent buttons.
+  // The default (no size) keeps the existing min-h-10 input look.
+  variants: {
+    size: {
+      xxs: "h-6 min-h-0 py-0",
+      xs: "h-7 min-h-0 py-0",
+      sm: "h-8 min-h-0 py-0",
+      md: "h-9 min-h-0 py-0",
+    },
+  },
 });
 
-export function SelectTrigger({ className, ...props }: Omit<AriaButtonProps, "children">) {
+export interface SelectTriggerProps
+  extends Omit<AriaButtonProps, "children">, VariantProps<typeof triggerStyles> {}
+
+export function SelectTrigger({ className, size, ...props }: SelectTriggerProps) {
   return (
-    <AriaButton className={composeAriaClassName(className, triggerStyles())} {...props}>
+    <AriaButton className={composeAriaClassName(className, triggerStyles({ size }))} {...props}>
       <AriaSelectValue className="truncate data-placeholder:text-neutral-400" />
       <ChevronDownIcon className="ml-auto size-4" />
     </AriaButton>

--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
@@ -1,32 +1,31 @@
-import type React from "react";
-
 import { GripVerticalIcon } from "lucide-react";
+import React from "react";
 import {
-  DropIndicator,
   GridList as AriaGridList,
-  type DropTarget,
-  type DroppableCollectionReorderEvent,
   GridListItem as AriaGridListItem,
   type GridListItemProps as AriaGridListItemProps,
   type GridListProps as AriaGridListProps,
+  DropIndicator,
+  type DroppableCollectionReorderEvent,
+  type DropTarget,
   type Key,
   useDragAndDrop,
 } from "react-aria-components";
-import { cn, tv } from "tailwind-variants";
+import { tv } from "tailwind-variants";
 
-import { focusVisibleStyle } from "../../styles/focus-visible";
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { Button } from "../button/button";
 
-function reorderItems<T extends { id: Key }>(
+function reorderItems<T>(
   items: T[],
   event: DroppableCollectionReorderEvent,
+  getId: (item: T) => Key,
 ): T[] {
   const { keys, target } = event;
-  const moved = items.filter((item) => keys.has(item.id));
-  const rest = items.filter((item) => !keys.has(item.id));
+  const moved = items.filter((item) => keys.has(getId(item)));
+  const rest = items.filter((item) => !keys.has(getId(item)));
 
-  const targetItem = rest.find((item) => item.id === target.key);
+  const targetItem = rest.find((item) => getId(item) === target.key);
   if (!targetItem) {
     return items;
   }
@@ -36,7 +35,7 @@ function reorderItems<T extends { id: Key }>(
   return [...rest.slice(0, insertIndex), ...moved, ...rest.slice(insertIndex)];
 }
 
-export interface SortableListProps<T extends { id: Key }> extends Omit<
+export interface SortableListProps<T extends object> extends Omit<
   AriaGridListProps<T>,
   "items" | "children" | "dragAndDropHooks"
 > {
@@ -47,24 +46,30 @@ export interface SortableListProps<T extends { id: Key }> extends Omit<
 
 function SortableDropIndicator({ target }: { target: DropTarget }) {
   return (
-    // -mt-px offsets the line's own height so this in-flow row adds no space, keeping siblings put.
+    // -mt-px offsets the line's own height so this in-flow row never shifts siblings.
     <DropIndicator
       target={target}
-      className="-mt-px mx-2 h-px rounded-full bg-cyan-600 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden"
+      className="-mt-px h-px rounded-full bg-cyan-800 opacity-0 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden transition-opacity data-drop-target:opacity-100"
     />
   );
 }
 
-export function SortableList<T extends { id: Key }>({
+export function SortableList<T extends object>({
   items,
   onReorder,
   children,
   ...props
 }: SortableListProps<T>) {
+  const getItemId = (item: T): Key => {
+    const element = children(item);
+    const id = React.isValidElement<{ id?: Key }>(element) ? element.props.id : undefined;
+    return id ?? (item as { id: Key }).id;
+  };
+
   const { dragAndDropHooks } = useDragAndDrop({
     getItems: (keys) => [...keys].map((key) => ({ "text/plain": String(key) })),
     onReorder: (event) => {
-      onReorder(reorderItems(items, event));
+      onReorder(reorderItems(items, event, getItemId));
     },
     renderDropIndicator: (target) => <SortableDropIndicator target={target} />,
   });
@@ -78,8 +83,8 @@ export function SortableList<T extends { id: Key }>({
 
 const sortableItemStyles = tv({
   base: [
-    "flex cursor-grab select-none items-center gap-2 rounded-lg border border-transparent p-1 text-sm text-stone-600 outline-hidden",
-    "data-hovered:bg-stone-700/10 data-hovered:text-stone-800",
+    "flex cursor-grab select-none items-center gap-1.5 rounded-lg border border-transparent p-0.5 text-sm text-stone-600 outline-hidden",
+    "data-focus-visible:bg-stone-700/10 data-focus-visible:text-stone-800",
     "data-selected:bg-stone-700/10 data-selected:text-stone-800",
     "data-dragging:cursor-grabbing",
     "data-disabled:pointer-events-none data-disabled:opacity-50",
@@ -98,7 +103,7 @@ export function SortableItem({ children, className, ref, ...props }: SortableIte
     <AriaGridListItem
       ref={ref}
       className={composeAriaClassName(className, ({ isDragging }) =>
-        cn(focusVisibleStyle, sortableItemStyles({ isDragging })),
+        sortableItemStyles({ isDragging }),
       )}
       {...props}
     >

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -43,6 +43,7 @@ export {
   MenuSection,
   type MenuSectionProps,
   MenuTrigger,
+  SubmenuTrigger,
 } from "./components/menu/menu";
 export { Meter, type MeterProps } from "./components/meter/meter";
 export {
@@ -69,6 +70,7 @@ export {
   SelectList,
   type SelectListProps,
   SelectTrigger,
+  type SelectTriggerProps,
 } from "./components/select/select";
 export { Sheet, type SheetProps } from "./components/sheet/sheet";
 export {

--- a/frontend/packages/ui/src/styles/focus-visible.ts
+++ b/frontend/packages/ui/src/styles/focus-visible.ts
@@ -1,4 +1,4 @@
 // Mirror of frontend/app/src/shared/components/aria/style-rac.ts.
 // Keep both copies in sync until the app's aria/* components migrate to @infrahub/ui and we can delete the app copy.
 export const focusVisibleStyle =
-  "transition-all data-focus-visible:outline-hidden data-focus-visible:ring-2 data-focus-visible:ring-cyan-700/25 data-focus-visible:border-cyan-700";
+  "outline-hidden transition-all data-focus-visible:ring-2 data-focus-visible:ring-cyan-700/25 data-focus-visible:border-cyan-700";


### PR DESCRIPTION
WIP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a multi-field Sort Picker to object lists with URL persistence and GraphQL `order` integration. Users can add fields, pick directions, drag to reorder priority, and reset to the schema default.

- **New Features**
  - Sort Picker in the toolbar with a count badge; searchable field list opens a direction submenu; drag to reorder; shows “Default order · applied now” vs “Custom order” and supports Reset/Clear.
  - `useSort` syncs `?sort` via `nuqs`, validates against the schema, normalizes a schema-default sort to `null`, and ignores non-sortable fields. `getObjects`/`getObjectsFromApi` accept `sort`; `addOrderByToRequest` sends `order.by` with enum directions via `json-to-graphql-query`. Query keys: list includes `sort`; count does not.
  - Schema-aware fields: attributes, one-to-one relationships, and created/updated timestamps; utils to parse/format/validate tokens; tests for parsing/validation, URL syncing, and GraphQL enums.

- **Refactors**
  - `@infrahub/ui` Menu: add `variant="picker"`, `SubmenuTrigger`, submenu chevron, and stories showing action vs picker and submenu patterns.
  - `SelectTrigger`: new sizes and styling; `SortableList`: ID-agnostic reordering with a clearer drop indicator.
  - New shared `CountBadge`; Filter button uses it and `variant="outline"`.
  - Minor `focus-visible` style tweak.

<sup>Written for commit 619061254ed25a48b8657c3c6953ed90b3986fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

