### PR TITLE
feat(schema): cascade repository deletion to its managed objects

### DIFF
--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -29,8 +29,8 @@ class NodeDeleteIndex:
         self._dependency_graph: dict[str, dict[DeleteRelationshipType, dict[str, set[str]]]] = {}
 
     def index(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
-        self._index_cascading_deletes(start_schemas=start_schemas)
-        self._index_dependent_schema(start_schemas=start_schemas)
+        cascade_kinds = self._index_cascading_deletes(start_schemas=start_schemas)
+        self._index_dependent_schema(cascade_kinds=cascade_kinds)
 
     def _get_schema_kinds(self, schema_kind: str) -> set[str]:
         schema = self._all_schemas_map[schema_kind]
@@ -50,13 +50,17 @@ class NodeDeleteIndex:
             self._dependency_graph[kind][relationship_type] = defaultdict(set)
         self._dependency_graph[kind][relationship_type][relationship_identifier].update(peer_kinds)
 
-    def _index_cascading_deletes(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
+    def _index_cascading_deletes(
+        self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]
+    ) -> set[str]:
+        visited: set[str] = set()
         kinds_to_check: set[str] = {schema.kind for schema in start_schemas}
         while True:
             try:
                 kind_to_check = kinds_to_check.pop()
             except KeyError:
                 break
+            visited.add(kind_to_check)
             node_schema = self._all_schemas_map[kind_to_check]
             for relationship_schema in node_schema.relationships:
                 if relationship_schema.on_delete != RelationshipDeleteBehavior.CASCADE:
@@ -69,15 +73,17 @@ class NodeDeleteIndex:
                     peer_kinds=peer_kinds,
                 )
                 for peer_kind in peer_kinds:
-                    if peer_kind not in self._dependency_graph:
+                    if peer_kind not in visited:
                         kinds_to_check.add(peer_kind)
+        return visited
 
-    def _index_dependent_schema(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
+    def _index_dependent_schema(self, cascade_kinds: set[str]) -> None:
         start_schema_kinds: set[str] = set()
-        for start_schema in start_schemas:
-            start_schema_kinds.add(start_schema.kind)
-            if start_schema.inherit_from:
-                start_schema_kinds.update(set(start_schema.inherit_from))
+        for kind in cascade_kinds:
+            start_schema_kinds.add(kind)
+            inherit_from = getattr(self._all_schemas_map[kind], "inherit_from", None)
+            if inherit_from:
+                start_schema_kinds.update(set(inherit_from))
         for node_schema in self._all_schemas_map.values():
             for relationship_schema in node_schema.relationships:
                 if relationship_schema.optional is True or relationship_schema.peer not in start_schema_kinds:

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -440,6 +440,7 @@ class CoreGraphQLQuery(CoreNode):
     height: IntegerOptional
     repository: RelationshipManager[CoreGenericRepository]
     tags: RelationshipManager[BuiltinTag]
+    query_groups: RelationshipManager[CoreGraphQLQueryGroup]
 
 
 class CoreGraphQLQueryGroup(CoreGroup):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -217,6 +217,7 @@ class CoreTransformation(CoreNode):
     query: RelationshipManager[CoreGraphQLQuery]
     repository: RelationshipManager[CoreGenericRepository]
     tags: RelationshipManager[BuiltinTag]
+    artifact_definitions: RelationshipManager[CoreArtifactDefinition]
 
 
 class CoreTriggerRule(CoreNode):
@@ -309,6 +310,8 @@ class CoreArtifactDefinition(CoreTaskTarget):
     fingerprint: StringOptional
     targets: RelationshipManager[CoreGroup]
     transformation: RelationshipManager[CoreTransformation]
+    artifacts: RelationshipManager[CoreArtifact]
+    validators: RelationshipManager[CoreArtifactValidator]
 
 
 class CoreArtifactThread(CoreThread):
@@ -340,6 +343,7 @@ class CoreCheckDefinition(CoreTaskTarget):
     query: RelationshipManager[CoreGraphQLQuery]
     targets: RelationshipManager[CoreGroup]
     tags: RelationshipManager[BuiltinTag]
+    validators: RelationshipManager[CoreUserValidator]
 
 
 class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
@@ -400,6 +404,8 @@ class CoreGeneratorDefinition(CoreTaskTarget):
     query: RelationshipManager[CoreGraphQLQuery]
     repository: RelationshipManager[CoreGenericRepository]
     targets: RelationshipManager[CoreGroup]
+    instances: RelationshipManager[CoreGeneratorInstance]
+    validators: RelationshipManager[CoreGeneratorValidator]
 
 
 class CoreGeneratorGroup(CoreGroup):

--- a/backend/infrahub/core/schema/definitions/core/artifact.py
+++ b/backend/infrahub/core/schema/definitions/core/artifact.py
@@ -146,5 +146,22 @@ core_artifact_definition = NodeSchema(
             cardinality=Cardinality.ONE,
             optional=False,
         ),
+        Rel(
+            name="artifacts",
+            peer=InfrahubKind.ARTIFACT,
+            identifier="artifact__artifact_definition",
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
+        ),
+        Rel(
+            name="validators",
+            peer=InfrahubKind.ARTIFACTVALIDATOR,
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
+        ),
     ],
 )

--- a/backend/infrahub/core/schema/definitions/core/check.py
+++ b/backend/infrahub/core/schema/definitions/core/check.py
@@ -1,6 +1,7 @@
 from infrahub.core.constants import (
     BranchSupportType,
     InfrahubKind,
+    RelationshipDeleteBehavior,
 )
 from infrahub.core.constants import RelationshipCardinality as Cardinality
 from infrahub.core.constants import RelationshipKind as RelKind
@@ -69,6 +70,14 @@ core_check_definition = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             optional=True,
             cardinality=Cardinality.MANY,
+        ),
+        Rel(
+            name="validators",
+            peer=InfrahubKind.USERVALIDATOR,
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
         ),
     ],
 )

--- a/backend/infrahub/core/schema/definitions/core/generator.py
+++ b/backend/infrahub/core/schema/definitions/core/generator.py
@@ -2,6 +2,7 @@ from infrahub.core.constants import (
     BranchSupportType,
     GeneratorInstanceStatus,
     InfrahubKind,
+    RelationshipDeleteBehavior,
 )
 from infrahub.core.constants import RelationshipCardinality as Cardinality
 from infrahub.core.constants import RelationshipKind as RelKind
@@ -97,6 +98,23 @@ core_generator_definition = NodeSchema(
             identifier="generator_definition___group",
             cardinality=Cardinality.ONE,
             optional=False,
+        ),
+        Rel(
+            name="instances",
+            peer=InfrahubKind.GENERATORINSTANCE,
+            identifier="generator__generator_definition",
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
+        ),
+        Rel(
+            name="validators",
+            peer=InfrahubKind.GENERATORVALIDATOR,
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
         ),
     ],
 )

--- a/backend/infrahub/core/schema/definitions/core/graphql_query.py
+++ b/backend/infrahub/core/schema/definitions/core/graphql_query.py
@@ -1,6 +1,7 @@
 from infrahub.core.constants import (
     BranchSupportType,
     InfrahubKind,
+    RelationshipDeleteBehavior,
 )
 from infrahub.core.constants import RelationshipCardinality as Cardinality
 from infrahub.core.constants import RelationshipKind as RelKind
@@ -80,6 +81,14 @@ core_graphql_query = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             optional=True,
             cardinality=Cardinality.MANY,
+        ),
+        Rel(
+            name="query_groups",
+            peer=InfrahubKind.GRAPHQLQUERYGROUP,
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
         ),
     ],
 )

