### PR TITLE
prep release 1.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.9.10](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.10) - 2026-07-07
+
+### Fixed
+
+- Fixed the branch merge rollback so that a database error (such as an out-of-memory error) raised
+  partway through the merge queries no longer leaves partially merged data on the destination
+  branch. The rollback now removes every change stamped with the merge timestamp even when the
+  failure occurred before the merge finished writing all of its batches.
+
 ## [Infrahub - v1.9.9](https://github.com/opsmill/infrahub/tree/infrahub-v1.9.9) - 2026-06-23
 
 ### Security

--- a/changelog/+merge-failure-rollback.fixed.md
+++ b/changelog/+merge-failure-rollback.fixed.md
@@ -1,4 +1,0 @@
-Fixed the branch merge rollback so that a database error (such as an out-of-memory error) raised
-partway through the merge queries no longer leaves partially merged data on the destination
-branch. The rollback now removes every change stamped with the merge timestamp even when the
-failure occurred before the merge finished writing all of its batches.

--- a/docs/docs/release-notes/infrahub/release-1_9_10.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_9_10.mdx
@@ -1,0 +1,26 @@
+---
+title: Release 1.9.10
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.9.10</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>July 7th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.9.10](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.9.10)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fixed the branch merge rollback so that a database error (such as an out-of-memory error) raised
+  partway through the merge queries no longer leaves partially merged data on the destination
+  branch. The rollback now removes every change stamped with the merge timestamp even when the
+  failure occurred before the merge finished writing all of its batches.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -641,6 +641,7 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 { type: 'doc', id: 'release-notes/infrahub/docs-restructure', label: 'Documentation restructure' },
+                'release-notes/infrahub/release-1_9_10',
                 'release-notes/infrahub/release-1_9_9',
                 'release-notes/infrahub/release-1_9_8',
                 'release-notes/infrahub/release-1_9_7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.9.9"
+version = "1.9.10"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.9.9"
+version = "1.9.10"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.9"
+version = "1.9.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.9.9"
+version = "1.9.10"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prep for the 1.9.10 release: bumped package versions, added release notes, and updated docs navigation. This release includes a fix to ensure merge rollback fully cleans up partial merges if a database error occurs.

- **Dependencies**
  - Bumped `infrahub-server` and `infrahub-testcontainers` to 1.9.10.
  - Updated `uv.lock` and `python_testcontainers/uv.lock`.

<sup>Written for commit a7972032ca216b27f3ace0f825a9a48fbf08f37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

