### PR TITLE
fix(backend): align database name validation with Neo4j naming rules

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -38,7 +38,8 @@ if TYPE_CHECKING:
 
 log = get_logger()
 
-VALID_DATABASE_NAME_REGEX = r"^[a-z][a-z0-9\.]+$"
+# Neo4j naming rules: 3-63 chars, alphanumeric start/end, dots and dashes allowed within.
+VALID_DATABASE_NAME_REGEX = r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$"
 THIRTY_DAYS_IN_SECONDS = 3600 * 24 * 30
 
 

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -469,7 +469,9 @@ class InfrahubDatabase:
 
 async def create_database(driver: AsyncDriver, database_name: str) -> None:
     default_db = driver.session()
-    await default_db.run(f"CREATE DATABASE {database_name} WAIT")
+    # Backtick-quote so dashes and dots in the name are not parsed as Cypher operators.
+    escaped_name = database_name.replace("`", "``")
+    await default_db.run(f"CREATE DATABASE `{escaped_name}` WAIT")
 
 
 async def validate_database(

--- a/backend/tests/unit/config/test_config.py
+++ b/backend/tests/unit/config/test_config.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from infrahub.config import (
     SETTINGS,
+    DatabaseSettings,
     GitSettings,
     MainSettings,
     SecurityOAuth2Provider1,
@@ -196,6 +197,53 @@ def test_groups_claim_is_stripped_oauth2(case: GroupsClaimStripCase) -> None:
 def test_groups_claim_is_stripped_oidc(case: GroupsClaimStripCase) -> None:
     assert _build_oidc_provider(groups_claim=case.value).groups_claim == case.expected
     assert _build_oidc_provider_2(groups_claim=case.value).groups_claim == case.expected
+
+
+@dataclass
+class DatabaseNameCase:
+    name: str
+    value: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        DatabaseNameCase(name="simple", value="infrahub"),
+        DatabaseNameCase(name="minimum_length", value="abc"),
+        DatabaseNameCase(name="with_digits", value="infrahub2"),
+        DatabaseNameCase(name="leading_digit", value="1nfrahub"),
+        DatabaseNameCase(name="with_dash", value="my-database"),
+        DatabaseNameCase(name="with_dot", value="my.database"),
+        DatabaseNameCase(name="dash_and_dot", value="my-infrahub.db"),
+        DatabaseNameCase(name="maximum_length", value="a" * 63),
+        DatabaseNameCase(name="default_neo4j", value="neo4j"),
+        DatabaseNameCase(name="default_memgraph", value="memgraph"),
+    ],
+    ids=lambda case: case.name,
+)
+def test_database_name_accepts_valid_neo4j_names(case: DatabaseNameCase) -> None:
+    assert DatabaseSettings(database=case.value).database == case.value
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        DatabaseNameCase(name="too_short", value="ab"),
+        DatabaseNameCase(name="too_long", value="a" * 64),
+        DatabaseNameCase(name="trailing_dot", value="infrahub."),
+        DatabaseNameCase(name="trailing_dash", value="infrahub-"),
+        DatabaseNameCase(name="leading_dot", value=".infrahub"),
+        DatabaseNameCase(name="leading_dash", value="-infrahub"),
+        DatabaseNameCase(name="uppercase", value="Infrahub"),
+        DatabaseNameCase(name="underscore", value="my_database"),
+        DatabaseNameCase(name="space", value="my database"),
+        DatabaseNameCase(name="backtick", value="my`database"),
+    ],
+    ids=lambda case: case.name,
+)
+def test_database_name_rejects_invalid_neo4j_names(case: DatabaseNameCase) -> None:
+    with pytest.raises(ValidationError, match="String should match pattern"):
+        DatabaseSettings(database=case.value)
 
 
 def test_fixture_loaded_providers_have_expected_groups_claim(helper: TestHelper) -> None:

