### PR TITLE
fix(core): check mandatory dependents across the full cascade closure

### DIFF
--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -82,7 +82,7 @@ class NodeDeleteIndex:
         for kind in cascade_kinds:
             start_schema_kinds.add(kind)
             schema = self._all_schemas_map[kind]
-            if isinstance(schema, NodeSchema):
+            if isinstance(schema, (NodeSchema, ProfileSchema, TemplateSchema)):
                 start_schema_kinds.update(schema.inherit_from)
         for node_schema in self._all_schemas_map.values():
             for relationship_schema in node_schema.relationships:

--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -29,8 +29,8 @@ class NodeDeleteIndex:
         self._dependency_graph: dict[str, dict[DeleteRelationshipType, dict[str, set[str]]]] = {}
 
     def index(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
-        self._index_cascading_deletes(start_schemas=start_schemas)
-        self._index_dependent_schema(start_schemas=start_schemas)
+        cascade_kinds = self._index_cascading_deletes(start_schemas=start_schemas)
+        self._index_dependent_schema(cascade_kinds=cascade_kinds)
 
     def _get_schema_kinds(self, schema_kind: str) -> set[str]:
         schema = self._all_schemas_map[schema_kind]
@@ -50,13 +50,17 @@ class NodeDeleteIndex:
             self._dependency_graph[kind][relationship_type] = defaultdict(set)
         self._dependency_graph[kind][relationship_type][relationship_identifier].update(peer_kinds)
 
-    def _index_cascading_deletes(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
+    def _index_cascading_deletes(
+        self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]
+    ) -> set[str]:
+        visited: set[str] = set()
         kinds_to_check: set[str] = {schema.kind for schema in start_schemas}
         while True:
             try:
                 kind_to_check = kinds_to_check.pop()
             except KeyError:
                 break
+            visited.add(kind_to_check)
             node_schema = self._all_schemas_map[kind_to_check]
             for relationship_schema in node_schema.relationships:
                 if relationship_schema.on_delete != RelationshipDeleteBehavior.CASCADE:
@@ -69,15 +73,17 @@ class NodeDeleteIndex:
                     peer_kinds=peer_kinds,
                 )
                 for peer_kind in peer_kinds:
-                    if peer_kind not in self._dependency_graph:
+                    if peer_kind not in visited:
                         kinds_to_check.add(peer_kind)
+        return visited
 
-    def _index_dependent_schema(self, start_schemas: Iterable[NodeSchema | ProfileSchema | TemplateSchema]) -> None:
+    def _index_dependent_schema(self, cascade_kinds: set[str]) -> None:
         start_schema_kinds: set[str] = set()
-        for start_schema in start_schemas:
-            start_schema_kinds.add(start_schema.kind)
-            if start_schema.inherit_from:
-                start_schema_kinds.update(set(start_schema.inherit_from))
+        for kind in cascade_kinds:
+            start_schema_kinds.add(kind)
+            schema = self._all_schemas_map[kind]
+            if isinstance(schema, NodeSchema):
+                start_schema_kinds.update(schema.inherit_from)
         for node_schema in self._all_schemas_map.values():
             for relationship_schema in node_schema.relationships:
                 if relationship_schema.optional is True or relationship_schema.peer not in start_schema_kinds:

--- a/backend/tests/component/core/test_node_manager_delete.py
+++ b/backend/tests/component/core/test_node_manager_delete.py
@@ -591,3 +591,43 @@ async def test_delete_cascade_artifacts(
     assert artifact.id in {d.id for d in deleted}
     node_map = await NodeManager.get_many(db=db, ids=[c1.id, artifact.id])
     assert node_map == {}
+
+
+async def test_cascade_delete_blocked_by_external_mandatory_dependent(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main: Node,
+    person_john_main: Node,
+    person_jane_main: Node,
+) -> None:
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    person_schema = schema_branch.get(name="TestPerson", duplicate=False)
+    person_schema.get_relationship("cars").on_delete = RelationshipDeleteBehavior.CASCADE
+
+    person_schema.relationships.append(
+        RelationshipSchema(
+            name="favorite_car",
+            kind="Attribute",
+            optional=False,
+            peer="TestCar",
+            cardinality="one",
+            identifier="person__favorite_car",
+            on_delete=RelationshipDeleteBehavior.NO_ACTION,
+            branch=BranchSupportType.AWARE,
+        )
+    )
+
+    # Jane is NOT being deleted and mandatorily references one of John's (cascaded) cars.
+    jane = await NodeManager.get_one(db=db, id=person_jane_main.id)
+    await jane.favorite_car.update(db=db, data=car_accord_main.id)
+    await jane.save(db=db)
+
+    with pytest.raises(ValidationError) as exc:
+        await NodeManager.delete(db=db, branch=default_branch, nodes=[person_john_main])
+
+    expected_msg = (
+        f"Cannot delete TestCar '{car_accord_main.id}'. "
+        f"It is linked to mandatory relationship favorite_car on node TestPerson '{person_jane_main.id}' "
+        f"at TestPerson.favorite_car"
+    )
+    assert str(exc.value) == expected_msg

--- a/changelog/+delete-validator-cascade-orphan-check.fixed.md
+++ b/changelog/+delete-validator-cascade-orphan-check.fixed.md
@@ -1,0 +1,1 @@
+Deleting a node with cascade now checks mandatory relationships across the full set of cascaded objects. Previously a node pulled into the delete by a cascade could be removed even while a mandatory relationship from an object outside the delete set still referenced it, leaving a dangling mandatory relationship. Such deletes are now correctly blocked with a validation error.


### PR DESCRIPTION
## What

Backport of the standalone delete-validator correctness fix from the repository cascade-delete work (#9832, targeting `develop`), sent to `stable` per review.

`NodeDeleteIndex` now seeds its mandatory-relationship (orphan) check from **every kind reachable by cascade**, not just the explicitly-deleted node's kind. Two effects:

1. **No more silent orphaning.** Previously the orphan-check was shallow — a node pulled into the delete set by a cascade, but still referenced by a *mandatory* relationship from an object outside that set, was deleted anyway (leaving a dangling mandatory relationship). It now raises the existing `ValidationError` instead.
2. **Latent bug fix.** The cascade traversal used dependency-graph membership as its termination guard, which let leaf kinds (no outgoing cascade edges) be re-queued once per incoming path in a diamond-shaped graph. A `visited` set makes each kind process exactly once.

This does **not** include the new repository cascade relationships (those stay on `develop` and reach `stable` via the normal release) — only the delete-validator behavior, which is independently correct and low-risk.

## Testing

- `backend/tests/component/core/test_node_manager_delete.py` — full module passes (16 existing + 1 new). New `test_cascade_delete_blocked_by_external_mandatory_dependent` proves an out-of-tree mandatory referrer to a cascaded node now blocks the delete with the expected error.
- ruff / ruff format / ty all clean on the changed file.

Related: #9832 (the develop feature this was extracted from).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delete validation to check mandatory dependents across the full cascade closure, preventing silent orphaning and dangling mandatory relationships. Also deduplicates cascade traversal by tracking visited kinds.

- **Bug Fixes**
  - Seed the mandatory-relationship check from all kinds reachable via cascade (including `inherit_from` on `NodeSchema`, `ProfileSchema`, and `TemplateSchema`); raise `ValidationError` when external mandatory referrers exist.
  - Track a `visited` set so each kind is processed once, avoiding re-queuing in diamond-shaped graphs.

<sup>Written for commit 8dcc965c6bd917337d9d23899486aafb4081d628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

