### PR TITLE
fix(backend): block relationship identifier update in schema

### DIFF
--- a/backend/infrahub/core/migrations/__init__.py
+++ b/backend/infrahub/core/migrations/__init__.py
@@ -27,6 +27,6 @@ MIGRATION_MAP: dict[str, type[SchemaMigration] | None] = {
     "attribute.unique.update": AttributeSupportsGeneratedSchemaMigration,
     "relationship.branch.update": None,
     "relationship.direction.update": None,
-    "relationship.identifier.update": PlaceholderDummyMigration,
+    "relationship.identifier.update": None,
     "relationship.hierarchical.update": None,
 }

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -760,7 +760,7 @@ relationship_schema = SchemaNode(
             regex=str(NAME_REGEX),
             max_length=DEFAULT_REL_IDENTIFIER_LENGTH,
             optional=True,
-            extra={"update": UpdateSupport.ALLOWED},
+            extra={"update": UpdateSupport.NOT_SUPPORTED},
         ),
         SchemaAttribute(
             name="cardinality",

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -57,7 +57,7 @@ class GeneratedRelationshipSchema(HashableModel):
         description="Unique identifier of the relationship within a model, identifiers must match to traverse a relationship on both direction.",
         pattern=r"^[a-z0-9\_]+$",
         max_length=128,
-        json_schema_extra={"update": "allowed"},
+        json_schema_extra={"update": "not_supported"},
     )
     cardinality: RelationshipCardinality = Field(
         default=RelationshipCardinality.MANY,

--- a/backend/tests/unit/core/test_models.py
+++ b/backend/tests/unit/core/test_models.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from infrahub.core.constants import UpdateValidationErrorType
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+
+WIDGET_GADGET_SCHEMA: dict[str, Any] = {
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "Widget",
+            "namespace": "Test",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+            "relationships": [
+                {
+                    "name": "gadgets",
+                    "peer": "TestGadget",
+                    "cardinality": "many",
+                    "identifier": "widget__gadget",
+                    "optional": True,
+                }
+            ],
+        },
+        {
+            "name": "Gadget",
+            "namespace": "Test",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+        },
+    ],
+}
+
+
+def _build_schema() -> SchemaBranch:
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**WIDGET_GADGET_SCHEMA))
+    schema.process()
+    return schema
+
+
+async def test_relationship_identifier_update_is_not_supported() -> None:
+    """Changing a relationship's identifier must be rejected rather than silently orphaning data."""
+    schema = _build_schema()
+
+    candidate = schema.duplicate()
+    widget = candidate.get_node(name="TestWidget", duplicate=True)
+    relationship = widget.get_relationship(name="gadgets")
+    relationship.identifier = "widget__gadget_renamed"
+    candidate.set(name="TestWidget", schema=widget)
+
+    diff = schema.diff(other=candidate)
+    result = schema.validate_update(other=candidate, diff=diff)
+
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert error.error == UpdateValidationErrorType.NOT_SUPPORTED
+    assert error.path.schema_kind == "TestWidget"
+    assert error.path.field_name == "gadgets"
+    assert error.path.property_name == "identifier"
+    assert result.migrations == []

--- a/changelog/+relationship-identifier-update-blocked.fixed.md
+++ b/changelog/+relationship-identifier-update-blocked.fixed.md
@@ -1,0 +1,1 @@
+Changing the `identifier` of a relationship in a schema is now rejected with a "not supported" validation error instead of being silently incorrectly applied.

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -84,7 +84,7 @@ For each element of the schema, when its value is being updated, Infrahub will d
 | **kind** | allowed |
 | **label** | allowed |
 | **description** | allowed |
-| **identifier** | allowed |
+| **identifier** | not_supported |
 | **cardinality** | validate_constraint |
 | **min_count** | validate_constraint |
 | **max_count** | validate_constraint |

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -6170,7 +6170,7 @@
                         ],
                         "title": "Identifier",
                         "description": "Unique identifier of the relationship within a model, identifiers must match to traverse a relationship on both direction.",
-                        "update": "allowed"
+                        "update": "not_supported"
                     },
                     "cardinality": {
                         "$ref": "#/components/schemas/RelationshipCardinality",


### PR DESCRIPTION
Changing a relationship's `identifier` was marked `UpdateSupport.ALLOWED` but had no data migration, so the schema change applied silently and orphaned the relationship data: the old Relationship vertex kept active `IS_RELATED` edges while the runtime resolved the new identifier (empty), making the peer vanish.

Mark the field NOT_SUPPORTED so the update is rejected with a validation error, and drop the now-unreachable placeholder migration-map entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block schema updates that change a relationship’s `identifier` to prevent orphaned relationship data and disappearing peers. These updates now fail validation as not supported (addresses IFC-402).

- **Bug Fixes**
  - Set `identifier` update policy to not supported in internal and generated relationship schema.
  - Removed `relationship.identifier.update` placeholder from the migration map.
  - Regenerated `openapi.json` to reflect `identifier` update as `not_supported`.
  - Added unit test, updated validator docs table, and added a changelog entry.

<sup>Written for commit 2995c0a03b7879915a6efc65613d4d98ea7a76b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

