### PR TITLE
fix: restore account_id on outbound webhook payloads (closes #9881)

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -191,14 +191,13 @@ class EventContext(BaseModel):
     def from_event(cls, event_id: str, event_type: str, event_occured_at: str, event_payload: dict[str, Any]) -> Self:
         """Extract the context from the raw event we are getting from Prefect."""
         infrahub_context: dict[str, Any] = event_payload.get("context", {})
-        account_info: dict[str, Any] = infrahub_context.get("account", {})
         branch_info: dict[str, Any] = infrahub_context.get("branch", {})
 
         return cls(
             id=event_id,
             # We use `GLOBAL_BRANCH_NAME` constant instead of `registry.get_global_branch().name` to the flow from depending on the registry
             branch=branch_info.get("name") if branch_info and branch_info.get("name") != GLOBAL_BRANCH_NAME else None,
-            account_id=account_info.get("account_id"),
+            account_id=infrahub_context.get("account_id"),
             occured_at=event_occured_at,
             event=event_type,
         )

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -24,19 +24,9 @@ if TYPE_CHECKING:
 
 BRANCH_CREATED_PAYLOAD: dict[str, Any] = {
     "context": {
-        "event": {
-            "id": "24790022-2bc8-42ab-a447-bf3e84675901",
-            "name": "infrahub.branch.created",
-            "ancestors": [],
-            "parent_id": None,
-        },
         "branch": {"id": "182853ef-58a3-b3cc-3e80-c5161f4171c1", "name": "-global-"},
-        "account": {
-            "auth_type": "api",
-            "account_id": "182853f2-3a43-c7f9-3e84-c5152eff4b17",
-            "session_id": None,
-            "authenticated": None,
-        },
+        "account_id": "182853f2-3a43-c7f9-3e84-c5152eff4b17",
+        "parent_event": None,
     }
 }
 

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-# Built from the source event context so the fixture tracks the real serialization
-# instead of restating it as a literal that can silently drift.
 BRANCH_CREATED_PAYLOAD: dict[str, Any] = {
     "context": EventContext(
         branch=EventBranchContext(name=GLOBAL_BRANCH_NAME, id="182853ef-58a3-b3cc-3e80-c5161f4171c1"),

--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator
 import pytest
 from prefect.client.orchestration import PrefectClient, get_client
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind
 from infrahub.core.node import Node
+from infrahub.events.models import EventBranchContext, EventContext
 from infrahub.workflows.catalogue import WEBHOOK_CONFIGURE, WEBHOOK_INVALIDATE_HEADERS, WEBHOOK_PROCESS, WORKER_POOLS
 from infrahub.workflows.initialization import setup_worker_pools
 from tests.constants import TestKind
@@ -22,12 +23,13 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
+# Built from the source event context so the fixture tracks the real serialization
+# instead of restating it as a literal that can silently drift.
 BRANCH_CREATED_PAYLOAD: dict[str, Any] = {
-    "context": {
-        "branch": {"id": "182853ef-58a3-b3cc-3e80-c5161f4171c1", "name": "-global-"},
-        "account_id": "182853f2-3a43-c7f9-3e84-c5152eff4b17",
-        "parent_event": None,
-    }
+    "context": EventContext(
+        branch=EventBranchContext(name=GLOBAL_BRANCH_NAME, id="182853ef-58a3-b3cc-3e80-c5161f4171c1"),
+        account_id="182853f2-3a43-c7f9-3e84-c5152eff4b17",
+    ).to_event()
 }
 
 

--- a/backend/tests/unit/webhook/test_models.py
+++ b/backend/tests/unit/webhook/test_models.py
@@ -4,8 +4,11 @@ from uuid import UUID
 
 import pytest
 
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.timestamp import Timestamp
-from infrahub.webhook.models import CustomWebhook, HeaderKind, StandardWebhook, WebhookHeader
+from infrahub.events.models import EventBranchContext
+from infrahub.events.models import EventContext as SourceEventContext
+from infrahub.webhook.models import CustomWebhook, EventContext, HeaderKind, StandardWebhook, WebhookHeader
 
 
 def test_standard_webhook() -> None:
@@ -193,3 +196,42 @@ def test_webhook_signature_with_payload() -> None:
         "webhook-timestamp": "1740656629",
         "webhook-signature": "v1,5JQxZW3lMNdaSnofcSV0Y3krxQ7aZI7EyThUqHVDGc4=",
     }
+
+
+def _event_payload(source_context: SourceEventContext) -> dict:
+    """Wrap a serialized event context the way it reaches the webhook processor."""
+    return {"data": {}, "context": source_context.to_event()}
+
+
+def test_event_context_from_event_extracts_account_id() -> None:
+    account_id = "d3f1c0a2-7b3f-4ee3-9351-1065a393b80c"
+    source_context = SourceEventContext(
+        branch=EventBranchContext(name="test4", id="18c0f7a2-7b3f-7ee3-1351-1065a393b80c"),
+        account_id=account_id,
+    )
+
+    context = EventContext.from_event(
+        event_id="673a2d93-a9e0-464a-a635-aba2b42ff2b0",
+        event_type="infrahub.branch.created",
+        event_occured_at="2026-07-10 15:35:29.674921+00:00",
+        event_payload=_event_payload(source_context),
+    )
+
+    assert context.account_id == account_id
+    assert context.branch == "test4"
+
+
+def test_event_context_from_event_global_branch_is_none() -> None:
+    source_context = SourceEventContext(
+        branch=EventBranchContext(name=GLOBAL_BRANCH_NAME),
+        account_id="d3f1c0a2-7b3f-4ee3-9351-1065a393b80c",
+    )
+
+    context = EventContext.from_event(
+        event_id="673a2d93-a9e0-464a-a635-aba2b42ff2b0",
+        event_type="infrahub.branch.created",
+        event_occured_at="2026-07-10 15:35:29.674921+00:00",
+        event_payload=_event_payload(source_context),
+    )
+
+    assert context.branch is None

--- a/changelog/9881.fixed.md
+++ b/changelog/9881.fixed.md
@@ -1,0 +1,1 @@
+Outbound webhook payloads now include the `account_id` of the account that triggered the event again, instead of always sending `null`.


### PR DESCRIPTION
# Why

Since 1.9.6 → 1.10.x, every outbound webhook payload carried `account_id: null` regardless of which account triggered the event, dropping attribution for all webhook consumers.

Closes #9881

## What changed

- Outbound webhook payloads again include the `account_id` of the triggering account.

The event-context refactor moved `account_id` to the top level of the event payload's `context` block and removed the nested `account` object. The webhook payload builder still read the old nested path (`context["account"]["account_id"]`), which no longer exists, so it always resolved to `None`. It now reads the top-level `account_id`.

Branch extraction was unaffected and is unchanged. No schema or event-model changes.

## How to review

Single change in `WebhookEventContext.from_event` (`backend/infrahub/webhook/models.py`). The added unit tests build the payload from the real `EventContext.to_event()` serialization, so they stay coupled to the actual contract.

## How to test

```bash
uv run pytest backend/tests/unit/webhook/test_models.py -q
```

Verified the new `from_event` account_id test fails without the fix and passes with it.

The functional payload-transform test exercises the full delivery flow against the testcontainers stack:

```bash
uv run pytest --neo4j "backend/tests/functional/webhook/test_process.py::TestWebhookProcess::test_webhook_check_payload_transform"
```

### Live end-to-end verification

Validated on a local stack built from this branch (`dev.deps` → single-platform image build → `dev.start`), through the real Prefect `webhook-process` → `webhook-send` delivery path:

1. Logged in as `admin` and created a `CoreCustomWebhook` pointing at a local HTTP receiver.
2. Created a branch as `admin`, firing `infrahub.branch.created`.
3. The receiver captured the delivered payload, whose `account_id` equalled the `admin` account id — the same event shape as the reported regression, now carrying the triggering account instead of `null`.

Confirmed the running task-worker executed this branch's image before triggering, so the observed payload reflects the fixed code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `account_id` in outbound webhook payloads by reading it from the top-level `context.account_id` after the event-context refactor. Fixes the 1.10.x regression that sent `account_id: null`.

- **Bug Fixes**
  - Read from `context.account_id` instead of `context.account.account_id`.
  - Tests: unit checks using `SourceEventContext.to_event()`; functional fixture now derives `context` via `EventContext.to_event()`; verifies global branch is `None`.
  - No schema changes; branch extraction unchanged.

<sup>Written for commit bc74427feea113006d47b928057b0fa2ac154eb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

