### PR TITLE
fix(task): resolve Cubic findings in flow-run queries and retention (backport #9795 to stable)

### DIFF
--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -258,7 +258,7 @@ class PrefectTask:
     def _to_uuid(value: str) -> UUID:
         try:
             return UUID(value)
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             raise ValidationError(input_value=f"'{value}' is not a valid task id") from exc
 
     @classmethod

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -33,6 +33,7 @@ from infrahub import config
 from infrahub.core.constants import TaskConclusion
 from infrahub.core.query.node import NodeGetKindQuery
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import ValidationError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
 from infrahub.utils import get_nested_dict
@@ -135,6 +136,9 @@ class PrefectTask:
         if log_limit > NB_LOGS_LIMIT:
             raise ValueError(f"log_limit cannot be greater than {NB_LOGS_LIMIT}")
 
+        if not flow_ids:
+            return logs_flow
+
         all_logs = []
 
         # Fetch the logs in batches of PREFECT_MAX_LOGS_PER_CALL, as prefect does not allow to fetch more logs at once.
@@ -164,8 +168,12 @@ class PrefectTask:
     async def _get_flows(
         cls, client: PrefectClient, ids: list[UUID] | None = None, names: list[str] | None = None
     ) -> list[Flow]:
-        if not names and not ids:
+        if names is None and ids is None:
             return await client.read_flows()
+
+        # An empty filter list means no flows can match; an unfiltered call would return every flow instead.
+        if not names and not ids:
+            return []
 
         flow_filter = FlowFilter()
         flow_filter.name = FlowFilterName(any_=names) if names else None
@@ -174,11 +182,15 @@ class PrefectTask:
 
     @classmethod
     async def _get_progress(cls, client: PrefectClient, flow_ids: list[UUID]) -> FlowProgress:
+        flow_progress = FlowProgress()
+
+        if not flow_ids:
+            return flow_progress
+
         artifacts = await client.read_artifacts(
             artifact_filter=ArtifactFilter(type=ArtifactFilterType(any_=["progress"])),
             flow_run_filter=FlowRunFilter(id=FlowRunFilterId(any_=flow_ids)),
         )
-        flow_progress = FlowProgress()
         for artifact in artifacts:
             if artifact.flow_run_id in flow_progress.data:
                 log.warning(
@@ -232,7 +244,7 @@ class PrefectTask:
             tags=FlowRunFilterTags(all_=filter_tags),
         )
         if ids:
-            flow_run_filter.id = FlowRunFilterId(any_=[UUID(id) for id in ids])
+            flow_run_filter.id = FlowRunFilterId(any_=[cls._to_uuid(id) for id in ids])
 
         if statuses:
             flow_run_filter.state = FlowRunFilterState(type=FlowRunFilterStateType(any_=statuses))
@@ -241,6 +253,13 @@ class PrefectTask:
             flow_run_filter.name = FlowRunFilterName(like_=q)
 
         return flow_run_filter
+
+    @staticmethod
+    def _to_uuid(value: str) -> UUID:
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            raise ValidationError(input_value=f"'{value}' is not a valid task id") from exc
 
     @classmethod
     async def query(
@@ -263,7 +282,7 @@ class PrefectTask:
         count = None
 
         node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"])
-        log_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node", "logs", "edges", "node"])
+        log_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node", "logs"])
         logs_flow = FlowLogs()
         progress_flow = FlowProgress()
         workflow_names: dict[UUID, str] = {}
@@ -355,6 +374,8 @@ class PrefectTask:
         """Delete flow runs in the specified states and older than specified days."""
         logger = get_logger()
 
+        action = "delete" if delete else "mark as crashed"
+
         async with get_client(sync_client=False) as client:
             cutoff = DateTime.now(tz=UTC) - timedelta(days=days_to_keep)
 
@@ -366,14 +387,14 @@ class PrefectTask:
             # Get flow runs to delete
             flow_runs = await client.read_flow_runs(flow_run_filter=flow_run_filter, limit=batch_size)
 
-            deleted_total = 0
+            purged_total = 0
 
             while True:
-                batch_deleted = 0
-                failed_deletes = []
+                batch_purged = 0
+                failed_purges = []
 
                 # Delete each flow run through the API
-                for flow_run in flow_runs:
+                for index, flow_run in enumerate(flow_runs, start=1):
                     try:
                         if delete:
                             await client.delete_flow_run(flow_run_id=flow_run.id)
@@ -383,31 +404,31 @@ class PrefectTask:
                                 state=State(type=StateType.CRASHED),
                                 force=True,
                             )
-                        deleted_total += 1
-                        batch_deleted += 1
+                        purged_total += 1
+                        batch_purged += 1
                     except Exception as e:
-                        logger.warning(f"Failed to delete flow run {flow_run.id}: {e}")
-                        failed_deletes.append(flow_run.id)
+                        logger.warning(f"Failed to {action} flow run {flow_run.id}: {e}")
+                        failed_purges.append(flow_run.id)
 
-                    # Rate limiting
-                    if batch_deleted % 10 == 0:
+                    # Rate limiting, based on runs processed so failures throttle the same way as successes.
+                    if index % 10 == 0:
                         await asyncio.sleep(0.5)
 
-                logger.info(f"Delete {batch_deleted}/{len(flow_runs)} flow runs (total: {deleted_total})")
+                logger.info(f"Purged ({action}) {batch_purged}/{len(flow_runs)} flow runs (total: {purged_total})")
 
                 # Get next batch
                 previous_flow_run_ids = [fr.id for fr in flow_runs]
                 flow_runs = await client.read_flow_runs(flow_run_filter=flow_run_filter, limit=batch_size)
 
                 if not flow_runs:
-                    logger.info("No more flow runs to delete")
+                    logger.info("No more flow runs to purge")
                     break
 
                 if previous_flow_run_ids == [fr.id for fr in flow_runs]:
-                    logger.info("Found same flow runs to delete, aborting")
+                    logger.info("Found same flow runs to purge, aborting")
                     break
 
                 # Delay between batches to avoid overwhelming the API
                 await asyncio.sleep(1.0)
 
-            logger.info(f"Retention complete. Total deleted tasks: {deleted_total}")
+            logger.info(f"Retention complete. Total purged tasks: {purged_total}")

--- a/backend/tests/unit/task_manager/test_task.py
+++ b/backend/tests/unit/task_manager/test_task.py
@@ -1,5 +1,5 @@
 from datetime import UTC
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -69,7 +69,7 @@ class TestQueryLogSelection:
     async def test_logs_count_alone_fetches_logs(self) -> None:
         """A `logs { count }` selection without edges still triggers the log fetch."""
         client = FakePrefectClient(flow_runs=[FlowRun(id=uuid4(), flow_id=uuid4(), name="r1")])
-        fields = {"edges": {"node": {"logs": {"count": {}}}}}
+        fields: dict[str, Any] = {"edges": {"node": {"logs": {"count": {}}}}}
 
         with patch("infrahub.task_manager.task.get_client") as mock_get_client:
             mock_get_client.return_value.__aenter__.return_value = client

--- a/backend/tests/unit/task_manager/test_task.py
+++ b/backend/tests/unit/task_manager/test_task.py
@@ -93,6 +93,11 @@ class TestGenerateFlowRunFilter:
         with pytest.raises(ValidationError, match=r"^'not-a-uuid' is not a valid task id$"):
             PrefectTask._generate_flow_run_filter(ids=["not-a-uuid"])
 
+    def test_null_id_raises_validation_error(self) -> None:
+        # ids=List(String) in GraphQL permits null elements, which reach UUID() as None.
+        with pytest.raises(ValidationError, match=r"^'None' is not a valid task id$"):
+            PrefectTask._generate_flow_run_filter(ids=cast("list[str]", [None]))
+
 
 class TestGetLogs:
     async def test_no_flow_ids_returns_empty_without_remote_call(self) -> None:

--- a/backend/tests/unit/task_manager/test_task.py
+++ b/backend/tests/unit/task_manager/test_task.py
@@ -1,0 +1,167 @@
+from datetime import UTC
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from prefect.client.schemas.filters import ArtifactFilter, FlowFilter, FlowRunFilter, LogFilter
+from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log
+from prefect.client.schemas.sorting import FlowRunSort
+from prefect.types import DateTime
+
+from infrahub.exceptions import ValidationError
+from infrahub.task_manager.task import NB_LOGS_LIMIT, PREFECT_MAX_LOGS_PER_CALL, PrefectTask
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+
+
+class FakePrefectClient:
+    """Minimal Prefect client stand-in that records the read calls PrefectTask makes."""
+
+    def __init__(
+        self,
+        logs: list[Log] | None = None,
+        artifacts: list[Artifact] | None = None,
+        flows: list[Flow] | None = None,
+        flow_runs: list[FlowRun] | None = None,
+    ) -> None:
+        self._logs = logs or []
+        self._artifacts = artifacts or []
+        self._flows = flows or []
+        self._flow_runs = flow_runs or []
+        self.read_logs_calls: list[tuple[int, int]] = []
+        self.read_artifacts_calls: list[FlowRunFilter] = []
+        self.read_flows_calls: list[FlowFilter | None] = []
+
+    async def read_flow_runs(
+        self,
+        flow_filter: FlowFilter | None = None,
+        flow_run_filter: FlowRunFilter | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        sort: FlowRunSort | None = None,
+    ) -> list[FlowRun]:
+        return self._flow_runs
+
+    async def read_logs(self, log_filter: LogFilter, offset: int, limit: int) -> list[Log]:
+        self.read_logs_calls.append((offset, limit))
+        return self._logs[offset : offset + limit]
+
+    async def read_artifacts(self, artifact_filter: ArtifactFilter, flow_run_filter: FlowRunFilter) -> list[Artifact]:
+        self.read_artifacts_calls.append(flow_run_filter)
+        return self._artifacts
+
+    async def read_flows(self, flow_filter: FlowFilter | None = None) -> list[Flow]:
+        self.read_flows_calls.append(flow_filter)
+        return self._flows
+
+
+def make_log(flow_run_id: UUID | None, message: str = "log line") -> Log:
+    return Log(name="task", level=20, message=message, timestamp=DateTime.now(tz=UTC), flow_run_id=flow_run_id)
+
+
+def make_artifact(flow_run_id: UUID, data: object) -> Artifact:
+    return Artifact(type="progress", flow_run_id=flow_run_id, data=data)
+
+
+class TestQueryLogSelection:
+    async def test_logs_count_alone_fetches_logs(self) -> None:
+        """A `logs { count }` selection without edges still triggers the log fetch."""
+        client = FakePrefectClient(flow_runs=[FlowRun(id=uuid4(), flow_id=uuid4(), name="r1")])
+        fields = {"edges": {"node": {"logs": {"count": {}}}}}
+
+        with patch("infrahub.task_manager.task.get_client") as mock_get_client:
+            mock_get_client.return_value.__aenter__.return_value = client
+            mock_get_client.return_value.__aexit__.return_value = None
+            await PrefectTask.query(db=MagicMock(), fields=fields)
+
+        assert client.read_logs_calls != []
+
+
+class TestGenerateFlowRunFilter:
+    def test_ids_are_converted_to_uuid(self) -> None:
+        id_a = "00000000-0000-0000-0000-000000000001"
+        id_b = "00000000-0000-0000-0000-000000000002"
+
+        flow_run_filter = PrefectTask._generate_flow_run_filter(ids=[id_a, id_b])
+
+        assert flow_run_filter.id is not None
+        assert flow_run_filter.id.any_ == [UUID(id_a), UUID(id_b)]
+
+    def test_invalid_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError, match=r"^'not-a-uuid' is not a valid task id$"):
+            PrefectTask._generate_flow_run_filter(ids=["not-a-uuid"])
+
+
+class TestGetLogs:
+    async def test_no_flow_ids_returns_empty_without_remote_call(self) -> None:
+        client = FakePrefectClient(logs=[make_log(uuid4())])
+
+        result = await PrefectTask._get_logs(
+            client=cast("PrefectClient", client), flow_ids=[], log_limit=None, log_offset=None
+        )
+
+        assert result.logs == {}
+        assert client.read_logs_calls == []
+
+    async def test_paginates_beyond_a_single_batch(self) -> None:
+        flow_id = uuid4()
+        total = PREFECT_MAX_LOGS_PER_CALL + 50
+        client = FakePrefectClient(logs=[make_log(flow_id) for _ in range(total)])
+
+        result = await PrefectTask._get_logs(
+            client=cast("PrefectClient", client), flow_ids=[flow_id], log_limit=None, log_offset=None
+        )
+
+        assert len(result.logs[flow_id]) == total
+        assert client.read_logs_calls == [
+            (0, PREFECT_MAX_LOGS_PER_CALL),
+            (PREFECT_MAX_LOGS_PER_CALL, PREFECT_MAX_LOGS_PER_CALL),
+        ]
+
+    async def test_rejects_log_limit_above_max(self) -> None:
+        with pytest.raises(ValueError, match=rf"^log_limit cannot be greater than {NB_LOGS_LIMIT}$"):
+            await PrefectTask._get_logs(
+                client=cast("PrefectClient", FakePrefectClient()),
+                flow_ids=[uuid4()],
+                log_limit=NB_LOGS_LIMIT + 1,
+                log_offset=None,
+            )
+
+
+class TestGetProgress:
+    async def test_no_flow_ids_returns_empty_without_remote_call(self) -> None:
+        client = FakePrefectClient(artifacts=[make_artifact(uuid4(), 0.5)])
+
+        result = await PrefectTask._get_progress(client=cast("PrefectClient", client), flow_ids=[])
+
+        assert result.data == {}
+        assert client.read_artifacts_calls == []
+
+
+class TestGetFlows:
+    async def test_reads_all_when_no_ids_or_names(self) -> None:
+        flows = [Flow(id=uuid4(), name="wf", labels={})]
+        client = FakePrefectClient(flows=flows)
+
+        result = await PrefectTask._get_flows(client=cast("PrefectClient", client))
+
+        assert result == flows
+        assert client.read_flows_calls == [None]
+
+    async def test_empty_ids_return_no_flows_without_remote_call(self) -> None:
+        client = FakePrefectClient(flows=[Flow(id=uuid4(), name="wf", labels={})])
+
+        result = await PrefectTask._get_flows(client=cast("PrefectClient", client), ids=[])
+
+        assert result == []
+        assert client.read_flows_calls == []
+
+    async def test_empty_names_return_no_flows_without_remote_call(self) -> None:
+        client = FakePrefectClient(flows=[Flow(id=uuid4(), name="wf", labels={})])
+
+        result = await PrefectTask._get_flows(client=cast("PrefectClient", client), names=[])
+
+        assert result == []
+        assert client.read_flows_calls == []

