### PR TITLE
Migrate account menu to @infrahub/ui Menu with picker variant

### DIFF
--- a/frontend/app/src/entities/config/ui/app-info.tsx
+++ b/frontend/app/src/entities/config/ui/app-info.tsx
@@ -6,7 +6,7 @@ import { useGetAppInfo } from "@/entities/config/ui/queries/get-app-info.query";
 
 export function AppInfo() {
   return (
-    <div className="inline-flex w-full items-center justify-end text-gray-400 text-xs">
+    <div className="inline-flex w-full items-center justify-end text-stone-400 text-xs">
       Infrahub - <AppInstallationType /> - <AppVersion />
     </div>
   );

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -120,6 +120,7 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
           variant="ghost"
           shape="square"
           size="xs"
+          aria-label="Open account menu"
           data-testid="unauthenticated-menu-trigger"
           className="absolute top-1/2 right-1 -translate-y-1/2 group-data-[state=collapsed]:hidden"
         >

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -101,7 +101,7 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
       <LinkButton
         variant="ghost"
         size="sm"
-        className="h-10 w-full justify-stretch gap-2 pr-9 data-pressed:scale-100 group-data-[state=collapsed]:pr-2"
+        className="h-10 w-full justify-stretch gap-2 data-pressed:scale-100"
         href="/login"
         routerOptions={{ state: { from: location } }}
       >

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -1,20 +1,29 @@
 import { Icon } from "@iconify-icon/react";
-import { Button, LinkButton, Spinner } from "@infrahub/ui";
-import { EllipsisVerticalIcon } from "lucide-react";
+import {
+  Button,
+  LinkButton,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  MenuTrigger,
+  Popover,
+  Spinner,
+} from "@infrahub/ui";
+import {
+  CircleUserIcon,
+  EllipsisVerticalIcon,
+  FileTextIcon,
+  InfoIcon,
+  LogInIcon,
+  LogOutIcon,
+} from "lucide-react";
 import React from "react";
-import { Link, useLocation } from "react-router";
+import { useLocation } from "react-router";
 
 import { queryClient } from "@/shared/api/rest/client";
 import { constructPath } from "@/shared/api/rest/fetch";
 import { Avatar } from "@/shared/components/display/avatar";
 import { Skeleton } from "@/shared/components/loading/skeleton";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuDivider,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/shared/components/ui/dropdown-menu";
 import {
   INFRAHUB_DISCORD_URL,
   INFRAHUB_DOC_LOCAL,
@@ -46,59 +55,53 @@ export const AccountMenu = () => {
 
 const CommonMenuItems = ({ onAboutClick }: { onAboutClick: () => void }) => (
   <>
-    <DropdownMenuItem onSelect={onAboutClick}>
-      <Icon icon="mdi:information-outline" className="text-base" />
-      About Infrahub
-    </DropdownMenuItem>
+    <MenuItem onAction={onAboutClick}>
+      <InfoIcon /> About Infrahub
+    </MenuItem>
 
-    <DropdownMenuItem asChild>
-      <Link to={INFRAHUB_DOC_LOCAL} target="_blank" rel="noreferrer">
-        <Icon icon="mdi:file-document" className="text-base" />
-        Infrahub documentation
-      </Link>
-    </DropdownMenuItem>
+    <MenuItem href={INFRAHUB_DOC_LOCAL} target="_blank" rel="noreferrer">
+      <FileTextIcon /> Infrahub documentation
+    </MenuItem>
 
-    <DropdownMenuItem asChild>
-      <Link to={constructPath("/graphql")} className="text-base">
-        <Icon icon="mdi:graphql" className="text-base" />
-        GraphQL Sandbox
-      </Link>
-    </DropdownMenuItem>
+    <MenuItem href={constructPath("/graphql")}>
+      <Icon icon="mdi:graphql" className="text-base" />
+      GraphQL Sandbox
+    </MenuItem>
 
-    <DropdownMenuItem asChild>
-      <Link to={INFRAHUB_SWAGGER_DOC_URL} target="_blank" rel="noreferrer">
-        <Icon icon="mdi:code-json" className="text-base" />
-        Swagger documentation
-      </Link>
-    </DropdownMenuItem>
+    <MenuItem href={INFRAHUB_SWAGGER_DOC_URL} target="_blank" rel="noreferrer">
+      <Icon icon="mdi:code-json" className="text-base" />
+      Swagger documentation
+    </MenuItem>
 
-    <DropdownMenuDivider />
+    <MenuSeparator />
 
-    <DropdownMenuItem asChild>
-      <Link to={INFRAHUB_GITHUB_URL} target="_blank" rel="noreferrer">
-        <Icon icon="mdi:github" className="text-base" />
-        GitHub Repository
-      </Link>
-    </DropdownMenuItem>
+    <MenuItem href={INFRAHUB_GITHUB_URL} target="_blank" rel="noreferrer">
+      <Icon icon="mdi:github" className="text-base" />
+      GitHub Repository
+    </MenuItem>
 
-    <DropdownMenuItem asChild>
-      <Link to={INFRAHUB_DISCORD_URL} target="_blank" rel="noreferrer">
-        <Icon icon="mdi:discord" className="text-base" />
-        Join our Discord server
-      </Link>
-    </DropdownMenuItem>
+    <MenuItem href={INFRAHUB_DISCORD_URL} target="_blank" rel="noreferrer">
+      <Icon icon="mdi:discord" className="text-base" />
+      Join our Discord server
+    </MenuItem>
   </>
+);
+
+const AppInfoFooter = () => (
+  <div className="border-stone-300 border-t px-2.5 py-1">
+    <AppInfo />
+  </div>
 );
 
 const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }) => {
   const location = useLocation();
 
   return (
-    <DropdownMenu>
+    <div className="relative">
       <LinkButton
         variant="ghost"
         size="sm"
-        className="h-10 justify-stretch gap-2 data-pressed:scale-100"
+        className="h-10 w-full justify-stretch gap-2 pr-9 data-pressed:scale-100 group-data-[state=collapsed]:pr-2"
         href="/login"
         routerOptions={{ state: { from: location } }}
       >
@@ -110,38 +113,32 @@ const UnauthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void
           <div className="truncate font-medium leading-4">Log in</div>
           <div className="truncate text-stone-500 text-xs">anonymous</div>
         </div>
-
-        <DropdownMenuTrigger
-          onClick={(event) => {
-            event.preventDefault();
-          }}
-          asChild
-        >
-          <Button
-            variant="ghost"
-            shape="square"
-            size="xs"
-            data-testid="unauthenticated-menu-trigger"
-            className="ml-auto data-hovered:bg-stone-300 group-data-[state=collapsed]:hidden"
-          >
-            <EllipsisVerticalIcon />
-          </Button>
-        </DropdownMenuTrigger>
       </LinkButton>
 
-      <DropdownMenuContent align="end" side="right">
-        <CommonMenuItems onAboutClick={onAboutClick} />
-        <DropdownMenuDivider />
-        <DropdownMenuItem asChild>
-          <Link to="/login" state={{ from: location }}>
-            <Icon icon="mdi:login" className="text-base" />
-            Log in
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuDivider />
-        <AppInfo />
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <MenuTrigger>
+        <Button
+          variant="ghost"
+          shape="square"
+          size="xs"
+          data-testid="unauthenticated-menu-trigger"
+          className="absolute top-1/2 right-1 -translate-y-1/2 group-data-[state=collapsed]:hidden"
+        >
+          <EllipsisVerticalIcon />
+        </Button>
+
+        <Popover placement="right bottom">
+          <Menu variant="picker" aria-label="Account menu">
+            <CommonMenuItems onAboutClick={onAboutClick} />
+            <MenuSeparator />
+            <MenuItem href="/login" routerOptions={{ state: { from: location } }}>
+              <LogInIcon />
+              Log in
+            </MenuItem>
+          </Menu>
+          <AppInfoFooter />
+        </Popover>
+      </MenuTrigger>
+    </div>
   );
 };
 
@@ -169,42 +166,42 @@ const AuthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-10 justify-stretch gap-2 data-pressed:scale-100"
-          data-testid="authenticated-menu-trigger"
-        >
-          <Avatar name={profile?.name?.value} className="size-6 shrink-0" />
+    <MenuTrigger>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-10 justify-stretch gap-2 data-pressed:scale-100"
+        data-testid="authenticated-menu-trigger"
+      >
+        <Avatar name={profile?.name?.value} className="size-6" />
 
-          <div className="overflow-hidden group-data-[state=collapsed]:hidden">
-            <div className="truncate font-medium text-sm">{profile?.label?.value}</div>
-          </div>
+        <div className="overflow-hidden group-data-[state=collapsed]:hidden">
+          <div className="truncate font-medium text-sm">{profile?.label?.value}</div>
+        </div>
 
-          <EllipsisVerticalIcon className="ml-auto group-data-[state=collapsed]:hidden" />
-        </Button>
-      </DropdownMenuTrigger>
+        <EllipsisVerticalIcon className="ml-auto group-data-[state=collapsed]:hidden" />
+      </Button>
 
-      <DropdownMenuContent align="end" side="right">
-        <DropdownMenuItem asChild>
-          <Link to={constructPath("/profile")}>
-            <Icon icon="mdi:account-circle" className="text-base" />
-            Account settings
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuDivider />
-        <CommonMenuItems onAboutClick={onAboutClick} />
-        <DropdownMenuDivider />
-        <DropdownMenuItem onClick={handleSignOut} disabled={isLoggingOut}>
-          {isLoggingOut ? <Spinner /> : <Icon icon="mdi:logout" className="text-base" />}
-          Logout
-        </DropdownMenuItem>
-        <DropdownMenuDivider />
-        <AppInfo />
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <Popover placement="right bottom">
+        <Menu variant="picker" aria-label="Account menu">
+          <MenuItem href={constructPath("/profile")}>
+            <CircleUserIcon /> Account settings
+          </MenuItem>
+
+          <MenuSeparator />
+
+          <CommonMenuItems onAboutClick={onAboutClick} />
+
+          <MenuSeparator />
+
+          <MenuItem onAction={handleSignOut} isDisabled={isLoggingOut}>
+            {isLoggingOut ? <Spinner /> : <LogOutIcon />}
+            Logout
+          </MenuItem>
+        </Menu>
+        <AppInfoFooter />
+      </Popover>
+    </MenuTrigger>
   );
 };
 