--- a/backend/infrahub/core/schema/definitions/core/repository.py
+++ b/backend/infrahub/core/schema/definitions/core/repository.py
@@ -2,6 +2,7 @@ from infrahub.core.constants import (
     AllowOverrideType,
     BranchSupportType,
     InfrahubKind,
+    RelationshipDeleteBehavior,
     RepositoryInternalStatus,
     RepositoryOperationalStatus,
     RepositorySyncStatus,
@@ -267,6 +268,7 @@ core_generic_repository = GenericSchema(
             identifier="repository__transformation",
             optional=True,
             cardinality=Cardinality.MANY,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
             order_weight=10000,
         ),
         Rel(
@@ -275,6 +277,7 @@ core_generic_repository = GenericSchema(
             identifier="graphql_query__repository",
             optional=True,
             cardinality=Cardinality.MANY,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
             order_weight=9000,
         ),
         Rel(
@@ -283,6 +286,7 @@ core_generic_repository = GenericSchema(
             identifier="check_definition__repository",
             optional=True,
             cardinality=Cardinality.MANY,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
             order_weight=11000,
         ),
         Rel(
@@ -291,6 +295,7 @@ core_generic_repository = GenericSchema(
             identifier="generator_definition__repository",
             optional=True,
             cardinality=Cardinality.MANY,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
             order_weight=12000,
         ),
         Rel(

--- a/backend/infrahub/core/schema/definitions/core/transform.py
+++ b/backend/infrahub/core/schema/definitions/core/transform.py
@@ -1,6 +1,7 @@
 from infrahub.core.constants import (
     BranchSupportType,
     InfrahubKind,
+    RelationshipDeleteBehavior,
 )
 from infrahub.core.constants import RelationshipCardinality as Cardinality
 from infrahub.core.constants import RelationshipKind as RelKind
@@ -73,6 +74,15 @@ core_transform = GenericSchema(
             kind=RelKind.ATTRIBUTE,
             optional=True,
             cardinality=Cardinality.MANY,
+        ),
+        Rel(
+            name="artifact_definitions",
+            peer=InfrahubKind.ARTIFACTDEFINITION,
+            identifier="artifact_definition___transformation",
+            kind=RelKind.GENERIC,
+            cardinality=Cardinality.MANY,
+            optional=True,
+            on_delete=RelationshipDeleteBehavior.CASCADE,
         ),
     ],
 )

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -591,3 +591,61 @@ async def test_delete_cascade_artifacts(
     assert artifact.id in {d.id for d in deleted}
     node_map = await NodeManager.get_many(db=db, ids=[c1.id, artifact.id])
     assert node_map == {}
+
+
+async def test_delete_repository_cascades_managed_objects(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_data_generic: dict[str, Node],
+) -> None:
+    """Deleting a repository must cascade-delete its transforms and everything they own."""
+    c1 = car_person_data_generic["c1"]
+    q1 = car_person_data_generic["q1"]
+    r1 = car_person_data_generic["r1"]
+
+    group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await group.new(db=db, name="repo-cascade-group", members=[c1])
+    await group.save(db=db)
+
+    transform = await Node.init(db=db, schema=InfrahubKind.TRANSFORMPYTHON)
+    await transform.new(
+        db=db,
+        name="repo-cascade-transform",
+        query=str(q1.id),
+        repository=str(r1.id),
+        file_path="transform.py",
+        class_name="Transform",
+    )
+    await transform.save(db=db)
+
+    definition = await Node.init(db=db, schema=InfrahubKind.ARTIFACTDEFINITION)
+    await definition.new(
+        db=db,
+        name="repo-cascade-def",
+        targets=group,
+        transformation=transform,
+        content_type="application/json",
+        artifact_name="repo-cascade-artifact",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await definition.save(db=db)
+
+    artifact = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
+    await artifact.new(
+        db=db,
+        name="repo-cascade-artifact",
+        definition=definition,
+        status="Ready",
+        object=c1,
+        storage_id="00000000-0000-0000-0000-000000000002",
+        checksum="def456",
+        content_type="application/json",
+    )
+    await artifact.save(db=db)
+
+    deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[r1])
+
+    deleted_ids = {d.id for d in deleted}
+    assert {r1.id, transform.id, definition.id, artifact.id} <= deleted_ids
+    node_map = await NodeManager.get_many(db=db, ids=[r1.id, transform.id, definition.id, artifact.id])
+    assert node_map == {}

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -596,9 +596,7 @@ async def test_delete_cascade_artifacts(
 async def test_cascade_delete_blocked_by_external_mandatory_dependent(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_camry_main: Node,
     car_accord_main: Node,
-    car_prius_main: Node,
     person_john_main: Node,
     person_jane_main: Node,
 ) -> None:
@@ -685,9 +683,88 @@ async def test_delete_repository_cascades_managed_objects(
     )
     await artifact.save(db=db)
 
+    check_def = await Node.init(db=db, schema=InfrahubKind.CHECKDEFINITION)
+    await check_def.new(
+        db=db,
+        name="repo-cascade-check",
+        repository=str(r1.id),
+        class_name="MyCheck",
+        file_path="check.py",
+    )
+    await check_def.save(db=db)
+
+    generator_def = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION)
+    await generator_def.new(
+        db=db,
+        name="repo-cascade-generator",
+        repository=str(r1.id),
+        query=str(q1.id),
+        targets=group,
+        file_path="generator.py",
+        class_name="MyGenerator",
+        parameters={"value": {"name": "name__value"}},
+    )
+    await generator_def.save(db=db)
+
+    generator_instance = await Node.init(db=db, schema=InfrahubKind.GENERATORINSTANCE)
+    await generator_instance.new(
+        db=db,
+        name="repo-cascade-gen-instance",
+        definition=generator_def,
+        object=c1,
+        status="Ready",
+    )
+    await generator_instance.save(db=db)
+
     deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[r1])
 
     deleted_ids = {d.id for d in deleted}
-    assert {r1.id, transform.id, definition.id, artifact.id} <= deleted_ids
-    node_map = await NodeManager.get_many(db=db, ids=[r1.id, transform.id, definition.id, artifact.id])
+    assert {
+        r1.id,
+        transform.id,
+        definition.id,
+        artifact.id,
+        check_def.id,
+        generator_def.id,
+        generator_instance.id,
+    } <= deleted_ids
+    node_map = await NodeManager.get_many(
+        db=db,
+        ids=[r1.id, transform.id, definition.id, artifact.id, check_def.id, generator_def.id, generator_instance.id],
+    )
+    assert node_map == {}
+
+
+async def test_delete_repository_query_group_cascade(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_data_generic: dict[str, Node],
+) -> None:
+    """Deleting a repository cascades to its queries, which in turn cascade to their query groups."""
+    r1 = car_person_data_generic["r1"]
+
+    repo_query = await Node.init(db=db, schema=InfrahubKind.GRAPHQLQUERY)
+    await repo_query.new(
+        db=db,
+        name="repo-owned-query",
+        query="{ TestPerson { edges { node { id } } } }",
+        repository=str(r1.id),
+    )
+    await repo_query.save(db=db)
+
+    query_group = await Node.init(db=db, schema=InfrahubKind.GRAPHQLQUERYGROUP)
+    await query_group.new(
+        db=db,
+        name="repo-cascade-query-group",
+        query=str(repo_query.id),
+    )
+    await query_group.save(db=db)
+
+    deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[r1])
+
+    deleted_ids = {d.id for d in deleted}
+    assert r1.id in deleted_ids
+    assert repo_query.id in deleted_ids
+    assert query_group.id in deleted_ids
+    node_map = await NodeManager.get_many(db=db, ids=[r1.id, repo_query.id, query_group.id])
     assert node_map == {}

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -593,6 +593,48 @@ async def test_delete_cascade_artifacts(
     assert node_map == {}
 
 
+async def test_cascade_delete_blocked_by_external_mandatory_dependent(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_camry_main: Node,
+    car_accord_main: Node,
+    car_prius_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+) -> None:
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    person_schema = schema_branch.get(name="TestPerson", duplicate=False)
+    person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
+
+    person_schema.relationships.append(
+        RelationshipSchema(
+            name="favorite_car",
+            kind="Attribute",
+            optional=False,
+            peer="TestCar",
+            cardinality="one",
+            identifier="person__favorite_car",
+            on_delete=RelationshipDeleteBehavior.NO_ACTION,
+            branch=BranchSupportType.AWARE,
+        )
+    )
+
+    # Jane is NOT being deleted and mandatorily references one of John's (cascaded) cars.
+    jane = await NodeManager.get_one(db=db, id=person_jane_main.id)
+    await jane.favorite_car.update(db=db, data=car_accord_main.id)
+    await jane.save(db=db)
+
+    with pytest.raises(ValidationError) as exc:
+        await NodeManager.delete(db=db, branch=default_branch, nodes=[person_john_main])
+
+    expected_msg = (
+        f"Cannot delete TestCar '{car_accord_main.id}'. "
+        f"It is linked to mandatory relationship favorite_car on node TestPerson '{person_jane_main.id}' "
+        f"at TestPerson.favorite_car"
+    )
+    assert str(exc.value) == expected_msg
+
+
 async def test_delete_repository_cascades_managed_objects(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/backend/tests/protocols.py
+++ b/backend/tests/protocols.py
@@ -217,6 +217,7 @@ class CoreTransformation(CoreNode):
     query: RelationshipManager[CoreGraphQLQuery]
     repository: RelationshipManager[CoreGenericRepository]
     tags: RelationshipManager[BuiltinTag]
+    artifact_definitions: RelationshipManager[CoreArtifactDefinition]
 
 
 class CoreTriggerRule(CoreNode):
@@ -325,6 +326,8 @@ class CoreArtifactDefinition(CoreTaskTarget):
     fingerprint: StringOptional
     targets: RelationshipManager[CoreGroup]
     transformation: RelationshipManager[CoreTransformation]
+    artifacts: RelationshipManager[CoreArtifact]
+    validators: RelationshipManager[CoreArtifactValidator]
 
 
 class CoreArtifactThread(CoreThread):
@@ -356,6 +359,7 @@ class CoreCheckDefinition(CoreTaskTarget):
     query: RelationshipManager[CoreGraphQLQuery]
     targets: RelationshipManager[CoreGroup]
     tags: RelationshipManager[BuiltinTag]
+    validators: RelationshipManager[CoreUserValidator]
 
 
 class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
@@ -416,6 +420,8 @@ class CoreGeneratorDefinition(CoreTaskTarget):
     query: RelationshipManager[CoreGraphQLQuery]
     repository: RelationshipManager[CoreGenericRepository]
     targets: RelationshipManager[CoreGroup]
+    instances: RelationshipManager[CoreGeneratorInstance]
+    validators: RelationshipManager[CoreGeneratorValidator]
 
 
 class CoreGeneratorGroup(CoreGroup):

--- a/backend/tests/protocols.py
+++ b/backend/tests/protocols.py
@@ -456,6 +456,7 @@ class CoreGraphQLQuery(CoreNode):
     height: IntegerOptional
     repository: RelationshipManager[CoreGenericRepository]
     tags: RelationshipManager[BuiltinTag]
+    query_groups: RelationshipManager[CoreGraphQLQueryGroup]
 
 
 class CoreGraphQLQueryGroup(CoreGroup):

--- a/backend/tests/unit/core/node/test_delete_validator.py
+++ b/backend/tests/unit/core/node/test_delete_validator.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node.delete_validator import DeleteRelationshipType, NodeDeleteIndex
+from infrahub.core.schema import NodeSchema, SchemaRoot
+from infrahub.core.schema.definitions.core import core_models
+from infrahub.core.schema.schema_branch import SchemaBranch
+
+
+def _cascade_closure(index: NodeDeleteIndex, root_kind: str) -> set[str]:
+    """All kinds reachable from root_kind by following CASCADE_DELETE edges."""
+    reachable: set[str] = set()
+    stack = [root_kind]
+    while stack:
+        kind = stack.pop()
+        # _dependency_graph is accessed directly on purpose: there is no public
+        # traversal API, and the closure is exactly what this test needs to prove.
+        edges = index._dependency_graph.get(kind, {}).get(DeleteRelationshipType.CASCADE_DELETE, {})
+        for peer_kinds in edges.values():
+            for peer in peer_kinds:
+                if peer not in reachable:
+                    reachable.add(peer)
+                    stack.append(peer)
+    return reachable
+
+
+@dataclass
+class RepositoryCase:
+    name: str
+    kind: str
+
+
+REPOSITORY_CASES = [
+    RepositoryCase(name="read-only-repository", kind=InfrahubKind.READONLYREPOSITORY),
+    RepositoryCase(name="read-write-repository", kind=InfrahubKind.REPOSITORY),
+]
+
+
+@pytest.mark.parametrize("case", REPOSITORY_CASES, ids=[case.name for case in REPOSITORY_CASES])
+def test_repository_cascade_reaches_all_managed_leaves(case: RepositoryCase) -> None:
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(**core_models))
+    schema_branch.process()
+    all_schemas = schema_branch.get_all(duplicate=False)
+
+    index = NodeDeleteIndex(all_schemas_map=all_schemas)
+    repo_schema = all_schemas[case.kind]
+    assert isinstance(repo_schema, NodeSchema)
+    index.index(start_schemas=[repo_schema])
+
+    reachable = _cascade_closure(index, case.kind)
+
+    expected_leaves = {
+        InfrahubKind.ARTIFACT,
+        InfrahubKind.ARTIFACTVALIDATOR,
+        InfrahubKind.GENERATORINSTANCE,
+        InfrahubKind.GENERATORVALIDATOR,
+        InfrahubKind.USERVALIDATOR,
+    }
+    assert expected_leaves <= reachable

--- a/backend/tests/unit/core/node/test_delete_validator.py
+++ b/backend/tests/unit/core/node/test_delete_validator.py
@@ -57,6 +57,7 @@ def test_repository_cascade_reaches_all_managed_leaves(case: RepositoryCase) -> 
         InfrahubKind.ARTIFACTVALIDATOR,
         InfrahubKind.GENERATORINSTANCE,
         InfrahubKind.GENERATORVALIDATOR,
+        InfrahubKind.GRAPHQLQUERYGROUP,
         InfrahubKind.USERVALIDATOR,
     }
     assert expected_leaves <= reachable

--- a/changelog/3076.fixed.md
+++ b/changelog/3076.fixed.md
@@ -1,0 +1,1 @@
+Deleting a repository now cascades to the objects it manages (transforms, checks, GraphQL queries, generators, and their artifact definitions, artifacts, and validators), so a repository can be removed in a single operation instead of deleting each dependent object by hand.

--- a/frontend/app/src/shared/api/graphql/generated/types.ts
+++ b/frontend/app/src/shared/api/graphql/generated/types.ts
@@ -7837,6 +7837,7 @@ export type CoreGraphQlQuery = CoreNode & {
   operations: Maybe<ListAttribute>;
   /** The GraphQL query string (required) */
   query: Maybe<TextAttribute>;
+  query_groups: NestedPaginatedCoreGraphQlQueryGroup;
   repository: NestedEdgedCoreGenericRepository;
   subscriber_of_groups: NestedPaginatedCoreGroup;
   tags: NestedPaginatedBuiltinTag;
@@ -7875,6 +7876,44 @@ export type CoreGraphQlQueryMember_Of_GroupsArgs = {
   name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<OrderInput>;
+};
+
+
+/** A pre-defined GraphQL Query */
+export type CoreGraphQlQueryQuery_GroupsArgs = {
+  description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  description__value?: InputMaybe<Scalars['String']['input']>;
+  description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  group_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  group_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  group_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  group_type__value?: InputMaybe<Scalars['String']['input']>;
+  group_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  label__value?: InputMaybe<Scalars['String']['input']>;
+  label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
 };
 
 
@@ -7949,6 +7988,7 @@ export type CoreGraphQlQueryCreateInput = {
   name?: InputMaybe<TextAttributeCreate>;
   /** The GraphQL query string */
   query?: InputMaybe<TextAttributeCreate>;
+  query_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   tags?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
@@ -8199,6 +8239,7 @@ export type CoreGraphQlQueryUpdateInput = {
   name?: InputMaybe<TextAttributeUpdate>;
   /** The GraphQL query string */
   query?: InputMaybe<TextAttributeUpdate>;
+  query_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   tags?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
@@ -8221,6 +8262,7 @@ export type CoreGraphQlQueryUpsertInput = {
   name?: InputMaybe<TextAttributeUpdate>;
   /** The GraphQL query string */
   query?: InputMaybe<TextAttributeUpdate>;
+  query_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   tags?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
@@ -15343,6 +15385,11 @@ export type CoreTransformJinja2Artifact_DefinitionsArgs = {
   display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   display_label__value?: InputMaybe<Scalars['String']['input']>;
   display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   isnull?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -15601,6 +15648,11 @@ export type CoreTransformPythonArtifact_DefinitionsArgs = {
   display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   display_label__value?: InputMaybe<Scalars['String']['input']>;
   display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   isnull?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -15864,6 +15916,11 @@ export type CoreTransformationArtifact_DefinitionsArgs = {
   display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   display_label__value?: InputMaybe<Scalars['String']['input']>;
   display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   isnull?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -30988,6 +31045,36 @@ export type QueryCoreGraphQlQueryArgs = {
   query__source__id?: InputMaybe<Scalars['ID']['input']>;
   query__value?: InputMaybe<Scalars['String']['input']>;
   query__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__description__value?: InputMaybe<Scalars['String']['input']>;
+  query_groups__description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  query_groups__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__group_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__group_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__group_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__group_type__value?: InputMaybe<Scalars['String']['input']>;
+  query_groups__group_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  query_groups__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__label__value?: InputMaybe<Scalars['String']['input']>;
+  query_groups__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__name__value?: InputMaybe<Scalars['String']['input']>;
+  query_groups__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  query_groups__parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  query_groups__parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  query_groups__parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  query_groups__parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
   repository__description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   repository__description__owner__id?: InputMaybe<Scalars['ID']['input']>;
   repository__description__source__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35922,6 +36009,11 @@ export type QueryCoreTransformJinja2Args = {
   artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
   artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
@@ -36154,6 +36246,11 @@ export type QueryCoreTransformPythonArgs = {
   artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
   artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
@@ -36398,6 +36495,11 @@ export type QueryCoreTransformationArgs = {
   artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
   artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__fingerprint__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__fingerprint__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__fingerprint__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;

--- a/frontend/app/src/shared/api/graphql/generated/types.ts
+++ b/frontend/app/src/shared/api/graphql/generated/types.ts
@@ -2515,6 +2515,7 @@ export type CoreArtifactDefinition = CoreNode & CoreTaskTarget & {
   __typename: 'CoreArtifactDefinition';
   /** Name template for generated artifacts (required) */
   artifact_name: Maybe<TextAttribute>;
+  artifacts: NestedPaginatedCoreArtifact;
   /** MIME type of the generated artifacts (required) */
   content_type: Maybe<TextAttribute>;
   /** None */
@@ -2534,6 +2535,50 @@ export type CoreArtifactDefinition = CoreNode & CoreTaskTarget & {
   subscriber_of_groups: NestedPaginatedCoreGroup;
   targets: NestedEdgedCoreGroup;
   transformation: NestedEdgedCoreTransformation;
+  validators: NestedPaginatedCoreArtifactValidator;
+};
+
+
+/** Defines how artifacts are generated from a transformation for a group of targets */
+export type CoreArtifactDefinitionArtifactsArgs = {
+  checksum__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  checksum__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  checksum__source__id?: InputMaybe<Scalars['ID']['input']>;
+  checksum__value?: InputMaybe<Scalars['String']['input']>;
+  checksum__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__value?: InputMaybe<Scalars['String']['input']>;
+  content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
+  status__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  status__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  status__source__id?: InputMaybe<Scalars['ID']['input']>;
+  status__value?: InputMaybe<Scalars['String']['input']>;
+  status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  storage_id__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  storage_id__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  storage_id__source__id?: InputMaybe<Scalars['ID']['input']>;
+  storage_id__value?: InputMaybe<Scalars['String']['input']>;
+  storage_id__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -2602,6 +2647,44 @@ export type CoreArtifactDefinitionSubscriber_Of_GroupsArgs = {
   order?: InputMaybe<OrderInput>;
 };
 
+
+/** Defines how artifacts are generated from a transformation for a group of targets */
+export type CoreArtifactDefinitionValidatorsArgs = {
+  completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  label__value?: InputMaybe<Scalars['String']['input']>;
+  label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  state__value?: InputMaybe<Scalars['String']['input']>;
+  state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
 /** Defines how artifacts are generated from a transformation for a group of targets */
 export type CoreArtifactDefinitionCreate = {
   __typename: 'CoreArtifactDefinitionCreate';
@@ -2612,6 +2695,7 @@ export type CoreArtifactDefinitionCreate = {
 export type CoreArtifactDefinitionCreateInput = {
   /** Name template for generated artifacts */
   artifact_name?: InputMaybe<TextAttributeCreate>;
+  artifacts?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** MIME type of the generated artifacts */
   content_type?: InputMaybe<TextAttributeCreate>;
   description?: InputMaybe<TextAttributeCreate>;
@@ -2625,6 +2709,7 @@ export type CoreArtifactDefinitionCreateInput = {
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
   transformation?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines how artifacts are generated from a transformation for a group of targets */
@@ -2643,6 +2728,7 @@ export type CoreArtifactDefinitionUpdate = {
 export type CoreArtifactDefinitionUpdateInput = {
   /** Name template for generated artifacts */
   artifact_name?: InputMaybe<TextAttributeUpdate>;
+  artifacts?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** MIME type of the generated artifacts */
   content_type?: InputMaybe<TextAttributeUpdate>;
   description?: InputMaybe<TextAttributeUpdate>;
@@ -2657,6 +2743,7 @@ export type CoreArtifactDefinitionUpdateInput = {
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
   transformation?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines how artifacts are generated from a transformation for a group of targets */
@@ -2669,6 +2756,7 @@ export type CoreArtifactDefinitionUpsert = {
 export type CoreArtifactDefinitionUpsertInput = {
   /** Name template for generated artifacts */
   artifact_name?: InputMaybe<TextAttributeUpdate>;
+  artifacts?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** MIME type of the generated artifacts */
   content_type?: InputMaybe<TextAttributeUpdate>;
   description?: InputMaybe<TextAttributeUpdate>;
@@ -2683,6 +2771,7 @@ export type CoreArtifactDefinitionUpsertInput = {
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
   transformation?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** A file generated by a transformation, associated with a specific object */
@@ -3825,6 +3914,7 @@ export type CoreCheckDefinition = CoreNode & CoreTaskTarget & {
   targets: NestedEdgedCoreGroup;
   /** Maximum execution time in seconds before the check times out */
   timeout: Maybe<NumberAttribute>;
+  validators: NestedPaginatedCoreUserValidator;
 };
 
 
@@ -3916,6 +4006,44 @@ export type CoreCheckDefinitionTagsArgs = {
   order?: InputMaybe<OrderInput>;
 };
 
+
+/** Defines a user-defined check that validates data in a proposed change */
+export type CoreCheckDefinitionValidatorsArgs = {
+  completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  label__value?: InputMaybe<Scalars['String']['input']>;
+  label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  state__value?: InputMaybe<Scalars['String']['input']>;
+  state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
 /** Defines a user-defined check that validates data in a proposed change */
 export type CoreCheckDefinitionCreate = {
   __typename: 'CoreCheckDefinitionCreate';
@@ -3941,6 +4069,7 @@ export type CoreCheckDefinitionCreateInput = {
   targets?: InputMaybe<RelatedNodeInput>;
   /** Maximum execution time in seconds before the check times out */
   timeout?: InputMaybe<NumberAttributeCreate>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines a user-defined check that validates data in a proposed change */
@@ -3975,6 +4104,7 @@ export type CoreCheckDefinitionUpdateInput = {
   targets?: InputMaybe<RelatedNodeInput>;
   /** Maximum execution time in seconds before the check times out */
   timeout?: InputMaybe<NumberAttributeUpdate>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines a user-defined check that validates data in a proposed change */
@@ -4003,6 +4133,7 @@ export type CoreCheckDefinitionUpsertInput = {
   targets?: InputMaybe<RelatedNodeInput>;
   /** Maximum execution time in seconds before the check times out */
   timeout?: InputMaybe<NumberAttributeUpdate>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** A check result within a validator that reports on specific validation outcomes */
@@ -6157,6 +6288,7 @@ export type CoreGeneratorDefinition = CoreNode & CoreTaskTarget & {
   hfid: Maybe<Array<Scalars['String']['output']>>;
   /** Unique identifier */
   id: Scalars['String']['output'];
+  instances: NestedPaginatedCoreGeneratorInstance;
   member_of_groups: NestedPaginatedCoreGroup;
   /** None (required) */
   name: Maybe<TextAttribute>;
@@ -6166,6 +6298,30 @@ export type CoreGeneratorDefinition = CoreNode & CoreTaskTarget & {
   repository: NestedEdgedCoreGenericRepository;
   subscriber_of_groups: NestedPaginatedCoreGroup;
   targets: NestedEdgedCoreGroup;
+  validators: NestedPaginatedCoreGeneratorValidator;
+};
+
+
+/** Defines a generator that creates or updates objects based on a GraphQL query */
+export type CoreGeneratorDefinitionInstancesArgs = {
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  status__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  status__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  status__source__id?: InputMaybe<Scalars['ID']['input']>;
+  status__value?: InputMaybe<Scalars['String']['input']>;
+  status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -6234,6 +6390,44 @@ export type CoreGeneratorDefinitionSubscriber_Of_GroupsArgs = {
   order?: InputMaybe<OrderInput>;
 };
 
+
+/** Defines a generator that creates or updates objects based on a GraphQL query */
+export type CoreGeneratorDefinitionValidatorsArgs = {
+  completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  label__value?: InputMaybe<Scalars['String']['input']>;
+  label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  state__value?: InputMaybe<Scalars['String']['input']>;
+  state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
 /** Defines a generator that creates or updates objects based on a GraphQL query */
 export type CoreGeneratorDefinitionCreate = {
   __typename: 'CoreGeneratorDefinitionCreate';
@@ -6260,6 +6454,7 @@ export type CoreGeneratorDefinitionCreateInput = {
   /** Content hash of the definition's inputs, recomputed on each import */
   fingerprint?: InputMaybe<TextAttributeCreate>;
   id?: InputMaybe<Scalars['String']['input']>;
+  instances?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   member_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   name?: InputMaybe<TextAttributeCreate>;
   /** GraphQL query parameters for the generator */
@@ -6268,6 +6463,7 @@ export type CoreGeneratorDefinitionCreateInput = {
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines a generator that creates or updates objects based on a GraphQL query */
@@ -6303,6 +6499,7 @@ export type CoreGeneratorDefinitionUpdateInput = {
   fingerprint?: InputMaybe<TextAttributeUpdate>;
   hfid?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   id?: InputMaybe<Scalars['String']['input']>;
+  instances?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   member_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   name?: InputMaybe<TextAttributeUpdate>;
   /** GraphQL query parameters for the generator */
@@ -6311,6 +6508,7 @@ export type CoreGeneratorDefinitionUpdateInput = {
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Defines a generator that creates or updates objects based on a GraphQL query */
@@ -6340,6 +6538,7 @@ export type CoreGeneratorDefinitionUpsertInput = {
   fingerprint?: InputMaybe<TextAttributeUpdate>;
   hfid?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   id?: InputMaybe<Scalars['String']['input']>;
+  instances?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   member_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   name?: InputMaybe<TextAttributeUpdate>;
   /** GraphQL query parameters for the generator */
@@ -6348,6 +6547,7 @@ export type CoreGeneratorDefinitionUpsertInput = {
   repository?: InputMaybe<RelatedNodeInput>;
   subscriber_of_groups?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   targets?: InputMaybe<RelatedNodeInput>;
+  validators?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
 };
 
 /** Group of nodes that are created by a generator. (local) */
@@ -15096,6 +15296,7 @@ export type CoreThreadUpdateInput = {
 /** A file rendered from a Jinja2 template */
 export type CoreTransformJinja2 = CoreNode & CoreTransformation & {
   __typename: 'CoreTransformJinja2';
+  artifact_definitions: NestedPaginatedCoreArtifactDefinition;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies: Maybe<ListAttribute>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -15119,6 +15320,44 @@ export type CoreTransformJinja2 = CoreNode & CoreTransformation & {
   template_path: Maybe<TextAttribute>;
   /** Maximum execution time in seconds */
   timeout: Maybe<NumberAttribute>;
+};
+
+
+/** A file rendered from a Jinja2 template */
+export type CoreTransformJinja2Artifact_DefinitionsArgs = {
+  artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__value?: InputMaybe<Scalars['String']['input']>;
+  content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  description__value?: InputMaybe<Scalars['String']['input']>;
+  description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
 };
 
 
@@ -15218,6 +15457,7 @@ export type CoreTransformJinja2Create = {
 };
 
 export type CoreTransformJinja2CreateInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies?: InputMaybe<ListAttributeCreate>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -15253,6 +15493,7 @@ export type CoreTransformJinja2Update = {
 };
 
 export type CoreTransformJinja2UpdateInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies?: InputMaybe<ListAttributeUpdate>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -15283,6 +15524,7 @@ export type CoreTransformJinja2Upsert = {
 };
 
 export type CoreTransformJinja2UpsertInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies?: InputMaybe<ListAttributeUpdate>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -15308,6 +15550,7 @@ export type CoreTransformJinja2UpsertInput = {
 /** A transform function written in Python */
 export type CoreTransformPython = CoreNode & CoreTransformation & {
   __typename: 'CoreTransformPython';
+  artifact_definitions: NestedPaginatedCoreArtifactDefinition;
   /** Name of the Python class implementing the transformation (required) */
   class_name: Maybe<TextAttribute>;
   /** Whether to convert the GraphQL response to SDK objects */
@@ -15335,6 +15578,44 @@ export type CoreTransformPython = CoreNode & CoreTransformation & {
   tags: NestedPaginatedBuiltinTag;
   /** Maximum execution time in seconds */
   timeout: Maybe<NumberAttribute>;
+};
+
+
+/** A transform function written in Python */
+export type CoreTransformPythonArtifact_DefinitionsArgs = {
+  artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__value?: InputMaybe<Scalars['String']['input']>;
+  content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  description__value?: InputMaybe<Scalars['String']['input']>;
+  description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
 };
 
 
@@ -15434,6 +15715,7 @@ export type CoreTransformPythonCreate = {
 };
 
 export type CoreTransformPythonCreateInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Name of the Python class implementing the transformation */
   class_name?: InputMaybe<TextAttributeCreate>;
   /** Whether to convert the GraphQL response to SDK objects */
@@ -15473,6 +15755,7 @@ export type CoreTransformPythonUpdate = {
 };
 
 export type CoreTransformPythonUpdateInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Name of the Python class implementing the transformation */
   class_name?: InputMaybe<TextAttributeUpdate>;
   /** Whether to convert the GraphQL response to SDK objects */
@@ -15507,6 +15790,7 @@ export type CoreTransformPythonUpsert = {
 };
 
 export type CoreTransformPythonUpsertInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Name of the Python class implementing the transformation */
   class_name?: InputMaybe<TextAttributeUpdate>;
   /** Whether to convert the GraphQL response to SDK objects */
@@ -15535,6 +15819,7 @@ export type CoreTransformPythonUpsertInput = {
 
 /** Generic Transformation Object. */
 export type CoreTransformation = {
+  artifact_definitions: NestedPaginatedCoreArtifactDefinition;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies: Maybe<ListAttribute>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -15556,6 +15841,44 @@ export type CoreTransformation = {
   tags: NestedPaginatedBuiltinTag;
   /** Maximum execution time in seconds */
   timeout: Maybe<NumberAttribute>;
+};
+
+
+/** Generic Transformation Object. */
+export type CoreTransformationArtifact_DefinitionsArgs = {
+  artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  content_type__value?: InputMaybe<Scalars['String']['input']>;
+  content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  description__value?: InputMaybe<Scalars['String']['input']>;
+  description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  display_label__value?: InputMaybe<Scalars['String']['input']>;
+  display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  name__value?: InputMaybe<Scalars['String']['input']>;
+  name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<OrderInput>;
+  parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
 };
 
 
@@ -15655,6 +15978,7 @@ export type CoreTransformationUpdate = {
 };
 
 export type CoreTransformationUpdateInput = {
+  artifact_definitions?: InputMaybe<Array<InputMaybe<RelatedNodeInput>>>;
   /** Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate. */
   dependencies?: InputMaybe<ListAttributeUpdate>;
   /** True when the dependency closure can be trusted. False when auto-detection found unresolved references. */
@@ -26533,6 +26857,41 @@ export type QueryCoreArtifactDefinitionArgs = {
   artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
   artifact_name__value?: InputMaybe<Scalars['String']['input']>;
   artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__checksum__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__checksum__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__checksum__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__checksum__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__checksum__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__content_type__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  artifacts__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__name__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  artifacts__parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
+  artifacts__status__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__status__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__status__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__status__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifacts__storage_id__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifacts__storage_id__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__storage_id__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifacts__storage_id__value?: InputMaybe<Scalars['String']['input']>;
+  artifacts__storage_id__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   content_type__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -26673,6 +27032,36 @@ export type QueryCoreArtifactDefinitionArgs = {
   transformation__timeout__source__id?: InputMaybe<Scalars['ID']['input']>;
   transformation__timeout__value?: InputMaybe<Scalars['BigInt']['input']>;
   transformation__timeout__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  validators__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  validators__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  validators__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__value?: InputMaybe<Scalars['String']['input']>;
+  validators__state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -27720,6 +28109,36 @@ export type QueryCoreCheckDefinitionArgs = {
   timeout__source__id?: InputMaybe<Scalars['ID']['input']>;
   timeout__value?: InputMaybe<Scalars['BigInt']['input']>;
   timeout__values?: InputMaybe<Array<InputMaybe<Scalars['BigInt']['input']>>>;
+  validators__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  validators__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  validators__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__value?: InputMaybe<Scalars['String']['input']>;
+  validators__state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -29294,6 +29713,21 @@ export type QueryCoreGeneratorDefinitionArgs = {
   fingerprint__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   hfid?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  instances__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  instances__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  instances__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  instances__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  instances__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  instances__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  instances__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  instances__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  instances__name__value?: InputMaybe<Scalars['String']['input']>;
+  instances__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  instances__status__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  instances__status__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  instances__status__source__id?: InputMaybe<Scalars['ID']['input']>;
+  instances__status__value?: InputMaybe<Scalars['String']['input']>;
+  instances__status__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   member_of_groups__description__value?: InputMaybe<Scalars['String']['input']>;
   member_of_groups__description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -29456,6 +29890,36 @@ export type QueryCoreGeneratorDefinitionArgs = {
   targets__name__source__id?: InputMaybe<Scalars['ID']['input']>;
   targets__name__value?: InputMaybe<Scalars['String']['input']>;
   targets__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__completed_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__completed_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__completed_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__completed_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__conclusion__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__conclusion__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__conclusion__value?: InputMaybe<Scalars['String']['input']>;
+  validators__conclusion__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  validators__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__label__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__label__value?: InputMaybe<Scalars['String']['input']>;
+  validators__label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  validators__started_at__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__started_at__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__started_at__value?: InputMaybe<Scalars['DateTime']['input']>;
+  validators__started_at__values?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  validators__state__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  validators__state__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__source__id?: InputMaybe<Scalars['ID']['input']>;
+  validators__state__value?: InputMaybe<Scalars['String']['input']>;
+  validators__state__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -35440,6 +35904,36 @@ export type QueryCoreTransformJinja2Args = {
   any__source__id?: InputMaybe<Scalars['ID']['input']>;
   any__value?: InputMaybe<Scalars['String']['input']>;
   any__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  artifact_definitions__parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
   dependencies__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   dependencies__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   dependencies__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35642,6 +36136,36 @@ export type QueryCoreTransformPythonArgs = {
   any__source__id?: InputMaybe<Scalars['ID']['input']>;
   any__value?: InputMaybe<Scalars['String']['input']>;
   any__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  artifact_definitions__parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
   class_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   class_name__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   class_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
@@ -35856,6 +36380,36 @@ export type QueryCoreTransformationArgs = {
   any__source__id?: InputMaybe<Scalars['ID']['input']>;
   any__value?: InputMaybe<Scalars['String']['input']>;
   any__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__artifact_name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__artifact_name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__artifact_name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__artifact_name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__content_type__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__content_type__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__content_type__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__content_type__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__description__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__description__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__description__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__description__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__display_label__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__display_label__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__display_label__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  artifact_definitions__isnull?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__name__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__name__value?: InputMaybe<Scalars['String']['input']>;
+  artifact_definitions__name__values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  artifact_definitions__parameters__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
+  artifact_definitions__parameters__owner__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__source__id?: InputMaybe<Scalars['ID']['input']>;
+  artifact_definitions__parameters__value?: InputMaybe<Scalars['GenericScalar']['input']>;
+  artifact_definitions__parameters__values?: InputMaybe<Array<InputMaybe<Scalars['GenericScalar']['input']>>>;
   dependencies__is_protected?: InputMaybe<Scalars['Boolean']['input']>;
   dependencies__isnull?: InputMaybe<Scalars['Boolean']['input']>;
   dependencies__owner__id?: InputMaybe<Scalars['ID']['input']>;

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1231,6 +1231,7 @@ Defines how artifacts are generated from a transformation for a group of targets
 type CoreArtifactDefinition implements CoreNode & CoreTaskTarget {
   """Name template for generated artifacts (required)"""
   artifact_name: TextAttribute
+  artifacts(checksum__is_protected: Boolean, checksum__owner__id: ID, checksum__source__id: ID, checksum__value: String, checksum__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar], status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String], storage_id__is_protected: Boolean, storage_id__owner__id: ID, storage_id__source__id: ID, storage_id__value: String, storage_id__values: [String]): NestedPaginatedCoreArtifact!
   """MIME type of the generated artifacts (required)"""
   content_type: TextAttribute
   """None"""
@@ -1250,6 +1251,7 @@ type CoreArtifactDefinition implements CoreNode & CoreTaskTarget {
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   targets: NestedEdgedCoreGroup!
   transformation: NestedEdgedCoreTransformation!
+  validators(completed_at__is_protected: Boolean, completed_at__owner__id: ID, completed_at__source__id: ID, completed_at__value: DateTime, completed_at__values: [DateTime], conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, offset: Int, order: OrderInput, started_at__is_protected: Boolean, started_at__owner__id: ID, started_at__source__id: ID, started_at__value: DateTime, started_at__values: [DateTime], state__is_protected: Boolean, state__owner__id: ID, state__source__id: ID, state__value: String, state__values: [String]): NestedPaginatedCoreArtifactValidator!
 }
 
 """
@@ -1263,6 +1265,7 @@ type CoreArtifactDefinitionCreate {
 input CoreArtifactDefinitionCreateInput {
   """Name template for generated artifacts"""
   artifact_name: TextAttributeCreate
+  artifacts: [RelatedNodeInput]
   """MIME type of the generated artifacts"""
   content_type: TextAttributeCreate
   description: TextAttributeCreate
@@ -1276,6 +1279,7 @@ input CoreArtifactDefinitionCreateInput {
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
   transformation: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -1296,6 +1300,7 @@ type CoreArtifactDefinitionUpdate {
 input CoreArtifactDefinitionUpdateInput {
   """Name template for generated artifacts"""
   artifact_name: TextAttributeUpdate
+  artifacts: [RelatedNodeInput]
   """MIME type of the generated artifacts"""
   content_type: TextAttributeUpdate
   description: TextAttributeUpdate
@@ -1310,6 +1315,7 @@ input CoreArtifactDefinitionUpdateInput {
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
   transformation: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -1323,6 +1329,7 @@ type CoreArtifactDefinitionUpsert {
 input CoreArtifactDefinitionUpsertInput {
   """Name template for generated artifacts"""
   artifact_name: TextAttributeUpdate
+  artifacts: [RelatedNodeInput]
   """MIME type of the generated artifacts"""
   content_type: TextAttributeUpdate
   description: TextAttributeUpdate
@@ -1337,6 +1344,7 @@ input CoreArtifactDefinitionUpsertInput {
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
   transformation: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -1849,6 +1857,7 @@ type CoreCheckDefinition implements CoreNode & CoreTaskTarget {
   targets: NestedEdgedCoreGroup!
   """Maximum execution time in seconds before the check times out"""
   timeout: NumberAttribute
+  validators(completed_at__is_protected: Boolean, completed_at__owner__id: ID, completed_at__source__id: ID, completed_at__value: DateTime, completed_at__values: [DateTime], conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, offset: Int, order: OrderInput, started_at__is_protected: Boolean, started_at__owner__id: ID, started_at__source__id: ID, started_at__value: DateTime, started_at__values: [DateTime], state__is_protected: Boolean, state__owner__id: ID, state__source__id: ID, state__value: String, state__values: [String]): NestedPaginatedCoreUserValidator!
 }
 
 """Defines a user-defined check that validates data in a proposed change"""
@@ -1875,6 +1884,7 @@ input CoreCheckDefinitionCreateInput {
   targets: RelatedNodeInput
   """Maximum execution time in seconds before the check times out"""
   timeout: NumberAttributeCreate
+  validators: [RelatedNodeInput]
 }
 
 """Defines a user-defined check that validates data in a proposed change"""
@@ -1907,6 +1917,7 @@ input CoreCheckDefinitionUpdateInput {
   targets: RelatedNodeInput
   """Maximum execution time in seconds before the check times out"""
   timeout: NumberAttributeUpdate
+  validators: [RelatedNodeInput]
 }
 
 """Defines a user-defined check that validates data in a proposed change"""
@@ -1934,6 +1945,7 @@ input CoreCheckDefinitionUpsertInput {
   targets: RelatedNodeInput
   """Maximum execution time in seconds before the check times out"""
   timeout: NumberAttributeUpdate
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -3078,6 +3090,7 @@ type CoreGeneratorDefinition implements CoreNode & CoreTaskTarget {
   hfid: [String!]
   """Unique identifier"""
   id: String!
+  instances(display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, status__is_protected: Boolean, status__owner__id: ID, status__source__id: ID, status__value: String, status__values: [String]): NestedPaginatedCoreGeneratorInstance!
   member_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   """None (required)"""
   name: TextAttribute
@@ -3087,6 +3100,7 @@ type CoreGeneratorDefinition implements CoreNode & CoreTaskTarget {
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   targets: NestedEdgedCoreGroup!
+  validators(completed_at__is_protected: Boolean, completed_at__owner__id: ID, completed_at__source__id: ID, completed_at__value: DateTime, completed_at__values: [DateTime], conclusion__is_protected: Boolean, conclusion__owner__id: ID, conclusion__source__id: ID, conclusion__value: String, conclusion__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, offset: Int, order: OrderInput, started_at__is_protected: Boolean, started_at__owner__id: ID, started_at__source__id: ID, started_at__value: DateTime, started_at__values: [DateTime], state__is_protected: Boolean, state__owner__id: ID, state__source__id: ID, state__value: String, state__values: [String]): NestedPaginatedCoreGeneratorValidator!
 }
 
 """
@@ -3120,6 +3134,7 @@ input CoreGeneratorDefinitionCreateInput {
   """Content hash of the definition's inputs, recomputed on each import"""
   fingerprint: TextAttributeCreate
   id: String
+  instances: [RelatedNodeInput]
   member_of_groups: [RelatedNodeInput]
   name: TextAttributeCreate
   """GraphQL query parameters for the generator"""
@@ -3128,6 +3143,7 @@ input CoreGeneratorDefinitionCreateInput {
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -3169,6 +3185,7 @@ input CoreGeneratorDefinitionUpdateInput {
   fingerprint: TextAttributeUpdate
   hfid: [String]
   id: String
+  instances: [RelatedNodeInput]
   member_of_groups: [RelatedNodeInput]
   name: TextAttributeUpdate
   """GraphQL query parameters for the generator"""
@@ -3177,6 +3194,7 @@ input CoreGeneratorDefinitionUpdateInput {
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """
@@ -3211,6 +3229,7 @@ input CoreGeneratorDefinitionUpsertInput {
   fingerprint: TextAttributeUpdate
   hfid: [String]
   id: String
+  instances: [RelatedNodeInput]
   member_of_groups: [RelatedNodeInput]
   name: TextAttributeUpdate
   """GraphQL query parameters for the generator"""
@@ -3219,6 +3238,7 @@ input CoreGeneratorDefinitionUpsertInput {
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   targets: RelatedNodeInput
+  validators: [RelatedNodeInput]
 }
 
 """Group of nodes that are created by a generator. (local)"""
@@ -6872,6 +6892,7 @@ input CoreThreadUpdateInput {
 
 """A file rendered from a Jinja2 template"""
 type CoreTransformJinja2 implements CoreNode & CoreTransformation {
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -6908,6 +6929,7 @@ type CoreTransformJinja2Create {
 }
 
 input CoreTransformJinja2CreateInput {
+  artifact_definitions: [RelatedNodeInput]
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -6945,6 +6967,7 @@ type CoreTransformJinja2Update {
 }
 
 input CoreTransformJinja2UpdateInput {
+  artifact_definitions: [RelatedNodeInput]
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -6978,6 +7001,7 @@ type CoreTransformJinja2Upsert {
 }
 
 input CoreTransformJinja2UpsertInput {
+  artifact_definitions: [RelatedNodeInput]
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -7006,6 +7030,7 @@ input CoreTransformJinja2UpsertInput {
 
 """A transform function written in Python"""
 type CoreTransformPython implements CoreNode & CoreTransformation {
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """Name of the Python class implementing the transformation (required)"""
   class_name: TextAttribute
   """Whether to convert the GraphQL response to SDK objects"""
@@ -7046,6 +7071,7 @@ type CoreTransformPythonCreate {
 }
 
 input CoreTransformPythonCreateInput {
+  artifact_definitions: [RelatedNodeInput]
   """Name of the Python class implementing the transformation"""
   class_name: TextAttributeCreate
   """Whether to convert the GraphQL response to SDK objects"""
@@ -7087,6 +7113,7 @@ type CoreTransformPythonUpdate {
 }
 
 input CoreTransformPythonUpdateInput {
+  artifact_definitions: [RelatedNodeInput]
   """Name of the Python class implementing the transformation"""
   class_name: TextAttributeUpdate
   """Whether to convert the GraphQL response to SDK objects"""
@@ -7124,6 +7151,7 @@ type CoreTransformPythonUpsert {
 }
 
 input CoreTransformPythonUpsertInput {
+  artifact_definitions: [RelatedNodeInput]
   """Name of the Python class implementing the transformation"""
   class_name: TextAttributeUpdate
   """Whether to convert the GraphQL response to SDK objects"""
@@ -7156,6 +7184,7 @@ input CoreTransformPythonUpsertInput {
 
 """Generic Transformation Object."""
 interface CoreTransformation {
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -7190,6 +7219,7 @@ type CoreTransformationUpdate {
 }
 
 input CoreTransformationUpdateInput {
+  artifact_definitions: [RelatedNodeInput]
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -14331,6 +14361,41 @@ type Query {
     artifact_name__source__id: ID
     artifact_name__value: String
     artifact_name__values: [String]
+    artifacts__checksum__is_protected: Boolean
+    artifacts__checksum__owner__id: ID
+    artifacts__checksum__source__id: ID
+    artifacts__checksum__value: String
+    artifacts__checksum__values: [String]
+    artifacts__content_type__is_protected: Boolean
+    artifacts__content_type__owner__id: ID
+    artifacts__content_type__source__id: ID
+    artifacts__content_type__value: String
+    artifacts__content_type__values: [String]
+    artifacts__display_label__isnull: Boolean
+    artifacts__display_label__value: String
+    artifacts__display_label__values: [String]
+    artifacts__ids: [ID]
+    artifacts__isnull: Boolean
+    artifacts__name__is_protected: Boolean
+    artifacts__name__owner__id: ID
+    artifacts__name__source__id: ID
+    artifacts__name__value: String
+    artifacts__name__values: [String]
+    artifacts__parameters__is_protected: Boolean
+    artifacts__parameters__owner__id: ID
+    artifacts__parameters__source__id: ID
+    artifacts__parameters__value: GenericScalar
+    artifacts__parameters__values: [GenericScalar]
+    artifacts__status__is_protected: Boolean
+    artifacts__status__owner__id: ID
+    artifacts__status__source__id: ID
+    artifacts__status__value: String
+    artifacts__status__values: [String]
+    artifacts__storage_id__is_protected: Boolean
+    artifacts__storage_id__owner__id: ID
+    artifacts__storage_id__source__id: ID
+    artifacts__storage_id__value: String
+    artifacts__storage_id__values: [String]
     content_type__is_protected: Boolean
     content_type__isnull: Boolean
     content_type__owner__id: ID
@@ -14481,6 +14546,36 @@ type Query {
     transformation__timeout__source__id: ID
     transformation__timeout__value: BigInt
     transformation__timeout__values: [BigInt]
+    validators__completed_at__is_protected: Boolean
+    validators__completed_at__owner__id: ID
+    validators__completed_at__source__id: ID
+    validators__completed_at__value: DateTime
+    validators__completed_at__values: [DateTime]
+    validators__conclusion__is_protected: Boolean
+    validators__conclusion__owner__id: ID
+    validators__conclusion__source__id: ID
+    validators__conclusion__value: String
+    validators__conclusion__values: [String]
+    validators__display_label__isnull: Boolean
+    validators__display_label__value: String
+    validators__display_label__values: [String]
+    validators__ids: [ID]
+    validators__isnull: Boolean
+    validators__label__is_protected: Boolean
+    validators__label__owner__id: ID
+    validators__label__source__id: ID
+    validators__label__value: String
+    validators__label__values: [String]
+    validators__started_at__is_protected: Boolean
+    validators__started_at__owner__id: ID
+    validators__started_at__source__id: ID
+    validators__started_at__value: DateTime
+    validators__started_at__values: [DateTime]
+    validators__state__is_protected: Boolean
+    validators__state__owner__id: ID
+    validators__state__source__id: ID
+    validators__state__value: String
+    validators__state__values: [String]
   ): PaginatedCoreArtifactDefinition!
   CoreArtifactTarget(
     any__is_protected: Boolean
@@ -15592,6 +15687,36 @@ type Query {
     timeout__source__id: ID
     timeout__value: BigInt
     timeout__values: [BigInt]
+    validators__completed_at__is_protected: Boolean
+    validators__completed_at__owner__id: ID
+    validators__completed_at__source__id: ID
+    validators__completed_at__value: DateTime
+    validators__completed_at__values: [DateTime]
+    validators__conclusion__is_protected: Boolean
+    validators__conclusion__owner__id: ID
+    validators__conclusion__source__id: ID
+    validators__conclusion__value: String
+    validators__conclusion__values: [String]
+    validators__display_label__isnull: Boolean
+    validators__display_label__value: String
+    validators__display_label__values: [String]
+    validators__ids: [ID]
+    validators__isnull: Boolean
+    validators__label__is_protected: Boolean
+    validators__label__owner__id: ID
+    validators__label__source__id: ID
+    validators__label__value: String
+    validators__label__values: [String]
+    validators__started_at__is_protected: Boolean
+    validators__started_at__owner__id: ID
+    validators__started_at__source__id: ID
+    validators__started_at__value: DateTime
+    validators__started_at__values: [DateTime]
+    validators__state__is_protected: Boolean
+    validators__state__owner__id: ID
+    validators__state__source__id: ID
+    validators__state__value: String
+    validators__state__values: [String]
   ): PaginatedCoreCheckDefinition!
   CoreComment(
     any__is_protected: Boolean
@@ -17260,6 +17385,21 @@ type Query {
     fingerprint__values: [String]
     hfid: [String]
     ids: [ID]
+    instances__display_label__isnull: Boolean
+    instances__display_label__value: String
+    instances__display_label__values: [String]
+    instances__ids: [ID]
+    instances__isnull: Boolean
+    instances__name__is_protected: Boolean
+    instances__name__owner__id: ID
+    instances__name__source__id: ID
+    instances__name__value: String
+    instances__name__values: [String]
+    instances__status__is_protected: Boolean
+    instances__status__owner__id: ID
+    instances__status__source__id: ID
+    instances__status__value: String
+    instances__status__values: [String]
     limit: Int
     member_of_groups__description__value: String
     member_of_groups__description__values: [String]
@@ -17432,6 +17572,36 @@ type Query {
     targets__name__source__id: ID
     targets__name__value: String
     targets__name__values: [String]
+    validators__completed_at__is_protected: Boolean
+    validators__completed_at__owner__id: ID
+    validators__completed_at__source__id: ID
+    validators__completed_at__value: DateTime
+    validators__completed_at__values: [DateTime]
+    validators__conclusion__is_protected: Boolean
+    validators__conclusion__owner__id: ID
+    validators__conclusion__source__id: ID
+    validators__conclusion__value: String
+    validators__conclusion__values: [String]
+    validators__display_label__isnull: Boolean
+    validators__display_label__value: String
+    validators__display_label__values: [String]
+    validators__ids: [ID]
+    validators__isnull: Boolean
+    validators__label__is_protected: Boolean
+    validators__label__owner__id: ID
+    validators__label__source__id: ID
+    validators__label__value: String
+    validators__label__values: [String]
+    validators__started_at__is_protected: Boolean
+    validators__started_at__owner__id: ID
+    validators__started_at__source__id: ID
+    validators__started_at__value: DateTime
+    validators__started_at__values: [DateTime]
+    validators__state__is_protected: Boolean
+    validators__state__owner__id: ID
+    validators__state__source__id: ID
+    validators__state__value: String
+    validators__state__values: [String]
   ): PaginatedCoreGeneratorDefinition!
   CoreGeneratorGroup(
     any__is_protected: Boolean
@@ -23762,6 +23932,36 @@ type Query {
     any__source__id: ID
     any__value: String
     any__values: [String]
+    artifact_definitions__artifact_name__is_protected: Boolean
+    artifact_definitions__artifact_name__owner__id: ID
+    artifact_definitions__artifact_name__source__id: ID
+    artifact_definitions__artifact_name__value: String
+    artifact_definitions__artifact_name__values: [String]
+    artifact_definitions__content_type__is_protected: Boolean
+    artifact_definitions__content_type__owner__id: ID
+    artifact_definitions__content_type__source__id: ID
+    artifact_definitions__content_type__value: String
+    artifact_definitions__content_type__values: [String]
+    artifact_definitions__description__is_protected: Boolean
+    artifact_definitions__description__owner__id: ID
+    artifact_definitions__description__source__id: ID
+    artifact_definitions__description__value: String
+    artifact_definitions__description__values: [String]
+    artifact_definitions__display_label__isnull: Boolean
+    artifact_definitions__display_label__value: String
+    artifact_definitions__display_label__values: [String]
+    artifact_definitions__ids: [ID]
+    artifact_definitions__isnull: Boolean
+    artifact_definitions__name__is_protected: Boolean
+    artifact_definitions__name__owner__id: ID
+    artifact_definitions__name__source__id: ID
+    artifact_definitions__name__value: String
+    artifact_definitions__name__values: [String]
+    artifact_definitions__parameters__is_protected: Boolean
+    artifact_definitions__parameters__owner__id: ID
+    artifact_definitions__parameters__source__id: ID
+    artifact_definitions__parameters__value: GenericScalar
+    artifact_definitions__parameters__values: [GenericScalar]
     dependencies__is_protected: Boolean
     dependencies__isnull: Boolean
     dependencies__owner__id: ID
@@ -23972,6 +24172,36 @@ type Query {
     any__source__id: ID
     any__value: String
     any__values: [String]
+    artifact_definitions__artifact_name__is_protected: Boolean
+    artifact_definitions__artifact_name__owner__id: ID
+    artifact_definitions__artifact_name__source__id: ID
+    artifact_definitions__artifact_name__value: String
+    artifact_definitions__artifact_name__values: [String]
+    artifact_definitions__content_type__is_protected: Boolean
+    artifact_definitions__content_type__owner__id: ID
+    artifact_definitions__content_type__source__id: ID
+    artifact_definitions__content_type__value: String
+    artifact_definitions__content_type__values: [String]
+    artifact_definitions__description__is_protected: Boolean
+    artifact_definitions__description__owner__id: ID
+    artifact_definitions__description__source__id: ID
+    artifact_definitions__description__value: String
+    artifact_definitions__description__values: [String]
+    artifact_definitions__display_label__isnull: Boolean
+    artifact_definitions__display_label__value: String
+    artifact_definitions__display_label__values: [String]
+    artifact_definitions__ids: [ID]
+    artifact_definitions__isnull: Boolean
+    artifact_definitions__name__is_protected: Boolean
+    artifact_definitions__name__owner__id: ID
+    artifact_definitions__name__source__id: ID
+    artifact_definitions__name__value: String
+    artifact_definitions__name__values: [String]
+    artifact_definitions__parameters__is_protected: Boolean
+    artifact_definitions__parameters__owner__id: ID
+    artifact_definitions__parameters__source__id: ID
+    artifact_definitions__parameters__value: GenericScalar
+    artifact_definitions__parameters__values: [GenericScalar]
     class_name__is_protected: Boolean
     class_name__isnull: Boolean
     class_name__owner__id: ID
@@ -24194,6 +24424,36 @@ type Query {
     any__source__id: ID
     any__value: String
     any__values: [String]
+    artifact_definitions__artifact_name__is_protected: Boolean
+    artifact_definitions__artifact_name__owner__id: ID
+    artifact_definitions__artifact_name__source__id: ID
+    artifact_definitions__artifact_name__value: String
+    artifact_definitions__artifact_name__values: [String]
+    artifact_definitions__content_type__is_protected: Boolean
+    artifact_definitions__content_type__owner__id: ID
+    artifact_definitions__content_type__source__id: ID
+    artifact_definitions__content_type__value: String
+    artifact_definitions__content_type__values: [String]
+    artifact_definitions__description__is_protected: Boolean
+    artifact_definitions__description__owner__id: ID
+    artifact_definitions__description__source__id: ID
+    artifact_definitions__description__value: String
+    artifact_definitions__description__values: [String]
+    artifact_definitions__display_label__isnull: Boolean
+    artifact_definitions__display_label__value: String
+    artifact_definitions__display_label__values: [String]
+    artifact_definitions__ids: [ID]
+    artifact_definitions__isnull: Boolean
+    artifact_definitions__name__is_protected: Boolean
+    artifact_definitions__name__owner__id: ID
+    artifact_definitions__name__source__id: ID
+    artifact_definitions__name__value: String
+    artifact_definitions__name__values: [String]
+    artifact_definitions__parameters__is_protected: Boolean
+    artifact_definitions__parameters__owner__id: ID
+    artifact_definitions__parameters__source__id: ID
+    artifact_definitions__parameters__value: GenericScalar
+    artifact_definitions__parameters__values: [GenericScalar]
     dependencies__is_protected: Boolean
     dependencies__isnull: Boolean
     dependencies__owner__id: ID

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -3709,6 +3709,7 @@ type CoreGraphQLQuery implements CoreNode {
   operations: ListAttribute
   """The GraphQL query string (required)"""
   query: TextAttribute
+  query_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreGraphQLQueryGroup!
   repository: NestedEdgedCoreGenericRepository!
   subscriber_of_groups(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], group_type__is_protected: Boolean, group_type__owner__id: ID, group_type__source__id: ID, group_type__value: String, group_type__values: [String], ids: [ID], isnull: Boolean, label__is_protected: Boolean, label__owner__id: ID, label__source__id: ID, label__value: String, label__values: [String], limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedCoreGroup!
   tags(description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput): NestedPaginatedBuiltinTag!
@@ -3731,6 +3732,7 @@ input CoreGraphQLQueryCreateInput {
   name: TextAttributeCreate
   """The GraphQL query string"""
   query: TextAttributeCreate
+  query_groups: [RelatedNodeInput]
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   tags: [RelatedNodeInput]
@@ -3853,6 +3855,7 @@ input CoreGraphQLQueryUpdateInput {
   name: TextAttributeUpdate
   """The GraphQL query string"""
   query: TextAttributeUpdate
+  query_groups: [RelatedNodeInput]
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   tags: [RelatedNodeInput]
@@ -3874,6 +3877,7 @@ input CoreGraphQLQueryUpsertInput {
   name: TextAttributeUpdate
   """The GraphQL query string"""
   query: TextAttributeUpdate
+  query_groups: [RelatedNodeInput]
   repository: RelatedNodeInput
   subscriber_of_groups: [RelatedNodeInput]
   tags: [RelatedNodeInput]
@@ -6892,7 +6896,7 @@ input CoreThreadUpdateInput {
 
 """A file rendered from a Jinja2 template"""
 type CoreTransformJinja2 implements CoreNode & CoreTransformation {
-  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], fingerprint__is_protected: Boolean, fingerprint__owner__id: ID, fingerprint__source__id: ID, fingerprint__value: String, fingerprint__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -7030,7 +7034,7 @@ input CoreTransformJinja2UpsertInput {
 
 """A transform function written in Python"""
 type CoreTransformPython implements CoreNode & CoreTransformation {
-  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], fingerprint__is_protected: Boolean, fingerprint__owner__id: ID, fingerprint__source__id: ID, fingerprint__value: String, fingerprint__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """Name of the Python class implementing the transformation (required)"""
   class_name: TextAttribute
   """Whether to convert the GraphQL response to SDK objects"""
@@ -7184,7 +7188,7 @@ input CoreTransformPythonUpsertInput {
 
 """Generic Transformation Object."""
 interface CoreTransformation {
-  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
+  artifact_definitions(artifact_name__is_protected: Boolean, artifact_name__owner__id: ID, artifact_name__source__id: ID, artifact_name__value: String, artifact_name__values: [String], content_type__is_protected: Boolean, content_type__owner__id: ID, content_type__source__id: ID, content_type__value: String, content_type__values: [String], description__is_protected: Boolean, description__owner__id: ID, description__source__id: ID, description__value: String, description__values: [String], display_label__isnull: Boolean, display_label__value: String, display_label__values: [String], fingerprint__is_protected: Boolean, fingerprint__owner__id: ID, fingerprint__source__id: ID, fingerprint__value: String, fingerprint__values: [String], ids: [ID], isnull: Boolean, limit: Int, name__is_protected: Boolean, name__owner__id: ID, name__source__id: ID, name__value: String, name__values: [String], offset: Int, order: OrderInput, parameters__is_protected: Boolean, parameters__owner__id: ID, parameters__source__id: ID, parameters__value: GenericScalar, parameters__values: [GenericScalar]): NestedPaginatedCoreArtifactDefinition!
   """
   Canonical repo-relative paths feeding this transform's output. Null falls back to legacy file gate.
   """
@@ -18726,6 +18730,36 @@ type Query {
     query__source__id: ID
     query__value: String
     query__values: [String]
+    query_groups__description__is_protected: Boolean
+    query_groups__description__owner__id: ID
+    query_groups__description__source__id: ID
+    query_groups__description__value: String
+    query_groups__description__values: [String]
+    query_groups__display_label__isnull: Boolean
+    query_groups__display_label__value: String
+    query_groups__display_label__values: [String]
+    query_groups__group_type__is_protected: Boolean
+    query_groups__group_type__owner__id: ID
+    query_groups__group_type__source__id: ID
+    query_groups__group_type__value: String
+    query_groups__group_type__values: [String]
+    query_groups__ids: [ID]
+    query_groups__isnull: Boolean
+    query_groups__label__is_protected: Boolean
+    query_groups__label__owner__id: ID
+    query_groups__label__source__id: ID
+    query_groups__label__value: String
+    query_groups__label__values: [String]
+    query_groups__name__is_protected: Boolean
+    query_groups__name__owner__id: ID
+    query_groups__name__source__id: ID
+    query_groups__name__value: String
+    query_groups__name__values: [String]
+    query_groups__parameters__is_protected: Boolean
+    query_groups__parameters__owner__id: ID
+    query_groups__parameters__source__id: ID
+    query_groups__parameters__value: GenericScalar
+    query_groups__parameters__values: [GenericScalar]
     repository__description__is_protected: Boolean
     repository__description__owner__id: ID
     repository__description__source__id: ID
@@ -23950,6 +23984,11 @@ type Query {
     artifact_definitions__display_label__isnull: Boolean
     artifact_definitions__display_label__value: String
     artifact_definitions__display_label__values: [String]
+    artifact_definitions__fingerprint__is_protected: Boolean
+    artifact_definitions__fingerprint__owner__id: ID
+    artifact_definitions__fingerprint__source__id: ID
+    artifact_definitions__fingerprint__value: String
+    artifact_definitions__fingerprint__values: [String]
     artifact_definitions__ids: [ID]
     artifact_definitions__isnull: Boolean
     artifact_definitions__name__is_protected: Boolean
@@ -24190,6 +24229,11 @@ type Query {
     artifact_definitions__display_label__isnull: Boolean
     artifact_definitions__display_label__value: String
     artifact_definitions__display_label__values: [String]
+    artifact_definitions__fingerprint__is_protected: Boolean
+    artifact_definitions__fingerprint__owner__id: ID
+    artifact_definitions__fingerprint__source__id: ID
+    artifact_definitions__fingerprint__value: String
+    artifact_definitions__fingerprint__values: [String]
     artifact_definitions__ids: [ID]
     artifact_definitions__isnull: Boolean
     artifact_definitions__name__is_protected: Boolean
@@ -24442,6 +24486,11 @@ type Query {
     artifact_definitions__display_label__isnull: Boolean
     artifact_definitions__display_label__value: String
     artifact_definitions__display_label__values: [String]
+    artifact_definitions__fingerprint__is_protected: Boolean
+    artifact_definitions__fingerprint__owner__id: ID
+    artifact_definitions__fingerprint__source__id: ID
+    artifact_definitions__fingerprint__value: String
+    artifact_definitions__fingerprint__values: [String]
     artifact_definitions__ids: [ID]
     artifact_definitions__isnull: Boolean
     artifact_definitions__name__is_protected: Boolean


### PR DESCRIPTION
## Problem

Deleting a repository fails because the objects it imports/generates (transforms, checks, GraphQL queries, generators → artifact definitions → artifacts/validators, generator definitions → instances/validators, check definitions → user validators) are attached through **mandatory** relationships. Infrahub correctly refuses to orphan a mandatory child, so users are forced to delete the whole dependency tree by hand, leaf-first. Tracked in #3076.

Infrahub already has an `on_delete` cascade capability, but it was never wired to the repository-managed relationships.

## Solution

1. **Wire the repository ownership tree with `on_delete=CASCADE`.** Mark the repository's owner-side relationships (`transformations`, `queries`, `checks`, `generators`) as `CASCADE`, and add the missing parent-side relationships so the cascade reaches every leaf:
   - `Transformation → ArtifactDefinition`
   - `ArtifactDefinition → Artifact`, `→ ArtifactValidator`
   - `GeneratorDefinition → GeneratorInstance`, `→ GeneratorValidator`
   - `CheckDefinition → UserValidator`
   - `GraphQLQuery → GraphQLQueryGroup`

   Each new relationship reuses (or symmetrically auto-derives) its child-side identifier, so it maps to the existing edge — no data migration. This mirrors the existing `ArtifactTarget.artifacts` / `Validator.checks` cascade pattern.

2. **Make the mandatory-orphan check deep.** `NodeDeleteIndex` now seeds its dependent-check from every cascade-reachable kind, not just the explicitly-deleted kind. Previously the check was shallow, so an incomplete cascade would *silently orphan* a mandatory child. Now, if a cascaded node is still referenced by a mandatory relationship from an object outside the delete set, deletion fails with a clear error instead of corrupting data. (This also fixed a latent re-queue bug in the cascade traversal for leaf kinds.)

3. **Cascade `GraphQLQuery → GraphQLQueryGroup`.** `CoreGraphQLQueryGroup.query` is a mandatory back-reference and these groups are created routinely by the artifact/generator/computed-attribute pipelines. Without this, deleting a repository whose queries had ever run would be blocked — moving the wall of manual deletions one node over.

## Accepted trade-off

Deleting a repository (or an artifact/generator/check definition directly) now also deletes validators attached to proposed changes and their generated artifacts/instances. This is the intended ownership semantics and the alternative is the manual wall-of-deletions this fixes.

## Testing

- **Unit** (`test_delete_validator.py`): asserts the cascade closure from both `ReadOnlyRepository` and `Repository` reaches every managed leaf (`Artifact`, `ArtifactValidator`, `GeneratorInstance`, `GeneratorValidator`, `UserValidator`, `GraphQLQueryGroup`).
- **Component** (`test_node_manager_delete.py`, against live Neo4j): deleting a repository cascades through transform → artifact definition → artifact, plus check/generator definitions and generator instances; deleting a repository with a `GraphQLQueryGroup` succeeds and removes the query + group; an out-of-tree mandatory referrer to a cascaded node raises `ValidationError` instead of silently orphaning.
- Regenerated `protocols.py`, `schema.graphql`, and frontend GraphQL types; schema validation and ruff/ty/mypy all pass.

## Migration

**No graph migration required.** `on_delete` values and relationship definitions are reconciled into the graph by `update_core_schema` during `infrahub upgrade` (it diffs the code-defined candidate schema against the DB and upserts changed attribute values + new relationships), and the delete path reads `on_delete` from the in-memory registry that is populated from that reconciled graph. Graph migrations (`mNNN_*`) are only needed for structural changes to the meta-schema itself (e.g. `m006` added the `on_delete` *field* to `SchemaRelationship`) — not for changing values on existing relationships or adding new ones. `GRAPH_VERSION` stays at 73.

## Related issues

- Closes #3076 — the bug this fixes (repository-managed objects not cleaned up on delete).
- #2767 (closed) — the `on_delete` cascade schema capability this builds on; #2680 (closed) — its parent "schema integrity on node deletion" task. Both carry `state/ref`, so there is likely a corresponding **INFP** Jira ticket tracking the on_delete/cascade work worth linking.
- #6849 (open) — related race-condition in cascade delete (not addressed here). #9790 (open) — sibling stale-artifact cleanup gap (different trigger).