--- a/changelog/+task-filter-invalid-id.fixed.md
+++ b/changelog/+task-filter-invalid-id.fixed.md
@@ -1,0 +1,1 @@
+Filtering tasks by an id that is not a valid UUID now returns a validation error instead of an internal server error.

--- a/changelog/+task-logs-count-selection.fixed.md
+++ b/changelog/+task-logs-count-selection.fixed.md
@@ -1,0 +1,1 @@
+The task GraphQL query now returns the correct log count when only `logs { count }` is selected, without requesting the log entries themselves.


### PR DESCRIPTION
Closes [IFC-2865](https://opsmill.atlassian.net/browse/IFC-2865).

# Why

Backport of #9795 to `stable`. #9795 resolved 7 Cubic findings in the flow-run task manager (Jira [IFC-2756](https://opsmill.atlassian.net/browse/IFC-2756)): two user-visible bugs plus several wasted Prefect calls and misleading retention throttling/logging.

Those fixes were written on `develop` against the `flow_run/` components introduced by the #9599 refactoring, which is **not on stable**. This PR re-applies each fix to stable's pre-refactor `PrefectTask` god class, resolving the structural conflicts by hand.

## What changed

Behavioral changes:

- The tasks GraphQL query returns the correct log count when only `logs { count }` is selected.
- Filtering tasks by an id that is not a valid UUID returns a 422 validation error instead of a 500.

Internal changes (no visible output change):

- A task query matching zero runs no longer calls Prefect for logs, progress artifacts, or an unfiltered read of every flow.
- Flow-run retention throttles on runs processed instead of successes only, and its log messages reflect the configured action (delete vs mark as crashed).

### Mapping to the original commits

| Original commit (#9795) | Applied to stable in |
|---|---|
| `fix(task): fetch logs when only the log count is selected` | `PrefectTask.query` log-fields detection |
| `fix(task): report invalid task id filters as validation errors` | `PrefectTask._generate_flow_run_filter` / new `_to_uuid` |
| `perf(task): skip the log fetch when no flow runs are selected` | `PrefectTask._get_logs` |
| `perf(task): skip the progress artifact query when no flow runs are selected` | `PrefectTask._get_progress` |
| `perf(task): treat an empty flow filter as matching no flows` | `PrefectTask._get_flows` |
| `fix(task): throttle flow-run retention on runs processed rather than successes` | `PrefectTask.delete_flow_runs` |
| `fix(task): make retention log messages reflect the purge action` | `PrefectTask.delete_flow_runs` |

On stable the `flow_run/` unit test files do not exist, so the regression coverage is backported as new unit tests in `backend/tests/unit/task_manager/test_task.py`, exercising the same behaviors against `PrefectTask` classmethods with a fake Prefect client.

## How to test

```bash
uv run pytest backend/tests/unit/task_manager/test_task.py
```

## Impact & rollout

- **Backward compatibility:** no schema or API contract changes; malformed task id filters now return 422 instead of 500.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entries added (two fragments, for the two user-visible fixes)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2756]: https://opsmill.atlassian.net/browse/IFC-2756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports flow-run task manager fixes to `stable` to address Cubic findings (IFC-2756/IFC-2865). Fixes two user-facing issues, removes unnecessary Prefect calls, and improves retention behavior and logs.

- **Bug Fixes**
  - Task query returns the correct log count when only `logs { count }` is selected.
  - Invalid or null task id filters return a 422 validation error instead of a 500.

- **Refactors**
  - Skip Prefect log/progress fetches when a query matches no runs; treat empty flow filters as match-none.
  - Retention throttles on runs processed and logs the action (delete vs mark as crashed).
  - Tests cover these behaviors; typed the fields dict in the log-selection test for mypy.

<sup>Written for commit fb8cf2b2656f3078115bb7dcb8c745ba63e6978a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

[IFC-2865]: https://opsmill.atlassian.net/browse/IFC-2865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

## Manual verification against a live instance

Ran a local stack on the backport branch and exercised the two user-visible fixes through the GraphQL API (`/graphql/main`):

| Check | Query | Result |
|---|---|---|
| Invalid non-UUID id | `InfrahubTask(ids: ["not-a-uuid"]) { count }` | error `'not-a-uuid' is not a valid task id`, `http_status: 422` |
| Null id | `InfrahubTask(ids: $ids) { count }` with `{"ids": [null]}` | error `'None' is not a valid task id`, `http_status: 422` |
| Valid UUID (control) | `InfrahubTask(ids: ["00000000-…-0001"]) { count }` | succeeds, `count: 0` |
| `logs { count }` alone | `InfrahubTask { edges { node { logs { count } } } }` | `count: 3` — matches the count returned when `logs { edges }` is also selected (was `0` before the fix) |

Before the fix, filtering by a malformed id returned a 500, and selecting only `logs { count }` returned `0`.
