### PR TITLE
fix(backend): roll back partially merged data when a bulk merge query fails

### DIFF
--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -56,6 +56,7 @@ class DiffMerger:
         self.diff_repository = diff_repository
         self.exclusion_plan_builder = exclusion_plan_builder
         self._affected_node_uuids: list[str] = []
+        self._merge_started = False
 
     async def merge_graph(self, at: Timestamp) -> None:
         tracking_id = BranchTrackingId(name=self.source_branch.name)
@@ -86,6 +87,16 @@ class DiffMerger:
             carry_over_diff_rel_props=len(plan.carry_over_diff_relationship_properties),
         )
 
+        log.info("Discovering affected node UUIDs")
+        affected_node_uuids = await self.diff_repository.get_affected_node_uuids(
+            source_branch=self.source_branch,
+            target_branch=self.destination_branch,
+            at=at,
+            tracking_id=tracking_id,
+        )
+        self._affected_node_uuids = affected_node_uuids
+        self._merge_started = True
+
         log.info("Running bulk node existence merge")
         await self._bulk_merge_node_existence(at=at, plan=plan)
 
@@ -100,15 +111,6 @@ class DiffMerger:
 
         log.info("Running bulk relationship property edge merge")
         await self._bulk_merge_relationship_property_edges(at=at, plan=plan)
-
-        log.info("Discovering affected node UUIDs for metadata update")
-        affected_node_uuids = await self.diff_repository.get_affected_node_uuids(
-            source_branch=self.source_branch,
-            target_branch=self.destination_branch,
-            at=at,
-            tracking_id=tracking_id,
-        )
-        self._affected_node_uuids = affected_node_uuids
 
         if affected_node_uuids:
             for i in range(0, len(affected_node_uuids), self.metadata_batch_size):
@@ -199,7 +201,7 @@ class DiffMerger:
         await query.execute(db=self.db)
 
     async def rollback(self, at: Timestamp) -> None:
