### PR TITLE
chore: ignore .specify/feature.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ schema/node_modules/*
 **/.worktrees/
 .bug-analysis-*.md
 .specify/**/.cache/
+.specify/feature.json


### PR DESCRIPTION
# Why

`.specify/feature.json` is local spec-kit session state and shouldn't be tracked in git.

## What changed

- Added `.specify/feature.json` to `.gitignore`, next to the existing `.specify/**/.cache/` entry in the "AI and SDD" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.specify/feature.json` to `.gitignore` to prevent committing local Spec Kit session state. This keeps the repo clean and avoids noisy diffs.

<sup>Written for commit 05bbdfe2be89dc6b823418914276ae9161507c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

