### PR TITLE
feat(webhook): format the delivery logs for readability

### DIFF
--- a/backend/infrahub/webhook/log_formatter.py
+++ b/backend/infrahub/webhook/log_formatter.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+import ujson
+
+PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
+
+
+class WebhookLogFormatter:
+    """Builds the log messages emitted during a webhook delivery.
+
+    Its sole responsibility is the wording and layout of those messages, laid out over several
+    labeled lines so an operator can find the request target, headers, payload, outcome, and retry
+    position at a glance. It only returns strings; emitting them is left to the caller. Header
+    redaction is not done here: the caller passes headers that are already masked.
+    """
+
+    def __init__(self, *, attempts: int, retry_delay_seconds: float, payload_log_limit: int) -> None:
+        self._attempts = attempts
+        self._retry_delay_seconds = retry_delay_seconds
+        self._payload_log_limit = payload_log_limit
+
+    def attempt_phrase(self, attempt: int | None) -> str:
+        """Position a send within its retry sequence, or note that no flow run is driving retries."""
+        if attempt is None:
+            return "outside a flow run"
+        return f"attempt {attempt}/{self._attempts}"
+
+    def outgoing_request(
+        self, *, webhook_name: str, url: str, headers: dict[str, Any], payload: Any, attempt: int | None
+    ) -> str:
+        """Summarize the outgoing request: target, headers one per line, and the truncated payload."""
+        return (
+            f"Webhook '{webhook_name}' {self.attempt_phrase(attempt)}\n"
+            f"POST {url}\n"
+            f"Headers:\n{self._headers_block(headers)}\n"
+            f"Payload:\n{self._indent(self._truncate(self._to_json(payload)))}"
+        )
+
+    def full_payload(self, *, webhook_name: str, payload: Any, attempt: int | None) -> str:
+        """Render the full, untruncated payload for the debug-level line."""
+        return (
+            f"Webhook '{webhook_name}' {self.attempt_phrase(attempt)} full payload:\n"
+            f"{self._indent(self._to_json(payload))}"
+        )
+
+    def delivery_succeeded(self, *, url: str, status_code: int, attempt: int | None, elapsed_ms: float) -> str:
+        return f"Webhook delivered to {url} {self.attempt_phrase(attempt)}, HTTP {status_code} in {elapsed_ms:.0f} ms"
+
+    def delivery_failed(
+        self, *, status_class: str, message: str, remediation: str, attempt: int | None, elapsed_ms: float
+    ) -> str:
+        return (
+            f"Webhook delivery failed [{status_class}] {self.attempt_phrase(attempt)} "
+            f"after {elapsed_ms:.0f} ms: {message.rstrip('.')}. {remediation}{self._retry_note(attempt)}"
+        )
+
+    def _retry_note(self, attempt: int | None) -> str:
+        """State when the next attempt runs, or that none remain. Empty when no flow run drives retries."""
+        if attempt is None:
+            return ""
+        if attempt < self._attempts:
+            return f" Retrying in {self._retry_delay_seconds:.0f}s (attempt {attempt + 1}/{self._attempts})."
+        return " No retries remaining."
+
+    def _headers_block(self, headers: dict[str, Any]) -> str:
+        if not headers:
+            return "  (none)"
+        return "\n".join(f"  {key}: {value}" for key, value in headers.items())
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self._payload_log_limit:
+            return text
+        remaining = len(text) - self._payload_log_limit
+        return (
+            f"{text[: self._payload_log_limit]}… (+{remaining} characters; enable debug logging for the full payload)"
+        )
+
+    @staticmethod
+    def _to_json(payload: Any) -> str:
+        return ujson.dumps(payload, indent=2)
+
+    @staticmethod
+    def _indent(text: str) -> str:
+        return "\n".join(f"  {line}" for line in text.splitlines())

--- a/backend/infrahub/webhook/log_formatter.py
+++ b/backend/infrahub/webhook/log_formatter.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import ujson
+
+logger = logging.getLogger(__name__)
 
 PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
 
@@ -35,7 +38,7 @@ class WebhookLogFormatter:
             f"Webhook '{webhook_name}' {self.attempt_phrase(attempt)}\n"
             f"POST {url}\n"
             f"Headers:\n{self._headers_block(headers)}\n"
-            f"Payload:\n{self._indent(self._truncate(self._to_json(payload)))}"
+            f"Payload:\n{self._truncate(self._indent(self._to_json(payload)))}"
         )
 
     def full_payload(self, *, webhook_name: str, payload: Any, attempt: int | None) -> str:
@@ -79,7 +82,16 @@ class WebhookLogFormatter:
 
     @staticmethod
     def _to_json(payload: Any) -> str:
-        return ujson.dumps(payload, indent=2)
+        try:
+            return ujson.dumps(payload, indent=2)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Webhook payload of type '%s' could not be serialized to JSON for logging (%s); "
+                "falling back to its plain representation",
+                type(payload).__name__,
+                exc,
+            )
+            return str(payload)
 
     @staticmethod
     def _indent(text: str) -> str:

--- a/backend/infrahub/webhook/log_formatter.py
+++ b/backend/infrahub/webhook/log_formatter.py
@@ -24,7 +24,7 @@ class WebhookLogFormatter:
         self._retry_delay_seconds = retry_delay_seconds
         self._payload_log_limit = payload_log_limit
 
-    def attempt_phrase(self, attempt: int | None) -> str:
+    def _attempt_phrase(self, attempt: int | None) -> str:
         """Position a send within its retry sequence, or note that no flow run is driving retries."""
         if attempt is None:
             return "outside a flow run"
