### PR TITLE
ci: run the dev-guideline link check on ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1013,7 +1013,8 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       (needs.files-changed.outputs.python == 'true') ||
       (needs.files-changed.outputs.dev_guidelines == 'true') ||
-      (needs.files-changed.outputs.javascript == 'true')
+      (needs.files-changed.outputs.javascript == 'true') ||
+      (needs.files-changed.outputs.github_workflows == 'true')
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on: "ubuntu-24.04"
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,7 +1015,7 @@ jobs:
       (needs.files-changed.outputs.dev_guidelines == 'true') ||
       (needs.files-changed.outputs.javascript == 'true')
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"


### PR DESCRIPTION
# Why

`validate-dev-guideline-links` fails whenever it triggers: the job installs the **latest** `lychee` binary via `lycheeverse/lychee-action@v2`, and current lychee (0.24.2) is built against glibc 2.38/2.39. The `ubuntu-22.04` runner ships glibc 2.35, so the binary aborts before checking a single link:

```
lychee: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by lychee)
lychee: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by lychee)
```

A toolchain/runner mismatch, not a broken link (lychee passes locally with 0 errors).

**Origin.** The link checker was introduced already unpinned (`lychee-action@v2`, no `lycheeVersion`) on `ubuntu-22.04` in #8103. Nothing changed since; this was a latent time-bomb — the unpinned action pulls the *latest* lychee, so it broke once lychee upstream released a build requiring a newer glibc than the runner provides. The same job config exists on both `stable` and `develop`; this is the `stable` companion to #9863 (develop).

## What changed

- Run the job on `ubuntu-24.04` (glibc 2.39), which satisfies the lychee binary.
- Trigger the job when workflow files change (`github_workflows` filter), so changes to the link-check config are exercised by the job itself.

No change to link content or the lychee config.

## How to test

`validate-dev-guideline-links` runs on `ubuntu-24.04` and completes lychee successfully instead of failing on the GLIBC error.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the dev-guideline link check in CI by fixing the runner/toolchain mismatch that caused it to abort before checking links. The job now runs to completion and also triggers on workflow changes.

- **Bug Fixes**
  - Run `validate-dev-guideline-links` on `ubuntu-24.04` to satisfy the `lychee` binary from `lycheeverse/lychee-action@v2` (glibc 2.38/2.39).
  - Include `github_workflows` in the file-change filter so the job runs when `.github/workflows` files change.

<sup>Written for commit a98bf6a911a29fad30569e9d3c548e7c7177a39c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

