### PR TITLE
Extract FilterPicker count badge to shared component with new design

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-picker.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { useRef, useState } from "react";
 import type { Key } from "react-aria-components";
 
+import { CountBadge } from "@/shared/components/buttons/count-badge";
 import { classNames } from "@/shared/utils/common";
 
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
@@ -59,10 +60,10 @@ export function FilterPicker({ schema, filters }: FilterPickerProps) {
           if (!isOpen) setSelectedField(null);
         }}
       >
-        <Button variant="ghost" size="sm" className="rounded-xl border-gray-300">
+        <Button variant="outline" size="sm" className="rounded-xl">
           <Icon icon="mdi:filter-variant" className="text-base" />
           Filter
-          {filterCount > 0 && <FilterCountBadge count={filterCount} />}
+          {filterCount > 0 && <CountBadge count={filterCount} />}
         </Button>
 
         <Popover
@@ -135,14 +136,6 @@ function FilterPickerItem({ definition, hasActiveFilter, ref }: FilterPickerItem
       {hasActiveFilter && <ActiveFilterIndicator />}
       <ChevronRightIcon className={classNames("size-3.5")} />
     </ListBoxItem>
-  );
-}
-
-function FilterCountBadge({ count }: { count: number }) {
-  return (
-    <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-stone-200 px-1 text-stone-600 text-xs">
-      {count}
-    </span>
   );
 }
 

--- a/frontend/app/src/shared/components/buttons/count-badge.tsx
+++ b/frontend/app/src/shared/components/buttons/count-badge.tsx
@@ -1,0 +1,11 @@
+interface CountBadgeProps {
+  count: number;
+}
+
+export function CountBadge({ count }: CountBadgeProps) {
+  return (
+    <span className="inset-shadow-[0_1px_0_rgba(255,255,255,0.9)] inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full border border-cyan-600/30 bg-gradient-to-b from-cyan-50 to-white px-1 font-medium text-cyan-700 text-xs tabular-nums shadow-xs">
+      {count}
+    </span>
+  );
+}


### PR DESCRIPTION
To reuse the same count badge in SortPicker

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted the FilterPicker count badge into a shared `CountBadge` component with a new cyan badge design. Switched the Filter button to `outline` for consistent styling.

- **Refactors**
  - Added `CountBadge` (`shared/components/buttons/count-badge.tsx`) and used it in `FilterPicker`.
  - Removed local `FilterCountBadge` and changed button variant from `ghost` to `outline`.

<sup>Written for commit 6163eb782e1d4932b5fc3db3a4b7b22096075eae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

