### PR TITLE
fix: sanitize git GraphQL query import errors

### DIFF
--- a/backend/infrahub/errors/catalogue.py
+++ b/backend/infrahub/errors/catalogue.py
@@ -15,6 +15,7 @@ from .exceptions import (
     AttributeConstraintViolationError,
     AttributeInvalidTypeError,
     AttributeRequiredError,
+    GraphQLQueryInvalidError,
 )
 from .payloads import (
     AttributeConstraintViolationData,
@@ -22,6 +23,7 @@ from .payloads import (
     AttributeRequiredData,
     AuthenticationRequiredData,
     BranchNotFoundData,
+    GraphQLQueryInvalidData,
     NodeNotFoundData,
     PermissionDeniedData,
     SchemaNotFoundData,
@@ -130,6 +132,16 @@ CATALOGUE: "OrderedDict[str, CatalogueEntry]" = OrderedDict(
                 http_status=422,
                 payload_model=SchemaNotFoundData,
                 exception_class=SchemaNotFoundError,
+            ),
+        ),
+        (
+            "GRAPHQL_QUERY_INVALID",
+            CatalogueEntry(
+                description="The submitted GraphQL query failed validation against the GraphQL schema.",
+                stability="evolving",
+                http_status=422,
+                payload_model=GraphQLQueryInvalidData,
+                exception_class=GraphQLQueryInvalidError,
             ),
         ),
         (

--- a/backend/infrahub/errors/exceptions.py
+++ b/backend/infrahub/errors/exceptions.py
@@ -47,3 +47,10 @@ class AttributeConstraintViolationError(ValidationError):
             reason = f"{constraint}" if detail is None else f"{constraint}: {detail}"
             input_value = {field_name: reason}
         super().__init__(input_value)
+
+
+class GraphQLQueryInvalidError(ValidationError):
+    def __init__(self, messages: list[str]) -> None:
+        detail = "; ".join(messages)
+        message = f"Query is not valid: {detail}" if detail else "Query is not valid"
+        super().__init__(message)

--- a/backend/infrahub/errors/payloads.py
+++ b/backend/infrahub/errors/payloads.py
@@ -54,5 +54,9 @@ class SchemaNotFoundData(PayloadBase):
     kind: str
 
 
+class GraphQLQueryInvalidData(PayloadBase):
+    pass
+
+
 class UndefinedErrorData(PayloadBase):
     pass

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +12,7 @@ import ujson
 import yaml
 from infrahub_sdk import InfrahubClient  # noqa: TC002
 from infrahub_sdk.exceptions import Error as InfrahubSdkError
+from infrahub_sdk.exceptions import GraphQLError as InfrahubSdkGraphQLError
 from infrahub_sdk.exceptions import ValidationError
 from infrahub_sdk.graphql.query_renderer import render_query
 from infrahub_sdk.node import InfrahubNode
@@ -77,6 +79,30 @@ if TYPE_CHECKING:
 
     from infrahub.artifacts.models import CheckArtifactCreate
     from infrahub.git.models import RequestArtifactGenerate
+
+
+GRAPHQL_VALIDATION_ERROR_PATTERN = re.compile(r"GraphQLError\((?P<quote>['\"])(?P<message>.*?)(?P=quote)(?:,|\))")
+
+
+def _clean_sdk_graphql_error_message(message: str) -> str:
+    if not message.startswith("Query is not valid"):
+        return message
+
+    match = GRAPHQL_VALIDATION_ERROR_PATTERN.search(message)
+    if not match:
+        return message
+
+    return f"Query is not valid: {match.group('message')}"
+
+
+def _format_sdk_graphql_error_messages(errors: list[dict[str, Any]]) -> str:
+    messages = []
+    for error in errors:
+        message = error.get("message") if isinstance(error, dict) else str(error)
+        if message:
+            messages.append(_clean_sdk_graphql_error_message(message))
+
+    return "; ".join(messages) or "GraphQL query validation failed."
 
 
 class ArtifactGenerateResult(BaseModel):
@@ -858,7 +884,14 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             is_protected=True,
         )
         obj = await self.sdk.create(kind=CoreGraphQLQuery, branch=branch_name, **create_payload)
-        await obj.save()
+        try:
+            await obj.save()
+        except InfrahubSdkGraphQLError as exc:
+            reason = _format_sdk_graphql_error_messages(exc.errors)
+            message = f"Unable to import GraphQL query {name!r} from repository {self.name!r}: {reason}"
+            get_logger().error(message)
+            raise RepositoryConfigurationError(identifier=self.name, message=message) from None
+
         return obj
 
     @task(name="import-python-check-definitions", task_run_name="Import Python Check Definitions", cache_policy=NONE)

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import importlib
-import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -81,28 +80,12 @@ if TYPE_CHECKING:
     from infrahub.git.models import RequestArtifactGenerate
 
 
-GRAPHQL_VALIDATION_ERROR_PATTERN = re.compile(r"GraphQLError\((?P<quote>['\"])(?P<message>.*?)(?P=quote)(?:,|\))")
-
-
-def _clean_sdk_graphql_error_message(message: str) -> str:
-    if not message.startswith("Query is not valid"):
-        return message
-
-    match = GRAPHQL_VALIDATION_ERROR_PATTERN.search(message)
-    if not match:
-        return message
-
-    return f"Query is not valid: {match.group('message')}"
-
-
-def _format_sdk_graphql_error_messages(errors: list[dict[str, Any]]) -> str:
-    messages = []
-    for error in errors:
-        message = error.get("message") if isinstance(error, dict) else str(error)
-        if message:
-            messages.append(_clean_sdk_graphql_error_message(message))
-
-    return "; ".join(messages) or "GraphQL query validation failed."
+def _graphql_error_messages(exc: InfrahubSdkGraphQLError) -> str:
+    """Join the server-provided error messages, which are concise and safe to surface to operators."""
+    return (
+        "; ".join(error["message"] for error in exc.errors if isinstance(error, dict) and error.get("message"))
+        or "unknown error"
+    )
 
 
 class ArtifactGenerateResult(BaseModel):
@@ -838,6 +821,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         Mutates graph nodes whose names are globally unique, so it must run serialized against any
         concurrent import of the same repository.
+
+        Raises:
+            RepositoryConfigurationError: A created or updated query was rejected by the server as invalid.
+
         """
         log = get_run_logger()
 
@@ -866,7 +853,17 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             if local_query != graph_query.query.value:
                 log.info(f"New version of the Graphql Query {query_name!r} found, updating")
                 graph_query.query.value = local_query
-                await graph_query.save()
+                try:
+                    await graph_query.save()
+                except InfrahubSdkGraphQLError as exc:
+                    message = (
+                        f"Unable to import GraphQL query {query_name!r} from repository {self.name!r}: "
+                        f"{_graphql_error_messages(exc)}"
+                    )
+                    log.error(message)
+                    # The SDK exception text embeds the full rendered mutation; suppress the chained
+                    # context so it cannot surface in tracebacks or operator-facing logs.
+                    raise RepositoryConfigurationError(identifier=self.name, message=message) from None
 
         for query_name in only_graph:
             graph_query = queries_in_graph[query_name]
@@ -887,9 +884,12 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         try:
             await obj.save()
         except InfrahubSdkGraphQLError as exc:
-            reason = _format_sdk_graphql_error_messages(exc.errors)
-            message = f"Unable to import GraphQL query {name!r} from repository {self.name!r}: {reason}"
+            message = (
+                f"Unable to import GraphQL query {name!r} from repository {self.name!r}: {_graphql_error_messages(exc)}"
+            )
             get_logger().error(message)
+            # The SDK exception text embeds the full rendered mutation; suppress the chained
+            # context so it cannot surface in tracebacks or operator-facing logs.
             raise RepositoryConfigurationError(identifier=self.name, message=message) from None
 
         return obj

--- a/backend/infrahub/graphql/error_formatter.py
+++ b/backend/infrahub/graphql/error_formatter.py
@@ -16,6 +16,7 @@ from infrahub.errors.payloads import (
     AttributeRequiredData,
     AuthenticationRequiredData,
     BranchNotFoundData,
+    GraphQLQueryInvalidData,
     NodeNotFoundData,
     PermissionDeniedData,
     SchemaNotFoundData,
@@ -78,6 +79,8 @@ def _build_payload(exc: BaseException | None, code: str) -> dict[str, Any]:
             payload = BranchNotFoundData(branch_name=exc.identifier)
         case "SCHEMA_NOT_FOUND" if isinstance(exc, SchemaNotFoundError):
             payload = SchemaNotFoundData(kind=exc.identifier)
+        case "GRAPHQL_QUERY_INVALID":
+            payload = GraphQLQueryInvalidData()
     return payload.model_dump(mode="json")
 
 

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -8,6 +8,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase
+from infrahub.errors.exceptions import GraphQLQueryInvalidError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 
@@ -49,7 +50,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
 
         valid, errors = analyzer.is_valid
         if not valid:
-            raise ValueError(f"Query is not valid, {str(errors)}")
+            raise GraphQLQueryInvalidError(messages=[error.message for error in errors or []])
 
         query_info["models"] = {"value": analyzer.query_report.impacted_models}
         query_info["depth"] = {"value": await analyzer.calculate_depth()}

--- a/backend/tests/component/git/test_graphql_query_import.py
+++ b/backend/tests/component/git/test_graphql_query_import.py
@@ -198,7 +198,9 @@ async def test_create_graphql_query_surfaces_server_validation_error(
 
     # The upstream SDK GraphQLError embeds the full rendered mutation in its message; the
     # chained context must stay suppressed and only the concise server message may be logged.
+    # The positive check guards the negative ones: if log capture broke, they would pass vacuously.
     assert exc_info.value.__suppress_context__ is True
+    assert "Unable to import GraphQL query 'broken_query' from repository 'fragment_repo'" in caplog.text
     assert "An error occurred while executing the GraphQL Query" not in caplog.text
     assert "SourceLocation" not in caplog.text
 

--- a/backend/tests/component/git/test_graphql_query_import.py
+++ b/backend/tests/component/git/test_graphql_query_import.py
@@ -9,15 +9,16 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from git import Repo as GitRepo
 from infrahub_sdk import Config, InfrahubClient
-from infrahub_sdk.exceptions import FragmentFileNotFoundError, FragmentNotFoundError
+from infrahub_sdk.exceptions import FragmentFileNotFoundError, FragmentNotFoundError, GraphQLError
 from infrahub_sdk.schema.repository import InfrahubRepositoryFragmentConfig, InfrahubRepositoryGraphQLConfig
 from infrahub_sdk.uuidt import UUIDT
 
+from infrahub.exceptions import RepositoryConfigurationError
 from infrahub.git import InfrahubRepository
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from tests.constants import FIXTURE_REPOS_DIR
@@ -149,6 +150,44 @@ async def test_unresolved_fragment_raises(
 
     with pytest.raises(FragmentNotFoundError):
         await fragment_repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)
+
+
+async def test_create_graphql_query_sanitizes_sdk_graphql_error(
+    fragment_repo: InfrahubRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """SDK GraphQLError messages include raw mutations; repository import should not surface them to operators."""
+    raw_query = "mutation SensitiveMutation { CoreGraphQLQueryCreate { ok } }"
+    server_message = (
+        'Query is not valid, [GraphQLError("Cannot query field \'DemoMissingNode\' on type \'Query\'.", '
+        "locations=[SourceLocation(line=2, column=3)])]"
+    )
+    sdk_error = GraphQLError(
+        errors=[{"message": server_message, "path": ["CoreGraphQLQueryCreate"]}],
+        query=raw_query,
+        variables={"secret": "should-not-leak"},
+    )
+
+    node = AsyncMock()
+    node.save.side_effect = sdk_error
+
+    fragment_repo.client.schema.get = AsyncMock(return_value=MagicMock())
+    fragment_repo.client.schema.generate_payload_create = MagicMock(return_value={"data": {}})
+    fragment_repo.client.create = AsyncMock(return_value=node)
+
+    with pytest.raises(RepositoryConfigurationError) as exc_info:
+        await fragment_repo.create_graphql_query(
+            branch_name="main", name="broken_query", query_string="query Broken { DemoMissingNode { edges { node { id } } } }"
+        )
+
+    error_message = str(exc_info.value)
+    assert "broken_query" in error_message
+    assert fragment_repo.name in error_message
+    assert "Query is not valid: Cannot query field 'DemoMissingNode' on type 'Query'." in error_message
+    assert "SourceLocation" not in error_message
+    assert raw_query not in error_message
+    assert "should-not-leak" not in error_message
+    assert raw_query not in caplog.text
+    assert "should-not-leak" not in caplog.text
 
 
 async def test_missing_fragment_file_raises_with_path(

--- a/backend/tests/component/git/test_graphql_query_import.py
+++ b/backend/tests/component/git/test_graphql_query_import.py
@@ -7,14 +7,16 @@ calls are stubbed so no live server is required.
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from git import Repo as GitRepo
 from infrahub_sdk import Config, InfrahubClient
-from infrahub_sdk.exceptions import FragmentFileNotFoundError, FragmentNotFoundError, GraphQLError
+from infrahub_sdk.exceptions import FragmentFileNotFoundError, FragmentNotFoundError
 from infrahub_sdk.schema.repository import InfrahubRepositoryFragmentConfig, InfrahubRepositoryGraphQLConfig
 from infrahub_sdk.uuidt import UUIDT
 
@@ -23,6 +25,9 @@ from infrahub.git import InfrahubRepository
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from tests.constants import FIXTURE_REPOS_DIR
 from tests.helpers.test_client import dummy_async_request
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
 
 FRAGMENT_INLINING_FIXTURE = FIXTURE_REPOS_DIR / "fragment-inlining"
 
@@ -152,42 +157,50 @@ async def test_unresolved_fragment_raises(
         await fragment_repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)
 
 
-async def test_create_graphql_query_sanitizes_sdk_graphql_error(
-    fragment_repo: InfrahubRepository, caplog: pytest.LogCaptureFixture
+@pytest.mark.httpx_mock(should_mock=lambda request: request.url.host == "mock")
+async def test_create_graphql_query_surfaces_server_validation_error(
+    fragment_repo: InfrahubRepository,
+    client: InfrahubClient,
+    mock_schema_query_01: HTTPXMock,
+    httpx_mock: HTTPXMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """SDK GraphQLError messages include raw mutations; repository import should not surface them to operators."""
-    raw_query = "mutation SensitiveMutation { CoreGraphQLQueryCreate { ok } }"
-    server_message = (
-        'Query is not valid, [GraphQLError("Cannot query field \'DemoMissingNode\' on type \'Query\'.", '
-        "locations=[SourceLocation(line=2, column=3)])]"
+    """An invalid imported query must fail with the concise server-side validation message only."""
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"^http://mock/graphql/main$"),
+        json={
+            "data": None,
+            "errors": [
+                {
+                    "message": "Query is not valid: Cannot query field 'DemoMissingNode' on type 'Query'.",
+                    "locations": [{"line": 1, "column": 17}],
+                    "path": ["CoreGraphQLQueryCreate"],
+                    "extensions": {"code": "GRAPHQL_QUERY_INVALID", "http_status": 422, "data": {}},
+                }
+            ],
+        },
     )
-    sdk_error = GraphQLError(
-        errors=[{"message": server_message, "path": ["CoreGraphQLQueryCreate"]}],
-        query=raw_query,
-        variables={"secret": "should-not-leak"},
-    )
+    fragment_repo.client = client
 
-    node = AsyncMock()
-    node.save.side_effect = sdk_error
-
-    fragment_repo.client.schema.get = AsyncMock(return_value=MagicMock())
-    fragment_repo.client.schema.generate_payload_create = MagicMock(return_value={"data": {}})
-    fragment_repo.client.create = AsyncMock(return_value=node)
-
-    with pytest.raises(RepositoryConfigurationError) as exc_info:
+    with pytest.raises(
+        RepositoryConfigurationError,
+        match=(
+            r"^Unable to import GraphQL query 'broken_query' from repository 'fragment_repo': "
+            r"Query is not valid: Cannot query field 'DemoMissingNode' on type 'Query'\.$"
+        ),
+    ) as exc_info:
         await fragment_repo.create_graphql_query(
-            branch_name="main", name="broken_query", query_string="query Broken { DemoMissingNode { edges { node { id } } } }"
+            branch_name="main",
+            name="broken_query",
+            query_string="query Broken { DemoMissingNode { edges { node { id } } } }",
         )
 
-    error_message = str(exc_info.value)
-    assert "broken_query" in error_message
-    assert fragment_repo.name in error_message
-    assert "Query is not valid: Cannot query field 'DemoMissingNode' on type 'Query'." in error_message
-    assert "SourceLocation" not in error_message
-    assert raw_query not in error_message
-    assert "should-not-leak" not in error_message
-    assert raw_query not in caplog.text
-    assert "should-not-leak" not in caplog.text
+    # The upstream SDK GraphQLError embeds the full rendered mutation in its message; the
+    # chained context must stay suppressed and only the concise server message may be logged.
+    assert exc_info.value.__suppress_context__ is True
+    assert "An error occurred while executing the GraphQL Query" not in caplog.text
+    assert "SourceLocation" not in caplog.text
 
 
 async def test_missing_fragment_file_raises_with_path(

--- a/backend/tests/component/graphql/test_mutation_graphqlquery.py
+++ b/backend/tests/component/graphql/test_mutation_graphqlquery.py
@@ -4,6 +4,8 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+from infrahub.errors.exceptions import GraphQLQueryInvalidError
+from infrahub.graphql.error_formatter import build_catalogue_extensions
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
@@ -300,3 +302,104 @@ async def test_update_query_no_update(
     assert obj2.operations.value == ["query"]
     assert obj2.variables.value == []
     assert obj2.models.value == [InfrahubKind.REPOSITORY]
+
+
+async def test_create_query_invalid_query_returns_catalogued_error(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    query_value = "query MyQuery { ThisModelDoesNotExist { edges { node { id } } } }"
+
+    query = """
+    mutation {
+        CoreGraphQLQueryCreate(
+            data: {
+                name: { value: "invalid_query"},
+                query: { value: "%s" }}) {
+            ok
+        }
+    }
+    """ % query_value.replace('"', '\\"')
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert isinstance(error.original_error, GraphQLQueryInvalidError)
+    assert error.message == "Query is not valid: Cannot query field 'ThisModelDoesNotExist' on type 'Query'."
+    assert build_catalogue_extensions(error.original_error) == {
+        "code": "GRAPHQL_QUERY_INVALID",
+        "http_status": 422,
+        "data": {},
+    }
+
+
+async def test_update_query_invalid_query_returns_catalogued_error(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    query_create = """
+    query MyQuery {
+        CoreRepository {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    obj = await Node.init(db=db, branch=default_branch, schema=InfrahubKind.GRAPHQLQUERY)
+    await obj.new(
+        db=db,
+        name="query1",
+        query=query_create,
+        depth=6,
+        height=7,
+        operations=["query"],
+        variables=[],
+        models=[InfrahubKind.REPOSITORY],
+    )
+    await obj.save(db=db)
+
+    query_value = "query MyQuery { ThisModelDoesNotExist { edges { node { id } } } }"
+
+    query = """
+    mutation {
+        CoreGraphQLQueryUpdate(
+            data: {
+                id: "%s"
+                query: { value: "%s" }}) {
+            ok
+        }
+    }
+    """ % (obj.id, query_value.replace('"', '\\"'))
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert isinstance(error.original_error, GraphQLQueryInvalidError)
+    assert error.message == "Query is not valid: Cannot query field 'ThisModelDoesNotExist' on type 'Query'."
+    assert build_catalogue_extensions(error.original_error) == {
+        "code": "GRAPHQL_QUERY_INVALID",
+        "http_status": 422,
+        "data": {},
+    }

--- a/backend/tests/unit/graphql/test_error_formatter.py
+++ b/backend/tests/unit/graphql/test_error_formatter.py
@@ -10,6 +10,7 @@ from infrahub.errors.exceptions import (
     AttributeConstraintViolationError,
     AttributeInvalidTypeError,
     AttributeRequiredError,
+    GraphQLQueryInvalidError,
 )
 from infrahub.errors.validation import MultiFieldValidationError
 from infrahub.exceptions import (
@@ -121,6 +122,13 @@ CASES = [
         expected_code="SCHEMA_NOT_FOUND",
         expected_http_status=422,
         expected_data={"kind": "MissingKind"},
+    ),
+    CodeCase(
+        name="graphql_query_invalid",
+        exc=GraphQLQueryInvalidError(messages=["Cannot query field 'DemoMissingNode' on type 'Query'."]),
+        expected_code="GRAPHQL_QUERY_INVALID",
+        expected_http_status=422,
+        expected_data={},
     ),
 ]
 

--- a/changelog/7498.fixed.md
+++ b/changelog/7498.fixed.md
@@ -1,0 +1,1 @@
+Importing a repository that adds or updates an invalid GraphQL query now fails with a concise validation message instead of an error dump that embedded the full query text. The GraphQLQuery create and update mutations now return the catalogued `GRAPHQL_QUERY_INVALID` error.

--- a/docs/docs/reference/error-catalogue.mdx
+++ b/docs/docs/reference/error-catalogue.mdx
@@ -4,7 +4,7 @@ title: Error Catalogue
 
 # Error Catalogue
 
-**Catalogue version**: 1 — 10 codes
+**Catalogue version**: 1 — 11 codes
 
 Every GraphQL error response carries an `extensions` block with a stable string `code`, the logical `http_status`, and a typed `data` payload. Switch on `code` rather than parsing the human-readable `message`, which is not part of the stable contract.
 
@@ -177,6 +177,33 @@ The requested branch does not exist.
         "data": {
           "branch_name": "example"
         }
+      }
+    }
+  ]
+}
+```
+
+### GRAPHQL_QUERY_INVALID
+
+The submitted GraphQL query failed validation against the GraphQL schema.
+
+- **Stability**: `evolving`
+- **HTTP status**: `422`
+
+This code carries no `data` payload; `data` is always `{}`.
+
+**Example response**
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "The submitted GraphQL query failed validation against the GraphQL schema.",
+      "extensions": {
+        "code": "GRAPHQL_QUERY_INVALID",
+        "http_status": 422,
+        "data": {}
       }
     }
   ]

--- a/frontend/app/src/shared/api/errors/catalogue.generated.ts
+++ b/frontend/app/src/shared/api/errors/catalogue.generated.ts
@@ -28,6 +28,8 @@ export interface BranchNotFoundData {
   branch_name: string;
 }
 
+export type GraphQLQueryInvalidData = Record<string, never>;
+
 export interface NodeNotFoundData {
   node_kind: string;
   identifier: string;
@@ -54,6 +56,7 @@ export const ERROR_CODES = {
   ATTRIBUTE_REQUIRED: "ATTRIBUTE_REQUIRED",
   AUTHENTICATION_REQUIRED: "AUTHENTICATION_REQUIRED",
   BRANCH_NOT_FOUND: "BRANCH_NOT_FOUND",
+  GRAPHQL_QUERY_INVALID: "GRAPHQL_QUERY_INVALID",
   NODE_NOT_FOUND: "NODE_NOT_FOUND",
   PERMISSION_DENIED: "PERMISSION_DENIED",
   SCHEMA_NOT_FOUND: "SCHEMA_NOT_FOUND",
@@ -72,6 +75,7 @@ export const ERROR_HTTP_STATUS: Record<ErrorCode, number> = {
   ATTRIBUTE_REQUIRED: 422,
   AUTHENTICATION_REQUIRED: 401,
   BRANCH_NOT_FOUND: 400,
+  GRAPHQL_QUERY_INVALID: 422,
   NODE_NOT_FOUND: 404,
   PERMISSION_DENIED: 403,
   SCHEMA_NOT_FOUND: 422,
@@ -87,6 +91,7 @@ export type CatalogueError =
   | { code: typeof ERROR_CODES.ATTRIBUTE_REQUIRED; http_status: number; data: AttributeRequiredData }
   | { code: typeof ERROR_CODES.AUTHENTICATION_REQUIRED; http_status: number; data: AuthenticationRequiredData }
   | { code: typeof ERROR_CODES.BRANCH_NOT_FOUND; http_status: number; data: BranchNotFoundData }
+  | { code: typeof ERROR_CODES.GRAPHQL_QUERY_INVALID; http_status: number; data: GraphQLQueryInvalidData }
   | { code: typeof ERROR_CODES.NODE_NOT_FOUND; http_status: number; data: NodeNotFoundData }
   | { code: typeof ERROR_CODES.PERMISSION_DENIED; http_status: number; data: PermissionDeniedData }
   | { code: typeof ERROR_CODES.SCHEMA_NOT_FOUND; http_status: number; data: SchemaNotFoundData }

--- a/frontend/app/src/shared/api/errors/index.test.ts
+++ b/frontend/app/src/shared/api/errors/index.test.ts
@@ -228,6 +228,7 @@ describe("ErrorCode exhaustiveness", () => {
         case ERROR_CODES.ATTRIBUTE_INVALID_TYPE:
         case ERROR_CODES.ATTRIBUTE_CONSTRAINT_VIOLATION:
         case ERROR_CODES.BRANCH_NOT_FOUND:
+        case ERROR_CODES.GRAPHQL_QUERY_INVALID:
         case ERROR_CODES.SCHEMA_NOT_FOUND:
         case ERROR_CODES.UNDEFINED_ERROR:
           return code;

--- a/frontend/app/src/shared/api/errors/index.ts
+++ b/frontend/app/src/shared/api/errors/index.ts
@@ -24,6 +24,7 @@ export {
   ERROR_CODES,
   ERROR_HTTP_STATUS,
   type ErrorCode,
+  type GraphQLQueryInvalidData,
   type NodeNotFoundData,
   type PermissionDeniedData,
   type SchemaNotFoundData,

--- a/schema/error-catalogue.json
+++ b/schema/error-catalogue.json
@@ -238,6 +238,18 @@
         "type": "object"
       }
     },
+    "GRAPHQL_QUERY_INVALID": {
+      "description": "The submitted GraphQL query failed validation against the GraphQL schema.",
+      "stability": "evolving",
+      "http_status": 422,
+      "data_schema": {
+        "additionalProperties": false,
+        "properties": {},
+        "title": "GraphQLQueryInvalidData",
+        "type": "object",
+        "required": []
+      }
+    },
     "UNDEFINED_ERROR": {
       "description": "An error not yet covered by the catalogue. Its occurrence indicates a catalogue gap and should be triaged.",
       "stability": "stable",


### PR DESCRIPTION
## Problem
Git repository imports can fail while creating `CoreGraphQLQuery` nodes. When that happens, the SDK `GraphQLError` currently surfaces the full generated mutation, variables, location reprs, and traceback-heavy text in task logs. That makes a user/configuration error hard to scan and can expose implementation details that are not useful to operators.

## Change
- catch `infrahub_sdk.exceptions.GraphQLError` around GraphQL query creation during Git import
- convert SDK validation output into a concise `RepositoryConfigurationError` that keeps the repository name, query name, and server validation message
- strip raw GraphQL mutation text, variables, and `SourceLocation` reprs from the operator-facing error/log message
- add regression coverage proving the sanitized error keeps the useful context without leaking the raw payload

## Before / After
Before, the worker/task output could include the full `CoreGraphQLQueryCreate` mutation and SDK exception payload.

After, the task reports a focused message like:

```text
Unable to import GraphQL query 'backbone_service' from repository 'opsmill-demo-edge-clean-message': Query is not valid: Cannot query field 'InfraBackBoneService' on type 'Query'.
```

## Screenshot
Filtered task log showing the sanitized `RepositoryConfigurationError` after reproducing the Git import failure locally:

![InfraHub task log showing sanitized RepositoryConfigurationError](https://raw.githubusercontent.com/Timtech4u/infrahub/pr-assets-9815-sanitized-error/pr-assets/infrahub-pr-9815-sanitized-error.png)

## Scope
This targets the Git integration path from #7498. It is related to the broader user-error logging cleanup in #4589, but intentionally does not attempt to change general API/GraphQL resolver logging in this PR.

## Testing
- `uv run ruff check backend/infrahub/git/integrator.py backend/tests/component/git/test_graphql_query_import.py`
- `uv run pytest backend/tests/component/git/test_graphql_query_import.py -q`
- local Docker verification against the InfraHub task UI with a failing Git GraphQL import

Addresses #7498. Related to #4589.