### PR TITLE
fix(webhook): honor cancellation during retry wait and stop crashing waiting runs

### DIFF
--- a/backend/infrahub/task_manager/flow_run/prefect_client.py
+++ b/backend/infrahub/task_manager/flow_run/prefect_client.py
@@ -7,6 +7,8 @@ from prefect.client.schemas.filters import ArtifactFilter, FlowFilter, FlowRunFi
 from prefect.client.schemas.objects import Artifact, Flow, FlowRun, Log, StateType
 from prefect.client.schemas.sorting import FlowRunSort
 
+CANCEL_REQUEST_STATE_TYPES = frozenset({StateType.CANCELLING, StateType.CANCELLED})
+
 
 class FlowRunQuerying(Protocol):
     async def read_flow_runs(
@@ -38,6 +40,17 @@ class FlowRunMaintenance(Protocol):
 
     async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> StateType | None:
         """Request a state transition, returning the state the run ended in after orchestration."""
+        ...
+
+
+class FlowRunCancellationReading(Protocol):
+    async def cancellation_requested(self, flow_run_id: UUID) -> bool:
+        """Return whether a cancellation was ever recorded for the flow run.
+
+        The state history is consulted rather than the current state, because a transition that
+        happens after the cancellation (such as a retry resuming) overwrites the current state
+        while the recorded request remains in the history.
+        """
         ...
 
 
@@ -87,3 +100,7 @@ class PrefectClientAdapter:
     async def set_flow_run_state(self, flow_run_id: UUID, state: State, force: bool) -> StateType | None:
         result = await self.client.set_flow_run_state(flow_run_id=flow_run_id, state=state, force=force)
         return result.state.type if result.state else None
+
+    async def cancellation_requested(self, flow_run_id: UUID) -> bool:
+        states = await self.client.read_flow_run_states(flow_run_id=flow_run_id)
+        return any(state.type in CANCEL_REQUEST_STATE_TYPES for state in states)

--- a/backend/infrahub/trigger/system.py
+++ b/backend/infrahub/trigger/system.py
@@ -9,6 +9,16 @@ from datetime import timedelta
 from prefect.client.schemas.objects import StateType
 
 from infrahub.trigger.models import ChangeFlowRunStateAction, ProactiveEventTrigger, SystemTriggerDefinition
+from infrahub.webhook.constants import WEBHOOK_SEND_RETRY_DELAY_SECONDS
+
+# A proactive trigger keeps a per-run countdown: every expected event restarts it, and the
+# action fires when the countdown lapses. A run waiting out a retry backoff emits nothing at
+# all, so the window must outlast the longest configured backoff or every such wait is
+# mistaken for a dead process. The retry-wait transition is an expected event so the countdown
+# is anchored at the start of the silence it explains. The margin absorbs event-propagation
+# and scheduler jitter between the retry-wait transition and the resumed run's next heartbeat.
+ZOMBIE_DETECTION_MARGIN = timedelta(seconds=60)
+ZOMBIE_HEARTBEAT_WINDOW = timedelta(seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS) + ZOMBIE_DETECTION_MARGIN
 
 TRIGGER_CRASH_ZOMBIE_FLOWS = SystemTriggerDefinition(
     name="crash-zombie-flows",
@@ -17,6 +27,7 @@ TRIGGER_CRASH_ZOMBIE_FLOWS = SystemTriggerDefinition(
         after={"prefect.flow-run.heartbeat"},
         events={
             "prefect.flow-run.heartbeat",
+            "prefect.flow-run.AwaitingRetry",
             "prefect.flow-run.Completed",
             "prefect.flow-run.Failed",
             "prefect.flow-run.Cancelled",
@@ -25,7 +36,7 @@ TRIGGER_CRASH_ZOMBIE_FLOWS = SystemTriggerDefinition(
         match={"prefect.resource.id": ["prefect.flow-run.*"]},
         for_each={"prefect.resource.id"},
         threshold=1,
-        within=timedelta(seconds=90),
+        within=ZOMBIE_HEARTBEAT_WINDOW,
     ),
     actions=[
         ChangeFlowRunStateAction(

--- a/backend/infrahub/webhook/constants.py
+++ b/backend/infrahub/webhook/constants.py
@@ -2,6 +2,10 @@ from enum import StrEnum
 
 CACHE_KEY_PREFIX = "webhook"
 
+WEBHOOK_SEND_RETRIES: int = 3
+WEBHOOK_SEND_RETRY_DELAY_SECONDS: float = 120  # fixed 2m delay between attempts
+WEBHOOK_SEND_ATTEMPTS: int = WEBHOOK_SEND_RETRIES + 1  # the initial try plus its retries
+
 
 class WebhookAction(StrEnum):
     CONFIGURE = "configure"

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import time
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 import ujson
 from infrahub_sdk import InfrahubClient  # noqa: TC002  needed for prefect flow
 from infrahub_sdk.protocols import CoreTransformPython, CoreWebhook
 from prefect import flow, task
 from prefect.cache_policies import NONE
+from prefect.client.orchestration import get_client as get_prefect_client
 from prefect.logging import get_run_logger
 from prefect.runtime import flow_run
-from prefect.states import Failed
+from prefect.states import Cancelled, Failed
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.message_bus.types import KVTTL
+from infrahub.task_manager.flow_run.prefect_client import PrefectClientAdapter
 from infrahub.workers.dependencies import get_cache, get_client, get_http
 from infrahub.workflows.utils import add_tags
 
@@ -51,6 +54,21 @@ def _attempt_phrase(attempt: int | None) -> str:
     if attempt is None:
         return "outside a flow run"
     return f"attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}"
+
+
+async def _cancellation_requested() -> bool:
+    """Return whether cancellation was requested for the flow run driving this delivery.
+
+    A cancellation that lands while the run waits between attempts is only recorded server-side:
+    nothing interrupts the in-process wait, and the next attempt would start anyway and overwrite
+    the cancelled state. Each attempt therefore re-checks for a recorded cancellation before
+    sending, so the request is honored no matter when it arrived. Outside a flow run there is no
+    state to consult and nothing to cancel.
+    """
+    if flow_run.id is None:
+        return False
+    async with get_prefect_client(sync_client=False) as client:
+        return await PrefectClientAdapter(client).cancellation_requested(flow_run_id=UUID(flow_run.id))
 
 
 def _log_outgoing_request(
@@ -103,19 +121,24 @@ async def webhook_post(
 )
 async def webhook_send(
     webhook_id: str, webhook_kind: str, webhook_name: str, payload: Any, branch_name: str | None = None
-) -> Response:
+) -> Response | State:
     """Send the webhook delivery, retrying the whole send on failure.
 
     This is the operator-facing delivery: it carries the webhook node and branch tags so it is
     listed and addressable on its own. Expected delivery failures (transport, HTTP status,
     configuration) are classified and re-raised with a clean, user-facing message. An unexpected
-    error keeps its traceback so the run surfaces as a genuine crash.
+    error keeps its traceback so the run surfaces as a genuine crash. A delivery whose
+    cancellation was requested ends as cancelled before sending, so no attempt goes out after an
+    operator cancelled it.
 
     Raises:
         WebhookDeliveryError: When an expected delivery failure occurs, carrying the classified reason.
 
     """
     log = get_run_logger()
+    if await _cancellation_requested():
+        log.info("Delivery cancellation was requested; ending the run without sending.")
+        return Cancelled(message="The delivery was cancelled.")
     await add_tags(nodes=[webhook_id], branches=[branch_name] if branch_name else None)
     # flow_run.run_count is the 1-based attempt number within a flow run; it is None outside one, where
     # there is no retry sequence to report.
@@ -260,7 +283,11 @@ async def webhook_process(
     if state.is_completed():
         return None
 
-    # Any non-completed terminal state (failed, crashed, cancelled) is surfaced, not reported as success.
+    # A cancelled delivery carries no result to read; the cancelled state itself is the outcome.
+    if state.is_cancelled():
+        return state
+
+    # Any other non-completed terminal state (failed, crashed) is surfaced, not reported as success.
     outcome = await state.aresult(raise_on_failure=False)
     if isinstance(outcome, WebhookDeliveryError):
         return Failed(message=f"{outcome.failure.message.rstrip('.')}. {outcome.failure.remediation}")

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -21,7 +21,12 @@ from infrahub.workers.dependencies import get_cache, get_client, get_http
 from infrahub.workflows.utils import add_tags
 
 from ..classifier import EXPECTED_DELIVERY_ERRORS, WebhookDeliveryError, WebhookFailureClassifier
-from ..constants import CACHE_KEY_PREFIX
+from ..constants import (
+    CACHE_KEY_PREFIX,
+    WEBHOOK_SEND_ATTEMPTS,
+    WEBHOOK_SEND_RETRIES,
+    WEBHOOK_SEND_RETRY_DELAY_SECONDS,
+)
 from ..models import CustomWebhook, EventContext, HeaderKind, StandardWebhook, TransformWebhook, Webhook, WebhookHeader
 
 if TYPE_CHECKING:
@@ -36,9 +41,6 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-WEBHOOK_SEND_RETRIES: int = 3
-WEBHOOK_SEND_RETRY_DELAY_SECONDS: float = 120  # fixed 2m delay between attempts
-WEBHOOK_SEND_ATTEMPTS: int = WEBHOOK_SEND_RETRIES + 1  # the initial try plus its retries
 PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
 
 

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess  # noqa: S404
 import sys
+from collections.abc import AsyncGenerator
 from itertools import islice
 from pathlib import Path
 from typing import Any, Generator
@@ -13,6 +14,7 @@ from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
 from neo4j._codec.hydration.v1.hydration_handler import _GraphHydrator
+from prefect.client.orchestration import PrefectClient, get_client
 from prefect.settings import get_current_settings
 from prefect.testing.utilities import prefect_test_harness
 from pytest_httpx import HTTPXMock
@@ -142,6 +144,12 @@ def prefect_test_fixture() -> Generator[None, None, None]:
     with patch("prefect.server.api.server.SubprocessASGIServer._run_uvicorn_command", _run_uvicorn_command):
         with prefect_test_harness(server_startup_timeout=60):
             yield
+
+
+@pytest.fixture
+async def prefect_client(prefect_test_fixture: None) -> AsyncGenerator[PrefectClient, None]:
+    async with get_client(sync_client=False) as client:
+        yield client
 
 
 @pytest.fixture

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -73,6 +73,7 @@ from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_workflow
 from tests.conftest import TestHelper
 from tests.helpers.constants import (
+    PREFECT_EVENTS_PROACTIVE_GRANULARITY,
     PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS,
     PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS,
 )
@@ -139,6 +140,7 @@ def prefect_test_fixture() -> Generator[None, None, None]:
         )
 
     os.environ["PREFECT_FLOWS_HEARTBEAT_FREQUENCY"] = PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS
+    os.environ["PREFECT_SERVER_EVENTS_PROACTIVE_GRANULARITY"] = PREFECT_EVENTS_PROACTIVE_GRANULARITY
     os.environ.update(PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS)
 
     with patch("prefect.server.api.server.SubprocessASGIServer._run_uvicorn_command", _run_uvicorn_command):

--- a/backend/tests/component/task_manager/test_prefect_client.py
+++ b/backend/tests/component/task_manager/test_prefect_client.py
@@ -39,3 +39,21 @@ async def test_set_flow_run_state_leaves_a_settled_run_terminal(prefect_client: 
     )
 
     assert resulting_state == StateType.COMPLETED
+
+
+async def test_cancellation_requested_sees_an_overwritten_cancellation(prefect_client: PrefectClient) -> None:
+    adapter = PrefectClientAdapter(prefect_client)
+    run = await prefect_client.create_flow_run(flow=_noop_flow, state=State(type=StateType.SCHEDULED))
+
+    await adapter.set_flow_run_state(flow_run_id=run.id, state=State(type=StateType.CANCELLING), force=False)
+    # A retry resuming overwrites the current state; the recorded request must still be seen.
+    await adapter.set_flow_run_state(flow_run_id=run.id, state=State(type=StateType.RUNNING), force=True)
+
+    assert await adapter.cancellation_requested(flow_run_id=run.id) is True
+
+
+async def test_cancellation_requested_is_false_without_a_request(prefect_client: PrefectClient) -> None:
+    adapter = PrefectClientAdapter(prefect_client)
+    run = await prefect_client.create_flow_run(flow=_noop_flow, state=State(type=StateType.SCHEDULED))
+
+    assert await adapter.cancellation_requested(flow_run_id=run.id) is False

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -22,8 +22,10 @@ if TYPE_CHECKING:
     from infrahub.trigger.models import SystemTriggerDefinition
 
 # The shipped window outlasts the longest configured backoff; the event-driven tests scale it
-# down so a verdict arrives within seconds instead of minutes.
-SCALED_WINDOW = timedelta(seconds=20)
+# down to Prefect's minimum proactive window so a verdict arrives within seconds instead of
+# minutes. The server's proactive evaluation cadence is tightened to match (see the component
+# conftest) so a scaled run is judged within this window rather than lagging behind it.
+SCALED_WINDOW = timedelta(seconds=10)
 VERDICT_TIMEOUT_SECONDS = 60.0
 POLL_INTERVAL_SECONDS = 1.0
 
@@ -113,7 +115,7 @@ async def test_wait_transition_restarts_the_countdown(
 
     # Check between the heartbeat's expiry and the transition's: crashed here means the
     # transition did not restart the countdown.
-    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.65)
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.7)
     run = await prefect_client.read_flow_run(flow_run_id)
     assert run.state is not None
     assert run.state.type == StateType.SCHEDULED

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from prefect import flow
+from prefect.automations import AutomationCore
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.objects import State, StateType
+from prefect.events.clients import get_events_client
+from prefect.events.schemas.events import Event
+
+from infrahub.trigger.system import TRIGGER_CRASH_ZOMBIE_FLOWS
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from prefect.client.orchestration import PrefectClient
+
+    from infrahub.trigger.models import SystemTriggerDefinition
+
+# Longer than the 90s window the automation used to have (the regression this file guards
+# against), and shorter than its current window so the wait is survivable at all.
+RETRY_DELAY_SECONDS = 100.0
+SETTLE_TIMEOUT_SECONDS = RETRY_DELAY_SECONDS + 60.0
+
+# The shipped window outlasts the longest configured backoff; the event-driven tests scale it
+# down so a verdict arrives within seconds instead of minutes.
+SCALED_WINDOW = timedelta(seconds=20)
+VERDICT_TIMEOUT_SECONDS = 60.0
+POLL_INTERVAL_SECONDS = 1.0
+
+
+@flow(name="retrying-under-zombie-watch", retries=1, retry_delay_seconds=RETRY_DELAY_SECONDS)
+async def _always_failing() -> None:
+    raise ValueError("the target is unavailable")
+
+
+@pytest.fixture
+async def prefect_client(prefect_test_fixture: Generator[None]) -> AsyncGenerator[PrefectClient, None]:
+    async with get_client(sync_client=False) as client:
+        yield client
+
+
+async def register_automation(prefect_client: PrefectClient, definition: SystemTriggerDefinition) -> UUID:
+    automation = AutomationCore(
+        name=f"{definition.generate_name()}-{uuid4()}",
+        description=definition.get_description(),
+        enabled=True,
+        trigger=definition.trigger.get_prefect(),
+        actions=[action.get_prefect() for action in definition.actions],
+    )
+    return await prefect_client.create_automation(automation=automation)
+
+
+@pytest.fixture
+async def registered_zombie_automation(prefect_client: PrefectClient) -> AsyncGenerator[None, None]:
+    """Register the shipped zombie-detection automation on the live server, then remove it."""
+    automation_id = await register_automation(prefect_client, TRIGGER_CRASH_ZOMBIE_FLOWS)
+    yield
+    await prefect_client.delete_automation(automation_id=automation_id)
+
+
+async def test_retry_wait_is_not_marked_crashed(
+    prefect_client: PrefectClient, registered_zombie_automation: None
+) -> None:
+    """A run waiting out its retry backoff is expected silence, not a zombie.
+
+    The flow fails, waits longer than the automation's no-heartbeat window, retries, and fails
+    for good. At no point may the automation mark the run as crashed: a crashed state makes the
+    run look settled mid-delivery and invites conflicting operator actions.
+    """
+    state = await asyncio.wait_for(
+        _always_failing(return_state=True),  # type: ignore[call-overload]
+        timeout=SETTLE_TIMEOUT_SECONDS,
+    )
+
+    assert state.type == StateType.FAILED
+    assert state.state_details.flow_run_id is not None
+
+    history = await prefect_client.read_flow_run_states(flow_run_id=state.state_details.flow_run_id)
+    crashed = [item for item in history if item.type == StateType.CRASHED]
+    assert crashed == [], "the zombie automation crashed a run that was waiting between attempts"
+
+
+@pytest.fixture
+async def scaled_zombie_automation(prefect_client: PrefectClient) -> AsyncGenerator[None, None]:
+    """Register the shipped zombie automation with a test-sized window, then remove it."""
+    scaled = TRIGGER_CRASH_ZOMBIE_FLOWS.model_copy(deep=True)
+    scaled.trigger.within = SCALED_WINDOW
+    automation_id = await register_automation(prefect_client, scaled)
+    yield
+    await prefect_client.delete_automation(automation_id=automation_id)
+
+
+async def emit_flow_run_event(event_name: str, flow_run_id: UUID) -> None:
+    async with get_events_client() as events_client:
+        await events_client.emit(
+            Event(
+                event=event_name,
+                occurred=datetime.now(UTC),
+                resource={"prefect.resource.id": f"prefect.flow-run.{flow_run_id}"},
+            )
+        )
+
+
+async def create_waiting_run(prefect_client: PrefectClient) -> UUID:
+    """Create a flow run parked in its retry wait, as an engine leaves it between attempts."""
+    run = await prefect_client.create_flow_run(
+        flow=_always_failing, state=State(type=StateType.SCHEDULED, name="AwaitingRetry")
+    )
+    return run.id
+
+
+async def wait_for_state(prefect_client: PrefectClient, flow_run_id: UUID, expected: StateType) -> bool:
+    deadline = asyncio.get_running_loop().time() + VERDICT_TIMEOUT_SECONDS
+    while asyncio.get_running_loop().time() < deadline:
+        run = await prefect_client.read_flow_run(flow_run_id)
+        if run.state is not None and run.state.type == expected:
+            return True
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    return False
+
+
+async def test_wait_that_never_resumes_is_marked_crashed(
+    prefect_client: PrefectClient, scaled_zombie_automation: None
+) -> None:
+    """A retry wait that never resumes is a dead process and must be declared crashed."""
+    flow_run_id = await create_waiting_run(prefect_client)
+    await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
+    await emit_flow_run_event("prefect.flow-run.AwaitingRetry", flow_run_id)
+
+    assert await wait_for_state(prefect_client, flow_run_id, StateType.CRASHED), (
+        "a retry wait that never resumed was not declared crashed"
+    )
+
+
+async def test_wait_transition_restarts_the_countdown(
+    prefect_client: PrefectClient, scaled_zombie_automation: None
+) -> None:
+    """Entering a retry wait restarts the no-heartbeat countdown rather than expiring it.
+
+    The heartbeat arms the countdown; half a window later the run enters its wait. Were the
+    transition not an expected event, the countdown armed by the heartbeat would expire on
+    schedule. It must instead run from the transition, so the run is still untouched shortly
+    after the original expiry.
+    """
+    flow_run_id = await create_waiting_run(prefect_client)
+    await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() / 2)
+    await emit_flow_run_event("prefect.flow-run.AwaitingRetry", flow_run_id)
+
+    # Check between the heartbeat's expiry and the transition's: crashed here means the
+    # transition did not restart the countdown.
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.65)
+    run = await prefect_client.read_flow_run(flow_run_id)
+    assert run.state is not None
+    assert run.state.type == StateType.SCHEDULED

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
 
     from infrahub.trigger.models import SystemTriggerDefinition
 
-# Longer than the 90s window the automation used to have (the regression this file guards
-# against), and shorter than its current window so the wait is survivable at all.
-RETRY_DELAY_SECONDS = 100.0
-SETTLE_TIMEOUT_SECONDS = RETRY_DELAY_SECONDS + 60.0
-
 # The shipped window outlasts the longest configured backoff; the event-driven tests scale it
 # down so a verdict arrives within seconds instead of minutes.
 SCALED_WINDOW = timedelta(seconds=20)
@@ -34,7 +29,7 @@ VERDICT_TIMEOUT_SECONDS = 60.0
 POLL_INTERVAL_SECONDS = 1.0
 
 
-@flow(name="retrying-under-zombie-watch", retries=1, retry_delay_seconds=RETRY_DELAY_SECONDS)
+@flow(name="retrying-under-zombie-watch")
 async def _always_failing() -> None:
     raise ValueError("the target is unavailable")
 
@@ -54,36 +49,6 @@ async def register_automation(prefect_client: PrefectClient, definition: SystemT
         actions=[action.get_prefect() for action in definition.actions],
     )
     return await prefect_client.create_automation(automation=automation)
-
-
-@pytest.fixture
-async def registered_zombie_automation(prefect_client: PrefectClient) -> AsyncGenerator[None, None]:
-    """Register the shipped zombie-detection automation on the live server, then remove it."""
-    automation_id = await register_automation(prefect_client, TRIGGER_CRASH_ZOMBIE_FLOWS)
-    yield
-    await prefect_client.delete_automation(automation_id=automation_id)
-
-
-async def test_retry_wait_is_not_marked_crashed(
-    prefect_client: PrefectClient, registered_zombie_automation: None
-) -> None:
-    """A run waiting out its retry backoff is expected silence, not a zombie.
-
-    The flow fails, waits longer than the automation's no-heartbeat window, retries, and fails
-    for good. At no point may the automation mark the run as crashed: a crashed state makes the
-    run look settled mid-delivery and invites conflicting operator actions.
-    """
-    state = await asyncio.wait_for(
-        _always_failing(return_state=True),  # type: ignore[call-overload]
-        timeout=SETTLE_TIMEOUT_SECONDS,
-    )
-
-    assert state.type == StateType.FAILED
-    assert state.state_details.flow_run_id is not None
-
-    history = await prefect_client.read_flow_run_states(flow_run_id=state.state_details.flow_run_id)
-    crashed = [item for item in history if item.type == StateType.CRASHED]
-    assert crashed == [], "the zombie automation crashed a run that was waiting between attempts"
 
 
 @pytest.fixture

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -8,7 +8,6 @@ from uuid import UUID, uuid4
 import pytest
 from prefect import flow
 from prefect.automations import AutomationCore
-from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import State, StateType
 from prefect.events.clients import get_events_client
 from prefect.events.schemas.events import Event
@@ -16,7 +15,7 @@ from prefect.events.schemas.events import Event
 from infrahub.trigger.system import TRIGGER_CRASH_ZOMBIE_FLOWS
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Generator
+    from collections.abc import AsyncGenerator
 
     from prefect.client.orchestration import PrefectClient
 
@@ -32,12 +31,6 @@ POLL_INTERVAL_SECONDS = 1.0
 @flow(name="retrying-under-zombie-watch")
 async def _always_failing() -> None:
     raise ValueError("the target is unavailable")
-
-
-@pytest.fixture
-async def prefect_client(prefect_test_fixture: Generator[None]) -> AsyncGenerator[PrefectClient, None]:
-    async with get_client(sync_client=False) as client:
-        yield client
 
 
 async def register_automation(prefect_client: PrefectClient, definition: SystemTriggerDefinition) -> UUID:

--- a/backend/tests/component/webhook/test_cancel_during_retry_wait.py
+++ b/backend/tests/component/webhook/test_cancel_during_retry_wait.py
@@ -8,7 +8,6 @@ import httpx
 import pytest
 import ujson
 from infrahub_sdk import Config, InfrahubClient
-from prefect.client.orchestration import get_client
 from prefect.client.schemas.filters import FlowFilter, FlowFilterName
 from prefect.client.schemas.objects import State, StateType
 from prefect.client.schemas.sorting import FlowRunSort
@@ -23,7 +22,6 @@ from tests.adapters.http import MemoryHTTP
 
 if TYPE_CHECKING:
     import ssl
-    from collections.abc import AsyncGenerator, Generator
     from uuid import UUID
 
     from fast_depends import Provider
@@ -53,12 +51,6 @@ class CountingHTTP(MemoryHTTP):
     ) -> httpx.Response:
         self.post_count += 1
         return await super().post(url=url, data=data, json=json, headers=headers, verify=verify)
-
-
-@pytest.fixture
-async def prefect_client(prefect_test_fixture: Generator[None]) -> AsyncGenerator[PrefectClient, None]:
-    async with get_client(sync_client=False) as client:
-        yield client
 
 
 @pytest.fixture

--- a/backend/tests/component/webhook/test_cancel_during_retry_wait.py
+++ b/backend/tests/component/webhook/test_cancel_during_retry_wait.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import httpx
+import pytest
+import ujson
+from infrahub_sdk import Config, InfrahubClient
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.filters import FlowFilter, FlowFilterName
+from prefect.client.schemas.objects import State, StateType
+from prefect.client.schemas.sorting import FlowRunSort
+
+from infrahub.task_manager.flow_run.prefect_client import PrefectClientAdapter
+from infrahub.webhook.constants import CACHE_KEY_PREFIX
+from infrahub.webhook.models import CustomWebhook
+from infrahub.webhook.tasks import process
+from infrahub.workers.dependencies import build_cache, build_client, build_http_service
+from tests.adapters.cache import MemoryCache
+from tests.adapters.http import MemoryHTTP
+
+if TYPE_CHECKING:
+    import ssl
+    from collections.abc import AsyncGenerator, Generator
+    from uuid import UUID
+
+    from fast_depends import Provider
+    from prefect.client.orchestration import PrefectClient
+    from prefect.client.schemas.objects import FlowRun
+
+TARGET_URL = "https://cancel.example.test/hook"
+RETRY_DELAY_SECONDS = 10.0
+POLL_INTERVAL_SECONDS = 0.2
+DISCOVERY_TIMEOUT_SECONDS = 30.0
+
+
+class CountingHTTP(MemoryHTTP):
+    """Record how many POSTs were made, on top of the canned responses."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.post_count = 0
+
+    async def post(
+        self,
+        url: str,
+        data: Any | None = None,
+        json: Any | None = None,
+        headers: dict[str, Any] | None = None,
+        verify: bool | ssl.SSLContext | None = None,
+    ) -> httpx.Response:
+        self.post_count += 1
+        return await super().post(url=url, data=data, json=json, headers=headers, verify=verify)
+
+
+@pytest.fixture
+async def prefect_client(prefect_test_fixture: Generator[None]) -> AsyncGenerator[PrefectClient, None]:
+    async with get_client(sync_client=False) as client:
+        yield client
+
+
+@pytest.fixture
+def failing_target() -> CountingHTTP:
+    http = CountingHTTP()
+    http.add_post_response(
+        url=TARGET_URL,
+        response=httpx.Response(request=httpx.Request(method="POST", url=TARGET_URL), status_code=500),
+    )
+    return http
+
+
+def seeded_cache(webhook_id: str) -> MemoryCache:
+    """Return a cache holding the webhook config, so resolution needs no database."""
+    cache = MemoryCache()
+    webhook = CustomWebhook(name="cancel-me", url=TARGET_URL, event_type="all", validate_certificates=False)
+    cache.storage[f"{CACHE_KEY_PREFIX}:{webhook_id}"] = ujson.dumps(webhook.to_cache())
+    return cache
+
+
+async def wait_for_retry_wait(prefect_client: PrefectClient, known_run_ids: set[UUID]) -> FlowRun:
+    """Return the new delivery run once its first attempt failed and it awaits its retry.
+
+    Raises:
+        TimeoutError: When no delivery reaches its retry wait within the discovery timeout.
+
+    """
+    deadline = asyncio.get_running_loop().time() + DISCOVERY_TIMEOUT_SECONDS
+    while asyncio.get_running_loop().time() < deadline:
+        runs = await prefect_client.read_flow_runs(
+            flow_filter=FlowFilter(name=FlowFilterName(any_=["webhook-send"])),
+            sort=FlowRunSort.START_TIME_DESC,
+            limit=10,
+        )
+        for run in runs:
+            if run.id in known_run_ids or run.state is None:
+                continue
+            if run.state.type == StateType.SCHEDULED and run.state.name == "AwaitingRetry":
+                return run
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise TimeoutError("The delivery never reached its retry wait.")
+
+
+async def read_send_run_ids(prefect_client: PrefectClient) -> set[UUID]:
+    runs = await prefect_client.read_flow_runs(
+        flow_filter=FlowFilter(name=FlowFilterName(any_=["webhook-send"])), limit=200
+    )
+    return {run.id for run in runs}
+
+
+async def test_cancel_during_retry_wait_stops_remaining_attempts(
+    prefect_client: PrefectClient,
+    dependency_provider: Provider,
+    failing_target: CountingHTTP,
+) -> None:
+    """Cancelling a delivery between attempts must stop the remaining attempts.
+
+    The delivery is driven to its retry wait against a real Prefect server, then cancelled through
+    the same call path the cancel mutation uses. No further attempt may reach the target, and the
+    run must settle as cancelled.
+    """
+    webhook_id = str(uuid4())
+    send = process.webhook_send.with_options(retries=1, retry_delay_seconds=RETRY_DELAY_SECONDS)
+
+    with (
+        dependency_provider.scope(build_http_service, lambda: failing_target),
+        dependency_provider.scope(build_cache, lambda: seeded_cache(webhook_id)),
+        # The webhook config is served from the seeded cache, so the client is never called;
+        # a bare one satisfies resolution without the runtime registry the real builder needs.
+        dependency_provider.scope(
+            build_client, lambda: InfrahubClient(config=Config(address="http://unused.example.test"))
+        ),
+    ):
+        known_run_ids = await read_send_run_ids(prefect_client)
+        delivery = asyncio.create_task(
+            send(
+                webhook_id=webhook_id,
+                webhook_kind="CoreCustomWebhook",
+                webhook_name="cancel-me",
+                payload={"event": "cancel-during-retry-wait"},
+                return_state=True,
+            )
+        )
+
+        run = await wait_for_retry_wait(prefect_client, known_run_ids)
+        assert failing_target.post_count == 1
+
+        resulting_state = await PrefectClientAdapter(prefect_client).set_flow_run_state(
+            flow_run_id=run.id, state=State(type=StateType.CANCELLING), force=False
+        )
+        assert resulting_state in {StateType.CANCELLING, StateType.CANCELLED}
+
+        final_state = await delivery
+
+    assert failing_target.post_count == 1, "an attempt was sent after the delivery was cancelled"
+    assert final_state.type == StateType.CANCELLED
+
+    settled = await prefect_client.read_flow_run(run.id)
+    assert settled.state is not None
+    assert settled.state.type == StateType.CANCELLED

--- a/backend/tests/component/webhook/test_cancel_during_retry_wait.py
+++ b/backend/tests/component/webhook/test_cancel_during_retry_wait.py
@@ -29,7 +29,10 @@ if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
 
 TARGET_URL = "https://cancel.example.test/hook"
-RETRY_DELAY_SECONDS = 10.0
+# The delivery only returns once this backoff elapses, so it sets the test's duration. It is
+# kept short while leaving ample slack for the cancellation to land during the wait: the first
+# attempt fails near-instantly and the run is discovered within a poll interval.
+RETRY_DELAY_SECONDS = 5.0
 POLL_INTERVAL_SECONDS = 0.2
 DISCOVERY_TIMEOUT_SECONDS = 30.0
 

--- a/backend/tests/helpers/constants.py
+++ b/backend/tests/helpers/constants.py
@@ -20,11 +20,17 @@ NEO4J_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", NEO4J_ENTERPRISE_IMAGE)
 PREFECT_EVENT_WAIT_SECONDS = 60
 
 # The crash-zombie-flows automation crashes flow runs whose heartbeats stop arriving within
-# a 90 second window, and the flow engine always emits an initial heartbeat when a flow
+# its no-heartbeat window, and the flow engine always emits an initial heartbeat when a flow
 # starts regardless of the configured frequency. The frequency must therefore stay well
 # below that window (production uses 30s); stretching it to "disable" heartbeats only
 # silences the follow-up beats and gets healthy long-running flows crashed.
 PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS = "30"
+
+# The server evaluates proactive automations (the crash-zombie-flows detector) on this cadence,
+# given as an ISO 8601 duration (one second). The tests scale the detection window down to
+# Prefect's 10s minimum, so evaluation must be finer than that window for a scaled run to be
+# judged promptly and predictably.
+PREFECT_EVENTS_PROACTIVE_GRANULARITY = "PT1S"
 
 # The test Prefect servers (ephemeral subprocess and the prefect container fixture) run
 # every background service in-process against a single SQLite database. SQLite serializes

--- a/changelog/+webhook-related-tasks.fixed.md
+++ b/changelog/+webhook-related-tasks.fixed.md
@@ -1,1 +1,1 @@
-Webhook task runs are now discoverable from the webhook's related tasks panel.
+Webhook task runs are now discoverable from the webhook related tasks panel.

--- a/changelog/+zombie-flow-detection-window.changed.md
+++ b/changelog/+zombie-flow-detection-window.changed.md
@@ -1,0 +1,1 @@
+Flow runs that stop sending heartbeats are marked as crashed only after a longer grace period, so a run waiting out an automatic retry is no longer prematurely marked as crashed.

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -259,6 +259,12 @@ Existing examples: `DisplayLabelNodeIDQuery`, `HFIDNodeIDQuery`, `ComputedAttrib
 
 A task run can expose recovery actions through the GraphQL `Task` type's `available_actions` field, gated by the run's current state. `TaskActionGenerator` derives the action set per workflow, and `InfrahubTaskRetry` and `InfrahubTaskCancel` carry the actions out. Only `WEBHOOK_SEND` runs expose actions today; see [Webhooks](webhooks.md) for the delivery-specific behavior.
 
+## Liveness and zombie detection
+
+A running flow emits a `prefect.flow-run.heartbeat` event on a fixed interval while it executes. The `crash-zombie-flows` system automation watches for the absence of these events: it keeps a per-run countdown that every expected event restarts, and marks a run `CRASHED` once the countdown lapses. This reaps runs whose worker process died without recording a terminal state, which would otherwise stay `RUNNING` indefinitely.
+
+A run waiting out a retry backoff emits nothing while it waits. The retry-wait transition is therefore registered as an expected event, anchoring the countdown at the start of that silence, and the detection window is sized above the longest configured retry backoff so a run waiting between attempts is not mistaken for a dead process. The window is derived from the webhook send retry delay plus a margin rather than hardcoded, so the relationship holds if the backoff changes. A run whose process genuinely died still lapses the window and is crashed, at the cost of the widened detection latency.
+
 ## Key Locations
 
 | Component | Location |
@@ -270,6 +276,7 @@ A task run can expose recovery actions through the GraphQL `Task` type's `availa
 | Branch tasks | `backend/infrahub/core/branch/tasks.py` |
 | Git tasks | `backend/infrahub/git/tasks.py` |
 | Schema tasks | `backend/infrahub/core/migrations/schema/tasks.py` |
+| System automations | `backend/infrahub/trigger/system.py` |
 
 ## See Also
 

--- a/dev/knowledge/backend/webhooks.md
+++ b/dev/knowledge/backend/webhooks.md
@@ -205,7 +205,7 @@ Each class carries a clean message and a remediation hint. `webhook_send` classi
 
 A `TLS` failure reaches this layer wrapped by httpx as a generic transport error, so the HTTP adapter's `SSLErrorExtractor` walks the exception chain to recognize the certificate problem and raise a TLS-specific error rather than a generic connection error.
 
-The `transient` flag on `ClassifiedFailure` records whether a class could plausibly succeed on a retry. `webhook_send` currently retries every failure (3 attempts, fixed 120s delay); the flag is reserved for a future transient-only retry policy.
+The `transient` flag on `ClassifiedFailure` records whether a class could plausibly succeed on a retry. `webhook_send` currently retries every failure (3 attempts, fixed 120s delay); the flag is reserved for a future transient-only retry policy. The run is silent for the duration of each retry wait, so the zombie-detection window is sized above this backoff to avoid crashing a waiting delivery; see [Liveness and zombie detection](async-tasks.md#liveness-and-zombie-detection).
 
 ## Delivery operability
 
@@ -214,7 +214,7 @@ A delivery run exposes recovery actions through the GraphQL `Task` type. `TaskAc
 | Action | Available when | Effect |
 |--------|----------------|--------|
 | `RETRY` | The delivery has settled (a terminal state) | Submits `WEBHOOK_SEND` again with the original run's frozen parameters, as a new independent run. The original run is left unchanged as a record. |
-| `CANCEL` | The delivery has not settled | Requests the `CANCELLING` state without forcing it. A run with no infrastructure (a delivery awaiting a retry) is routed straight to `CANCELLED` by Prefect's orchestration; a running delivery is torn down by its worker. An in-flight HTTP request is not recalled, but no further attempts run. |
+| `CANCEL` | The delivery has not settled | Requests the `CANCELLING` state without forcing it. A running delivery is torn down by its worker. A delivery waiting between attempts keeps its in-process wait, which nothing interrupts, so each attempt re-checks for a recorded cancellation before sending and stops the sequence once one is present. An in-flight HTTP request is not recalled, but no further attempts run. |
 
 The `available_actions` field on the task query reports each action with whether it currently applies and, when it does not, the reason. Selecting `available_actions` forces resolution of the run's workflow name, since the field is derived from it.
 


### PR DESCRIPTION
## Why

Webhook delivery drives its retries in-process: between attempts the flow run sits idle in a retry-wait state and emits no heartbeats. Two behaviors depended on that idle window and misfired.

- A cancellation requested during a retry wait was observed only when the next attempt began, so an in-flight delivery kept retrying. [IFC-2879 ](https://opsmill.atlassian.net/browse/IFC-2879)
- The zombie-flow automation, which crashes runs that stop heartbeating, read the silent retry wait as a dead process and crashed the run mid-wait. [IFC-2880](https://opsmill.atlassian.net/browse/IFC-2880)

Goal: honor cancellation at any point in the retry sequence, and let a legitimately waiting run survive its backoff, while still reaping genuinely dead runs.

## What changed

**Behavioral**

- A delivery checks for a requested cancellation before each send attempt and stops the sequence once one is recorded, so cancellation takes effect during the retry wait rather than only at attempt boundaries. The parent flow surfaces a cancelled child's state directly.
- The `crash-zombie-flows` automation treats the retry-wait transition as an expected event and sizes its no-heartbeat window from the longest configured retry backoff plus a margin. A waiting delivery survives its backoff; a run whose process has died is still crashed once the window lapses.


**Implementation**

- A `FlowRunCancellationReading` protocol and a `cancellation_requested()` method on the Prefect client adapter, so cancellation state is read through the adapter.
- The webhook retry constants move to the webhook constants module so the trigger layer derives the window from the backoff without a circular import.

**Unrelated changes**

- Reworded a pre-existing changelog fragment (`+webhook-related-tasks.fixed.md`, authored on the base branch) so the `validate-release-notes-style` Vale job passes. The spell checker does not recognize the possessive form of the accepted term; using it attributively reads the same and clears the error. Not part of the state-handling fixes — included only to unblock CI on this branch.


## How to test

```bash
uv run pytest \
  backend/tests/component/webhook/test_cancel_during_retry_wait.py \
  backend/tests/component/trigger/test_zombie_detection.py \
  backend/tests/component/task_manager/test_prefect_client.py
```

Against a live Prefect server: a delivery cancelled mid-retry-wait stops immediately; a full four-attempt delivery cycle records `Pending → Running → AwaitingRetry ×3 → Failed` with no `Crashed` state; a wait that never resumes is still crashed once the window lapses.

### Execution time

These are live-server tests, so they carry a real wall-clock cost. Measured per-test call duration (`pytest --durations`):

| Test | Time |
|------|------|
| `test_cancel_during_retry_wait_stops_remaining_attempts` | ~5s |
| `test_wait_that_never_resumes_is_marked_crashed` | ~11s |
| `test_wait_transition_restarts_the_countdown` | ~12s |

The remaining cost is intrinsic: each duration is bounded by Prefect's 10s minimum proactive-trigger window (zombie tests) or the flow's retry backoff (cancel test), not by fixed padding. A prior ~100s real-time zombie test was removed as redundant once the detection window became derived, and the server's proactive evaluation cadence is tightened in the component harness so the scaled runs are judged without lag.

## Impact & rollout

- **Backward compatibility:** no breaking changes.
- **Performance:** a genuinely dead run is now declared crashed after the widened window (~180s) rather than the previous 90s; detection is retained, latency is higher.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy; the zombie automation is re-synced to the Prefect server at startup.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry
- [x] Internal .md docs updated
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors webhook cancellation during retry backoff and prevents false “zombie” crashes, while still crashing genuinely dead runs. Updates docs and changelog, and aligns with Linear IFC-2119 by ensuring no request is sent after cancellation and retry waits aren’t mis-crashed.

- **Bug Fixes**
  - Each send attempt checks `PrefectClientAdapter.cancellation_requested()` (state history) and stops with `Cancelled` if a request was recorded; no further attempts are sent.
  - Zombie automation treats `AwaitingRetry` as an expected event and sizes its window to `WEBHOOK_SEND_RETRY_DELAY_SECONDS + 60s`, so a run waiting out backoff isn’t crashed, but a dead run still is.
  - Centralized retry constants in `infrahub/webhook/constants.py`; the system trigger derives its window from these to avoid circular imports.

<sup>Written for commit 4e1cdebfbc446b168fad72b00f1d282d72170a65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->









[IFC-2880]: https://opsmill.atlassian.net/browse/IFC-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