--- a/frontend/app/src/shared/components/display/avatar.tsx
+++ b/frontend/app/src/shared/components/display/avatar.tsx
@@ -11,7 +11,7 @@ export const initials = (name: string) =>
     .join("")
     .toUpperCase();
 
-const avatarVariants = cva("flex items-center justify-center rounded-full", {
+const avatarVariants = cva("flex shrink-0 items-center justify-center rounded-full", {
   variants: {
     variant: {
       primary: "bg-custom-blue-200 text-custom-white",

--- a/frontend/app/src/shared/components/ui/dropdown-menu.tsx
+++ b/frontend/app/src/shared/components/ui/dropdown-menu.tsx
@@ -55,17 +55,6 @@ export const DropdownMenuItem = ({ className, ref, ...props }: DropdownMenuItemP
   />
 );
 
-interface DropdownMenuDividerProps
-  extends React.ComponentProps<typeof DropdownMenuPrimitive.Separator> {}
-
-export const DropdownMenuDivider = ({ className, ref, ...props }: DropdownMenuDividerProps) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={classNames("-mx-1 my-1 h-px bg-gray-200", className)}
-    {...props}
-  />
-);
-
 export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 interface DropdownMenuSubTriggerProps

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type React from "react";
 
 import { CopyIcon, GroupIcon, PencilLineIcon, Trash2Icon } from "lucide-react";
+import React, { useState } from "react";
+import { Popover as AriaPopover } from "react-aria-components";
 
-import { Menu, MenuItem, MenuSection } from "./menu";
+import { Autocomplete } from "../autocomplete/autocomplete";
+import { Button } from "../button/button";
+import { Menu, MenuItem, MenuSection, MenuTrigger, SubmenuTrigger } from "./menu";
 
 const meta: Meta<typeof Menu> = {
   title: "Components/Menu",
@@ -30,70 +33,157 @@ const MenuSurface = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-export const Default: Story = {
+// Item sets shared across both variants, so each scenario renders identically as action and picker.
+const simpleItems = () => [
+  <MenuItem key="edit">
+    <PencilLineIcon />
+    <span>Edit</span>
+  </MenuItem>,
+  <MenuItem key="duplicate">
+    <CopyIcon />
+    <span>Duplicate</span>
+  </MenuItem>,
+  <MenuItem key="delete" className="text-red-500">
+    <Trash2Icon />
+    <span>Delete</span>
+  </MenuItem>,
+];
+
+const sectionItems = () => [
+  <MenuSection key="actions" title="Actions">
+    <MenuItem>Copy ID</MenuItem>
+    <MenuItem>Copy HFID</MenuItem>
+  </MenuSection>,
+  <MenuSection key="manage" title="Manage">
+    <MenuItem>
+      <PencilLineIcon />
+      <span>Edit</span>
+    </MenuItem>
+    <MenuItem>
+      <GroupIcon />
+      <span>Groups</span>
+    </MenuItem>
+  </MenuSection>,
+];
+
+const disabledItems = () => [
+  <MenuItem key="edit">
+    <PencilLineIcon />
+    <span>Edit</span>
+  </MenuItem>,
+  <MenuItem
+    key="delete"
+    isDisabled
+    tooltip="You don't have permission to delete this object"
+    className="text-red-500"
+  >
+    <Trash2Icon />
+    <span>Delete</span>
+  </MenuItem>,
+];
+
+export const AllVariants: Story = {
   render: () => (
-    <div className="grid grid-cols-[8rem_auto] items-start gap-x-6 gap-y-6">
+    <div className="grid grid-cols-[8rem_max-content_max-content] items-start gap-x-6 gap-y-6">
+      <div />
+      <ColumnLabel>action (default)</ColumnLabel>
+      <ColumnLabel>picker</ColumnLabel>
+
       <ColumnLabel>Simple</ColumnLabel>
       <MenuSurface>
-        <Menu aria-label="Simple menu">
-          <MenuItem>
-            <PencilLineIcon />
-            <span>Edit</span>
-          </MenuItem>
-          <MenuItem>
-            <CopyIcon />
-            <span>Duplicate</span>
-          </MenuItem>
-          <MenuItem className="text-red-500">
-            <Trash2Icon />
-            <span>Delete</span>
-          </MenuItem>
+        <Menu aria-label="Simple action menu" variant="action">
+          {simpleItems()}
+        </Menu>
+      </MenuSurface>
+      <MenuSurface>
+        <Menu aria-label="Simple picker menu" variant="picker">
+          {simpleItems()}
         </Menu>
       </MenuSurface>
 
       <ColumnLabel>With sections</ColumnLabel>
       <MenuSurface>
-        <Menu aria-label="Menu with sections">
-          <MenuSection title="Actions">
-            <MenuItem>Copy ID</MenuItem>
-            <MenuItem>Copy HFID</MenuItem>
-          </MenuSection>
-          <MenuSection title="Manage">
-            <MenuItem>
-              <PencilLineIcon />
-              <span>Edit</span>
-            </MenuItem>
-            <MenuItem>
-              <GroupIcon />
-              <span>Groups</span>
-            </MenuItem>
-          </MenuSection>
+        <Menu aria-label="Action menu with sections" variant="action">
+          {sectionItems()}
+        </Menu>
+      </MenuSurface>
+      <MenuSurface>
+        <Menu aria-label="Picker menu with sections" variant="picker">
+          {sectionItems()}
         </Menu>
       </MenuSurface>
 
       <ColumnLabel>Disabled + tooltip</ColumnLabel>
       <div className="space-y-1">
         <MenuSurface>
-          <Menu aria-label="Menu with a disabled item">
-            <MenuItem>
-              <PencilLineIcon />
-              <span>Edit</span>
-            </MenuItem>
-            <MenuItem
-              isDisabled
-              tooltip="You don't have permission to delete this object"
-              className="text-red-500"
-            >
-              <Trash2Icon />
-              <span>Delete</span>
-            </MenuItem>
+          <Menu aria-label="Action menu with a disabled item" variant="action">
+            {disabledItems()}
           </Menu>
         </MenuSurface>
         <p className="text-[10px] text-neutral-400">Hover the disabled item to see the tooltip.</p>
       </div>
+      <MenuSurface>
+        <Menu aria-label="Picker menu with a disabled item" variant="picker">
+          {disabledItems()}
+        </Menu>
+      </MenuSurface>
     </div>
   ),
   parameters: {
     layout: "padded",
   },
+};
+
+/*
+ * The picker pattern that drives AddSort: a filtered field list whose items each open an
+ * asc/desc submenu. The submenu inherits variant="picker" from its parent — no prop needed.
+ */
+const SORT_FIELDS = ["Name", "Description", "Created at", "Site › Name", "Device › Role"];
+const DIRECTIONS = [
+  { id: "asc", label: "Ascending" },
+  { id: "desc", label: "Descending" },
+];
+
+function PickerWithSubmenuRender() {
+  const [picked, setPicked] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <MenuTrigger>
+        <Button variant="outline" size="sm">
+          Add sort
+        </Button>
+        <AriaPopover
+          placement="bottom start"
+          className="w-56 rounded-lg border border-neutral-300 bg-white shadow-md"
+        >
+          <Autocomplete>
+            <Menu variant="picker" aria-label="Sort field" className="max-h-72">
+              {SORT_FIELDS.map((field) => (
+                <SubmenuTrigger key={field}>
+                  <MenuItem textValue={field}>{field}</MenuItem>
+                  <AriaPopover className="rounded-lg border border-neutral-300 bg-white shadow-md">
+                    <Menu
+                      aria-label={`Direction for ${field}`}
+                      onAction={(key) => setPicked(`${field} · ${key}`)}
+                    >
+                      {DIRECTIONS.map((d) => (
+                        <MenuItem key={d.id} id={d.id} textValue={d.label}>
+                          {d.label}
+                        </MenuItem>
+                      ))}
+                    </Menu>
+                  </AriaPopover>
+                </SubmenuTrigger>
+              ))}
+            </Menu>
+          </Autocomplete>
+        </AriaPopover>
+      </MenuTrigger>
+      <p className="text-xs text-neutral-500">Picked: {picked ?? "—"}</p>
+    </div>
+  );
+}
+
+export const PickerWithSubmenu: Story = {
+  render: () => <PickerWithSubmenuRender />,
 };

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -1,5 +1,5 @@
-import type React from "react";
-
+import { ChevronRightIcon } from "lucide-react";
+import React from "react";
 import {
   Header as AriaHeader,
   Menu as AriaMenu,
@@ -9,28 +9,59 @@ import {
   MenuSection as AriaMenuSection,
   type MenuSectionProps as AriaMenuSectionProps,
   MenuTrigger as AriaMenuTrigger,
+  Separator as AriaSeparator,
+  type SeparatorProps as AriaSeparatorProps,
+  SubmenuTrigger as AriaSubmenuTrigger,
   Collection,
 } from "react-aria-components";
-import { cn } from "tailwind-variants";
+import { type VariantProps, cn, tv } from "tailwind-variants";
 
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
 
 export const MenuTrigger = AriaMenuTrigger;
+export const SubmenuTrigger = AriaSubmenuTrigger;
 
-export interface MenuProps<T> extends AriaMenuProps<T> {}
-export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) => {
+const menuItemStyles = tv({
+  base: [
+    "flex min-w-40 cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden select-none",
+    "data-disabled:pointer-events-none data-disabled:opacity-50",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+  ],
+  variants: {
+    variant: {
+      action: [
+        "bg-white shadow-sm transition-colors [&:not(:last-child)]:mb-0.5",
+        "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
+      ],
+      picker: ["rounded-lg", "data-focused:bg-stone-700/10 data-focused:text-stone-800"],
+    },
+  },
+  defaultVariants: { variant: "action" },
+});
+
+type MenuVariants = VariantProps<typeof menuItemStyles>;
+
+const MenuVariantContext = React.createContext<MenuVariants["variant"]>("action");
+
+export interface MenuProps<T> extends AriaMenuProps<T>, MenuVariants {}
+
+export const Menu = <T extends object>({ className, variant, ...props }: MenuProps<T>) => {
+  const resolvedVariant = variant ?? React.use(MenuVariantContext);
+
   return (
-    <AriaMenu
-      className={composeAriaClassName(className, (resolvedClassName) =>
-        cn(
-          "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
-          "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
-          resolvedClassName,
-        ),
-      )}
-      {...props}
-    />
+    <MenuVariantContext.Provider value={resolvedVariant}>
+      <AriaMenu
+        className={composeAriaClassName(
+          className,
+          cn(
+            "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
+            "*:[[role='group']:not(:last-child)]:mb-2",
+          ),
+        )}
+        {...props}
+      />
+    </MenuVariantContext.Provider>
   );
 };
 
@@ -61,24 +92,29 @@ export const MenuItem = ({
     );
   }
 
+  const variant = React.use(MenuVariantContext);
+
   return (
     <AriaMenuItem
       textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={composeAriaClassName(className, (resolvedClassName) =>
-        cn(
-          "data-disabled:pointer-events-none data-disabled:opacity-50",
-          "flex min-w-40 cursor-pointer items-center gap-2 rounded-md border border-transparent bg-white px-2 py-1 text-sm text-stone-600 shadow-sm outline-hidden transition-colors select-none",
-          "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
-          "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
-          resolvedClassName,
-        ),
-      )}
+      className={composeAriaClassName(className, menuItemStyles({ variant }))}
       {...props}
     >
-      {children}
+      {(renderProps) => (
+        <>
+          {typeof children === "function" ? children(renderProps) : children}
+          {renderProps.hasSubmenu && <ChevronRightIcon className="ml-auto" />}
+        </>
+      )}
     </AriaMenuItem>
   );
 };
+
+export interface MenuSeparatorProps extends AriaSeparatorProps {}
+
+export const MenuSeparator = ({ className, ...props }: MenuSeparatorProps) => (
+  <AriaSeparator className={cn("-mx-1 my-1 h-px bg-stone-300", className)} {...props} />
+);
 
 export interface MenuSectionProps<T> extends AriaMenuSectionProps<T> {
   title?: React.ReactNode;
@@ -90,8 +126,8 @@ export const MenuSection = <T extends object>({
   ...props
 }: MenuSectionProps<T>) => {
   return (
-    <AriaMenuSection className={cn("flex flex-col gap-0.5", className)} {...props}>
-      {title && <AriaHeader className="px-1 text-xs text-stone-500">{title}</AriaHeader>}
+    <AriaMenuSection className={cn("flex flex-col", className)} {...props}>
+      {title && <AriaHeader className="mb-0.5 px-1 text-xs text-stone-500">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
+++ b/frontend/packages/ui/src/components/sortable-list/sortable-list.tsx
@@ -1,32 +1,31 @@
-import type React from "react";
-
 import { GripVerticalIcon } from "lucide-react";
+import React from "react";
 import {
-  DropIndicator,
   GridList as AriaGridList,
-  type DropTarget,
-  type DroppableCollectionReorderEvent,
   GridListItem as AriaGridListItem,
   type GridListItemProps as AriaGridListItemProps,
   type GridListProps as AriaGridListProps,
+  DropIndicator,
+  type DroppableCollectionReorderEvent,
+  type DropTarget,
   type Key,
   useDragAndDrop,
 } from "react-aria-components";
-import { cn, tv } from "tailwind-variants";
+import { tv } from "tailwind-variants";
 
-import { focusVisibleStyle } from "../../styles/focus-visible";
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { Button } from "../button/button";
 
-function reorderItems<T extends { id: Key }>(
+function reorderItems<T>(
   items: T[],
   event: DroppableCollectionReorderEvent,
+  getId: (item: T) => Key,
 ): T[] {
   const { keys, target } = event;
-  const moved = items.filter((item) => keys.has(item.id));
-  const rest = items.filter((item) => !keys.has(item.id));
+  const moved = items.filter((item) => keys.has(getId(item)));
+  const rest = items.filter((item) => !keys.has(getId(item)));
 
-  const targetItem = rest.find((item) => item.id === target.key);
+  const targetItem = rest.find((item) => getId(item) === target.key);
   if (!targetItem) {
     return items;
   }
@@ -36,7 +35,7 @@ function reorderItems<T extends { id: Key }>(
   return [...rest.slice(0, insertIndex), ...moved, ...rest.slice(insertIndex)];
 }
 
-export interface SortableListProps<T extends { id: Key }> extends Omit<
+export interface SortableListProps<T extends object> extends Omit<
   AriaGridListProps<T>,
   "items" | "children" | "dragAndDropHooks"
 > {
@@ -47,24 +46,30 @@ export interface SortableListProps<T extends { id: Key }> extends Omit<
 
 function SortableDropIndicator({ target }: { target: DropTarget }) {
   return (
-    // -mt-px offsets the line's own height so this in-flow row adds no space, keeping siblings put.
+    // -mt-px offsets the line's own height so this in-flow row never shifts siblings.
     <DropIndicator
       target={target}
-      className="mx-2 -mt-px h-px rounded-full bg-cyan-600 shadow-[0_0_6px_1px_rgba(6,182,212,0.55)] outline-hidden"
+      className="-mt-px h-px rounded-full bg-cyan-700 opacity-0 shadow-[0_0_2px_1px_rgba(6,182,212,0.25)] outline-hidden transition-opacity data-drop-target:opacity-100"
     />
   );
 }
 
-export function SortableList<T extends { id: Key }>({
+export function SortableList<T extends object>({
   items,
   onReorder,
   children,
   ...props
 }: SortableListProps<T>) {
+  const getItemId = (item: T): Key => {
+    const element = children(item);
+    const id = React.isValidElement<{ id?: Key }>(element) ? element.props.id : undefined;
+    return id ?? (item as { id: Key }).id;
+  };
+
   const { dragAndDropHooks } = useDragAndDrop({
     getItems: (keys) => [...keys].map((key) => ({ "text/plain": String(key) })),
     onReorder: (event) => {
-      onReorder(reorderItems(items, event));
+      onReorder(reorderItems(items, event, getItemId));
     },
     renderDropIndicator: (target) => <SortableDropIndicator target={target} />,
   });
@@ -78,8 +83,8 @@ export function SortableList<T extends { id: Key }>({
 
 const sortableItemStyles = tv({
   base: [
-    "flex cursor-grab items-center gap-2 rounded-lg border border-transparent p-1 text-sm text-stone-600 outline-hidden select-none",
-    "data-hovered:bg-stone-700/10 data-hovered:text-stone-800",
+    "flex cursor-grab items-center gap-1.5 rounded-lg border border-transparent p-0.5 text-sm text-stone-600 outline-hidden select-none",
+    "data-focus-visible:bg-stone-700/10 data-focus-visible:text-stone-800",
     "data-selected:bg-stone-700/10 data-selected:text-stone-800",
     "data-dragging:cursor-grabbing",
     "data-disabled:pointer-events-none data-disabled:opacity-50",
@@ -98,7 +103,7 @@ export function SortableItem({ children, className, ref, ...props }: SortableIte
     <AriaGridListItem
       ref={ref}
       className={composeAriaClassName(className, ({ isDragging }) =>
-        cn(focusVisibleStyle, sortableItemStyles({ isDragging })),
+        sortableItemStyles({ isDragging }),
       )}
       {...props}
     >

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -45,6 +45,7 @@ export {
   MenuSeparator,
   type MenuSeparatorProps,
   MenuTrigger,
+  SubmenuTrigger,
 } from "./components/menu/menu";
 export { Meter, type MeterProps } from "./components/meter/meter";
 export {

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -42,6 +42,8 @@ export {
   type MenuProps,
   MenuSection,
   type MenuSectionProps,
+  MenuSeparator,
+  type MenuSeparatorProps,
   MenuTrigger,
 } from "./components/menu/menu";
 export { Meter, type MeterProps } from "./components/meter/meter";


### PR DESCRIPTION
Migrates the sidebar account menu from the legacy radix `DropdownMenu` to the `@infrahub/ui` react-aria `Menu`, using the `picker` variant.

  ### Changes

  - **`account-menu.tsx`**: rebuilt on `MenuTrigger` + `Popover placement="right bottom"` + `Menu variant="picker"`. The `asChild` + `<Link>` wrappers become `MenuItem href` / `onAction`,
  and `AppInfo` moves to a footer below the `Menu` inside the `Popover`, since react-aria menus only accept items/sections/separators as children.
  - **Unauthenticated state**: the ellipsis trigger is no longer nested inside the login `LinkButton`. React-aria `MenuTrigger` wraps its children in a `PressResponder` that captures
  *every* pressable descendant, so a nested trigger turned the whole login row into a second menu trigger and broke navigation to `/login`. The trigger is now an absolutely-positioned
  sibling overlaid on the row's right side — which also fixes the previously invalid button-inside-anchor DOM.
  - **`packages/ui`**: adds `MenuSeparator` (a styled react-aria `Separator`) to keep the menu's visible dividers, exported from the package index.

The legacy `shared/components/ui/dropdown-menu.tsx` stays — the two sidebar menu sections still consume it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the sidebar account menu to the `@infrahub/ui` react-aria `Menu` using the `picker` variant. Adds submenu and separator support, fixes the unauthenticated trigger, and polishes stories and list behaviors.

- **New Features**
  - Rebuilt account menu with `MenuTrigger` + `Popover` (`placement="right bottom"`) and `Menu variant="picker"`; items use `MenuItem href`/`onAction`.
  - Moved `AppInfo` to a Popover footer outside the `Menu`; updated color to `text-stone-400`.
  - UI package: added `MenuSeparator`, `SubmenuTrigger`, chevrons for submenu items, and `variant="action" | "picker"`; stories show both variants and a picker-with-submenu flow.

- **Bug Fixes**
  - Unauthenticated state: overlaid the ellipsis trigger button (no nested trigger), restoring `/login` navigation and valid markup.
  - `Avatar` is now `shrink-0`; `SortableList` drop indicator fades in without shifting siblings and reordering is more robust via child `id` support.

<sup>Written for commit b0c119166b1ceff54efff877ace698a2853aed5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