-        if not self._affected_node_uuids:
+        if not self._merge_started:
             return
         rollback_query = await RollbackQuery.init(
             db=self.db,

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -58,7 +58,7 @@ class BranchMerger:
         self.diff_locker = diff_locker
         self.constraint_validator = constraint_validator
         self.migrations: list[SchemaUpdateMigrationInfo] = []
-        self._merge_at = Timestamp()
+        self._merge_at: Timestamp | None = None
 
         self._source_schema: SchemaBranch | None = None
         self._destination_schema: SchemaBranch | None = None
@@ -236,6 +236,8 @@ class BranchMerger:
             raise MergeConstraintsViolatedError(violations=result.violations, schema_conflicts=result.schema_conflicts)
 
     async def rollback(self) -> None:
+        if self._merge_at is None:
+            return
         await self.diff_merger.rollback(at=self._merge_at)
 
     async def merge_repositories(self) -> None:

--- a/backend/infrahub/core/query/rollback.py
+++ b/backend/infrahub/core/query/rollback.py
@@ -52,10 +52,12 @@ class RollbackQuery(Query):
         query = """
 // ---------------------------
 // Restore previous_updated_at/by on affected Node vertices
+// only vertices with updated_at = $at should have previous_* metadata restored
 // ---------------------------
 OPTIONAL MATCH (n:Node)
 WHERE n.uuid IN $node_uuids
 AND n.previous_updated_at IS NOT NULL
+AND n.updated_at = $at
 CALL (n) {
     SET n.updated_at = n.previous_updated_at, n.updated_by = n.previous_updated_by
     SET n.previous_updated_at = NULL, n.previous_updated_by = NULL
@@ -65,6 +67,7 @@ CALL (n) {
 // ---------------------------
 OPTIONAL MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
 WHERE attr_rel.previous_updated_at IS NOT NULL
+AND attr_rel.updated_at = $at
 WITH DISTINCT attr_rel
 CALL (attr_rel) {
     SET attr_rel.updated_at = attr_rel.previous_updated_at, attr_rel.updated_by = attr_rel.previous_updated_by

--- a/backend/tests/component/core/diff/test_merge_failure_rollback.py
+++ b/backend/tests/component/core/diff/test_merge_failure_rollback.py
@@ -1,0 +1,229 @@
+"""Rollback behavior when a branch merge fails partway through the bulk merge phase.
+
+A database error during one of the bulk merge queries leaves the earlier bulk
+queries committed on the destination branch. The merge must roll those changes
+back on its own before surfacing the failure, and a rollback requested before
+the merge ever wrote anything must leave the graph untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrahub import lock
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.diff_locker import DiffLocker
+from infrahub.core.diff.merger.exclusion_plan import MergeExclusionPlanBuilder
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.merge.branch_merger import BranchMerger
+from infrahub.core.merge.constraints import MergeConstraintValidator
+from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import MergeFailedError
+from tests.helpers.db_validation import verify_graph
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.diff.merger.exclusion_plan import MergeExclusionPlan
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class InducedBulkMergeError(Exception):
+    pass
+
+
+async def _count_branch_edges_at(db: InfrahubDatabase, branch: Branch, at: Timestamp) -> int:
+    result = await db.execute_query(
+        query="MATCH ()-[r {from: $at, branch: $branch}]->() RETURN count(r) AS c",
+        params={"at": at.to_string(), "branch": branch.name},
+    )
+    return result[0].get("c")
+
+
+class FailingBulkMergeDiffMerger(DiffMerger):
+    """Fails on the last bulk merge query, after the earlier bulk queries have committed.
+
+    Records how many merge-stamped edges the earlier bulk queries committed to the
+    destination branch so the test can prove the failure happened mid-merge.
+    """
+
+    edge_count_at_failure: int | None = None
+
+    async def _bulk_merge_relationship_property_edges(self, at: Timestamp, plan: MergeExclusionPlan) -> None:
+        self.edge_count_at_failure = await _count_branch_edges_at(db=self.db, branch=self.destination_branch, at=at)
+        raise InducedBulkMergeError()
+
+
+@dataclass
+class StagedMerge:
+    branch: Branch
+    new_person_id: str
+    car_id: str
+    original_nbr_seats: int
+
+
+class TestMergeFailureRollback:
+    @pytest.fixture(scope="class", autouse=True)
+    async def _schema(
+        self,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> None:
+        return
+
+    @pytest.fixture(scope="class")
+    async def staged(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> StagedMerge:
+        lock.initialize_lock(local_only=True)
+
+        john = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await john.new(db=db, name="John", height=175)
+        await john.save(db=db)
+
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", nbr_seats=5, is_electric=False, owner=john.id)
+        await car.save(db=db)
+
+        branch = await create_branch(branch_name="merge-fail-rollback", db=db)
+
+        new_person = await Node.init(db=db, schema="TestPerson", branch=branch)
+        await new_person.new(db=db, name="Newcomer", height=170)
+        await new_person.save(db=db)
+
+        car_branch = await NodeManager.get_one(db=db, id=car.id, branch=branch, raise_on_error=True)
+        car_branch.get_attribute("nbr_seats").value = 2
+        car_branch.get_attribute("color").value = "#123456"
+        await car_branch.save(db=db)
+
+        return StagedMerge(
+            branch=branch,
+            new_person_id=new_person.id,
+            car_id=car.id,
+            original_nbr_seats=5,
+        )
+
+    @pytest.fixture
+    async def diff_repository(self, db: InfrahubDatabase, staged: StagedMerge) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=staged.branch)
+
+    @pytest.fixture
+    async def diff_coordinator(self, db: InfrahubDatabase, staged: StagedMerge) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=staged.branch)
+        coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        return coordinator
+
+    def _build_branch_merger(
+        self,
+        db: InfrahubDatabase,
+        staged: StagedMerge,
+        destination_branch: Branch,
+        diff_merger: DiffMerger,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> BranchMerger:
+        return BranchMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=destination_branch,
+            diff_coordinator=diff_coordinator,
+            diff_merger=diff_merger,
+            diff_repository=diff_repository,
+            diff_locker=DiffLocker(),
+            constraint_validator=MergeConstraintValidator(db=db, branch=staged.branch, diff_repository=diff_repository),
+        )
+
+    async def test_branch_merger_rolls_back_on_bulk_merge_failure(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        failing_diff_merger = FailingBulkMergeDiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            exclusion_plan_builder=MergeExclusionPlanBuilder(),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            staged=staged,
+            destination_branch=default_branch_scope_class,
+            diff_merger=failing_diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+
+        merge_at = Timestamp()
+        with pytest.raises(MergeFailedError) as exc_info:
+            await merger.merge(at=merge_at)
+        assert isinstance(exc_info.value.__cause__, InducedBulkMergeError), (
+            "The merge failure must originate from the induced bulk merge error"
+        )
+
+        assert failing_diff_merger.edge_count_at_failure is not None
+        assert failing_diff_merger.edge_count_at_failure > 0, (
+            "The bulk queries that ran before the failure must have committed edges"
+        )
+
+        edges_after = await _count_branch_edges_at(db=db, branch=default_branch_scope_class, at=merge_at)
+        assert edges_after == 0, "The merge must remove every edge committed by the partial merge before raising"
+
+        person_on_main = await NodeManager.get_one(db=db, id=staged.new_person_id, branch=default_branch_scope_class)
+        assert person_on_main is None, "The branch-created node must not exist on the destination branch"
+
+        car_on_main = await NodeManager.get_one(
+            db=db, id=staged.car_id, branch=default_branch_scope_class, raise_on_error=True
+        )
+        assert car_on_main.get_attribute("nbr_seats").value == staged.original_nbr_seats
+
+        await verify_graph(db=db)
+
+    async def test_rollback_before_merge_is_a_noop(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        at_existing = Timestamp()
+        bystander = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await bystander.new(db=db, name="Bystander", height=180)
+        await bystander.save(db=db, at=at_existing)
+
+        diff_merger = DiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            exclusion_plan_builder=MergeExclusionPlanBuilder(),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            staged=staged,
+            destination_branch=default_branch_scope_class,
+            diff_merger=diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+
+        await merger.rollback()
+        await diff_merger.rollback(at=at_existing)
+
+        bystander_after = await NodeManager.get_one(db=db, id=bystander.id, branch=default_branch_scope_class)
+        assert bystander_after is not None, "Rollback before any merge must not delete data at the given timestamp"
+        assert bystander_after.get_attribute("name").value == "Bystander"

--- a/backend/tests/component/core/diff/test_merge_failure_rollback.py
+++ b/backend/tests/component/core/diff/test_merge_failure_rollback.py
@@ -126,7 +126,7 @@ class TestMergeFailureRollback:
     def _build_branch_merger(
         self,
         db: InfrahubDatabase,
-        staged: StagedMerge,
+        source_branch: Branch,
         destination_branch: Branch,
         diff_merger: DiffMerger,
         diff_coordinator: DiffCoordinator,
@@ -134,13 +134,13 @@ class TestMergeFailureRollback:
     ) -> BranchMerger:
         return BranchMerger(
             db=db,
-            source_branch=staged.branch,
+            source_branch=source_branch,
             destination_branch=destination_branch,
             diff_coordinator=diff_coordinator,
             diff_merger=diff_merger,
             diff_repository=diff_repository,
             diff_locker=DiffLocker(),
-            constraint_validator=MergeConstraintValidator(db=db, branch=staged.branch, diff_repository=diff_repository),
+            constraint_validator=MergeConstraintValidator(db=db, branch=source_branch, diff_repository=diff_repository),
         )
 
     async def test_branch_merger_rolls_back_on_bulk_merge_failure(
@@ -160,7 +160,7 @@ class TestMergeFailureRollback:
         )
         merger = self._build_branch_merger(
             db=db,
-            staged=staged,
+            source_branch=staged.branch,
             destination_branch=default_branch_scope_class,
             diff_merger=failing_diff_merger,
             diff_coordinator=diff_coordinator,
@@ -214,7 +214,7 @@ class TestMergeFailureRollback:
         )
         merger = self._build_branch_merger(
             db=db,
-            staged=staged,
+            source_branch=staged.branch,
             destination_branch=default_branch_scope_class,
             diff_merger=diff_merger,
             diff_coordinator=diff_coordinator,
@@ -227,3 +227,100 @@ class TestMergeFailureRollback:
         bystander_after = await NodeManager.get_one(db=db, id=bystander.id, branch=default_branch_scope_class)
         assert bystander_after is not None, "Rollback before any merge must not delete data at the given timestamp"
         assert bystander_after.get_attribute("name").value == "Bystander"
+
+    async def test_failed_merge_rollback_preserves_metadata_of_earlier_merge(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        """A failed merge must not rewind updated_at/by metadata written by an earlier successful merge.
+
+        previous_updated_at/by snapshots survive successful merges, so the rollback of a later failed
+        merge over the same nodes must only restore metadata stamped with its own merge timestamp.
+        """
+        # the overlap merge changes an attribute the staged branch does not touch, so the staged
+        # branch's later merge fails on the induced error rather than on an unresolved conflict
+        overlap_branch = await create_branch(branch_name="overlap-merged-first", db=db)
+        car_overlap = await NodeManager.get_one(db=db, id=staged.car_id, branch=overlap_branch, raise_on_error=True)
+        car_overlap.get_attribute("transmission").value = "manual"
+        await car_overlap.save(db=db)
+        merger = self._build_branch_merger(
+            db=db,
+            source_branch=overlap_branch,
+            destination_branch=default_branch_scope_class,
+            diff_merger=await self._build_diff_merger(db=db, branch=overlap_branch),
+            diff_coordinator=await self._build_diff_coordinator(db=db, branch=overlap_branch),
+            diff_repository=await self._build_diff_repository(db=db, branch=overlap_branch),
+        )
+        await merger.merge(at=Timestamp())
+
+        metadata_before = await self._get_node_metadata(db=db, node_uuid=staged.car_id)
+        assert metadata_before["previous_updated_at"] is not None, (
+            "The successful merge must leave a previous_updated_at snapshot in place"
+        )
+
+        failing_diff_merger = FailingBulkMergeDiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            exclusion_plan_builder=MergeExclusionPlanBuilder(),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_merger=failing_diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+        with pytest.raises(MergeFailedError) as exc_info:
+            await merger.merge(at=Timestamp())
+        assert isinstance(exc_info.value.__cause__, InducedBulkMergeError), (
+            "The merge must fail on the induced mid-merge error, not an earlier validation step"
+        )
+        assert failing_diff_merger.edge_count_at_failure is not None, (
+            "The merge must reach the graph write phase before failing"
+        )
+
+        metadata_after = await self._get_node_metadata(db=db, node_uuid=staged.car_id)
+        assert metadata_after["updated_at"] == metadata_before["updated_at"], (
+            "The failed merge's rollback must not rewind updated_at written by the earlier successful merge"
+        )
+        assert metadata_after["previous_updated_at"] == metadata_before["previous_updated_at"], (
+            "The failed merge's rollback must not consume the earlier merge's previous_updated_at snapshot"
+        )
+
+    @staticmethod
+    async def _build_diff_merger(db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+    @staticmethod
+    async def _build_diff_coordinator(db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        return coordinator
+
+    @staticmethod
+    async def _build_diff_repository(db: InfrahubDatabase, branch: Branch) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+    @staticmethod
+    async def _get_node_metadata(db: InfrahubDatabase, node_uuid: str) -> dict[str, str | None]:
+        result = await db.execute_query(
+            query=(
+                "MATCH (n:Node {uuid: $uuid}) "
+                "RETURN n.updated_at AS updated_at, n.previous_updated_at AS previous_updated_at"
+            ),
+            params={"uuid": node_uuid},
+        )
+        return {
+            "updated_at": result[0].get("updated_at"),
+            "previous_updated_at": result[0].get("previous_updated_at"),
+        }

--- a/changelog/+merge-bulk-failure-rollback.fixed.md
+++ b/changelog/+merge-bulk-failure-rollback.fixed.md
@@ -1,0 +1,4 @@
+Fixed the branch merge rollback so that a database error (such as an out-of-memory error) raised
+partway through the bulk merge queries no longer leaves partially merged data on the destination
+branch. The rollback now removes every change stamped with the merge timestamp even when the
+failure occurred before the merge finished discovering the affected nodes.


### PR DESCRIPTION
The diff merger only discovered the affected node UUIDs after all bulk merge queries had committed, and rollback was a no-op when that list was empty. A database error (e.g. out-of-memory) partway through the bulk merge phase therefore left the earlier bulk queries committed on the destination branch while the rollback silently did nothing.

Discover the affected node UUIDs before the first bulk merge query (they come from the diff subgraph, which exists before the merge mutates anything) and gate the rollback on whether the merge started writing rather than on a non-empty UUID list. Also make `BranchMerger.rollback()` a no-op when the merge never assigned a merge timestamp, instead of passing a stale construction-time timestamp.

The rollback's metadata-restore phase had a related flaw that the wider rollback window exposed: `previous_updated_at/by` snapshots survive successful merges (nothing ever clears them), and the restore matched on any non-null snapshot for the affected UUIDs. A failed merge over nodes that an earlier merge had touched would therefore rewind their `updated_at/by` to pre-earlier-merge values while the earlier merge's data remained in place. The restore now only applies to entities stamped with the failed merge's own timestamp, so leftover snapshots from prior merges are ignored.

### Testing

New component test class `TestMergeFailureRollback` (class-scoped staging, drives the real `BranchMerger.merge()`):

- `test_branch_merger_rolls_back_on_bulk_merge_failure` — a `DiffMerger` that fails on the last bulk query after earlier bulk queries committed; asserts the merge itself rolls everything back (no merge-stamped edges remain, branch-created node absent, attribute values intact) before raising `MergeFailedError` caused by the induced error.
- `test_rollback_before_merge_is_a_noop` — a rollback requested before any merge write cannot delete pre-existing data at a matching timestamp.
- `test_failed_merge_rollback_preserves_metadata_of_earlier_merge` — a successful overlapping merge first, then a failed merge over the same node; asserts the earlier merge's `updated_at` and its snapshot survive the rollback.

Each regression test was verified to fail against the unfixed code and pass with the fix.

closes IFC-2869