### PR TITLE
perf(backend): skip peer fetch for empty relationships on node create

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -51,6 +51,8 @@ from infrahub.core.utils import build_regex_attrs, extract_field_filters
 from infrahub.exceptions import QueryError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from neo4j.graph import Node as Neo4jNode
 
     from infrahub.core.attribute import AttributeCreateData, BaseAttribute
@@ -210,7 +212,10 @@ class NodeCreateAllQuery(NodeQuery):
         relationships: list[RelationshipCreateData] = []
         for rel_name in self.node._relationships:
             rel_manager: RelationshipManager = getattr(self.node, rel_name)
-            if rel_manager.schema.cardinality == "many":
+            peers: Mapping[str, Node] = {}
+            # This is a create query, so the node has no relationships in the database yet: only
+            # resolve peers when there are locally-set relationships to write.
+            if rel_manager.schema.cardinality == "many" and len(rel_manager._relationships):
                 # Fetch all relationship peers through a single database call for performances.
                 peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
 

--- a/changelog/+faster-node-creation-empty-relationships.changed.md
+++ b/changelog/+faster-node-creation-empty-relationships.changed.md
@@ -1,0 +1,1 @@
+Node creation no longer issues a redundant database query to resolve peers for empty many-cardinality relationships, since a newly created node has none stored yet. This removes hundreds of round-trips during the first-time database initialization and speeds up node creation.


### PR DESCRIPTION
## What

`NodeCreateAllQuery.query_init` resolved relationship peers from the database for **every** many-cardinality relationship on a node being created — including relationships with nothing set locally. On a create the node has no relationships stored in the graph yet, so that `relationship_get_peer` lookup can only ever return nothing.

This guards the fetch on a non-empty local relationship:

```python
if rel_manager.schema.cardinality == "many" and len(rel_manager._relationships):
    peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
```

## Why it's safe

`RelationshipManager.init` only sets `has_fetched_relationships=True` when a relationship is populated with data; an empty one leaves it `False`, so `get_peers` → `get_relationships` issues the DB fetch. For a brand-new node there is nothing to fetch, and the inner loop over `_relationships` is empty anyway — so no create-data is dropped. Only the *empty* case is skipped; populated relationships are unchanged.

## Impact (measured, empty-DB cold start)

| Metric | Before | After |
|---|---:|---:|
| `relationship_get_peer` queries | 373 | 2 |
| Total DB round-trips during init | 1215 | 844 |
| `initialization()` wall time | ~19.5s | ~16.6s (**−15%**) |

Benefits all node creation, not just bootstrap.

## Validation

- Full `backend/tests/component/core` suite green (2067 passed, 21 skipped, 1 xfailed).
- Focused suites green: `test_relationship_manager`, `test_relationship`, `test_node_query`, `test_initialization`.
- Data-integrity spot check on a real bootstrap: account groups → roles → permissions and the menu hierarchy all intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip peer resolution for empty many relationships during node creation to avoid no-op DB fetches. This cuts redundant round-trips and speeds up cold-start initialization by ~15%.

- **Performance**
  - Resolve peers only when a `many` relationship has locally set values.
  - `relationship_get_peer` queries: 373 -> 2; DB round-trips: 1215 -> 844.
  - Initialization wall time: ~19.5s -> ~16.6s (~15% faster).

<sup>Written for commit 9ba554091cca8056484eb9d2b0acf490e3016d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