@@ -35,7 +35,7 @@ class WebhookLogFormatter:
     ) -> str:
         """Summarize the outgoing request: target, headers one per line, and the truncated payload."""
         return (
-            f"Webhook '{webhook_name}' {self.attempt_phrase(attempt)}\n"
+            f"Webhook '{webhook_name}' {self._attempt_phrase(attempt)}\n"
             f"POST {url}\n"
             f"Headers:\n{self._headers_block(headers)}\n"
             f"Payload:\n{self._truncate(self._indent(self._to_json(payload)))}"
@@ -44,18 +44,18 @@ class WebhookLogFormatter:
     def full_payload(self, *, webhook_name: str, payload: Any, attempt: int | None) -> str:
         """Render the full, untruncated payload for the debug-level line."""
         return (
-            f"Webhook '{webhook_name}' {self.attempt_phrase(attempt)} full payload:\n"
+            f"Webhook '{webhook_name}' {self._attempt_phrase(attempt)} full payload:\n"
             f"{self._indent(self._to_json(payload))}"
         )
 
     def delivery_succeeded(self, *, url: str, status_code: int, attempt: int | None, elapsed_ms: float) -> str:
-        return f"Webhook delivered to {url} {self.attempt_phrase(attempt)}, HTTP {status_code} in {elapsed_ms:.0f} ms"
+        return f"Webhook delivered to {url} {self._attempt_phrase(attempt)}, HTTP {status_code} in {elapsed_ms:.0f} ms"
 
     def delivery_failed(
         self, *, status_class: str, message: str, remediation: str, attempt: int | None, elapsed_ms: float
     ) -> str:
         return (
-            f"Webhook delivery failed [{status_class}] {self.attempt_phrase(attempt)} "
+            f"Webhook delivery failed [{status_class}] {self._attempt_phrase(attempt)} "
             f"after {elapsed_ms:.0f} ms: {message.rstrip('.')}. {remediation}{self._retry_note(attempt)}"
         )
 

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -42,11 +43,14 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-_LOG_FORMATTER = WebhookLogFormatter(
-    attempts=WEBHOOK_SEND_ATTEMPTS,
-    retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS,
-    payload_log_limit=PAYLOAD_LOG_LIMIT,
-)
+@lru_cache(maxsize=1)
+def get_webhook_log_formatter() -> WebhookLogFormatter:
+    """Return the shared webhook log formatter, building it on first use."""
+    return WebhookLogFormatter(
+        attempts=WEBHOOK_SEND_ATTEMPTS,
+        retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS,
+        payload_log_limit=PAYLOAD_LOG_LIMIT,
+    )
 
 
 async def _cancellation_requested() -> bool:
@@ -85,7 +89,7 @@ async def webhook_post(
         webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
         headers = webhook.build_headers(payload=payload)
         log.info(
-            _LOG_FORMATTER.outgoing_request(
+            get_webhook_log_formatter().outgoing_request(
                 webhook_name=webhook_name,
                 url=webhook.url,
                 headers=webhook.redact_headers(headers),
@@ -93,7 +97,7 @@ async def webhook_post(
                 attempt=attempt,
             )
         )
-        log.debug(_LOG_FORMATTER.full_payload(webhook_name=webhook_name, payload=payload, attempt=attempt))
+        log.debug(get_webhook_log_formatter().full_payload(webhook_name=webhook_name, payload=payload, attempt=attempt))
         response = await webhook.send_payload(payload=payload, http_service=http_service, headers=headers)
         response.raise_for_status()
     except EXPECTED_DELIVERY_ERRORS as cause:
@@ -144,7 +148,7 @@ async def webhook_send(
         elapsed_ms = (time.monotonic() - started) * 1_000
         failure = error.failure
         log.error(
-            _LOG_FORMATTER.delivery_failed(
+            get_webhook_log_formatter().delivery_failed(
                 status_class=failure.status_class,
                 message=failure.message,
                 remediation=failure.remediation,
@@ -155,7 +159,7 @@ async def webhook_send(
         raise
     elapsed_ms = (time.monotonic() - started) * 1_000
     log.info(
-        _LOG_FORMATTER.delivery_succeeded(
+        get_webhook_log_formatter().delivery_succeeded(
             url=str(response.url), status_code=response.status_code, attempt=attempt, elapsed_ms=elapsed_ms
         )
     )

--- a/backend/infrahub/webhook/tasks/process.py
+++ b/backend/infrahub/webhook/tasks/process.py
@@ -27,6 +27,7 @@ from ..constants import (
     WEBHOOK_SEND_RETRIES,
     WEBHOOK_SEND_RETRY_DELAY_SECONDS,
 )
+from ..log_formatter import PAYLOAD_LOG_LIMIT, WebhookLogFormatter
 from ..models import CustomWebhook, EventContext, HeaderKind, StandardWebhook, TransformWebhook, Webhook, WebhookHeader
 
 if TYPE_CHECKING:
@@ -41,21 +42,11 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 }
 
 
-PAYLOAD_LOG_LIMIT: int = 2048  # characters shown inline; the full payload is logged at debug level
-
-
-def _truncate_for_log(text: str) -> str:
-    if len(text) <= PAYLOAD_LOG_LIMIT:
-        return text
-    remaining = len(text) - PAYLOAD_LOG_LIMIT
-    return f"{text[:PAYLOAD_LOG_LIMIT]}… (+{remaining} characters; enable debug logging for the full payload)"
-
-
-def _attempt_phrase(attempt: int | None) -> str:
-    """Position this send within its retry sequence, or note that no flow run is driving retries."""
-    if attempt is None:
-        return "outside a flow run"
-    return f"attempt {attempt}/{WEBHOOK_SEND_ATTEMPTS}"
+_LOG_FORMATTER = WebhookLogFormatter(
+    attempts=WEBHOOK_SEND_ATTEMPTS,
+    retry_delay_seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS,
+    payload_log_limit=PAYLOAD_LOG_LIMIT,
+)
 
 
 async def _cancellation_requested() -> bool:
@@ -71,19 +62,6 @@ async def _cancellation_requested() -> bool:
         return False
     async with get_prefect_client(sync_client=False) as client:
         return await PrefectClientAdapter(client).cancellation_requested(flow_run_id=UUID(flow_run.id))
-
-
-def _log_outgoing_request(
-    *, webhook: Webhook, webhook_name: str, attempt: int | None, headers: dict[str, Any], payload: Any
-) -> None:
-    """Log the outgoing request: a redacted, truncated summary at info and the full payload at debug."""
-    log = get_run_logger()
-    payload_json = ujson.dumps(payload)
-    log.info(
-        f"Webhook '{webhook_name}' {_attempt_phrase(attempt)}: POST {webhook.url} "
-        f"with headers {webhook.redact_headers(headers)} and payload {_truncate_for_log(payload_json)}"
-    )
-    log.debug(f"Webhook '{webhook_name}' {_attempt_phrase(attempt)} full payload: {payload_json}")
 
 
 async def webhook_post(
@@ -102,12 +80,20 @@ async def webhook_post(
 
     """
     http_service = get_http()
+    log = get_run_logger()
     try:
         webhook = await _resolve_webhook(webhook_id=webhook_id, webhook_kind=webhook_kind)
         headers = webhook.build_headers(payload=payload)
-        _log_outgoing_request(
-            webhook=webhook, webhook_name=webhook_name, attempt=attempt, headers=headers, payload=payload
+        log.info(
+            _LOG_FORMATTER.outgoing_request(
+                webhook_name=webhook_name,
+                url=webhook.url,
+                headers=webhook.redact_headers(headers),
+                payload=payload,
+                attempt=attempt,
+            )
         )
+        log.debug(_LOG_FORMATTER.full_payload(webhook_name=webhook_name, payload=payload, attempt=attempt))
         response = await webhook.send_payload(payload=payload, http_service=http_service, headers=headers)
         response.raise_for_status()
     except EXPECTED_DELIVERY_ERRORS as cause:
@@ -157,23 +143,21 @@ async def webhook_send(
     except WebhookDeliveryError as error:
         elapsed_ms = (time.monotonic() - started) * 1_000
         failure = error.failure
-        # A retry is only scheduled when a flow run is driving the sequence and attempts remain.
-        retry_note = ""
-        if attempt is not None:
-            retry_note = (
-                f" Retrying in {WEBHOOK_SEND_RETRY_DELAY_SECONDS:.0f}s (attempt {attempt + 1}/{WEBHOOK_SEND_ATTEMPTS})."
-                if attempt < WEBHOOK_SEND_ATTEMPTS
-                else " No retries remaining."
-            )
         log.error(
-            f"Webhook delivery failed [{failure.status_class}] {_attempt_phrase(attempt)} "
-            f"after {elapsed_ms:.0f} ms: {failure.message.rstrip('.')}. {failure.remediation}{retry_note}"
+            _LOG_FORMATTER.delivery_failed(
+                status_class=failure.status_class,
+                message=failure.message,
+                remediation=failure.remediation,
+                attempt=attempt,
+                elapsed_ms=elapsed_ms,
+            )
         )
         raise
     elapsed_ms = (time.monotonic() - started) * 1_000
     log.info(
-        f"Webhook delivered to {response.url} {_attempt_phrase(attempt)}, "
-        f"HTTP {response.status_code} in {elapsed_ms:.0f} ms"
+        _LOG_FORMATTER.delivery_succeeded(
+            url=str(response.url), status_code=response.status_code, attempt=attempt, elapsed_ms=elapsed_ms
+        )
     )
     return response
 

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.webhook.log_formatter import WebhookLogFormatter
+
+ATTEMPTS = 4
+RETRY_DELAY_SECONDS = 120.0
+PAYLOAD_LIMIT = 2048
+
+
+@pytest.fixture
+def formatter() -> WebhookLogFormatter:
+    return WebhookLogFormatter(
+        attempts=ATTEMPTS, retry_delay_seconds=RETRY_DELAY_SECONDS, payload_log_limit=PAYLOAD_LIMIT
+    )
+
+
+@dataclass
+class AttemptPhraseCase:
+    name: str
+    attempt: int | None
+    expected: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        AttemptPhraseCase(name="first_attempt", attempt=1, expected="attempt 1/4"),
+        AttemptPhraseCase(name="last_attempt", attempt=ATTEMPTS, expected="attempt 4/4"),
+        AttemptPhraseCase(name="no_flow_run", attempt=None, expected="outside a flow run"),
+    ],
+    ids=lambda case: case.name,
+)
+def test_attempt_phrase(formatter: WebhookLogFormatter, case: AttemptPhraseCase) -> None:
+    assert formatter.attempt_phrase(case.attempt) == case.expected
+
+
+def test_outgoing_request_lays_out_target_headers_and_payload_over_labeled_lines(
+    formatter: WebhookLogFormatter,
+) -> None:
+    message = formatter.outgoing_request(
+        webhook_name="notify",
+        url="https://example.test/hook",
+        headers={"Accept": "application/json", "X-Token": "***"},
+        payload={"event": "created", "data": {"name": "device-01"}},
+        attempt=1,
+    )
+
+    assert message == (
+        "Webhook 'notify' attempt 1/4\n"
+        "POST https://example.test/hook\n"
+        "Headers:\n"
+        "  Accept: application/json\n"
+        "  X-Token: ***\n"
+        "Payload:\n"
+        "  {\n"
+        '    "event": "created",\n'
+        '    "data": {\n'
+        '      "name": "device-01"\n'
+        "    }\n"
+        "  }"
+    )
+
+
+def test_outgoing_request_notes_when_there_are_no_headers(formatter: WebhookLogFormatter) -> None:
+    message = formatter.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload={}, attempt=1
+    )
+
+    assert message == (
+        "Webhook 'notify' attempt 1/4\nPOST https://example.test/hook\nHeaders:\n  (none)\nPayload:\n  {}"
+    )
+
+
+def test_outgoing_request_keeps_the_headers_in_the_order_given(formatter: WebhookLogFormatter) -> None:
+    message = formatter.outgoing_request(
+        webhook_name="notify",
+        url="https://example.test/hook",
+        headers={"webhook-id": "msg_1", "webhook-timestamp": "1783928359", "webhook-signature": "***"},
+        payload={},
+        attempt=2,
+    )
+
+    assert "Headers:\n  webhook-id: msg_1\n  webhook-timestamp: 1783928359\n  webhook-signature: ***\n" in message
+
+
+def test_outgoing_request_truncates_the_inline_payload_and_marks_the_overflow(
+    formatter: WebhookLogFormatter,
+) -> None:
+    payload = {"blob": "x" * (PAYLOAD_LIMIT * 2)}
+
+    message = formatter.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload=payload, attempt=1
+    )
+
+    payload_section = message.split("Payload:\n", 1)[1]
+    # The inline payload is capped at the limit (plus the overflow marker), each line indented by two spaces.
+    unindented = "\n".join(line[2:] for line in payload_section.splitlines())
+    assert unindented.startswith('{\n  "blob": "' + "x" * 100)
+    assert unindented.endswith("characters; enable debug logging for the full payload)")
+    assert "… (+" in unindented
+
+
+def test_outgoing_request_does_not_truncate_a_payload_at_the_limit(formatter: WebhookLogFormatter) -> None:
+    small = WebhookLogFormatter(attempts=ATTEMPTS, retry_delay_seconds=RETRY_DELAY_SECONDS, payload_log_limit=100)
+    message = small.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload={"k": "v"}, attempt=1
+    )
+
+    assert message.endswith('Payload:\n  {\n    "k": "v"\n  }')
+
+
+def test_full_payload_is_untruncated_and_indented(formatter: WebhookLogFormatter) -> None:
+    payload = {"blob": "y" * (PAYLOAD_LIMIT * 2)}
+
+    message = formatter.full_payload(webhook_name="notify", payload=payload, attempt=3)
+
+    assert message.startswith("Webhook 'notify' attempt 3/4 full payload:\n")
+    assert "… (+" not in message
+    assert ("y" * (PAYLOAD_LIMIT * 2)) in message
+
+
+def test_delivery_succeeded(formatter: WebhookLogFormatter) -> None:
+    message = formatter.delivery_succeeded(
+        url="https://example.test/hook", status_code=200, attempt=1, elapsed_ms=142.7
+    )
+
+    assert message == "Webhook delivered to https://example.test/hook attempt 1/4, HTTP 200 in 143 ms"
+
+
+@dataclass
+class FailureCase:
+    name: str
+    attempt: int | None
+    expected_tail: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        FailureCase(
+            name="mid_run_announces_next_retry",
+            attempt=2,
+            expected_tail=" Retrying in 120s (attempt 3/4).",
+        ),
+        FailureCase(
+            name="last_attempt_reports_no_retries_remaining",
+            attempt=ATTEMPTS,
+            expected_tail=" No retries remaining.",
+        ),
+        FailureCase(
+            name="outside_flow_run_has_no_retry_note",
+            attempt=None,
+            expected_tail="",
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_delivery_failed_reports_class_reason_remediation_and_retry_note(
+    formatter: WebhookLogFormatter, case: FailureCase
+) -> None:
+    message = formatter.delivery_failed(
+        status_class="HTTP_SERVER_ERROR",
+        message="The target responded with HTTP 503.",
+        remediation="The target returned a server error; retry, or check the target.",
+        attempt=case.attempt,
+        elapsed_ms=88.0,
+    )
+
+    location = "outside a flow run" if case.attempt is None else f"attempt {case.attempt}/4"
+    assert message == (
+        f"Webhook delivery failed [HTTP_SERVER_ERROR] {location} after 88 ms: "
+        "The target responded with HTTP 503. "
+        f"The target returned a server error; retry, or check the target.{case.expected_tail}"
+    )

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -101,7 +101,6 @@ def test_outgoing_request_truncates_the_inline_payload_and_marks_the_overflow(
     )
 
     payload_section = message.split("Payload:\n", 1)[1]
-    # The inline payload is capped at the limit (plus the overflow marker), each line indented by two spaces.
     unindented = "\n".join(line[2:] for line in payload_section.splitlines())
     assert unindented.startswith('{\n  "blob": "' + "x" * 100)
     assert unindented.endswith("characters; enable debug logging for the full payload)")
@@ -125,7 +124,7 @@ def test_inline_payload_stays_within_the_limit_including_indentation(formatter: 
     )
 
     payload_section = message.split("Payload:\n", 1)[1]
-    inline = payload_section.split("… (+", 1)[0]  # the shown payload, before the overflow marker
+    inline = payload_section.split("… (+", 1)[0]
     assert len(inline) <= PAYLOAD_LIMIT
 
 
@@ -138,8 +137,6 @@ def test_outgoing_request_falls_back_to_plain_repr_when_payload_is_not_json_seri
     formatter: WebhookLogFormatter, caplog: pytest.LogCaptureFixture
 ) -> None:
     payload = _Unserializable()
-    # The serializer's own error text is library-specific; capture it from the same call so the
-    # rest of the warning can be asserted exactly.
     with pytest.raises((TypeError, ValueError)) as exc_info:
         ujson.dumps(payload, indent=2)
     serialization_error = str(exc_info.value)

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -38,8 +38,14 @@ class AttemptPhraseCase:
     ],
     ids=lambda case: case.name,
 )
-def test_attempt_phrase(formatter: WebhookLogFormatter, case: AttemptPhraseCase) -> None:
-    assert formatter.attempt_phrase(case.attempt) == case.expected
+def test_message_positions_the_send_within_its_retry_sequence(
+    formatter: WebhookLogFormatter, case: AttemptPhraseCase
+) -> None:
+    message = formatter.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload={}, attempt=case.attempt
+    )
+
+    assert message.startswith(f"Webhook 'notify' {case.expected}\n")
 
 
 def test_outgoing_request_lays_out_target_headers_and_payload_over_labeled_lines(

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -114,12 +114,22 @@ def test_outgoing_request_truncates_the_inline_payload_and_marks_the_overflow(
 
 
 def test_outgoing_request_does_not_truncate_a_payload_at_the_limit(formatter: WebhookLogFormatter) -> None:
-    small = WebhookLogFormatter(attempts=ATTEMPTS, retry_delay_seconds=RETRY_DELAY_SECONDS, payload_log_limit=100)
-    message = small.outgoing_request(
-        webhook_name="notify", url="https://example.test/hook", headers={}, payload={"k": "v"}, attempt=1
+    payload = {"event": "created", "data": {"name": "device-01"}}
+
+    rendered = formatter.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload=payload, attempt=1
+    )
+    payload_block = rendered.split("Payload:\n", 1)[1]
+
+    at_limit = WebhookLogFormatter(
+        attempts=ATTEMPTS, retry_delay_seconds=RETRY_DELAY_SECONDS, payload_log_limit=len(payload_block)
+    )
+    message = at_limit.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload=payload, attempt=1
     )
 
-    assert message.endswith('Payload:\n  {\n    "k": "v"\n  }')
+    assert message.endswith(f"Payload:\n{payload_block}")
+    assert "… (+" not in message
 
 
 def test_inline_payload_stays_within_the_limit_including_indentation(formatter: WebhookLogFormatter) -> None:

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -153,7 +153,7 @@ def test_outgoing_request_falls_back_to_plain_repr_when_payload_is_not_json_seri
     formatter: WebhookLogFormatter, caplog: pytest.LogCaptureFixture
 ) -> None:
     payload = _Unserializable()
-    with pytest.raises((TypeError, ValueError)) as exc_info:
+    with pytest.raises(TypeError, match="is not JSON serializable") as exc_info:
         ujson.dumps(payload, indent=2)
     serialization_error = str(exc_info.value)
 

--- a/backend/tests/unit/webhook/test_log_formatter.py
+++ b/backend/tests/unit/webhook/test_log_formatter.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import pytest
+import ujson
 
 from infrahub.webhook.log_formatter import WebhookLogFormatter
+
+LOG_FORMATTER_LOGGER = "infrahub.webhook.log_formatter"
 
 ATTEMPTS = 4
 RETRY_DELAY_SECONDS = 120.0
@@ -111,6 +115,48 @@ def test_outgoing_request_does_not_truncate_a_payload_at_the_limit(formatter: We
     )
 
     assert message.endswith('Payload:\n  {\n    "k": "v"\n  }')
+
+
+def test_inline_payload_stays_within_the_limit_including_indentation(formatter: WebhookLogFormatter) -> None:
+    payload = {"blob": "x" * (PAYLOAD_LIMIT * 2)}
+
+    message = formatter.outgoing_request(
+        webhook_name="notify", url="https://example.test/hook", headers={}, payload=payload, attempt=1
+    )
+
+    payload_section = message.split("Payload:\n", 1)[1]
+    inline = payload_section.split("… (+", 1)[0]  # the shown payload, before the overflow marker
+    assert len(inline) <= PAYLOAD_LIMIT
+
+
+class _Unserializable:
+    def __repr__(self) -> str:
+        return "<unserializable>"
+
+
+def test_outgoing_request_falls_back_to_plain_repr_when_payload_is_not_json_serializable(
+    formatter: WebhookLogFormatter, caplog: pytest.LogCaptureFixture
+) -> None:
+    payload = _Unserializable()
+    # The serializer's own error text is library-specific; capture it from the same call so the
+    # rest of the warning can be asserted exactly.
+    with pytest.raises((TypeError, ValueError)) as exc_info:
+        ujson.dumps(payload, indent=2)
+    serialization_error = str(exc_info.value)
+
+    with caplog.at_level(logging.WARNING, logger=LOG_FORMATTER_LOGGER):
+        message = formatter.outgoing_request(
+            webhook_name="notify", url="https://example.test/hook", headers={}, payload=payload, attempt=1
+        )
+
+    assert message == (
+        "Webhook 'notify' attempt 1/4\nPOST https://example.test/hook\nHeaders:\n  (none)\nPayload:\n  <unserializable>"
+    )
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings == [
+        f"Webhook payload of type '_Unserializable' could not be serialized to JSON for logging "
+        f"({serialization_error}); falling back to its plain representation"
+    ]
 
 
 def test_full_payload_is_untruncated_and_indented(formatter: WebhookLogFormatter) -> None:

--- a/backend/tests/unit/webhook/test_process.py
+++ b/backend/tests/unit/webhook/test_process.py
@@ -6,14 +6,12 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
-import ujson
 
 from infrahub.exceptions import HTTPServerError
 from infrahub.webhook.classifier import WebhookDeliveryError, WebhookFailureClassifier
 from infrahub.webhook.models import CustomWebhook, HeaderKind, Webhook, WebhookHeader
 from infrahub.webhook.tasks import process
 from infrahub.webhook.tasks.process import (
-    PAYLOAD_LOG_LIMIT,
     WEBHOOK_SEND_ATTEMPTS,
     webhook_post,
     webhook_send,
@@ -83,13 +81,12 @@ def webhook_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
     return "super-secret-token"
 
 
-async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
+async def test_webhook_post_emits_the_formatted_request_at_info_and_the_full_payload_at_debug(
     caplog: pytest.LogCaptureFixture,
     recording_http: _RecordingHTTP,
     webhook_token_env: str,
     resolve_webhook_to: Callable[[Webhook], None],
 ) -> None:
-    # No shared_key: avoids the random webhook-id/timestamp/signature so the logged line is fully fixed.
     webhook = CustomWebhook(
         name="hook",
         url="https://target.example/hook",
@@ -101,15 +98,7 @@ async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
         ],
     )
     resolve_webhook_to(webhook)
-
     payload = {"event": "branch.created"}
-    payload_json = ujson.dumps(payload)
-    expected_headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "X-Static": "plain",
-        "X-Token": "***",
-    }
 
     with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
         await webhook_post(
@@ -119,78 +108,38 @@ async def test_webhook_post_logs_attempt_with_masked_headers_and_payload(
     info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
     debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
 
+    # The env-sourced header is masked before formatting; the static one and the standard ones are kept.
+    # The exact layout is specified by the formatter's own tests; here we assert the flow emits its output.
+    redacted_headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Static": "plain",
+        "X-Token": "***",
+    }
     assert info_messages == [
-        "Webhook 'hook' attempt 2/4: POST https://target.example/hook "
-        f"with headers {expected_headers} and payload {payload_json}"
-    ]
-    assert debug_messages == [f"Webhook 'hook' attempt 2/4 full payload: {payload_json}"]
-
-
-async def test_webhook_post_truncates_large_payload_inline_and_logs_it_in_full_at_debug(
-    caplog: pytest.LogCaptureFixture,
-    recording_http: _RecordingHTTP,
-    resolve_webhook_to: Callable[[Webhook], None],
-) -> None:
-    webhook = CustomWebhook(
-        name="hook",
-        url="https://target.example/hook",
-        event_type="infrahub.branch.created",
-        validate_certificates=False,
-    )
-    resolve_webhook_to(webhook)
-
-    payload = {"blob": "x" * (PAYLOAD_LOG_LIMIT * 2)}
-    payload_json = ujson.dumps(payload)
-    overflow = len(payload_json) - PAYLOAD_LOG_LIMIT
-    truncated = (
-        payload_json[:PAYLOAD_LOG_LIMIT] + f"… (+{overflow} characters; enable debug logging for the full payload)"
-    )
-    expected_headers = {"Accept": "application/json", "Content-Type": "application/json"}
-
-    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
-        await webhook_post(
-            webhook_id="id-1", webhook_kind="CustomWebhook", webhook_name="hook", payload=payload, attempt=1
+        process._LOG_FORMATTER.outgoing_request(
+            webhook_name="hook",
+            url="https://target.example/hook",
+            headers=redacted_headers,
+            payload=payload,
+            attempt=2,
         )
-
-    info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
-    debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
-
-    assert info_messages == [
-        "Webhook 'hook' attempt 1/4: POST https://target.example/hook "
-        f"with headers {expected_headers} and payload {truncated}"
     ]
-    assert debug_messages == [f"Webhook 'hook' attempt 1/4 full payload: {payload_json}"]
+    assert debug_messages == [process._LOG_FORMATTER.full_payload(webhook_name="hook", payload=payload, attempt=2)]
 
 
 @dataclass
 class FailureLogCase:
     name: str
     run_count: int | None
-    location: str  # the attempt phrase in the log line
-    retry_note: str  # the trailing retry note, empty when none is expected
 
 
 @pytest.mark.parametrize(
     "case",
     [
-        FailureLogCase(
-            name="mid_run_attempt_announces_next_retry",
-            run_count=1,
-            location="attempt 1/4",
-            retry_note=" Retrying in 120s (attempt 2/4).",
-        ),
-        FailureLogCase(
-            name="last_attempt_reports_no_retries_remaining",
-            run_count=WEBHOOK_SEND_ATTEMPTS,
-            location=f"attempt {WEBHOOK_SEND_ATTEMPTS}/4",
-            retry_note=" No retries remaining.",
-        ),
-        FailureLogCase(
-            name="outside_flow_run_omits_attempt_and_retry_note",
-            run_count=None,
-            location="outside a flow run",
-            retry_note="",
-        ),
+        FailureLogCase(name="mid_run_attempt", run_count=1),
+        FailureLogCase(name="last_attempt", run_count=WEBHOOK_SEND_ATTEMPTS),
+        FailureLogCase(name="outside_flow_run", run_count=None),
     ],
     ids=lambda case: case.name,
 )
@@ -201,9 +150,12 @@ async def test_webhook_send_logs_and_raises_the_classified_failure(
     # Pin the clock so the logged elapsed time is a fixed "0 ms" and the line can be matched exactly.
     monkeypatch.setattr(process.time, "monotonic", lambda: 0.0)
 
+    failure = WebhookFailureClassifier().classify(
+        cause=HTTPServerError(message="Connection to https://target.example failed")
+    )
+
     async def _failing_post(**_kwargs: object) -> httpx.Response:
-        cause = HTTPServerError(message="Connection to https://target.example failed")
-        raise WebhookDeliveryError(WebhookFailureClassifier().classify(cause=cause)) from None
+        raise WebhookDeliveryError(failure) from None
 
     monkeypatch.setattr(process, "webhook_post", _failing_post)
 
@@ -217,7 +169,11 @@ async def test_webhook_send_logs_and_raises_the_classified_failure(
 
     error_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.ERROR]
     assert error_messages == [
-        f"Webhook delivery failed [CONNECTION] {case.location} after 0 ms: "
-        "Connection to https://target.example failed. "
-        f"Verify the target endpoint is reachable from Infrahub.{case.retry_note}"
+        process._LOG_FORMATTER.delivery_failed(
+            status_class=failure.status_class,
+            message=failure.message,
+            remediation=failure.remediation,
+            attempt=case.run_count,
+            elapsed_ms=0.0,
+        )
     ]

--- a/backend/tests/unit/webhook/test_process.py
+++ b/backend/tests/unit/webhook/test_process.py
@@ -108,38 +108,51 @@ async def test_webhook_post_emits_the_formatted_request_at_info_and_the_full_pay
     info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
     debug_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
 
-    # The env-sourced header is masked before formatting; the static one and the standard ones are kept.
-    # The exact layout is specified by the formatter's own tests; here we assert the flow emits its output.
-    redacted_headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "X-Static": "plain",
-        "X-Token": "***",
-    }
     assert info_messages == [
-        process._LOG_FORMATTER.outgoing_request(
-            webhook_name="hook",
-            url="https://target.example/hook",
-            headers=redacted_headers,
-            payload=payload,
-            attempt=2,
-        )
+        "Webhook 'hook' attempt 2/4\n"
+        "POST https://target.example/hook\n"
+        "Headers:\n"
+        "  Accept: application/json\n"
+        "  Content-Type: application/json\n"
+        "  X-Static: plain\n"
+        "  X-Token: ***\n"
+        "Payload:\n"
+        "  {\n"
+        '    "event": "branch.created"\n'
+        "  }"
     ]
-    assert debug_messages == [process._LOG_FORMATTER.full_payload(webhook_name="hook", payload=payload, attempt=2)]
+    assert debug_messages == ['Webhook \'hook\' attempt 2/4 full payload:\n  {\n    "event": "branch.created"\n  }']
 
 
 @dataclass
 class FailureLogCase:
     name: str
     run_count: int | None
+    location: str
+    retry_note: str
 
 
 @pytest.mark.parametrize(
     "case",
     [
-        FailureLogCase(name="mid_run_attempt", run_count=1),
-        FailureLogCase(name="last_attempt", run_count=WEBHOOK_SEND_ATTEMPTS),
-        FailureLogCase(name="outside_flow_run", run_count=None),
+        FailureLogCase(
+            name="mid_run_attempt",
+            run_count=1,
+            location="attempt 1/4",
+            retry_note=" Retrying in 120s (attempt 2/4).",
+        ),
+        FailureLogCase(
+            name="last_attempt",
+            run_count=WEBHOOK_SEND_ATTEMPTS,
+            location="attempt 4/4",
+            retry_note=" No retries remaining.",
+        ),
+        FailureLogCase(
+            name="outside_flow_run",
+            run_count=None,
+            location="outside a flow run",
+            retry_note="",
+        ),
     ],
     ids=lambda case: case.name,
 )
@@ -147,15 +160,11 @@ async def test_webhook_send_logs_and_raises_the_classified_failure(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, case: FailureLogCase
 ) -> None:
     monkeypatch.setattr(process.flow_run, "run_count", case.run_count)
-    # Pin the clock so the logged elapsed time is a fixed "0 ms" and the line can be matched exactly.
     monkeypatch.setattr(process.time, "monotonic", lambda: 0.0)
 
-    failure = WebhookFailureClassifier().classify(
-        cause=HTTPServerError(message="Connection to https://target.example failed")
-    )
-
     async def _failing_post(**_kwargs: object) -> httpx.Response:
-        raise WebhookDeliveryError(failure) from None
+        cause = HTTPServerError(message="Connection to https://target.example failed")
+        raise WebhookDeliveryError(WebhookFailureClassifier().classify(cause=cause)) from None
 
     monkeypatch.setattr(process, "webhook_post", _failing_post)
 
@@ -169,11 +178,7 @@ async def test_webhook_send_logs_and_raises_the_classified_failure(
 
     error_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.ERROR]
     assert error_messages == [
-        process._LOG_FORMATTER.delivery_failed(
-            status_class=failure.status_class,
-            message=failure.message,
-            remediation=failure.remediation,
-            attempt=case.run_count,
-            elapsed_ms=0.0,
-        )
+        f"Webhook delivery failed [CONNECTION] {case.location} after 0 ms: "
+        "Connection to https://target.example failed. "
+        f"Verify the target endpoint is reachable from Infrahub.{case.retry_note}"
     ]

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -213,9 +213,6 @@ exports[`fix ts error`] = {
     "src/entities/schema/ui/computed-attribute-display.tsx:1618543609": [
       [37, 14, 8, "tsc: Type \'{ title: string; fileName: string; data: string; }\' is not assignable to type \'IntrinsicAttributes & DataViewerProps\'.\\n  Property \'fileName\' does not exist on type \'IntrinsicAttributes & DataViewerProps\'.", "3193632964"]
     ],
-    "src/entities/tasks/ui/logs.tsx:3377694090": [
-      [49, 31, 4, "tsc: Type \'{ values: { severity: any; timestamp: Element; id: string; message: string; }; }[]\' is not assignable to type \'tRow[]\'.\\n  Type \'{ values: { severity: any; timestamp: JSX.Element; id: string; message: string; }; }\' is not assignable to type \'tRow\'.\\n    Types of property \'values\' are incompatible.\\n      Type \'{ severity: any; timestamp: JSX.Element; id: string; message: string; }\' is not assignable to type \'Record<string, number | string | tRowValue>\'.\\n        Property \'timestamp\' is incompatible with index signature.\\n          Type \'Element\' is not assignable to type \'string | number | tRowValue\'.", "2088305148"]
-    ],
     "src/entities/tasks/ui/task-display.tsx:186971154": [
       [43, 16, 4, "tsc: Binding element \'task\' implicitly has an \'any\' type.", "2087951912"],
       [50, 10, 22, "tsc: Element implicitly has an \'any\' type because expression of type \'any\' can\'t be used to index type \'{ SCHEDULED: string; PENDING: string; RUNNING: string; PAUSED: string; CANCELLING: string; COMPLETED: string; CANCELLED: string; FAILED: string; CRASHED: string; }\'.", "1950518905"],

--- a/frontend/app/src/entities/tasks/ui/logs.tsx
+++ b/frontend/app/src/entities/tasks/ui/logs.tsx
@@ -39,9 +39,18 @@ export const Logs = ({ logs }: LogsProps) => {
 
   const rows = logs.map((log: tLog) => ({
     values: {
-      ...log,
-      severity: getSeverityBadge[log.severity],
-      timestamp: <DateDisplay date={log.timestamp} />,
+      message: {
+        value: log.message,
+        display: <span className="whitespace-pre-wrap break-words">{log.message}</span>,
+      },
+      severity: {
+        value: log.severity,
+        display: getSeverityBadge[log.severity],
+      },
+      timestamp: {
+        value: log.timestamp,
+        display: <DateDisplay date={log.timestamp} />,
+      },
     },
   }));
 


### PR DESCRIPTION
## Summary

Follow-up to the webhook delivery logging: make the delivery logs easy to read. Stacked on `pmi-20260618-ifc-2119-resend-webhook` (PR #9810).

Resolves [IFC-2905](https://opsmill.atlassian.net/browse/IFC-2905).

The outgoing-request log is laid out over labeled lines instead of one dense string, so an operator can pick out each element at a glance:

```
Webhook 'notify-slack' attempt 1/4
POST https://hooks.example.com/services/T000
Headers:
  Accept: application/json
  X-Api-Token: ***
  webhook-signature: ***
Payload:
  {
    "data": { "name": "device-01" },
    "event_type": "infrahub.node.updated"
  }
```

- Headers are printed one per line; secret values stay masked (`***`).
- The payload is pretty-printed (indented JSON) and truncated inline; the full untruncated payload is emitted at debug level.
- Success and classified-failure lines remain single readable sentences.

## What changed

- **`WebhookLogFormatter`** (`backend/infrahub/webhook/log_formatter.py`) — a dedicated component whose sole responsibility is the wording and layout of every delivery log line. It returns strings only (emitting stays in the flow) and does not redact (the caller passes already-masked headers). The send flow builds its messages through it.
- **`test_log_formatter.py`** — unit tests that specify the expected output: attempt phrasing, the labeled layout, headers one-per-line, `(none)` when empty, pretty-printed payload, inline truncation + overflow marker, untruncated debug payload, and the failure line's class/reason/remediation + retry note.
- **Frontend** (`logs.tsx`) — render task log messages with their whitespace preserved so the multi-line layout shows (same font as before), and migrate the rows to the Table's `{ value, display }` shape, which restores the severity and timestamp columns (previously rendered `-`).

## Verification

- Backend and frontend exercised end-to-end against a live stack: triggered a real `webhook-send` delivery and confirmed the stored task logs render un-stacked in the UI, including the debug full-payload line with debug logging enabled.
- `WebhookLogFormatter` and webhook flow unit tests pass; ruff, `ty`, and Biome clean; Betterer improved (removed one tracked `logs.tsx` type error).

## Out of scope

The `debug` severity has no badge in the logs table (`getSeverityBadge`), so debug rows show an empty Severity cell — tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves webhook delivery logs for quick scanning by laying out outgoing requests over labeled lines with masked headers and pretty JSON. The logs UI preserves multi-line formatting and restores the Severity and Timestamp columns; the formatter is now built lazily via a cached factory.

- New Features
  - Added `WebhookLogFormatter` and switched the send flow to use it; messages include the attempt, POST URL, per-line masked headers, pretty-printed JSON, a debug full-payload line, and clear success/failure lines with status, time, and retry notes. The formatter is constructed lazily with a cached factory to avoid import-time work.
  - Updated `logs.tsx` to use the Table `{ value, display }` shape and render messages with preserved whitespace; Severity and Timestamp columns are restored.

- Bug Fixes
  - Fall back to the payload’s plain representation with a warning when JSON serialization fails, so logging never blocks deliveries.
  - Apply the inline character limit after indentation so the shown payload stays within the configured bound.

<sup>Written for commit c43bd0b4cf6ba7fa21aa74528643d4206fcb72f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

[IFC-2905]: https://opsmill.atlassian.net/browse/IFC-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