--- a/changelog/database-name-neo4j-validation.fixed.md
+++ b/changelog/database-name-neo4j-validation.fixed.md
@@ -1,0 +1,1 @@
+The `INFRAHUB_DB_DATABASE` name validation now matches Neo4j's naming rules: names may contain dashes, must be 3-63 characters long, and may no longer end with a dot. Database names that contain dashes or dots are now correctly quoted when the database is created, so they no longer fail with a Cypher syntax error.


### PR DESCRIPTION
# Why

Infrahub's `INFRAHUB_DB_DATABASE` name validation regex (`^[a-z][a-z0-9\.]+$`) did not match [Neo4j's database naming rules](https://neo4j.com/docs/operations-manual/current/database-administration/standard-databases/naming-databases/). It **rejected valid names** (anything containing a dash), **accepted invalid ones** (names ending in a dot), and enforced **no length bounds** (Neo4j requires 3–63 characters). Separately, even a name that passed validation and contained a dash or dot would fail at database-creation time, because the name was interpolated unquoted into a `CREATE DATABASE` Cypher statement where `-` and `.` are parsed as operators.

Goal: make the accepted set of database names exactly the set Neo4j accepts, and make every accepted name actually usable end-to-end.

## What changed

Behavioral changes:
- Database names may now contain **dashes** and may **start with a digit**, matching Neo4j.
- Names must be **3–63 characters** and may **no longer end with a dot or dash** (previously a trailing dot was wrongly accepted).
- Names containing dashes/dots are now **backtick-quoted** in `CREATE DATABASE`, so they create successfully instead of failing with a Cypher syntax error.

Implementation notes:
- Regex is now `^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`. Kept lowercase-only on purpose: Neo4j normalizes names to lowercase, so accepting uppercase would make the configured value diverge from the actual database name.
- `create_database` backtick-quotes (and backtick-escapes) the name. This path is only reached on Neo4j's `DatabaseNotFound`, so the memgraph backend is unaffected.

What stayed the same: no schema changes, no API contract changes. The defaults (`neo4j`, `memgraph`) remain valid.

## How to review

- `backend/infrahub/config.py` — the regex and rationale comment.
- `backend/infrahub/database/__init__.py` — the `CREATE DATABASE` quoting.
- `backend/tests/unit/config/test_config.py` — 20 new parametrized valid/invalid cases.

## How to test

```bash
uv run pytest backend/tests/unit/config/test_config.py -q
```

Validated end-to-end against a live `neo4j:2025.10.1-enterprise` container by driving Infrahub's real `get_db() → validate_database() → create_database()` path: database names `my-database`, `infra-hub-1`, `1nfrahub`, `my-infrahub.db`, and `my.database` were all created and came up `online`, and reconnecting to an existing dash-named database works without recreating it. Confirmed that the unquoted `CREATE DATABASE my-db WAIT` fails with a Cypher syntax error while the backtick-quoted form succeeds — i.e. the quoting fix is required, not cosmetic.

## Impact & rollout

- **Backward compatibility:** Strictly widens the set of accepted names, except that names ending in a dot are now rejected. Such a name would previously have failed at `CREATE DATABASE` anyway, so no working configuration regresses.
- **Config/env changes:** Affects validation of the existing `INFRAHUB_DB_DATABASE` setting; no new settings.
- **Deployment notes:** Safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `INFRAHUB_DB_DATABASE` validation with Neo4j’s naming rules and quotes database names so ones with dashes or dots create successfully. Expands valid names while enforcing length and start/end characters to prevent Cypher errors.

- **Bug Fixes**
  - Validate with `^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$` (3–63 chars; allow dash/dot; allow leading digits; no leading/trailing dot/dash; lowercase only).
  - Backtick-quote and escape names in `CREATE DATABASE` so names with dashes/dots succeed.
  - Added unit tests for valid/invalid cases; no schema or API changes; defaults unchanged.

<sup>Written for commit 713452feb2368d21b36478565794128818f4705a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

