### PR TITLE
chore(ui): enable Tailwind class sorting in oxfmt for tv() and cn()

### DIFF
--- a/frontend/packages/ui/oxfmt.config.ts
+++ b/frontend/packages/ui/oxfmt.config.ts
@@ -16,4 +16,8 @@ export default defineConfig({
   sortPackageJson: {
     sortScripts: true,
   },
+  sortTailwindcss: {
+    functions: ["tv", "cn"],
+    stylesheet: "./src/index.css",
+  },
 });

--- a/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
+++ b/frontend/packages/ui/src/components/autocomplete/autocomplete.tsx
@@ -40,7 +40,7 @@ function AutocompleteSearchField({
         variant="ghost"
         shape="square"
         size="xxs"
-        className="opacity-50 hover:opacity-100 group-data-empty:invisible"
+        className="opacity-50 group-data-empty:invisible hover:opacity-100"
       >
         <XIcon />
       </Button>
@@ -66,7 +66,7 @@ export function Autocomplete({
   return (
     <AriaAutocomplete filter={resolvedFilter} onInputChange={onInputChange} {...props}>
       <div className="max-h-[inherit] overflow-hidden">
-        <div className="sticky flex w-full items-center gap-0 overflow-hidden border-neutral-300 border-b pr-1">
+        <div className="sticky flex w-full items-center gap-0 overflow-hidden border-b border-neutral-300 pr-1">
           <AutocompleteSearchField placeholder="Search..." className="grow" />
           {suffix}
         </div>

--- a/frontend/packages/ui/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/frontend/packages/ui/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -22,7 +22,7 @@ function AllVariantsRender() {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Links</div>
+        <div className="mb-1 text-xs text-neutral-500">Links</div>
         <Breadcrumbs>
           <BreadcrumbItem href="/">Home</BreadcrumbItem>
           <BreadcrumbItem href="/objects">Objects</BreadcrumbItem>
@@ -31,7 +31,7 @@ function AllVariantsRender() {
       </div>
 
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Buttons</div>
+        <div className="mb-1 text-xs text-neutral-500">Buttons</div>
         <Breadcrumbs>
           <BreadcrumbItem onPress={() => {}}>Home</BreadcrumbItem>
           <BreadcrumbItem onPress={() => {}}>Objects</BreadcrumbItem>
@@ -40,7 +40,7 @@ function AllVariantsRender() {
       </div>
 
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Mixed (links + button)</div>
+        <div className="mb-1 text-xs text-neutral-500">Mixed (links + button)</div>
         <Breadcrumbs>
           <BreadcrumbItem href="/">Home</BreadcrumbItem>
           <BreadcrumbItem href="/objects">Objects</BreadcrumbItem>
@@ -49,7 +49,7 @@ function AllVariantsRender() {
       </div>
 
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Loading</div>
+        <div className="mb-1 text-xs text-neutral-500">Loading</div>
         <Breadcrumbs>
           <BreadcrumbItem href="/">Home</BreadcrumbItem>
           <BreadcrumbItemLoading />
@@ -57,7 +57,7 @@ function AllVariantsRender() {
       </div>
 
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Error</div>
+        <div className="mb-1 text-xs text-neutral-500">Error</div>
         <Breadcrumbs>
           <BreadcrumbItem href="/">Home</BreadcrumbItem>
           <BreadcrumbItemError error={new Error("Failed to fetch")} />
@@ -65,7 +65,7 @@ function AllVariantsRender() {
       </div>
 
       <div>
-        <div className="mb-1 text-neutral-500 text-xs">Long content (truncation)</div>
+        <div className="mb-1 text-xs text-neutral-500">Long content (truncation)</div>
         <div className="w-96">
           <Breadcrumbs>
             <BreadcrumbItem href="/">Home</BreadcrumbItem>

--- a/frontend/packages/ui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/frontend/packages/ui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -31,7 +31,7 @@ export function Breadcrumb({ children, className, ...props }: BreadcrumbProps) {
           <span
             role="presentation"
             aria-hidden="true"
-            className="select-none font-medium text-lg text-neutral-300"
+            className="text-lg font-medium text-neutral-300 select-none"
           >
             /
           </span>

--- a/frontend/packages/ui/src/components/button/button.stories.tsx
+++ b/frontend/packages/ui/src/components/button/button.stories.tsx
@@ -31,7 +31,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ColumnLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="font-medium text-[10px] text-neutral-400 uppercase tracking-wider">
+  <div className="text-[10px] font-medium tracking-wider text-neutral-400 uppercase">
     {children}
   </div>
 );
@@ -52,7 +52,7 @@ export const AllVariants: Story = {
       rowProps: Partial<ButtonProps> = {},
     ) => (
       <div key={label} className="contents">
-        <div className="font-medium text-neutral-700 text-sm">{label}</div>
+        <div className="text-sm font-medium text-neutral-700">{label}</div>
 
         <div className="flex flex-wrap items-center gap-2">
           {SIZES.map((size) => (

--- a/frontend/packages/ui/src/components/button/button.tsx
+++ b/frontend/packages/ui/src/components/button/button.tsx
@@ -23,36 +23,36 @@ const buttonVariants = tv({
     "data-disabled:pointer-events-none data-disabled:cursor-default data-disabled:opacity-60 data-disabled:shadow-none",
     "data-pending:cursor-default data-pending:select-none",
     "data-pressed:scale-97 data-pressed:shadow-none data-pressed:duration-75",
-    "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
   ],
   variants: {
     variant: {
       primary: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] border-cyan-800 bg-gradient-to-b from-cyan-800 to-cyan-700 text-white",
+        "border-cyan-800 bg-gradient-to-b from-cyan-800 to-cyan-700 text-white inset-shadow-[0_1px_0_rgba(255,255,255,0.15)]",
         "data-hovered:inset-shadow-[0_-2px_2px_rgba(255,255,255,0.15),0_2px_2px_rgba(255,255,255,0.15)]",
       ],
       "primary-outline": [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.9)] border-cyan-700 bg-gradient-to-b from-stone-100 to-white text-cyan-700",
+        "border-cyan-700 bg-gradient-to-b from-stone-100 to-white text-cyan-700 inset-shadow-[0_1px_0_rgba(255,255,255,0.9)]",
         "data-hovered:from-neutral-100",
       ],
       danger: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] border-rose-700 bg-gradient-to-b from-rose-700 to-rose-600 text-white",
+        "border-rose-700 bg-gradient-to-b from-rose-700 to-rose-600 text-white inset-shadow-[0_1px_0_rgba(255,255,255,0.15)]",
         "data-hovered:inset-shadow-[0_-2px_2px_rgba(255,255,255,0.15),0_2px_2px_rgba(255,255,255,0.15)]",
       ],
       "danger-outline": [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.9)] border-rose-200 bg-gradient-to-b from-stone-100 to-white text-rose-600",
+        "border-rose-200 bg-gradient-to-b from-stone-100 to-white text-rose-600 inset-shadow-[0_1px_0_rgba(255,255,255,0.9)]",
         "data-hovered:from-rose-50",
       ],
       warning: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] border-amber-600 bg-gradient-to-b from-amber-600 to-amber-500 text-white",
+        "border-amber-600 bg-gradient-to-b from-amber-600 to-amber-500 text-white inset-shadow-[0_1px_0_rgba(255,255,255,0.15)]",
         "data-hovered:inset-shadow-[0_-2px_2px_rgba(255,255,255,0.15),0_2px_2px_rgba(255,255,255,0.15)]",
       ],
       active: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] border-emerald-700 bg-gradient-to-b from-emerald-700 to-emerald-700 text-white",
+        "border-emerald-700 bg-gradient-to-b from-emerald-700 to-emerald-700 text-white inset-shadow-[0_1px_0_rgba(255,255,255,0.15)]",
         "data-hovered:inset-shadow-[0_-2px_2px_rgba(255,255,255,0.15),0_2px_2px_rgba(255,255,255,0.15)]",
       ],
       outline: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.9)] border-neutral-200 bg-gradient-to-b from-stone-100 to-white text-stone-800",
+        "border-neutral-200 bg-gradient-to-b from-stone-100 to-white text-stone-800 inset-shadow-[0_1px_0_rgba(255,255,255,0.9)]",
         "data-hovered:from-neutral-100",
       ],
       ghost: [

--- a/frontend/packages/ui/src/components/card/card.tsx
+++ b/frontend/packages/ui/src/components/card/card.tsx
@@ -13,7 +13,7 @@ export function Card({ className, ref, ...props }: CardProps) {
       className={cn(
         "flex flex-col",
         "rounded-2xl",
-        "bg-linear-to-b from-stone-50 to-10% to-white",
+        "bg-linear-to-b from-stone-50 to-white to-10%",
         "border border-neutral-200",
         "shadow-[0_1px_1px_rgba(0,0,0,0.02)] inset-shadow-[0_2px_0_rgb(255,255,255),0_-1px_2px_1px_rgba(0,0,0,0.03)]",
         className,
@@ -36,7 +36,7 @@ export function CardHeader({ className, ref, ...props }: CardHeaderProps) {
         "border-b border-b-neutral-200",
         "bg-linear-to-b from-neutral-100 to-neutral-50",
         "px-3 py-2",
-        "font-medium text-neutral-700 text-sm tracking-tight",
+        "text-sm font-medium tracking-tight text-neutral-700",
         "inset-shadow-[0_1px_0_rgba(255,255,255,0.85)]",
         className,
       )}

--- a/frontend/packages/ui/src/components/checkbox-card/checkbox-card.tsx
+++ b/frontend/packages/ui/src/components/checkbox-card/checkbox-card.tsx
@@ -13,14 +13,14 @@ import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 const checkboxCardVariants = tv({
   base: [
     focusVisibleStyle,
-    "group/checkbox-card relative flex cursor-pointer items-center gap-3 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-neutral-600 text-sm transition-all",
+    "group/checkbox-card relative flex cursor-pointer items-center gap-3 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-600 transition-all",
     "data-disabled:cursor-not-allowed data-disabled:opacity-60",
     "data-pressed:scale-97 data-pressed:shadow-none data-pressed:duration-75",
   ],
   variants: {
     isSelected: {
       true: [
-        "inset-shadow-[0_1px_0_rgba(255,255,255,0.9)] bg-gradient-to-b from-stone-100 to-white text-neutral-800 shadow-xs",
+        "bg-gradient-to-b from-stone-100 to-white text-neutral-800 shadow-xs inset-shadow-[0_1px_0_rgba(255,255,255,0.9)]",
       ],
     },
   },

--- a/frontend/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/frontend/packages/ui/src/components/checkbox/checkbox.tsx
@@ -11,16 +11,16 @@ import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 
 const checkboxVariants = tv({
   base: [
-    "group/checkbox flex cursor-pointer select-none items-center gap-1.5 text-sm",
+    "group/checkbox flex cursor-pointer items-center gap-1.5 text-sm select-none",
     "data-disabled:cursor-not-allowed data-disabled:opacity-70",
   ],
 });
 
 const checkboxIndicatorVariants = tv({
   base: [
-    "flex size-4.5 shrink-0 items-center justify-center rounded-md border border-neutral-300 text-white bg-white transition-all duration-200",
+    "flex size-4.5 shrink-0 items-center justify-center rounded-md border border-neutral-300 bg-white text-white transition-all duration-200",
     "group-data-pressed/checkbox:scale-90",
-    "group-data-focus-visible/checkbox:border-cyan-700 group-data-focus-visible/checkbox:outline-hidden group-data-focus-visible/checkbox:ring-2 group-data-focus-visible/checkbox:ring-cyan-700/25",
+    "group-data-focus-visible/checkbox:border-cyan-700 group-data-focus-visible/checkbox:ring-2 group-data-focus-visible/checkbox:ring-cyan-700/25 group-data-focus-visible/checkbox:outline-hidden",
   ],
   variants: {
     isActive: {

--- a/frontend/packages/ui/src/components/label/label.tsx
+++ b/frontend/packages/ui/src/components/label/label.tsx
@@ -3,7 +3,7 @@ import { cn, tv } from "tailwind-variants";
 
 const labelStyles = tv({
   base: [
-    "cursor-pointer font-medium text-neutral-900 text-sm leading-none",
+    "cursor-pointer text-sm leading-none font-medium text-neutral-900",
     "data-disabled:cursor-not-allowed data-disabled:opacity-70",
   ],
 });

--- a/frontend/packages/ui/src/components/list-box/list-box.stories.tsx
+++ b/frontend/packages/ui/src/components/list-box/list-box.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ColumnLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="font-medium text-[10px] text-neutral-400 uppercase tracking-wider">
+  <div className="text-[10px] font-medium tracking-wider text-neutral-400 uppercase">
     {children}
   </div>
 );

--- a/frontend/packages/ui/src/components/list-box/list-box.tsx
+++ b/frontend/packages/ui/src/components/list-box/list-box.tsx
@@ -53,7 +53,7 @@ export function ListBox<T extends object>({
         renderEmptyState={
           emptyMessage === undefined
             ? undefined
-            : () => <div className="px-2 py-1 text-neutral-600 text-sm">{emptyMessage}</div>
+            : () => <div className="px-2 py-1 text-sm text-neutral-600">{emptyMessage}</div>
         }
         {...props}
       />
@@ -80,7 +80,7 @@ export function ListBox<T extends object>({
 
 const listBoxItemStyles = tv({
   base: [
-    "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden",
+    "flex min-w-40 cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden select-none",
     "data-disabled:pointer-events-none data-disabled:opacity-50",
   ],
   variants: {
@@ -107,7 +107,7 @@ export function ListBoxItem<T extends object>({
       className={composeAriaClassName(className, ({ isFocused, isSelected }) =>
         cn(
           listBoxItemStyles({ isFocused }),
-          isSelected && selectionIndicator === "highlight" && "bg-stone-700/10  text-stone-800",
+          isSelected && selectionIndicator === "highlight" && "bg-stone-700/10 text-stone-800",
         ),
       )}
       {...props}

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -18,7 +18,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ColumnLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="font-medium text-[10px] text-neutral-400 uppercase tracking-wider">
+  <div className="text-[10px] font-medium tracking-wider text-neutral-400 uppercase">
     {children}
   </div>
 );
@@ -32,7 +32,7 @@ const MenuSurface = ({ children }: { children: React.ReactNode }) => (
 
 export const Default: Story = {
   render: () => (
-    <div className="grid grid-cols-[8rem_auto]  items-start gap-x-6 gap-y-6">
+    <div className="grid grid-cols-[8rem_auto] items-start gap-x-6 gap-y-6">
       <ColumnLabel>Simple</ColumnLabel>
       <MenuSurface>
         <Menu aria-label="Simple menu">

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -67,8 +67,8 @@ export const MenuItem = ({
       className={composeAriaClassName(className, (resolvedClassName) =>
         cn(
           "data-disabled:pointer-events-none data-disabled:opacity-50",
-          "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-md border border-transparent bg-white px-2 py-1 text-sm text-stone-600 shadow-sm outline-hidden transition-colors",
-          "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+          "flex min-w-40 cursor-pointer items-center gap-2 rounded-md border border-transparent bg-white px-2 py-1 text-sm text-stone-600 shadow-sm outline-hidden transition-colors select-none",
+          "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
           "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
           resolvedClassName,
         ),
@@ -91,7 +91,7 @@ export const MenuSection = <T extends object>({
 }: MenuSectionProps<T>) => {
   return (
     <AriaMenuSection className={cn("flex flex-col gap-0.5", className)} {...props}>
-      {title && <AriaHeader className="px-1 text-stone-500 text-xs">{title}</AriaHeader>}
+      {title && <AriaHeader className="px-1 text-xs text-stone-500">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/components/meter/meter.tsx
+++ b/frontend/packages/ui/src/components/meter/meter.tsx
@@ -25,7 +25,7 @@ export function Meter({ label, className, ...props }: MeterProps) {
           <div
             className={cn(
               "h-2.5 overflow-hidden rounded-full bg-stone-200",
-              "inset-shadow-[0_1px_2px_rgba(0,0,0,0.15)] ring-1 ring-stone-300 ring-inset",
+              "ring-1 inset-shadow-[0_1px_2px_rgba(0,0,0,0.15)] ring-stone-300 ring-inset",
               "shadow-[0_1px_0_rgba(255,255,255,0.8)]",
               label ? "col-span-2 w-full" : "grow",
             )}
@@ -33,7 +33,7 @@ export function Meter({ label, className, ...props }: MeterProps) {
             <div
               className={cn(
                 "h-full rounded-[inherit] transition-all",
-                "bg-linear-to-b from-cyan-800 to-cyan-600 border border-cyan-800",
+                "border border-cyan-800 bg-linear-to-b from-cyan-800 to-cyan-600",
                 "inset-shadow-[0_1px_0_rgba(255,255,255,0.4)]",
               )}
               style={{ width: `${percentage}%` }}
@@ -46,7 +46,7 @@ export function Meter({ label, className, ...props }: MeterProps) {
         if (label) {
           return (
             <>
-              <span className="font-medium text-sm">{label}</span>
+              <span className="text-sm font-medium">{label}</span>
               {value}
               {track}
             </>

--- a/frontend/packages/ui/src/components/modal/modal.stories.tsx
+++ b/frontend/packages/ui/src/components/modal/modal.stories.tsx
@@ -27,8 +27,8 @@ export const Default: Story = {
   render: (args) => (
     <Modal {...args}>
       <div className="flex flex-col gap-3 p-3">
-        <h2 className="font-medium text-base text-stone-900">Confirm action</h2>
-        <p className="text-neutral-600 text-sm">
+        <h2 className="text-base font-medium text-stone-900">Confirm action</h2>
+        <p className="text-sm text-neutral-600">
           This is a typical modal body. It can contain any content.
         </p>
         <div className="flex justify-end gap-2">
@@ -55,7 +55,7 @@ function NestedModal({ depth = ROOT_DEPTH }: { depth?: number }) {
         aria-label={`Modal level ${depth + NEXT_LEVEL}`}
       >
         <div className="flex flex-col gap-3 p-3">
-          <p className="text-neutral-700 text-sm">Level {depth + NEXT_LEVEL}</p>
+          <p className="text-sm text-neutral-700">Level {depth + NEXT_LEVEL}</p>
           <NestedModal depth={depth + NEXT_LEVEL} />
         </div>
       </Modal>

--- a/frontend/packages/ui/src/components/modal/modal.tsx
+++ b/frontend/packages/ui/src/components/modal/modal.tsx
@@ -22,8 +22,8 @@ export function ModalOverlay({ className, ...props }: ModalOverlayProps) {
       isDismissable
       className={cn(
         "absolute inset-0 z-50 overflow-hidden bg-gray-600/25",
-        "data-entering:fade-in-0 data-entering:animate-in data-entering:duration-200",
-        "data-exiting:fade-out-0 data-exiting:animate-out data-exiting:duration-150",
+        "data-entering:animate-in data-entering:duration-200 data-entering:fade-in-0",
+        "data-exiting:animate-out data-exiting:duration-150 data-exiting:fade-out-0",
         className,
       )}
       {...props}
@@ -53,8 +53,8 @@ export function Modal({
                 "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transition-all duration-200",
                 "no-scrollbar box-border flex max-h-[calc(var(--visual-viewport-height)*0.95)] max-w-[90vw] flex-col overflow-hidden rounded-2xl p-1 shadow-lg",
                 "border border-neutral-100 bg-white/25 backdrop-blur",
-                "data-entering:zoom-in-80 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
-                "data-exiting:zoom-out-80 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
+                "data-entering:animate-in data-entering:duration-200 data-entering:ease-out data-entering:zoom-in-80",
+                "data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in data-exiting:zoom-out-80",
               )}
               style={{
                 top: `${CENTER_PERCENT - depth * TOP_OFFSET_PER_LAYER}%`,

--- a/frontend/packages/ui/src/components/popover/popover.tsx
+++ b/frontend/packages/ui/src/components/popover/popover.tsx
@@ -18,10 +18,10 @@ const popoverStyles = tv({
   ],
   variants: {
     isEntering: {
-      true: "fade-in-0 zoom-in-95 animate-in",
+      true: "animate-in fade-in-0 zoom-in-95",
     },
     isExiting: {
-      true: "fade-out-0 zoom-out-95 animate-out",
+      true: "animate-out fade-out-0 zoom-out-95",
     },
     matchTriggerWidth: {
       true: "w-(--trigger-width)",

--- a/frontend/packages/ui/src/components/resizable/resizable.stories.tsx
+++ b/frontend/packages/ui/src/components/resizable/resizable.stories.tsx
@@ -21,7 +21,7 @@ const PanelContent = ({ label }: { label: string }) => (
 
 export const Horizontal: Story = {
   render: () => (
-    <div className="h-64 w-[640px] rounded border border-stone-300 overflow-hidden">
+    <div className="h-64 w-[640px] overflow-hidden rounded border border-stone-300">
       <ResizablePanelGroup>
         <ResizablePanel defaultSize={200} minSize={80}>
           <PanelContent label="Left" />
@@ -37,7 +37,7 @@ export const Horizontal: Story = {
 
 export const Vertical: Story = {
   render: () => (
-    <div className="h-64 w-[640px] rounded border border-stone-300 overflow-hidden">
+    <div className="h-64 w-[640px] overflow-hidden rounded border border-stone-300">
       <ResizablePanelGroup orientation="vertical">
         <ResizablePanel defaultSize={120} minSize={40}>
           <PanelContent label="Top" />
@@ -62,7 +62,7 @@ export const Playground: Story = {
     },
   },
   render: (args) => (
-    <div className="h-64 w-[640px] rounded border border-stone-300 overflow-hidden">
+    <div className="h-64 w-[640px] overflow-hidden rounded border border-stone-300">
       <ResizablePanelGroup {...args}>
         <ResizablePanel defaultSize={200} minSize={80}>
           <PanelContent label="Panel A" />

--- a/frontend/packages/ui/src/components/scroll-area/scroll-area.stories.tsx
+++ b/frontend/packages/ui/src/components/scroll-area/scroll-area.stories.tsx
@@ -59,19 +59,19 @@ export const Default: Story = {
   render: () => (
     <div className="flex gap-4">
       <div className="rounded border border-stone-300">
-        <p className="px-3 py-2 font-medium text-stone-700 text-xs">Both</p>
+        <p className="px-3 py-2 text-xs font-medium text-stone-700">Both</p>
         <ScrollArea scrollX scrollY className="h-48 w-64">
           <BothContent />
         </ScrollArea>
       </div>
       <div className="rounded border border-stone-300">
-        <p className="px-3 py-2 font-medium text-stone-700 text-xs">Vertical</p>
+        <p className="px-3 py-2 text-xs font-medium text-stone-700">Vertical</p>
         <ScrollArea className="h-48 w-64">
           <VerticalContent />
         </ScrollArea>
       </div>
       <div className="rounded border border-stone-300">
-        <p className="px-3 py-2 font-medium text-stone-700 text-xs">Horizontal</p>
+        <p className="px-3 py-2 text-xs font-medium text-stone-700">Horizontal</p>
         <ScrollArea scrollX scrollY={false} className="h-48 w-64">
           <HorizontalContent />
         </ScrollArea>

--- a/frontend/packages/ui/src/components/scroll-area/scroll-area.tsx
+++ b/frontend/packages/ui/src/components/scroll-area/scroll-area.tsx
@@ -10,7 +10,7 @@ function ScrollBar({ className, orientation = "vertical", ...props }: ScrollBarP
     <ScrollAreaPrimitive.ScrollAreaScrollbar
       orientation={orientation}
       className={cn(
-        "flex touch-none rounded-full select-none bg-neutral-100 transition-colors",
+        "flex touch-none rounded-full bg-neutral-100 transition-colors select-none",
         orientation === "vertical" && "h-full w-1",
         orientation === "horizontal" && "h-1 flex-col",
         className,

--- a/frontend/packages/ui/src/components/sheet/sheet.stories.tsx
+++ b/frontend/packages/ui/src/components/sheet/sheet.stories.tsx
@@ -31,8 +31,8 @@ function NestedSheet({ depth = ROOT_DEPTH }: { depth?: number }) {
       </Button>
       <Sheet isOpen={isOpen} onOpenChange={setIsOpen} aria-label={`Sheet level ${level}`}>
         <div className="flex flex-col gap-3">
-          <h2 className="font-medium text-base text-stone-900">Level {level}</h2>
-          <p className="text-neutral-600 text-sm">
+          <h2 className="text-base font-medium text-stone-900">Level {level}</h2>
+          <p className="text-sm text-neutral-600">
             Each open sheet pushes the previous ones to the left. Press Escape or click outside to
             close the topmost sheet.
           </p>
@@ -67,8 +67,8 @@ function DismissGuardContent({ close }: { close: () => void }) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="font-medium text-base text-stone-900">Edit description</h2>
-      <p className="text-neutral-600 text-sm">
+      <h2 className="text-base font-medium text-stone-900">Edit description</h2>
+      <p className="text-sm text-neutral-600">
         Type something below, then press Escape or click outside: the sheet refuses to close while
         the text is unsaved. Clear the text to make it dismissable again.
       </p>
@@ -80,7 +80,7 @@ function DismissGuardContent({ close }: { close: () => void }) {
         onChange={(event) => setDraft(event.target.value)}
       />
       {showWarning && isDirty && (
-        <p className="text-red-600 text-sm" role="alert">
+        <p className="text-sm text-red-600" role="alert">
           Unsaved changes — save or discard them first.
         </p>
       )}
@@ -122,8 +122,8 @@ export const Playground: Story = {
   render: (args) => (
     <Sheet {...args}>
       <div className="flex flex-col gap-3">
-        <h2 className="font-medium text-base text-stone-900">Sheet</h2>
-        <p className="text-neutral-600 text-sm">
+        <h2 className="text-base font-medium text-stone-900">Sheet</h2>
+        <p className="text-sm text-neutral-600">
           A side panel anchored to the right edge of the viewport. Toggle the isOpen control to open
           and close it.
         </p>

--- a/frontend/packages/ui/src/components/sheet/sheet.tsx
+++ b/frontend/packages/ui/src/components/sheet/sheet.tsx
@@ -40,8 +40,8 @@ export function Sheet({
                 className={cn(
                   "fixed top-2 bottom-2 w-100 overflow-hidden rounded-2xl p-1 outline-hidden transition-all",
                   "border border-neutral-100 bg-white/25 shadow-xl backdrop-blur",
-                  "data-entering:slide-in-from-right-1/2 data-entering:animate-in data-entering:duration-200 data-entering:ease-out",
-                  "data-exiting:slide-out-to-right-1/2 data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in",
+                  "data-entering:animate-in data-entering:duration-200 data-entering:ease-out data-entering:slide-in-from-right-1/2",
+                  "data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in data-exiting:slide-out-to-right-1/2",
                 )}
                 style={{
                   ...style,

--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.stories.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.stories.tsx
@@ -47,7 +47,7 @@ function DefaultRender() {
           </SortableItem>
         )}
       </SortableList>
-      <ol className="w-48 rounded-lg border border-stone-200 bg-stone-50 p-2 text-stone-600 text-xs">
+      <ol className="w-48 rounded-lg border border-stone-200 bg-stone-50 p-2 text-xs text-stone-600">
         {tasks.map((task, index) => (
           <li key={task.id} className="flex gap-2 px-1 py-0.5">
             <span className="text-stone-400">{index + 1}.</span>

--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
@@ -50,7 +50,7 @@ function SortableDropIndicator({ target }: { target: DropTarget }) {
     // -mt-px offsets the line's own height so this in-flow row adds no space, keeping siblings put.
     <DropIndicator
       target={target}
-      className="-mt-px mx-2 h-px rounded-full bg-cyan-600 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden"
+      className="mx-2 -mt-px h-px rounded-full bg-cyan-600 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden"
     />
   );
 }
@@ -78,7 +78,7 @@ export function SortableList<T extends { id: Key }>({
 
 const sortableItemStyles = tv({
   base: [
-    "flex cursor-grab select-none items-center gap-2 rounded-lg border border-transparent p-1 text-sm text-stone-600 outline-hidden",
+    "flex cursor-grab items-center gap-2 rounded-lg border border-transparent p-1 text-sm text-stone-600 outline-hidden select-none",
     "data-hovered:bg-stone-700/10 data-hovered:text-stone-800",
     "data-selected:bg-stone-700/10 data-selected:text-stone-800",
     "data-dragging:cursor-grabbing",

--- a/frontend/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/frontend/packages/ui/src/components/tooltip/tooltip.tsx
@@ -22,13 +22,13 @@ export interface TooltipProps extends Omit<AriaTooltipProps, "children"> {
 }
 
 const tooltipStyles = tv({
-  base: "group box-border rounded-xl border border-neutral-800 bg-neutral-700 px-2 py-1 font-sans text-white text-xs drop-shadow-lg will-change-transform",
+  base: "group box-border rounded-xl border border-neutral-800 bg-neutral-700 px-2 py-1 font-sans text-xs text-white drop-shadow-lg will-change-transform",
   variants: {
     isEntering: {
-      true: "fade-in data-[placement=bottom]:slide-in-from-top-0.5 data-[placement=top]:slide-in-from-bottom-0.5 data-[placement=left]:slide-in-from-right-0.5 data-[placement=right]:slide-in-from-left-0.5 animate-in duration-200 ease-out",
+      true: "data-[placement=bottom]:slide-in-from-top-0.5 data-[placement=top]:slide-in-from-bottom-0.5 data-[placement=left]:slide-in-from-right-0.5 data-[placement=right]:slide-in-from-left-0.5 animate-in duration-200 ease-out fade-in",
     },
     isExiting: {
-      true: "fade-out data-[placement=bottom]:slide-out-to-top-0.5 data-[placement=top]:slide-out-to-bottom-0.5 data-[placement=left]:slide-out-to-right-0.5 data-[placement=right]:slide-out-to-left-0.5 animate-out duration-150 ease-in",
+      true: "data-[placement=bottom]:slide-out-to-top-0.5 data-[placement=top]:slide-out-to-bottom-0.5 data-[placement=left]:slide-out-to-right-0.5 data-[placement=right]:slide-out-to-left-0.5 animate-out duration-150 ease-in fade-out",
     },
   },
 });

--- a/frontend/packages/ui/src/components/tree/tree.tsx
+++ b/frontend/packages/ui/src/components/tree/tree.tsx
@@ -104,7 +104,7 @@ export function TreeItemLoader(props: AriaTreeLoadMoreItemProps) {
     <AriaTreeLoadMoreItem {...props}>
       {({ level }) => (
         <div
-          className="flex h-8 items-center justify-start gap-2 text-neutral-500 text-sm"
+          className="flex h-8 items-center justify-start gap-2 text-sm text-neutral-500"
           style={{ paddingLeft: level * LOADER_INDENT_PX }}
         >
           <Spinner />

--- a/frontend/packages/ui/src/styles/focus-visible.ts
+++ b/frontend/packages/ui/src/styles/focus-visible.ts
@@ -1,4 +1,7 @@
+import { cn } from "tailwind-variants";
+
 // Mirror of frontend/app/src/shared/components/aria/style-rac.ts.
 // Keep both copies in sync until the app's aria/* components migrate to @infrahub/ui and we can delete the app copy.
-export const focusVisibleStyle =
-  "transition-all data-focus-visible:outline-hidden data-focus-visible:ring-2 data-focus-visible:ring-cyan-700/25 data-focus-visible:border-cyan-700";
+export const focusVisibleStyle = cn(
+  "transition-all data-focus-visible:border-cyan-700 data-focus-visible:ring-2 data-focus-visible:ring-cyan-700/25 data-focus-visible:outline-hidden",
+);


### PR DESCRIPTION
### Why

  `oxfmt` was not sorting Tailwind classes inside `tv()` / `cn()` calls in `frontend/packages/ui`. The `sortTailwindcss` option is disabled by default, and even when enabled it only handles `class` / `className` JSX attributes — custom functions must be listed explicitly.

  ### What
  
  - Enabled `sortTailwindcss` in `oxfmt.config.ts` with `functions: ["tv", "cn"]`
  - Pointed `stylesheet` at `src/index.css` (Tailwind v4 entry) so the sorter resolves the full class universe, including `tw-animate-css` utilities (`fade-in`, `slide-in-from-*`, …)
  - Ran `pnpm format`: 26 files resorted — pure reordering, no classes added or removed

  Note: `oxfmt` also deduplicates repeated classes by default; none existed in this package, but that applies going forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Tailwind class sorting in `frontend/packages/ui` by configuring `oxfmt` to sort classes in `tv()` and `cn()`. Reformatted components, stories, and `focusVisibleStyle` (now a `cn(...)` call) for consistent diffs with no visual or runtime changes.

- **Refactors**
  - Added `sortTailwindcss` in `oxfmt.config.ts` with `functions: ["tv", "cn"]` and `stylesheet: "./src/index.css"`.
  - Reordered classes across UI files to match the sorter.
  - Wrapped `focusVisibleStyle` in `cn()` to enable sorting.

<sup>Written for commit 51d5d1f56afe0392c79c7df3c8fd0e55b127a08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

