### PR TITLE
fix(backend): roll back partially merged data when a merge query fails (1.9 backport)

### DIFF
--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -65,7 +65,6 @@ class DiffMerger:
         )
         log.info(f"Diff {latest_diff.uuid} retrieved")
         self._affected_node_uuids = [n.uuid for n in enriched_diff.nodes]
-        self._merge_started = True
         batch_num = 0
         migrated_kinds_id_map = {}
         for n in enriched_diff.nodes:
@@ -79,6 +78,9 @@ class DiffMerger:
                 migrated_kinds_id_map[n.uuid] = n.identifier.db_id
 
         async for node_diff_dicts, property_diff_dicts in self.serializer.serialize_diff(diff=enriched_diff):
+            # only arm the rollback once graph writes begin: rolling back without any writes at this
+            # timestamp can still rewind updated_at/by metadata left in place by a previous merge
+            self._merge_started = True
             if node_diff_dicts:
                 log.info(f"Merging batch of nodes #{batch_num}")
                 await self._merge_nodes(
@@ -93,6 +95,7 @@ class DiffMerger:
             batch_num += 1
         migrated_kind_uuids = {n.identifier.uuid for n in enriched_diff.nodes if n.is_node_kind_migration}
         if migrated_kind_uuids:
+            self._merge_started = True
             migrated_merge_query = await DiffMergeMigratedKindsQuery.init(
                 db=self.db,
                 branch=self.source_branch,
@@ -104,6 +107,7 @@ class DiffMerger:
 
         affected_node_uuids = self._affected_node_uuids
         if affected_node_uuids:
+            self._merge_started = True
             for i in range(0, len(affected_node_uuids), self.metadata_batch_size):
                 batch_uuids = affected_node_uuids[i : i + self.metadata_batch_size]
                 log.info(f"Updating metadata for batch {i // self.metadata_batch_size + 1} ({len(batch_uuids)} nodes)")

--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -44,6 +44,7 @@ class DiffMerger:
         self.diff_repository = diff_repository
         self.serializer = serializer
         self._affected_node_uuids: list[str] = []
+        self._merge_started = False
 
     async def merge_graph(self, at: Timestamp) -> EnrichedDiffRoot:
         tracking_id = BranchTrackingId(name=self.source_branch.name)
@@ -63,6 +64,8 @@ class DiffMerger:
             diff_branch_name=self.source_branch.name, diff_id=latest_diff.uuid
         )
         log.info(f"Diff {latest_diff.uuid} retrieved")
+        self._affected_node_uuids = [n.uuid for n in enriched_diff.nodes]
+        self._merge_started = True
         batch_num = 0
         migrated_kinds_id_map = {}
         for n in enriched_diff.nodes:
@@ -99,8 +102,7 @@ class DiffMerger:
             )
             await migrated_merge_query.execute(db=self.db)
 
-        affected_node_uuids = [n.uuid for n in enriched_diff.nodes]
-        self._affected_node_uuids = affected_node_uuids
+        affected_node_uuids = self._affected_node_uuids
         if affected_node_uuids:
             for i in range(0, len(affected_node_uuids), self.metadata_batch_size):
                 batch_uuids = affected_node_uuids[i : i + self.metadata_batch_size]
@@ -152,7 +154,7 @@ class DiffMerger:
         await merge_properties_query.execute(db=self.db)
 
     async def rollback(self, at: Timestamp) -> None:
-        if not self._affected_node_uuids:
+        if not self._merge_started:
             return
         rollback_query = await RollbackQuery.init(
             db=self.db,

--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -77,16 +77,17 @@ class DiffMerger:
                 # it will not if a node was migrated and then deleted
                 migrated_kinds_id_map[n.uuid] = n.identifier.db_id
 
+        # only arm the rollback once graph writes begin: rolling back without any writes at this
+        # timestamp can still rewind updated_at/by metadata left in place by a previous merge
         async for node_diff_dicts, property_diff_dicts in self.serializer.serialize_diff(diff=enriched_diff):
-            # only arm the rollback once graph writes begin: rolling back without any writes at this
-            # timestamp can still rewind updated_at/by metadata left in place by a previous merge
-            self._merge_started = True
             if node_diff_dicts:
+                self._merge_started = True
                 log.info(f"Merging batch of nodes #{batch_num}")
                 await self._merge_nodes(
                     at=at, node_diff_dicts=node_diff_dicts, migrated_kinds_id_map=migrated_kinds_id_map
                 )
             if property_diff_dicts:
+                self._merge_started = True
                 log.info(f"Merging batch of properties #{batch_num}")
                 await self._merge_properties(
                     at=at, property_diff_dicts=property_diff_dicts, migrated_kinds_id_map=migrated_kinds_id_map

--- a/backend/infrahub/core/merge/branch_merger.py
+++ b/backend/infrahub/core/merge/branch_merger.py
@@ -51,7 +51,7 @@ class BranchMerger:
         self.diff_repository = diff_repository
         self.diff_locker = diff_locker
         self.migrations: list[SchemaUpdateMigrationInfo] = []
-        self._merge_at = Timestamp()
+        self._merge_at: Timestamp | None = None
 
         self._source_schema: SchemaBranch | None = None
         self._destination_schema: SchemaBranch | None = None
@@ -199,6 +199,8 @@ class BranchMerger:
         return branch_diff
 
     async def rollback(self) -> None:
+        if self._merge_at is None:
+            return
         await self.diff_merger.rollback(at=self._merge_at)
 
     async def merge_repositories(self) -> None:

--- a/backend/infrahub/core/query/rollback.py
+++ b/backend/infrahub/core/query/rollback.py
@@ -52,10 +52,13 @@ class RollbackQuery(Query):
         query = """
 // ---------------------------
 // Restore previous_updated_at/by on affected Node vertices
+// only vertices written at $at are restored: previous_* snapshots left in place
+// by an earlier successful write at another timestamp must not be consumed
 // ---------------------------
 OPTIONAL MATCH (n:Node)
 WHERE n.uuid IN $node_uuids
 AND n.previous_updated_at IS NOT NULL
+AND n.updated_at = $at
 CALL (n) {
     SET n.updated_at = n.previous_updated_at, n.updated_by = n.previous_updated_by
     SET n.previous_updated_at = NULL, n.previous_updated_by = NULL
@@ -65,6 +68,7 @@ CALL (n) {
 // ---------------------------
 OPTIONAL MATCH (n)-[:HAS_ATTRIBUTE|IS_RELATED {branch: $target_branch}]-(attr_rel:Attribute|Relationship)
 WHERE attr_rel.previous_updated_at IS NOT NULL
+AND attr_rel.updated_at = $at
 WITH DISTINCT attr_rel
 CALL (attr_rel) {
     SET attr_rel.updated_at = attr_rel.previous_updated_at, attr_rel.updated_by = attr_rel.previous_updated_by

--- a/backend/tests/component/core/diff/test_merge_failure_rollback.py
+++ b/backend/tests/component/core/diff/test_merge_failure_rollback.py
@@ -1,0 +1,233 @@
+"""Rollback behavior when a branch merge fails partway through the merge queries.
+
+A database error during one of the batched merge queries leaves the earlier
+batches committed on the destination branch. The merge must roll those changes
+back on its own before surfacing the failure, and a rollback requested before
+the merge ever wrote anything must leave the graph untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from infrahub import lock
+from infrahub.core import registry
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.diff.diff_locker import DiffLocker
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.merger.serializer import DiffMergeSerializer
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.merge.branch_merger import BranchMerger
+from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import MergeFailedError
+from tests.conftest import do_car_person_schema_unregistered
+from tests.helpers.db_validation import verify_graph
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class InducedMergeError(Exception):
+    pass
+
+
+async def _count_branch_edges_at(db: InfrahubDatabase, branch: Branch, at: Timestamp) -> int:
+    result = await db.execute_query(
+        query="MATCH ()-[r {from: $at, branch: $branch}]->() RETURN count(r) AS c",
+        params={"at": at.to_string(), "branch": branch.name},
+    )
+    return result[0].get("c")
+
+
+class FailingPropertiesMergeDiffMerger(DiffMerger):
+    """Fails on the properties merge query, after node merge batches have committed.
+
+    Records how many merge-stamped edges the earlier batches committed to the
+    destination branch so the test can prove the failure happened mid-merge.
+    """
+
+    edge_count_at_failure: int | None = None
+
+    async def _merge_properties(
+        self, at: Timestamp, property_diff_dicts: list[dict], migrated_kinds_id_map: dict[str, str]
+    ) -> None:
+        self.edge_count_at_failure = await _count_branch_edges_at(db=self.db, branch=self.destination_branch, at=at)
+        raise InducedMergeError()
+
+
+@dataclass
+class StagedMerge:
+    branch: Branch
+    new_person_id: str
+    car_id: str
+    original_nbr_seats: int
+
+
+class TestMergeFailureRollback:
+    @pytest.fixture(scope="class", autouse=True)
+    async def car_person_schema_class(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+    ) -> SchemaBranch:
+        return registry.schema.register_schema(
+            schema=do_car_person_schema_unregistered(), branch=default_branch_scope_class.name
+        )
+
+    @pytest.fixture(scope="class")
+    async def staged(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> StagedMerge:
+        lock.initialize_lock(local_only=True)
+
+        john = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await john.new(db=db, name="John", height=175)
+        await john.save(db=db)
+
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", nbr_seats=5, is_electric=False, owner=john.id)
+        await car.save(db=db)
+
+        branch = await create_branch(branch_name="merge-fail-rollback", db=db)
+
+        new_person = await Node.init(db=db, schema="TestPerson", branch=branch)
+        await new_person.new(db=db, name="Newcomer", height=170)
+        await new_person.save(db=db)
+
+        car_branch = await NodeManager.get_one(db=db, id=car.id, branch=branch, raise_on_error=True)
+        car_branch.get_attribute("nbr_seats").value = 2
+        car_branch.get_attribute("color").value = "#123456"
+        await car_branch.save(db=db)
+
+        return StagedMerge(
+            branch=branch,
+            new_person_id=new_person.id,
+            car_id=car.id,
+            original_nbr_seats=5,
+        )
+
+    @pytest.fixture
+    async def diff_repository(self, db: InfrahubDatabase, staged: StagedMerge) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=staged.branch)
+
+    @pytest.fixture
+    async def diff_coordinator(self, db: InfrahubDatabase, staged: StagedMerge) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=staged.branch)
+        coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        return coordinator
+
+    def _build_branch_merger(
+        self,
+        db: InfrahubDatabase,
+        staged: StagedMerge,
+        destination_branch: Branch,
+        diff_merger: DiffMerger,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> BranchMerger:
+        return BranchMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=destination_branch,
+            diff_coordinator=diff_coordinator,
+            diff_merger=diff_merger,
+            diff_repository=diff_repository,
+            diff_locker=DiffLocker(),
+        )
+
+    async def test_branch_merger_rolls_back_on_merge_query_failure(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        failing_diff_merger = FailingPropertiesMergeDiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            serializer=DiffMergeSerializer(db=db, max_batch_size=100),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            staged=staged,
+            destination_branch=default_branch_scope_class,
+            diff_merger=failing_diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+
+        merge_at = Timestamp()
+        with pytest.raises(MergeFailedError) as exc_info:
+            await merger.merge(at=merge_at)
+        assert isinstance(exc_info.value.__cause__, InducedMergeError), (
+            "The merge failure must originate from the induced merge error"
+        )
+
+        assert failing_diff_merger.edge_count_at_failure is not None
+        assert failing_diff_merger.edge_count_at_failure > 0, (
+            "The merge queries that ran before the failure must have committed edges"
+        )
+
+        edges_after = await _count_branch_edges_at(db=db, branch=default_branch_scope_class, at=merge_at)
+        assert edges_after == 0, "The merge must remove every edge committed by the partial merge before raising"
+
+        person_on_main = await NodeManager.get_one(db=db, id=staged.new_person_id, branch=default_branch_scope_class)
+        assert person_on_main is None, "The branch-created node must not exist on the destination branch"
+
+        car_on_main = await NodeManager.get_one(
+            db=db, id=staged.car_id, branch=default_branch_scope_class, raise_on_error=True
+        )
+        assert car_on_main.get_attribute("nbr_seats").value == staged.original_nbr_seats
+
+        await verify_graph(db=db)
+
+    async def test_rollback_before_merge_is_a_noop(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        at_existing = Timestamp()
+        bystander = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await bystander.new(db=db, name="Bystander", height=180)
+        await bystander.save(db=db, at=at_existing)
+
+        diff_merger = DiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            serializer=DiffMergeSerializer(db=db, max_batch_size=100),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            staged=staged,
+            destination_branch=default_branch_scope_class,
+            diff_merger=diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+
+        await merger.rollback()
+        await diff_merger.rollback(at=at_existing)
+
+        bystander_after = await NodeManager.get_one(db=db, id=bystander.id, branch=default_branch_scope_class)
+        assert bystander_after is not None, "Rollback before any merge must not delete data at the given timestamp"
+        assert bystander_after.get_attribute("name").value == "Bystander"

--- a/backend/tests/component/core/diff/test_merge_failure_rollback.py
+++ b/backend/tests/component/core/diff/test_merge_failure_rollback.py
@@ -131,7 +131,7 @@ class TestMergeFailureRollback:
     def _build_branch_merger(
         self,
         db: InfrahubDatabase,
-        staged: StagedMerge,
+        source_branch: Branch,
         destination_branch: Branch,
         diff_merger: DiffMerger,
         diff_coordinator: DiffCoordinator,
@@ -139,7 +139,7 @@ class TestMergeFailureRollback:
     ) -> BranchMerger:
         return BranchMerger(
             db=db,
-            source_branch=staged.branch,
+            source_branch=source_branch,
             destination_branch=destination_branch,
             diff_coordinator=diff_coordinator,
             diff_merger=diff_merger,
@@ -164,7 +164,7 @@ class TestMergeFailureRollback:
         )
         merger = self._build_branch_merger(
             db=db,
-            staged=staged,
+            source_branch=staged.branch,
             destination_branch=default_branch_scope_class,
             diff_merger=failing_diff_merger,
             diff_coordinator=diff_coordinator,
@@ -218,7 +218,7 @@ class TestMergeFailureRollback:
         )
         merger = self._build_branch_merger(
             db=db,
-            staged=staged,
+            source_branch=staged.branch,
             destination_branch=default_branch_scope_class,
             diff_merger=diff_merger,
             diff_coordinator=diff_coordinator,
@@ -231,3 +231,100 @@ class TestMergeFailureRollback:
         bystander_after = await NodeManager.get_one(db=db, id=bystander.id, branch=default_branch_scope_class)
         assert bystander_after is not None, "Rollback before any merge must not delete data at the given timestamp"
         assert bystander_after.get_attribute("name").value == "Bystander"
+
+    async def test_failed_merge_rollback_preserves_metadata_of_earlier_merge(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        staged: StagedMerge,
+        diff_coordinator: DiffCoordinator,
+        diff_repository: DiffRepository,
+    ) -> None:
+        """A failed merge must not rewind updated_at/by metadata written by an earlier successful merge.
+
+        previous_updated_at/by snapshots survive successful merges, so the rollback of a later failed
+        merge over the same nodes must only restore metadata stamped with its own merge timestamp.
+        """
+        # the overlap merge changes an attribute the staged branch does not touch, so the staged
+        # branch's later merge fails on the induced error rather than on an unresolved conflict
+        overlap_branch = await create_branch(branch_name="overlap-merged-first", db=db)
+        car_overlap = await NodeManager.get_one(db=db, id=staged.car_id, branch=overlap_branch, raise_on_error=True)
+        car_overlap.get_attribute("transmission").value = "manual"
+        await car_overlap.save(db=db)
+        merger = self._build_branch_merger(
+            db=db,
+            source_branch=overlap_branch,
+            destination_branch=default_branch_scope_class,
+            diff_merger=await self._build_diff_merger(db=db, branch=overlap_branch),
+            diff_coordinator=await self._build_diff_coordinator(db=db, branch=overlap_branch),
+            diff_repository=await self._build_diff_repository(db=db, branch=overlap_branch),
+        )
+        await merger.merge(at=Timestamp())
+
+        metadata_before = await self._get_node_metadata(db=db, node_uuid=staged.car_id)
+        assert metadata_before["previous_updated_at"] is not None, (
+            "The successful merge must leave a previous_updated_at snapshot in place"
+        )
+
+        failing_diff_merger = FailingPropertiesMergeDiffMerger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_repository=diff_repository,
+            serializer=DiffMergeSerializer(db=db, max_batch_size=100),
+        )
+        merger = self._build_branch_merger(
+            db=db,
+            source_branch=staged.branch,
+            destination_branch=default_branch_scope_class,
+            diff_merger=failing_diff_merger,
+            diff_coordinator=diff_coordinator,
+            diff_repository=diff_repository,
+        )
+        with pytest.raises(MergeFailedError) as exc_info:
+            await merger.merge(at=Timestamp())
+        assert isinstance(exc_info.value.__cause__, InducedMergeError), (
+            "The merge must fail on the induced mid-merge error, not an earlier validation step"
+        )
+        assert failing_diff_merger.edge_count_at_failure is not None, (
+            "The merge must reach the graph write phase before failing"
+        )
+
+        metadata_after = await self._get_node_metadata(db=db, node_uuid=staged.car_id)
+        assert metadata_after["updated_at"] == metadata_before["updated_at"], (
+            "The failed merge's rollback must not rewind updated_at written by the earlier successful merge"
+        )
+        assert metadata_after["previous_updated_at"] == metadata_before["previous_updated_at"], (
+            "The failed merge's rollback must not consume the earlier merge's previous_updated_at snapshot"
+        )
+
+    @staticmethod
+    async def _build_diff_merger(db: InfrahubDatabase, branch: Branch) -> DiffMerger:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffMerger, db=db, branch=branch)
+
+    @staticmethod
+    async def _build_diff_coordinator(db: InfrahubDatabase, branch: Branch) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        coordinator.data_check_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        return coordinator
+
+    @staticmethod
+    async def _build_diff_repository(db: InfrahubDatabase, branch: Branch) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+    @staticmethod
+    async def _get_node_metadata(db: InfrahubDatabase, node_uuid: str) -> dict[str, str | None]:
+        result = await db.execute_query(
+            query=(
+                "MATCH (n:Node {uuid: $uuid}) "
+                "RETURN n.updated_at AS updated_at, n.previous_updated_at AS previous_updated_at"
+            ),
+            params={"uuid": node_uuid},
+        )
+        return {
+            "updated_at": result[0].get("updated_at"),
+            "previous_updated_at": result[0].get("previous_updated_at"),
+        }

--- a/changelog/+merge-failure-rollback.fixed.md
+++ b/changelog/+merge-failure-rollback.fixed.md
@@ -1,0 +1,4 @@
+Fixed the branch merge rollback so that a database error (such as an out-of-memory error) raised
+partway through the merge queries no longer leaves partially merged data on the destination
+branch. The rollback now removes every change stamped with the merge timestamp even when the
+failure occurred before the merge finished writing all of its batches.


### PR DESCRIPTION
### Summary

Backport of #9823 to `release-1.9`, adapted to 1.9's serializer-based batch merge.

A database error (such as an out-of-memory error) raised partway through the merge queries left partially merged data on the destination branch: `DiffMerger.rollback()` early-returned when `_affected_node_uuids` was empty, and that list was only populated **after** all merge batches had committed. Each batch runs in its own transaction, so a failure at batch N left batches 0..N-1 committed on the destination while the rollback silently did nothing — and the task-level rollback handler then logged "Merge rollback completed" and reopened the branch, inviting a retry on top of the half-merged state.

### Changes

- `DiffMerger.merge_graph` records the affected node UUIDs from the enriched diff **before** the first merge batch runs (the diff is already in memory at that point; no extra query) and arms a `_merge_started` flag adjacent to each graph write — inside the node/property payload guards of the batch loop (the serializer's final batch can be empty), and at the migrated-kinds and metadata write sites.
- `DiffMerger.rollback` gates on `_merge_started` instead of a non-empty UUID list. In 1.9 the UUID list is load-bearing for the whole `DiffMergeRollbackQuery` (its first `MATCH` filters on `$node_uuids`), so populating it early is what makes a mid-merge rollback work at all.
- `BranchMerger._merge_at` is now `Timestamp | None` and `rollback()` is a no-op when the merge never assigned a merge timestamp — previously a pre-write failure (including the unresolved-conflicts `ValidationError`, which fires inside the try block in 1.9) reached the rollback with a stale construction-time timestamp and was only saved by the guard this PR removes.
- `DiffMergeRollbackQuery`'s metadata-restore phase now only applies to entities stamped with the failed merge's own timestamp. `previous_updated_at/by` snapshots survive successful merges (nothing ever clears them), so the previous non-null-snapshot filter would rewind `updated_at/by` to pre-earlier-merge values on any node an earlier merge had touched, while that merge's data remained in place.

### Testing

New component test class `TestMergeFailureRollback` (class-scoped data staging, drives the real `BranchMerger.merge()`):

- `test_branch_merger_rolls_back_on_merge_query_failure` — a `DiffMerger` that fails in `_merge_properties` after node batches committed; asserts the merge itself rolls everything back (no merge-stamped edges remain on the destination, branch-created node absent, attribute values intact) before raising `MergeFailedError` caused by the induced error.
- `test_rollback_before_merge_is_a_noop` — a rollback requested before any merge write cannot delete pre-existing data at a matching timestamp.
- `test_failed_merge_rollback_preserves_metadata_of_earlier_merge` — a successful overlapping merge first (touching an attribute the staged branch does not change, so no conflict), then a failed merge over the same node; asserts the earlier merge's `updated_at` and its snapshot survive the rollback.

Each regression test was verified to fail against the unfixed code and pass with the fix. The existing `backend/tests/component/core/test_branch_merge.py` suite (5 tests) passes, confirming successful merges are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)