### PR TITLE
refactor(layout): extract composable DetailsColumns primitive

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details.tsx
@@ -1,4 +1,4 @@
-import { DetailsColumns } from "@/shared/components/layout/details-columns";
+import { DetailsLayout } from "@/shared/components/layout/details-layout";
 import { useTitle } from "@/shared/hooks/useTitle";
 
 import type {
@@ -25,8 +25,8 @@ export function ObjectDetails({ objectSchema, objectData, permission }: ObjectDe
   useTitle(`${getNodeLabel(objectData)} details`);
 
   return (
-    <DetailsColumns>
-      <DetailsColumns.Main>
+    <DetailsLayout>
+      <DetailsLayout.Main>
         <ObjectDetailsCard
           objectSchema={objectSchema}
           objectData={objectData}
@@ -36,16 +36,16 @@ export function ObjectDetails({ objectSchema, objectData, permission }: ObjectDe
         {isOfKind(FILE_OBJECT_KIND, objectSchema) && (
           <FilePreviewCard objectData={objectData as unknown as NodeFileObject} />
         )}
-      </DetailsColumns.Main>
+      </DetailsLayout.Main>
 
-      <DetailsColumns.Aside>
+      <DetailsLayout.Aside>
         <ObjectProfilesGroupsCard
           objectSchema={objectSchema}
           objectData={objectData}
           permission={permission}
         />
         <ObjectActivitiesCard objectKind={objectData.__typename} objectId={objectData.id} />
-      </DetailsColumns.Aside>
-    </DetailsColumns>
+      </DetailsLayout.Aside>
+    </DetailsLayout>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details.tsx
@@ -1,4 +1,4 @@
-import { Col } from "@/shared/components/container";
+import { DetailsColumns } from "@/shared/components/layout/details-columns";
 import { useTitle } from "@/shared/hooks/useTitle";
 
 import type {
@@ -25,8 +25,8 @@ export function ObjectDetails({ objectSchema, objectData, permission }: ObjectDe
   useTitle(`${getNodeLabel(objectData)} details`);
 
   return (
-    <div className="flex flex-col gap-2 overflow-auto p-2 xl:grid xl:grid-cols-3 xl:items-start">
-      <Col className="shrink-0 grow md:col-span-2">
+    <DetailsColumns>
+      <DetailsColumns.Main>
         <ObjectDetailsCard
           objectSchema={objectSchema}
           objectData={objectData}
@@ -36,16 +36,16 @@ export function ObjectDetails({ objectSchema, objectData, permission }: ObjectDe
         {isOfKind(FILE_OBJECT_KIND, objectSchema) && (
           <FilePreviewCard objectData={objectData as unknown as NodeFileObject} />
         )}
-      </Col>
+      </DetailsColumns.Main>
 
-      <Col>
+      <DetailsColumns.Aside>
         <ObjectProfilesGroupsCard
           objectSchema={objectSchema}
           objectData={objectData}
           permission={permission}
         />
         <ObjectActivitiesCard objectKind={objectData.__typename} objectId={objectData.id} />
-      </Col>
-    </div>
+      </DetailsColumns.Aside>
+    </DetailsColumns>
   );
 }

--- a/frontend/app/src/shared/components/layout/details-columns.tsx
+++ b/frontend/app/src/shared/components/layout/details-columns.tsx
@@ -1,0 +1,37 @@
+import type React from "react";
+
+import { Col } from "@/shared/components/container";
+import { classNames } from "@/shared/utils/common";
+
+// Responsive detail-screen layout: stacked on small viewports, 2/3 main + 1/3 aside from xl; pages compose their own cards.
+function DetailsColumns({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={classNames(
+        "flex flex-col gap-2 overflow-auto p-2 xl:grid xl:grid-cols-3 xl:items-start",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Main({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <Col className={classNames("shrink-0 grow md:col-span-2", className)}>{children}</Col>;
+}
+
+function Aside({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <Col className={className}>{children}</Col>;
+}
+
+DetailsColumns.Main = Main;
+DetailsColumns.Aside = Aside;
+
+export { DetailsColumns };

--- a/frontend/app/src/shared/components/layout/details-layout.tsx
+++ b/frontend/app/src/shared/components/layout/details-layout.tsx
@@ -4,13 +4,7 @@ import { Col } from "@/shared/components/container";
 import { classNames } from "@/shared/utils/common";
 
 // Responsive detail-screen layout: stacked on small viewports, 2/3 main + 1/3 aside from xl; pages compose their own cards.
-function DetailsColumns({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+function DetailsLayout({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <div
       className={classNames(
@@ -31,7 +25,7 @@ function Aside({ children, className }: { children: React.ReactNode; className?:
   return <Col className={className}>{children}</Col>;
 }
 
-DetailsColumns.Main = Main;
-DetailsColumns.Aside = Aside;
+DetailsLayout.Main = Main;
+DetailsLayout.Aside = Aside;
 
-export { DetailsColumns };
+export { DetailsLayout };


### PR DESCRIPTION
## What

Extracts the responsive two-column detail-screen layout out of `ObjectDetails` into a reusable `DetailsColumns` primitive with `Main` / `Aside` slots, so a page can compose its own cards into the columns rather than injecting content into a specific details component.

`ObjectDetails` now consumes the primitive; **rendered output is unchanged** (pure refactor).

## Why

First of a 3-PR stack splitting the user & organisation preferences UI (was #9776) for easier review. The Profile tab (PR 3) needs to compose the account details alongside a preferences card in the same responsive layout without a bespoke prop on `ObjectDetails` — this primitive is the shared seam.

## Stack
1. **this PR** — `DetailsColumns` layout primitive
2. `feat(permission)`: frontend global-permission checks
3. `feat(preferences)`: user & organisation preferences UI (IFC-2720)

## Test
- `biome ci` clean; `tsc` introduces no new errors; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable `DetailsLayout` primitive with `Main` and `Aside` slots and updated `ObjectDetails` to use it. Keeps the same responsive two-column UI and lets other pages (e.g., Profile) compose cards, supporting IFC-2720.

- **Refactors**
  - Added `frontend/app/src/shared/components/layout/details-layout.tsx` with `DetailsLayout.Main` and `DetailsLayout.Aside`.
  - Replaced inline layout in `ObjectDetails` with `DetailsLayout`.

<sup>Written for commit 1249bfbc87e036e33756d66880f1e50a462888ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

