### PR TITLE
Added useSort to sync object list sorting with the URL

### DIFF
--- a/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
@@ -7,11 +7,13 @@ import {
   type AddAttributesToRequestOptions,
   addAttributesToRequest,
   addFiltersToRequest,
+  addOrderByToRequest,
   addRelationshipsToRequest,
 } from "@/shared/api/graphql/utils";
 import type { ContextParams, PaginationParams } from "@/shared/api/types";
 
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
 
 interface GetObjectsQueryParams {
@@ -21,6 +23,7 @@ interface GetObjectsQueryParams {
   limit?: number;
   offset?: number;
   filters?: Array<Filter>;
+  sort?: Sort[] | null;
   attributesOptions?: AddAttributesToRequestOptions;
   relationshipsOptions?: AddAttributesToRequestOptions;
 }
@@ -32,6 +35,7 @@ const getObjectsQuery = ({
   limit,
   offset,
   filters,
+  sort,
   attributesOptions,
   relationshipsOptions,
 }: GetObjectsQueryParams) => {
@@ -43,7 +47,8 @@ const getObjectsQuery = ({
           __args: {
             limit,
             offset,
-            ...(filters ? addFiltersToRequest(filters) : {}),
+            ...(filters?.length ? addFiltersToRequest(filters) : {}),
+            ...(sort?.length ? addOrderByToRequest(sort) : {}),
           },
           edges: {
             node: {
@@ -72,6 +77,7 @@ export async function getObjectsFromApi({
   branchName,
   atDate,
   filters,
+  sort,
   attributesOptions,
   relationshipsOptions,
 }: GetObjectsFromApiParams) {
@@ -83,6 +89,7 @@ export async function getObjectsFromApi({
       limit,
       offset,
       filters,
+      sort,
       attributesOptions,
       relationshipsOptions,
     }),

--- a/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects.ts
+++ b/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects.ts
@@ -7,6 +7,7 @@ import { getObjectsFromApi } from "@/entities/nodes/object/api/get-objects-from-
 import type { NodeObject } from "@/entities/nodes/object/domain/model/node";
 import { getAttributesVisibleInListView } from "@/entities/nodes/object/domain/rules/get-attributes-visible-in-list-view";
 import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/domain/rules/get-relationships-visible-in-list-view";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import type {
   AttributeSchema,
   ModelSchema,
@@ -17,6 +18,7 @@ export type GetObjectsParams = ContextParams &
   PaginationParams & {
     schema: ModelSchema;
     filters?: Array<Filter>;
+    sort?: Array<Sort> | null;
     getAttributesVisible?: (attributes: AttributeSchema[]) => AttributeSchema[];
     getRelationshipsVisible?: (relationships: RelationshipSchema[]) => RelationshipSchema[];
     attributesOptions?: AddAttributesToRequestOptions;
@@ -32,6 +34,7 @@ export const getObjects: GetObjects = async ({
   branchName,
   atDate,
   filters,
+  sort,
   getAttributesVisible = getAttributesVisibleInListView,
   getRelationshipsVisible = getRelationshipsVisibleInListView,
   attributesOptions,
@@ -51,6 +54,7 @@ export const getObjects: GetObjects = async ({
     branchName,
     atDate,
     filters,
+    sort,
     attributesOptions,
     relationshipsOptions,
   });

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -8,9 +8,11 @@ import { getObjectActionsColumn } from "@/entities/nodes/object/ui/object-table/
 import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/utils/get-object-table-columns";
 import { useObjects } from "@/entities/nodes/object/ui/queries/get-objects.query";
 import { useObjectsCount } from "@/entities/nodes/object/ui/queries/get-objects-count.query";
+import { useSort } from "@/entities/nodes/sort/ui/hooks/use-sort";
 
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
+  const { sort } = useSort(selectedSchema);
 
   const { data: count } = useObjectsCount({
     objectKind: selectedSchema.kind!,
@@ -20,6 +22,7 @@ export const ObjectTable = () => {
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
     schema: selectedSchema,
     filters,
+    sort,
   });
 
   if (error) {

--- a/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.test.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
-
-import { objectQueryKeys } from "./object.query-keys";
+import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 
 describe("objectQueryKeys", () => {
   it("returns base query key for all", () => {
@@ -42,31 +42,35 @@ describe("objectQueryKeys", () => {
     expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind"]);
   });
 
-  it("returns query key for list", () => {
+  it("returns query key for list including filters and sort", () => {
     // GIVEN
     const filters: Filter[] = [{ name: "include_available", value: "true" }];
+    const sort: Sort[] = [{ field: "name__value", direction: "ASC" }];
     const params = {
       branchName: "branchName",
       atDate: new Date("2024-01-01"),
       objectKind: "RandomKind",
       filters,
+      sort,
     };
 
     // WHEN
     const result = objectQueryKeys.list(params);
 
     // THEN
-    expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind", filters]);
+    expect(result).toEqual(["objects", "branchName", params.atDate, "RandomKind", filters, sort]);
   });
 
-  it("returns query key for count", () => {
+  it("returns query key for count without sort, since sort never changes the row count", () => {
     // GIVEN
     const filters: Filter[] = [{ name: "include_available", value: "true" }];
+    const sort: Sort[] = [{ field: "name__value", direction: "ASC" }];
     const params = {
       branchName: "branchName",
       atDate: new Date("2024-01-01"),
       objectKind: "RandomKind",
       filters,
+      sort,
     };
 
     // WHEN

--- a/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/object.query-keys.ts
@@ -3,6 +3,7 @@ import type { ContextParams } from "@/shared/api/types";
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
 import { getAttributesVisibleInDetailedView } from "@/entities/nodes/object/domain/rules/get-attributes-visible-in-detailed-view";
 import { getRelationshipsVisibleInDetailedView } from "@/entities/nodes/object/domain/rules/get-relationships-visible-in-detailed-view";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import type {
   AttributeSchema,
   ModelSchema,
@@ -15,6 +16,7 @@ export interface ObjectKeysBaseParams extends ContextParams {
 
 export interface ObjectListKeysParams extends ObjectKeysBaseParams {
   filters?: Filter[];
+  sort?: Sort[] | null;
 }
 
 export interface ObjectDetailKeysParams extends ObjectKeysBaseParams {
@@ -48,7 +50,7 @@ export const objectQueryKeys = {
   count: (params: ObjectListKeysParams) =>
     [...objectQueryKeys.lists(params), "count", params.filters] as const,
   list: (params: ObjectListKeysParams) =>
-    [...objectQueryKeys.lists(params), params.filters] as const,
+    [...objectQueryKeys.lists(params), params.filters, params.sort] as const,
   profiles: (params: ObjectKeysBaseParams) =>
     [...objectQueryKeys.lists(params), "profiles"] as const,
   detail: (params: ObjectDetailKeysParams) =>

--- a/frontend/app/src/entities/nodes/sort/domain/model/sort.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/model/sort.ts
@@ -1,0 +1,17 @@
+import { OrderDirection } from "@/shared/api/graphql/generated/types";
+
+export type SortField = `${string}__${string}`;
+export type SortDirection = OrderDirection;
+export type SortToken = `${SortField}__${Lowercase<SortDirection>}`;
+
+export interface Sort {
+  field: SortField;
+  direction: SortDirection;
+}
+
+export interface SortableField {
+  field: SortField;
+  label: string;
+}
+
+export const SORT_DIRECTION = OrderDirection;

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-attributes.test.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-attributes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { getSortableAttributes } from "@/entities/nodes/sort/domain/rules/get-sortable-attributes";
+
+import { generateAttributeSchema } from "../../../../../../tests/fake/schema";
+
+describe("getSortableAttributes", () => {
+  it("returns a `{attribute}__value` field per attribute, labelled with the attribute label or its name", () => {
+    // GIVEN
+    const attributes = [
+      generateAttributeSchema({ name: "name", label: "Name", kind: "Text" }),
+      generateAttributeSchema({ name: "weight", label: null, kind: "Number" }),
+    ];
+
+    // WHEN
+    const fields = getSortableAttributes(attributes);
+
+    // THEN
+    expect(fields).toEqual([
+      { field: "name__value", label: "Name" },
+      { field: "weight__value", label: "weight" },
+    ]);
+  });
+
+  it("excludes attributes with complex or unorderable kinds", () => {
+    // GIVEN
+    const attributes = [
+      generateAttributeSchema({ name: "name", label: "Name", kind: "Text" }),
+      generateAttributeSchema({ name: "config", kind: "JSON" }),
+      generateAttributeSchema({ name: "tags", kind: "List" }),
+      generateAttributeSchema({ name: "payload", kind: "Any" }),
+      generateAttributeSchema({ name: "secret", kind: "Password" }),
+      generateAttributeSchema({ name: "token", kind: "HashedPassword" }),
+    ];
+
+    // WHEN
+    const fields = getSortableAttributes(attributes);
+
+    // THEN
+    expect(fields).toEqual([{ field: "name__value", label: "Name" }]);
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-attributes.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-attributes.ts
@@ -1,0 +1,23 @@
+import type { SortableField, SortField } from "@/entities/nodes/sort/domain/model/sort";
+import { ATTRIBUTE_KIND } from "@/entities/schema/domain/model/attribute-kind";
+import type { AttributeSchema } from "@/entities/schema/domain/model/schema";
+
+/** Kinds whose values have no meaningful (or safe) ordering. */
+const NON_SORTABLE_ATTRIBUTE_KINDS: readonly string[] = [
+  ATTRIBUTE_KIND.JSON,
+  ATTRIBUTE_KIND.LIST,
+  ATTRIBUTE_KIND.ANY,
+  ATTRIBUTE_KIND.PASSWORD,
+  ATTRIBUTE_KIND.HASHED_PASSWORD,
+];
+
+export function isSortableAttribute(attribute: AttributeSchema): boolean {
+  return !NON_SORTABLE_ATTRIBUTE_KINDS.includes(attribute.kind);
+}
+
+export function getSortableAttributes(attributes: AttributeSchema[]): SortableField[] {
+  return attributes.filter(isSortableAttribute).map((attribute) => ({
+    field: `${attribute.name}__value` as SortField,
+    label: attribute.label ?? attribute.name,
+  }));
+}

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.test.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import { getSortableFields } from "@/entities/nodes/sort/domain/rules/get-sortable-fields";
+import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
+
+import {
+  generateAttributeSchema,
+  generateNodeSchema,
+  generateRelationshipSchema,
+} from "../../../../../../tests/fake/schema";
+
+const NODE_METADATA_FIELDS = [
+  { field: "node_metadata__created_at", label: "Created at" },
+  { field: "node_metadata__updated_at", label: "Updated at" },
+];
+
+describe("getSortableFields", () => {
+  beforeEach(() => {
+    store.set(nodeSchemasAtom, []);
+  });
+
+  it("returns a `{attribute}__value` field per simple-valued attribute, plus node metadata fields", () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      attributes: [
+        generateAttributeSchema({ name: "name", label: "Name", kind: "Text" }),
+        generateAttributeSchema({ name: "weight", label: "Weight", kind: "Number" }),
+      ],
+      relationships: [],
+    });
+
+    // WHEN
+    const fields = getSortableFields(schema);
+
+    // THEN
+    expect(fields).toEqual([
+      { field: "name__value", label: "Name" },
+      { field: "weight__value", label: "Weight" },
+      ...NODE_METADATA_FIELDS,
+    ]);
+  });
+
+  it("returns `{relationship}__{attribute}__value` fields for cardinality-one relationships only, ordered by peer attribute order_weight", () => {
+    // GIVEN
+    const site = generateNodeSchema({
+      kind: "LocationSite",
+      attributes: [
+        generateAttributeSchema({ name: "name", label: "Name", kind: "Text", order_weight: 2000 }),
+        generateAttributeSchema({
+          name: "description",
+          label: "Description",
+          kind: "Text",
+          order_weight: 1000,
+        }),
+        generateAttributeSchema({ name: "metadata", kind: "JSON" }),
+      ],
+      relationships: [],
+    });
+    store.set(nodeSchemasAtom, [site]);
+    const schema = generateNodeSchema({
+      attributes: [],
+      relationships: [
+        generateRelationshipSchema({
+          name: "site",
+          label: "Site",
+          peer: "LocationSite",
+          cardinality: "one",
+        }),
+        generateRelationshipSchema({
+          name: "interfaces",
+          peer: "LocationSite",
+          cardinality: "many",
+        }),
+      ],
+    });
+
+    // WHEN
+    const fields = getSortableFields(schema);
+
+    // THEN
+    expect(fields).toEqual([
+      { field: "site__description__value", label: "Site › Description" },
+      { field: "site__name__value", label: "Site › Name" },
+      ...NODE_METADATA_FIELDS,
+    ]);
+  });
+
+  it("skips relationships whose peer schema cannot be resolved", () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      attributes: [generateAttributeSchema({ name: "name", label: "Name", kind: "Text" })],
+      relationships: [
+        generateRelationshipSchema({ name: "site", peer: "UnknownKind", cardinality: "one" }),
+      ],
+    });
+
+    // WHEN
+    const fields = getSortableFields(schema);
+
+    // THEN
+    expect(fields).toEqual([{ field: "name__value", label: "Name" }, ...NODE_METADATA_FIELDS]);
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.ts
@@ -17,10 +17,16 @@ function getSortableFieldsOfRelationship(
 ): SortableField[] {
   const sortablePeerAttributes = (peerSchema.attributes ?? []).filter(isSortableAttribute);
   const orderedPeerAttributes = sortByOrderWeight(sortablePeerAttributes);
-  return orderedPeerAttributes.map((attribute) => ({
-    field: `${relationship.name}__${attribute.name}__value`,
-    label: `${relationship.label}${PEER_LABEL_SEPARATOR}${attribute.label}`,
-  }));
+
+  const relationshipLabel = relationship.label ?? relationship.name;
+
+  return orderedPeerAttributes.map((attribute) => {
+    const attributeLabel = attribute.label ?? attribute.name;
+    return {
+      field: `${relationship.name}__${attribute.name}__value`,
+      label: `${relationshipLabel}${PEER_LABEL_SEPARATOR}${attributeLabel}`,
+    };
+  });
 }
 
 const NODE_METADATA_SORTABLE_FIELDS: SortableField[] = [

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-sortable-fields.ts
@@ -1,0 +1,44 @@
+import { sortByOrderWeight } from "@/shared/utils/common";
+
+import type { SortableField } from "@/entities/nodes/sort/domain/model/sort";
+import {
+  getSortableAttributes,
+  isSortableAttribute,
+} from "@/entities/nodes/sort/domain/rules/get-sortable-attributes";
+import type { ModelSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
+import { getSchema } from "@/entities/schema/domain/use-cases/get-schema";
+
+// "Peer › Attribute" separator. En-spaces ( ) around the chevron keep it from looking cramped.
+const PEER_LABEL_SEPARATOR = " › ";
+
+function getSortableFieldsOfRelationship(
+  relationship: RelationshipSchema,
+  peerSchema: ModelSchema
+): SortableField[] {
+  const sortablePeerAttributes = (peerSchema.attributes ?? []).filter(isSortableAttribute);
+  const orderedPeerAttributes = sortByOrderWeight(sortablePeerAttributes);
+  return orderedPeerAttributes.map((attribute) => ({
+    field: `${relationship.name}__${attribute.name}__value`,
+    label: `${relationship.label}${PEER_LABEL_SEPARATOR}${attribute.label}`,
+  }));
+}
+
+const NODE_METADATA_SORTABLE_FIELDS: SortableField[] = [
+  { field: "node_metadata__created_at", label: "Created at" },
+  { field: "node_metadata__updated_at", label: "Updated at" },
+];
+
+export function getSortableFields(schema: ModelSchema): SortableField[] {
+  const attributeFields = getSortableAttributes(schema.attributes ?? []);
+
+  const relationshipFields = (schema.relationships ?? [])
+    .filter((relationship) => relationship.cardinality === "one")
+    .flatMap((relationship) => {
+      const peerSchema = getSchema(relationship.peer).schema;
+      if (!peerSchema) return [];
+
+      return getSortableFieldsOfRelationship(relationship, peerSchema);
+    });
+
+  return [...attributeFields, ...relationshipFields, ...NODE_METADATA_SORTABLE_FIELDS];
+}

--- a/frontend/app/src/entities/nodes/sort/domain/rules/is-valid-sort.test.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/is-valid-sort.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import { isValidSort } from "@/entities/nodes/sort/domain/rules/is-valid-sort";
+import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
+
+import {
+  generateAttributeSchema,
+  generateNodeSchema,
+  generateRelationshipSchema,
+} from "../../../../../../tests/fake/schema";
+
+describe("isValidSort", () => {
+  beforeEach(() => {
+    store.set(nodeSchemasAtom, []);
+  });
+
+  it("accepts sortable attribute, relationship and node metadata fields", () => {
+    // GIVEN
+    const site = generateNodeSchema({
+      kind: "LocationSite",
+      attributes: [generateAttributeSchema({ name: "name", kind: "Text" })],
+      relationships: [],
+    });
+    store.set(nodeSchemasAtom, [site]);
+    const schema = generateNodeSchema({
+      attributes: [generateAttributeSchema({ name: "name", kind: "Text" })],
+      relationships: [
+        generateRelationshipSchema({ name: "site", peer: "LocationSite", cardinality: "one" }),
+      ],
+    });
+
+    // WHEN
+    const attributeSort = isValidSort({ field: "name__value", direction: "ASC" }, schema);
+    const relationshipSort = isValidSort({ field: "site__name__value", direction: "ASC" }, schema);
+    const metadataSort = isValidSort(
+      { field: "node_metadata__created_at", direction: "ASC" },
+      schema
+    );
+
+    // THEN
+    expect(attributeSort).toBe(true);
+    expect(relationshipSort).toBe(true);
+    expect(metadataSort).toBe(true);
+  });
+
+  it("rejects fields that are not sortable on the schema", () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      attributes: [
+        generateAttributeSchema({ name: "name", kind: "Text" }),
+        generateAttributeSchema({ name: "config", kind: "JSON" }),
+      ],
+      relationships: [],
+    });
+
+    // WHEN
+    const unknownAttribute = isValidSort({ field: "owner__value", direction: "ASC" }, schema);
+    const unsortableKind = isValidSort({ field: "config__value", direction: "ASC" }, schema);
+    const hostileToken = isValidSort(
+      { field: "name__value: ASC}) {password", direction: "ASC" },
+      schema
+    );
+
+    // THEN
+    expect(unknownAttribute).toBe(false);
+    expect(unsortableKind).toBe(false);
+    expect(hostileToken).toBe(false);
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/domain/rules/is-valid-sort.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/is-valid-sort.ts
@@ -1,0 +1,12 @@
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
+import { getSortableFields } from "@/entities/nodes/sort/domain/rules/get-sortable-fields";
+import type { ModelSchema } from "@/entities/schema/domain/model/schema";
+
+/**
+ * A sort is valid when its field is one of the schema's sortable fields.
+ * Sort fields come straight from the URL, so this allowlist is what keeps
+ * arbitrary user input out of GraphQL order arguments.
+ */
+export function isValidSort(sort: Sort, schema: ModelSchema): boolean {
+  return getSortableFields(schema).some((sortableField) => sortableField.field === sort.field);
+}

--- a/frontend/app/src/entities/nodes/sort/domain/rules/sort-token.test.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/sort-token.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { SORT_DIRECTION, type Sort } from "@/entities/nodes/sort/domain/model/sort";
+import { parseSortToken, serializeSortToken } from "@/entities/nodes/sort/domain/rules/sort-token";
+
+describe("parseSortToken", () => {
+  it("extracts the field and direction from a suffixed token", () => {
+    // GIVEN
+    const ascToken = "label__asc";
+    const descToken = "label__desc";
+
+    // WHEN
+    const ascSort = parseSortToken(ascToken);
+    const descSort = parseSortToken(descToken);
+
+    // THEN
+    expect(ascSort).toEqual({ field: "label", direction: SORT_DIRECTION.ASC });
+    expect(descSort).toEqual({ field: "label", direction: SORT_DIRECTION.DESC });
+  });
+
+  it("keeps `__` inside the field path and only strips the trailing direction", () => {
+    // GIVEN
+    const token = "name__value__desc";
+
+    // WHEN
+    const sort = parseSortToken(token);
+
+    // THEN
+    expect(sort).toEqual({ field: "name__value", direction: SORT_DIRECTION.DESC });
+  });
+
+  it("treats a token without a direction suffix as a bare field sorted ASC", () => {
+    // GIVEN
+    const schemaOrderByEntry = "name__value";
+    const singleSegment = "name";
+
+    // WHEN
+    const entrySort = parseSortToken(schemaOrderByEntry);
+    const singleSegmentSort = parseSortToken(singleSegment);
+
+    // THEN
+    expect(entrySort).toEqual({ field: "name__value", direction: SORT_DIRECTION.ASC });
+    expect(singleSegmentSort).toEqual({ field: "name", direction: SORT_DIRECTION.ASC });
+  });
+
+  it("treats a token that is only a direction suffix as a bare field, never an empty one", () => {
+    // GIVEN
+    const ascOnly = "__asc";
+    const descOnly = "__desc";
+
+    // WHEN
+    const ascSort = parseSortToken(ascOnly);
+    const descSort = parseSortToken(descOnly);
+
+    // THEN
+    expect(ascSort).toEqual({ field: "__asc", direction: SORT_DIRECTION.ASC });
+    expect(descSort).toEqual({ field: "__desc", direction: SORT_DIRECTION.ASC });
+  });
+
+  it("ignores an uppercase or unknown direction suffix", () => {
+    // GIVEN
+    const uppercase = "name__value__DESC";
+    const unknown = "name__value__descending";
+
+    // WHEN
+    const uppercaseSort = parseSortToken(uppercase);
+    const unknownSort = parseSortToken(unknown);
+
+    // THEN
+    expect(uppercaseSort).toEqual({ field: "name__value__DESC", direction: SORT_DIRECTION.ASC });
+    expect(unknownSort).toEqual({
+      field: "name__value__descending",
+      direction: SORT_DIRECTION.ASC,
+    });
+  });
+
+  it("returns hostile URL input verbatim as a field instead of throwing", () => {
+    // GIVEN
+    const empty = "";
+    const injection = "name__value: ASC}) {password__desc";
+
+    // WHEN
+    const emptySort = parseSortToken(empty);
+    const injectionSort = parseSortToken(injection);
+
+    // THEN
+    expect(emptySort).toEqual({ field: "", direction: SORT_DIRECTION.ASC });
+    expect(injectionSort).toEqual({
+      field: "name__value: ASC}) {password",
+      direction: SORT_DIRECTION.DESC,
+    });
+  });
+});
+
+describe("serializeSortToken", () => {
+  it("joins the field and the lowercased direction with `__`", () => {
+    // GIVEN
+    const ascSort: Sort = { field: "name__value", direction: SORT_DIRECTION.ASC };
+    const descSort: Sort = { field: "name__value", direction: SORT_DIRECTION.DESC };
+
+    // WHEN
+    const ascToken = serializeSortToken(ascSort);
+    const descToken = serializeSortToken(descSort);
+
+    // THEN
+    expect(ascToken).toBe("name__value__asc");
+    expect(descToken).toBe("name__value__desc");
+  });
+
+  it("round-trips through parseSortToken", () => {
+    // GIVEN
+    const ascSort: Sort = { field: "name__value", direction: SORT_DIRECTION.ASC };
+    const descSort: Sort = { field: "name__value", direction: SORT_DIRECTION.DESC };
+
+    // WHEN
+    const ascRoundTrip = parseSortToken(serializeSortToken(ascSort));
+    const descRoundTrip = parseSortToken(serializeSortToken(descSort));
+
+    // THEN
+    expect(ascRoundTrip).toEqual(ascSort);
+    expect(descRoundTrip).toEqual(descSort);
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/domain/rules/sort-token.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/sort-token.ts
@@ -1,0 +1,29 @@
+import * as R from "remeda";
+
+import {
+  SORT_DIRECTION,
+  type Sort,
+  type SortDirection,
+  type SortField,
+  type SortToken,
+} from "@/entities/nodes/sort/domain/model/sort";
+
+export function parseSortToken(token: string): Sort {
+  const segments = token.split("__");
+  const dir = R.last(segments);
+  const field = R.dropLast(segments, 1).join("__");
+  const isDirection = dir === "asc" || dir === "desc";
+
+  if (!field || !isDirection) {
+    return { field: token as SortField, direction: SORT_DIRECTION.ASC };
+  }
+
+  return {
+    field: field as SortField,
+    direction: dir === "desc" ? SORT_DIRECTION.DESC : SORT_DIRECTION.ASC,
+  };
+}
+
+export function serializeSortToken(sort: Sort): SortToken {
+  return `${sort.field}__${sort.direction.toLowerCase() as Lowercase<SortDirection>}`;
+}

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
@@ -1,0 +1,101 @@
+import { type OnUrlUpdateFunction, withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useSort } from "@/entities/nodes/sort/ui/hooks/use-sort";
+
+import { generateAttributeSchema, generateNodeSchema } from "../../../../../../tests/fake/schema";
+
+const schema = generateNodeSchema({
+  attributes: [
+    generateAttributeSchema({ name: "name", label: "Name", kind: "Text" }),
+    generateAttributeSchema({ name: "priority", label: "Priority", kind: "Number" }),
+  ],
+  relationships: [],
+});
+
+describe("useSort", () => {
+  it("reads sorts from the `sort` query param", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({
+      searchParams: "?sort=name__value__asc,priority__value__desc",
+    });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.sort).toEqual([
+      { field: "name__value", direction: "ASC" },
+      { field: "priority__value", direction: "DESC" },
+    ]);
+  });
+
+  it("keeps only the sorts that are valid for the schema", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({
+      searchParams: "?sort=owner__value__asc,name__value__desc",
+    });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.sort).toEqual([{ field: "name__value", direction: "DESC" }]);
+  });
+
+  it("returns null when the query param is absent or carries no valid sort", async () => {
+    // GIVEN
+    const withoutSort = withNuqsTestingAdapter({ searchParams: "" });
+    const withHostileSort = withNuqsTestingAdapter({
+      searchParams: "?sort=name__value: ASC}) {password__desc",
+    });
+
+    // WHEN
+    const absent = await renderHook(() => useSort(schema), { wrapper: withoutSort });
+    const hostile = await renderHook(() => useSort(schema), { wrapper: withHostileSort });
+
+    // THEN
+    expect(absent.result.current.sort).toBeNull();
+    expect(hostile.result.current.sort).toBeNull();
+  });
+
+  it("setSort writes the serialized sorts to the URL with history push", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+    const wrapper = withNuqsTestingAdapter({ searchParams: "", onUrlUpdate });
+    const hook = await renderHook(() => useSort(schema), { wrapper });
+
+    // WHEN
+    await hook.act(() => {
+      hook.result.current.setSort([
+        { field: "priority__value", direction: "DESC" },
+        { field: "name__value", direction: "ASC" },
+      ]);
+    });
+
+    // THEN
+    const event = onUrlUpdate.mock.lastCall?.[0];
+    expect(event?.searchParams.get("sort")).toBe("priority__value__desc,name__value__asc");
+    expect(event?.options.history).toBe("push");
+  });
+
+  it("setSort with an empty list removes the query param", async () => {
+    // GIVEN
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+    const wrapper = withNuqsTestingAdapter({
+      searchParams: "?sort=name__value__desc",
+      onUrlUpdate,
+    });
+    const hook = await renderHook(() => useSort(schema), { wrapper });
+
+    // WHEN
+    await hook.act(() => {
+      hook.result.current.setSort([]);
+    });
+
+    // THEN
+    const event = onUrlUpdate.mock.lastCall?.[0];
+    expect(event?.searchParams.get("sort")).toBeNull();
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.ts
@@ -1,0 +1,32 @@
+import { createParser, parseAsArrayOf, useQueryState } from "nuqs";
+
+import { QSP } from "@/shared/config/qsp";
+
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
+import { isValidSort } from "@/entities/nodes/sort/domain/rules/is-valid-sort";
+import { parseSortToken, serializeSortToken } from "@/entities/nodes/sort/domain/rules/sort-token";
+import type { ModelSchema } from "@/entities/schema/domain/model/schema";
+
+const sortParser = createParser({
+  parse: parseSortToken,
+  serialize: serializeSortToken,
+});
+
+type UseSort = (schema: ModelSchema) => {
+  sort: Sort[] | null;
+  setSort: (next: Sort[]) => void;
+};
+
+export const useSort: UseSort = (schema) => {
+  const [sortInQsp, setSortInQsp] = useQueryState(
+    QSP.SORT,
+    parseAsArrayOf(sortParser).withOptions({ history: "push" })
+  );
+
+  const validSort = (sortInQsp ?? []).filter((sort) => isValidSort(sort, schema));
+
+  const sort = validSort.length > 0 ? validSort : null;
+  const setSort = (next: Sort[]) => setSortInQsp(next.length > 0 ? next : null);
+
+  return { sort, setSort };
+};

--- a/frontend/app/src/shared/api/graphql/utils.test.ts
+++ b/frontend/app/src/shared/api/graphql/utils.test.ts
@@ -1,10 +1,18 @@
+import { EnumType, jsonToGraphQLQuery } from "json-to-graphql-query";
 import { describe, expect, it } from "vitest";
 
+import {
+  addAttributesToRequest,
+  addFiltersToRequest,
+  addOrderByToRequest,
+  addRelationshipsToRequest,
+} from "@/shared/api/graphql/utils";
+
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
 
 import { generateAttributeSchema, generateRelationshipSchema } from "../../../../tests/fake/schema";
-import { addAttributesToRequest, addFiltersToRequest, addRelationshipsToRequest } from "./utils";
 
 describe("addAttributesToRequest", () => {
   it("should return base fragment for simple attribute", () => {
@@ -386,5 +394,42 @@ describe("addFiltersToRequest", () => {
 
     // THEN
     expect(result).toEqual({});
+  });
+});
+
+describe("addOrderByToRequest", () => {
+  it("serializes direction as an unquoted enum the server accepts, not a quoted string", () => {
+    // GIVEN
+    const sort: Sort[] = [
+      { field: "name__value", direction: "ASC" },
+      { field: "owner__name__value", direction: "DESC" },
+    ];
+
+    // WHEN
+    const query = jsonToGraphQLQuery({ q: { __args: addOrderByToRequest(sort) } });
+
+    // THEN
+    expect(query).toContain("direction: ASC");
+    expect(query).toContain("direction: DESC");
+    expect(query).not.toContain('direction: "ASC"');
+    expect(query).not.toContain('direction: "DESC"');
+  });
+
+  it("passes relationship and node-metadata field keys through verbatim, wrapping only direction", () => {
+    // GIVEN
+    const sort: Sort[] = [
+      { field: "owner__name__value", direction: "ASC" },
+      { field: "node_metadata__updated_at", direction: "DESC" },
+    ];
+
+    // WHEN
+    const { order } = addOrderByToRequest(sort);
+
+    // THEN
+    expect(order.by.map((entry) => entry.field)).toEqual([
+      "owner__name__value",
+      "node_metadata__updated_at",
+    ]);
+    expect(order.by.every((entry) => entry.direction instanceof EnumType)).toBe(true);
   });
 });

--- a/frontend/app/src/shared/api/graphql/utils.ts
+++ b/frontend/app/src/shared/api/graphql/utils.ts
@@ -1,5 +1,8 @@
+import { EnumType } from "json-to-graphql-query";
+
 import { AVAILABLE_IP_FILTER_NAME } from "@/entities/ipam/ip-availability/domain/model/ip-availability-filter";
 import type { Filter } from "@/entities/nodes/filters/domain/model/filter";
+import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import { ATTRIBUTE_KIND } from "@/entities/schema/domain/model/attribute-kind";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
 
@@ -161,6 +164,14 @@ export const addFiltersToRequest = (filters: Array<Filter>) => {
     },
     {} as Record<string, string | number | boolean | string[]>
   );
+};
+
+export const addOrderByToRequest = (sort: Sort[]) => {
+  return {
+    order: {
+      by: sort.map(({ field, direction }) => ({ field, direction: new EnumType(direction) })),
+    },
+  };
 };
 
 export const dropIncludeAvailableWhenFalse = (filters?: Filter[]) =>

--- a/frontend/app/src/shared/config/qsp.ts
+++ b/frontend/app/src/shared/config/qsp.ts
@@ -8,6 +8,7 @@ export const QSP = {
   PROPOSED_CHANGES_STATE: "pr_state",
   QUERY: "query",
   SEARCH: "search",
+  SORT: "sort",
   IPAM_NAMESPACE: "namespace",
   STATUS: "status",
   HIGHLIGHT: "highlight",


### PR DESCRIPTION
# Why

Object lists have no way to sort, and there was no frontend home for sort logic: which fields of a schema are sortable, what the schema's default order is, and how a user's chosen sort survives in a shareable URL. Sort state also arrives from an untrusted source (the query string) and eventually feeds GraphQL order arguments, so it needs explicit validation.

This PR adds a complete, tested `entities/nodes/sort/` unit providing schema-aware, URL-synced sort state via a `useSort` hook.

  ## What changed

  No user-visible behavior changes yet — this is a new, not-yet-consumed entity plus one QSP key (`sort`) in `shared/config/qsp.ts`.

  New `entities/nodes/sort/`, by layer:

  - **`domain/model/sort.ts`** — vocabulary: `Sort`, `SortField`, `SortDirection`,
    `SortToken`, `SortableField`.
  - **`domain/rules/sort-token.ts`** — codec for the `field__asc|desc` token,
    mirroring the backend `order_by` grammar (`infrahub.core.schema.order_by`):
    optional suffix, `ASC` default, non-empty field required, `__` allowed inside
    field paths. Total function: malformed input degrades to "bare field, ASC",
    never throws.
  - **`domain/rules/get-schema-default-sort.ts`** — maps `schema.order_by` to `Sort[]`.
  - **`domain/rules/get-sortable-attributes.ts` / `get-sortable-fields.ts`** —
    sortable fields = simple-valued attributes (JSON/List/Any/Password/HashedPassword
    excluded), peer attributes of cardinality-one relationships (ordered by
    `order_weight`, labelled `Peer › Attribute`), and node metadata
    (`node_metadata__created_at`/`updated_at`). Matches what backend
    `validate_order_by` accepts (`ATTR_WITH_PROP | REL_ONE_ATTR_WITH_PROP`).
  - **`domain/rules/is-valid-sort.ts`** — the allowlist: a sort is valid only if its
    field is among the schema's sortable fields. This is the boundary keeping
    arbitrary URL input out of GraphQL order arguments.
  - **`ui/hooks/use-sort.ts`** — `useSort(schema)` returns `{ sort, setSort }`,
    backed by nuqs (`?sort=name__value__desc,...`, `history: "push"`). Invalid
    entries are dropped individually; empty/all-invalid yields `null`; `setSort([])`
    removes the param.

  Implementation notes:

  - Peer schemas are resolved internally via the existing `getSchema` use-case
    (store snapshot, same pattern as `is-hierarchical-schema`), so callers pass
    only the schema.
  - Token parsing is hand-rolled rather than zod: the QSP value is a micro-grammar
    string, not a JSON payload, and the security-relevant validation is semantic
    (allowlist vs schema), which zod can't express.

  ## How to review

  - Highest-value files: `is-valid-sort.ts` (security boundary) and
    `sort-token.ts` (grammar edge cases — `name__value` without suffix,
    `__desc` alone, unknown suffixes).
  - Extra scrutiny welcome on `get-sortable-fields.ts` reading the Jotai store
    through `getSchema`: it follows existing precedent but is a snapshot read —
    no re-render if schemas load after first render (fine today since schemas load
    before object pages, but worth a second opinion).
  - Tests mirror the source files one-to-one; the hook test introduces `nuqs/adapters/testing` (first use in the repo).