### PR TITLE
Add sort editor for viewing, editing, reordering and removing sorts

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -12,7 +12,7 @@ import { useSort } from "@/entities/nodes/sort/ui/hooks/use-sort";
 
 export const ObjectTable = () => {
   const { filters, selectedSchema, permission } = useObjectTableContext();
-  const { sort } = useSort(selectedSchema);
+  const { customSort } = useSort(selectedSchema);
 
   const { data: count } = useObjectsCount({
     objectKind: selectedSchema.kind!,
@@ -22,7 +22,7 @@ export const ObjectTable = () => {
   const { data, fetchNextPage, error, hasNextPage, isPending, isFetchingNextPage } = useObjects({
     schema: selectedSchema,
     filters,
-    sort,
+    sort: customSort,
   });
 
   if (error) {

--- a/frontend/app/src/entities/nodes/sort/domain/model/sort.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/model/sort.ts
@@ -11,7 +11,9 @@ export interface Sort {
 
 export const SORT_DIRECTION = OrderDirection;
 
-export const NODE_METADATA_SORT_FIELDS: { field: SortField; label: string }[] = [
-  { field: "node_metadata__created_at", label: "Created at" },
-  { field: "node_metadata__updated_at", label: "Updated at" },
-];
+export const NODE_METADATA_SORT_FIELDS = [
+  "node_metadata__created_at",
+  "node_metadata__updated_at",
+] as const satisfies SortField[];
+
+export type NodeMetadataSortField = (typeof NODE_METADATA_SORT_FIELDS)[number];

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.test.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.test.ts
@@ -84,6 +84,26 @@ describe("getValidSorts", () => {
     expect(validSorts).toEqual([{ field: "name__value", direction: "ASC" }]);
   });
 
+  it("keeps only the first occurrence of a duplicated field", () => {
+    // GIVEN
+    const schema = generateNodeSchema({
+      attributes: [generateAttributeSchema({ name: "name", kind: "Text" })],
+      relationships: [],
+    });
+
+    // WHEN
+    const validSorts = getValidSorts(
+      [
+        { field: "name__value", direction: "ASC" },
+        { field: "name__value", direction: "DESC" },
+      ],
+      schema
+    );
+
+    // THEN
+    expect(validSorts).toEqual([{ field: "name__value", direction: "ASC" }]);
+  });
+
   it("returns an empty list untouched without deriving anything", () => {
     // GIVEN
     const schema = generateNodeSchema({ attributes: [], relationships: [] });

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.ts
@@ -1,3 +1,5 @@
+import * as R from "remeda";
+
 import {
   NODE_METADATA_SORT_FIELDS,
   type Sort,
@@ -13,9 +15,9 @@ import type { ModelSchema } from "@/entities/schema/domain/model/schema";
 import { getSchema } from "@/entities/schema/domain/use-cases/get-schema";
 
 /**
- * Keeps only sorts targeting one of the schema's sortable fields.
- * Sort fields come straight from the URL, so this allowlist is what keeps
- * arbitrary user input out of GraphQL order arguments.
+ * Keeps only sorts targeting one of the schema's sortable fields, one sort
+ * per field. Sort fields come straight from the URL, so this allowlist is
+ * what keeps arbitrary user input out of GraphQL order arguments.
  */
 export function getValidSorts(sorts: Sort[], schema: ModelSchema): Sort[] {
   if (sorts.length === 0) return sorts;
@@ -43,5 +45,9 @@ export function getValidSorts(sorts: Sort[], schema: ModelSchema): Sort[] {
     ...NODE_METADATA_SORT_FIELDS,
   ]);
 
-  return sorts.filter((sort) => sortableFields.has(sort.field));
+  return R.pipe(
+    sorts,
+    R.filter((sort) => sortableFields.has(sort.field)),
+    R.uniqueBy((sort) => sort.field)
+  );
 }

--- a/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/get-valid-sorts.ts
@@ -40,7 +40,7 @@ export function getValidSorts(sorts: Sort[], schema: ModelSchema): Sort[] {
   const sortableFields = new Set<SortField>([
     ...attributeFields,
     ...relationshipFields,
-    ...NODE_METADATA_SORT_FIELDS.map(({ field }) => field),
+    ...NODE_METADATA_SORT_FIELDS,
   ]);
 
   return sorts.filter((sort) => sortableFields.has(sort.field));

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { SortField } from "@/entities/nodes/sort/domain/model/sort";
 
 import { render } from "../../../../../../tests/components/render";
+import { initPointerTracking } from "../../../../../../tests/components/utils";
 import { generateAttributeSchema, generateNodeSchema } from "../../../../../../tests/fake/schema";
 import { AddSortButton } from "./add-sort-button";
 
@@ -54,28 +55,20 @@ describe("AddSortButton", () => {
     await expect.element(component.getByRole("menuitem", { name: "Name" })).not.toBeInTheDocument();
   });
 
-  test("stays enabled while some fields remain available", async () => {
-    // GIVEN
-    const component = await render(
-      <AddSortButton schema={schema} activeFields={new Set<SortField>()} onSelect={vi.fn()} />
-    );
-
-    // WHEN
-    await component.getByRole("button", { name: "Add sort" }).click();
-
-    // THEN
-    await expect.element(component.getByRole("menu")).toBeVisible();
-  });
-
-  test("disables the button when every sortable field is in use", async () => {
+  test("disables the button with an explanatory tooltip when every sortable field is in use", async () => {
     // GIVEN
     const component = await render(
       <AddSortButton schema={schema} activeFields={ALL_SORTABLE_FIELDS} onSelect={vi.fn()} />
     );
 
+    // WHEN
+    await initPointerTracking(component.locator);
+    await component.getByRole("button", { name: "Add sort" }).hover();
+
     // THEN
+    await expect.element(component.getByRole("button", { name: "Add sort" })).toBeDisabled();
     await expect
-      .element(component.getByRole("button", { name: "Add sort" }))
-      .toHaveAttribute("aria-disabled", "true");
+      .element(component.getByRole("tooltip", { name: "All fields are already in use." }))
+      .toBeVisible();
   });
 });

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { SortField } from "@/entities/nodes/sort/domain/model/sort";
+
+import { render } from "../../../../../../tests/components/render";
+import { generateAttributeSchema, generateNodeSchema } from "../../../../../../tests/fake/schema";
+import { AddSortButton } from "./add-sort-button";
+
+const schema = generateNodeSchema({
+  attributes: [
+    generateAttributeSchema({ name: "name", label: "Name", kind: "Text" }),
+    generateAttributeSchema({ name: "description", label: "Description", kind: "Text" }),
+  ],
+  relationships: [],
+});
+
+const ALL_SORTABLE_FIELDS = new Set<SortField>([
+  "name__value",
+  "description__value",
+  "node_metadata__created_at",
+  "node_metadata__updated_at",
+]);
+
+describe("AddSortButton", () => {
+  test("opens the picker and forwards the selected sort", async () => {
+    // GIVEN
+    const onSelect = vi.fn();
+    const component = await render(<AddSortButton schema={schema} onSelect={onSelect} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Add sort" }).click();
+    await component.getByRole("menuitem", { name: "Name" }).click();
+    await component.getByRole("menuitem", { name: "Ascending" }).click();
+
+    // THEN
+    expect(onSelect).toHaveBeenCalledWith({ field: "name__value", direction: "ASC" });
+  });
+
+  test("hides fields that are already in use from the picker", async () => {
+    // GIVEN
+    const component = await render(
+      <AddSortButton
+        schema={schema}
+        activeFields={new Set<SortField>(["name__value"])}
+        onSelect={vi.fn()}
+      />
+    );
+
+    // WHEN
+    await component.getByRole("button", { name: "Add sort" }).click();
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Description" })).toBeVisible();
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).not.toBeInTheDocument();
+  });
+
+  test("stays enabled while some fields remain available", async () => {
+    // GIVEN
+    const component = await render(
+      <AddSortButton schema={schema} activeFields={new Set<SortField>()} onSelect={vi.fn()} />
+    );
+
+    // WHEN
+    await component.getByRole("button", { name: "Add sort" }).click();
+
+    // THEN
+    await expect.element(component.getByRole("menu")).toBeVisible();
+  });
+
+  test("disables the button when every sortable field is in use", async () => {
+    // GIVEN
+    const component = await render(
+      <AddSortButton schema={schema} activeFields={ALL_SORTABLE_FIELDS} onSelect={vi.fn()} />
+    );
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Add sort" }))
+      .toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-button.tsx
@@ -1,0 +1,35 @@
+import { Button, MenuTrigger, Popover, Tooltip } from "@infrahub/ui";
+import { PlusIcon } from "lucide-react";
+
+import {
+  AddSortPicker,
+  type AddSortPickerProps,
+} from "@/entities/nodes/sort/ui/add-sort/add-sort-picker";
+import { useSortableFields } from "@/entities/nodes/sort/ui/hooks/use-sortable-fields";
+
+interface AddSortProps extends AddSortPickerProps {}
+
+export function AddSortButton(props: AddSortProps) {
+  const sortableFields = useSortableFields(props.schema);
+  const noFieldsLeft = sortableFields.every(({ field }) => props.activeFields?.has(field));
+
+  return (
+    <MenuTrigger>
+      <Tooltip message={noFieldsLeft ? "All fields are already in use." : undefined}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="justify-start text-stone-600"
+          isDisabledAndFocusable={noFieldsLeft}
+        >
+          <PlusIcon />
+          Add sort
+        </Button>
+      </Tooltip>
+
+      <Popover placement="bottom start">
+        <AddSortPicker {...props} />
+      </Popover>
+    </MenuTrigger>
+  );
+}

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
@@ -75,6 +75,9 @@ describe("AddSortPicker", () => {
     await expect
       .element(component.getByRole("menuitem", { name: "Vault" }))
       .not.toBeInTheDocument();
+    await expect
+      .element(component.getByRole("menuitem", { name: "Relationship test" }))
+      .not.toBeInTheDocument();
   });
 
   test("selects a relationship field with a direction through the submenu cascade", async () => {
@@ -125,8 +128,7 @@ describe("AddSortPicker", () => {
 
   test("flattens fields with peer-prefixed labels when searching", async () => {
     // GIVEN
-    const onSelect = vi.fn();
-    const component = await render(<AddSortPicker schema={schema} onSelect={onSelect} />);
+    const component = await render(<AddSortPicker schema={schema} onSelect={vi.fn()} />);
 
     // WHEN
     await component.getByRole("searchbox").fill("des");
@@ -138,8 +140,15 @@ describe("AddSortPicker", () => {
     await expect
       .element(component.getByRole("menuitem", { name: "Site", exact: true }))
       .not.toBeInTheDocument();
+  });
+
+  test("selects a flattened field from the search results", async () => {
+    // GIVEN
+    const onSelect = vi.fn();
+    const component = await render(<AddSortPicker schema={schema} onSelect={onSelect} />);
 
     // WHEN
+    await component.getByRole("searchbox").fill("des");
     await component.getByRole("menuitem", { name: "Site › Description" }).click();
     await component.getByRole("menuitem", { name: "Descending" }).click();
 
@@ -161,6 +170,23 @@ describe("AddSortPicker", () => {
     await expect.element(component.getByRole("menuitem", { name: "Site › rack" })).toBeVisible();
   });
 
+  test("restores the grouped layout when the search is cleared", async () => {
+    // GIVEN
+    const component = await render(<AddSortPicker schema={schema} onSelect={vi.fn()} />);
+    await component.getByRole("searchbox").fill("des");
+
+    // WHEN
+    await component.getByRole("searchbox").fill("");
+
+    // THEN
+    await expect
+      .element(component.getByRole("menuitem", { name: "Site", exact: true }))
+      .toBeVisible();
+    await expect
+      .element(component.getByRole("menuitem", { name: "Site › Description" }))
+      .not.toBeInTheDocument();
+  });
+
   test("hides an attribute that is already active", async () => {
     // GIVEN
     const component = await render(
@@ -170,6 +196,19 @@ describe("AddSortPicker", () => {
     // THEN
     await expect.element(component.getByRole("menuitem", { name: "Site" })).toBeVisible();
     await expect.element(component.getByRole("menuitem", { name: "Name" })).not.toBeInTheDocument();
+  });
+
+  test("keeps a peer attribute visible when a same-named top-level attribute is active", async () => {
+    // GIVEN
+    const component = await render(
+      <AddSortPicker schema={schema} activeFields={new Set(["name__value"])} onSelect={vi.fn()} />
+    );
+
+    // WHEN
+    await component.getByRole("menuitem", { name: "Site" }).click();
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
   });
 
   test("hides a metadata field that is already active", async () => {
@@ -189,19 +228,6 @@ describe("AddSortPicker", () => {
       .not.toBeInTheDocument();
   });
 
-  test("keeps a peer attribute visible when a same-named top-level attribute is active", async () => {
-    // GIVEN
-    const component = await render(
-      <AddSortPicker schema={schema} activeFields={new Set(["name__value"])} onSelect={vi.fn()} />
-    );
-
-    // WHEN
-    await component.getByRole("menuitem", { name: "Site" }).click();
-
-    // THEN
-    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
-  });
-
   test("hides only the peer attribute when a relationship field is active", async () => {
     // GIVEN
     const component = await render(
@@ -212,13 +238,11 @@ describe("AddSortPicker", () => {
       />
     );
 
-    // THEN
-    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
-
     // WHEN
     await component.getByRole("menuitem", { name: "Site" }).click();
 
     // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" }).first()).toBeVisible();
     await expect.element(component.getByRole("menuitem", { name: "Description" })).toBeVisible();
     await expect
       .element(component.getByRole("menuitem", { name: "Name" }).nth(1))
@@ -282,18 +306,58 @@ describe("AddSortPicker", () => {
     await expect.element(component.getByText("All sortable fields are in use")).toBeVisible();
   });
 
-  test("restores the grouped layout when the search is cleared", async () => {
+  test("hides many-cardinality relationships", async () => {
     // GIVEN
     const component = await render(<AddSortPicker schema={schema} onSelect={vi.fn()} />);
-
-    // WHEN
-    await component.getByRole("searchbox").fill("des");
-    await component.getByRole("searchbox").fill("");
 
     // THEN
     await expect.element(component.getByRole("menuitem", { name: "Site" })).toBeVisible();
     await expect
-      .element(component.getByRole("menuitem", { name: "Site › Description" }))
+      .element(component.getByRole("menuitem", { name: "Relationship test" }))
       .not.toBeInTheDocument();
+  });
+
+  test("hides a relationship whose peer schema is unknown", async () => {
+    // GIVEN
+    const orphaned = generateNodeSchema({
+      attributes: [generateAttributeSchema({ name: "name", label: "Name", kind: "Text" })],
+      relationships: [
+        generateRelationshipSchema({
+          name: "owner",
+          label: "Owner",
+          peer: "UnknownKind",
+          cardinality: "one",
+        }),
+      ],
+    });
+    const component = await render(<AddSortPicker schema={orphaned} onSelect={vi.fn()} />);
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
+    await expect
+      .element(component.getByRole("menuitem", { name: "Owner" }))
+      .not.toBeInTheDocument();
+  });
+
+  test("omits unknown-peer fields from the search results", async () => {
+    // GIVEN
+    const orphaned = generateNodeSchema({
+      attributes: [generateAttributeSchema({ name: "name", label: "Name", kind: "Text" })],
+      relationships: [
+        generateRelationshipSchema({
+          name: "owner",
+          label: "Owner",
+          peer: "UnknownKind",
+          cardinality: "one",
+        }),
+      ],
+    });
+    const component = await render(<AddSortPicker schema={orphaned} onSelect={vi.fn()} />);
+
+    // WHEN
+    await component.getByRole("searchbox").fill("owner");
+
+    // THEN
+    await expect.element(component.getByText("No fields match")).toBeVisible();
   });
 });

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
@@ -80,6 +80,105 @@ describe("AddSortPicker", () => {
       .not.toBeInTheDocument();
   });
 
+  test("orders attributes and relationships by order weight, not declaration order", async () => {
+    // GIVEN
+    const weighted = generateNodeSchema({
+      attributes: [
+        generateAttributeSchema({
+          name: "priority",
+          label: "Priority",
+          kind: "Number",
+          order_weight: 3000,
+        }),
+        generateAttributeSchema({ name: "name", label: "Name", kind: "Text", order_weight: 1000 }),
+        generateAttributeSchema({
+          name: "status",
+          label: "Status",
+          kind: "Text",
+          order_weight: 2000,
+        }),
+      ],
+      relationships: [
+        generateRelationshipSchema({
+          name: "site",
+          label: "Site",
+          peer: "LocationSite",
+          cardinality: "one",
+          order_weight: 2000,
+        }),
+        generateRelationshipSchema({
+          name: "building",
+          label: "Building",
+          peer: "LocationSite",
+          cardinality: "one",
+          order_weight: 1000,
+        }),
+      ],
+    });
+    const component = await render(<AddSortPicker schema={weighted} onSelect={vi.fn()} />);
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
+    const labels = component
+      .getByRole("menuitem")
+      .elements()
+      .map((item) => item.textContent);
+    expect(labels).toEqual([
+      "Name",
+      "Status",
+      "Priority",
+      "Building",
+      "Site",
+      "Created at",
+      "Updated at",
+    ]);
+  });
+
+  test("orders peer attributes by order weight in the search results", async () => {
+    // GIVEN
+    const building = generateNodeSchema({
+      kind: "LocationBuilding",
+      attributes: [
+        generateAttributeSchema({ name: "rack", label: "Rack", kind: "Text", order_weight: 3000 }),
+        generateAttributeSchema({ name: "name", label: "Name", kind: "Text", order_weight: 2000 }),
+        generateAttributeSchema({
+          name: "description",
+          label: "Description",
+          kind: "Text",
+          order_weight: 1000,
+        }),
+      ],
+      relationships: [],
+    });
+    store.set(nodeSchemasAtom, [building]);
+    const weighted = generateNodeSchema({
+      attributes: [],
+      relationships: [
+        generateRelationshipSchema({
+          name: "building",
+          label: "Building",
+          peer: "LocationBuilding",
+          cardinality: "one",
+        }),
+      ],
+    });
+    const component = await render(<AddSortPicker schema={weighted} onSelect={vi.fn()} />);
+
+    // WHEN
+    await component.getByRole("searchbox").fill("building");
+
+    // THEN
+    await expect
+      .element(component.getByRole("menuitem", { name: "Building › Description" }))
+      .toBeVisible();
+    // The flat labels join segments with en-spaces around the chevron.
+    const labels = component
+      .getByRole("menuitem")
+      .elements()
+      .map((item) => item.textContent?.replaceAll(" ", " "));
+    expect(labels).toEqual(["Building › Description", "Building › Name", "Building › Rack"]);
+  });
+
   test("selects a relationship field with a direction through the submenu cascade", async () => {
     // GIVEN
     const onSelect = vi.fn();

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.test.tsx
@@ -4,12 +4,12 @@ import { store } from "@/shared/stores";
 
 import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
 
-import { render } from "../../../../../tests/components/render";
+import { render } from "../../../../../../tests/components/render";
 import {
   generateAttributeSchema,
   generateNodeSchema,
   generateRelationshipSchema,
-} from "../../../../../tests/fake/schema";
+} from "../../../../../../tests/fake/schema";
 import { AddSortPicker } from "./add-sort-picker";
 
 const site = generateNodeSchema({

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -189,11 +189,7 @@ export function AddSortPicker({
         variant="picker"
         aria-label="Add sort field"
         className="max-h-72"
-        renderEmptyState={() => (
-          <div className="px-2 py-1 text-sm text-stone-500">
-            {isSearching ? "No fields match" : "All sortable fields are in use"}
-          </div>
-        )}
+        emptyMessage={isSearching ? "No fields match" : "All sortable fields are in use"}
       >
         {isSearching ? (
           <FlatFieldItems schema={schema} activeFields={activeFields} onSelect={onSelect} />

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -147,11 +147,11 @@ function GroupedFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) 
 
   return (
     <>
-      {sortableAttributes.map((attribute) => (
+      {sortByOrderWeight(sortableAttributes).map((attribute) => (
         <SortableAttributeMenuItem key={attribute.name} attribute={attribute} onSelect={onSelect} />
       ))}
 
-      {sortableRelationships.map((relationship) => (
+      {sortByOrderWeight(sortableRelationships).map((relationship) => (
         <GroupedSortableRelationshipMenuItem
           key={relationship.name}
           relationship={relationship}

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -139,19 +139,21 @@ function FlatFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) {
 
 // Attributes, then relationships as submenus, then metadata — shown when not searching.
 function GroupedFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) {
-  const sortableAttributes = (schema.attributes ?? [])
+  const sortableAttributes = sortByOrderWeight(schema.attributes ?? [])
     .filter(isSortableAttribute)
     .filter((attribute) => !activeFields.has(buildAttributeSortField(attribute.name)));
-  const sortableRelationships = (schema.relationships ?? []).filter(isSortableRelationship);
+  const sortableRelationships = sortByOrderWeight(schema.relationships ?? []).filter(
+    isSortableRelationship
+  );
   const metadataFields = NODE_METADATA_SORT_OPTIONS.filter(({ field }) => !activeFields.has(field));
 
   return (
     <>
-      {sortByOrderWeight(sortableAttributes).map((attribute) => (
+      {sortableAttributes.map((attribute) => (
         <SortableAttributeMenuItem key={attribute.name} attribute={attribute} onSelect={onSelect} />
       ))}
 
-      {sortByOrderWeight(sortableRelationships).map((relationship) => (
+      {sortableRelationships.map((relationship) => (
         <GroupedSortableRelationshipMenuItem
           key={relationship.name}
           relationship={relationship}

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -4,47 +4,21 @@ import { useFilter } from "react-aria-components";
 
 import { sortByOrderWeight } from "@/shared/utils/common";
 
-import {
-  NODE_METADATA_SORT_FIELDS,
-  type Sort,
-  type SortDirection,
-  type SortField,
-} from "@/entities/nodes/sort/domain/model/sort";
+import type { Sort, SortField } from "@/entities/nodes/sort/domain/model/sort";
 import { isSortableAttribute } from "@/entities/nodes/sort/domain/rules/is-sortable-attribute";
 import { isSortableRelationship } from "@/entities/nodes/sort/domain/rules/is-sortable-relationship";
 import {
   buildAttributeSortField,
   buildRelationshipSortField,
 } from "@/entities/nodes/sort/domain/rules/sort-field";
+import { useSortableFields } from "@/entities/nodes/sort/ui/hooks/use-sortable-fields";
+import { DIRECTION_OPTIONS, METADATA_SORTABLE_FIELDS } from "@/entities/nodes/sort/ui/sort-options";
 import type {
   AttributeSchema,
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
-
-const DIRECTION_OPTIONS: { id: SortDirection; label: string }[] = [
-  { id: "ASC", label: "Ascending" },
-  { id: "DESC", label: "Descending" },
-];
-
-// "Peer › Attribute" separator. En-spaces (U+2002) around the chevron keep it from looking cramped.
-const PEER_LABEL_SEPARATOR = " › ";
-
-interface SortDirectionMenuProps {
-  fieldLabel: string;
-  onSelect: (direction: SortDirection) => void;
-}
-
-function SortDirectionMenu({ fieldLabel, onSelect }: SortDirectionMenuProps) {
-  return (
-    <Menu aria-label={`Sort direction for ${fieldLabel}`} items={DIRECTION_OPTIONS}>
-      {(direction) => (
-        <MenuItem onAction={() => onSelect(direction.id)}>{direction.label}</MenuItem>
-      )}
-    </Menu>
-  );
-}
 
 interface SortableFieldMenuItemProps {
   field: SortField;
@@ -58,10 +32,17 @@ function SortableFieldMenuItem({ field, children, onSelect }: SortableFieldMenuI
       <MenuItem>{children}</MenuItem>
 
       <Popover>
-        <SortDirectionMenu
-          fieldLabel={children}
-          onSelect={(direction) => onSelect({ field, direction })}
-        />
+        <Menu
+          variant="picker"
+          aria-label={`Sort direction for ${children}`}
+          items={DIRECTION_OPTIONS}
+        >
+          {(option) => (
+            <MenuItem onAction={() => onSelect({ field, direction: option.id })}>
+              {option.label}
+            </MenuItem>
+          )}
+        </Menu>
       </Popover>
     </SubmenuTrigger>
   );
@@ -135,39 +116,9 @@ function GroupedSortableRelationshipMenuItem({
   );
 }
 
-function FlatSortableRelationshipMenuItems({
-  relationship,
-  activeFields,
-  onSelect,
-}: SortableRelationshipMenuItemProps) {
-  const { schema: peerSchema } = useSchema(relationship.peer);
-  if (!peerSchema) return null;
-
-  const sortableAttributes = getAvailablePeerAttributes(peerSchema, relationship, activeFields);
-  const relationshipLabel = relationship.label ?? relationship.name;
-
-  return (
-    <>
-      {sortByOrderWeight(sortableAttributes).map((attribute) => {
-        const field = buildRelationshipSortField(
-          relationship.name,
-          buildAttributeSortField(attribute.name)
-        );
-        const attributeLabel = attribute.label ?? attribute.name;
-
-        return (
-          <SortableFieldMenuItem key={field} field={field} onSelect={onSelect}>
-            {`${relationshipLabel}${PEER_LABEL_SEPARATOR}${attributeLabel}`}
-          </SortableFieldMenuItem>
-        );
-      })}
-    </>
-  );
-}
-
 const NO_ACTIVE_FIELDS: ReadonlySet<SortField> = new Set();
 
-interface AddSortPickerProps {
+export interface AddSortPickerProps {
   schema: ModelSchema;
   activeFields?: ReadonlySet<SortField>;
   onSelect: (sort: Sort) => void;
@@ -182,15 +133,14 @@ export function AddSortPicker({
   const [search, setSearch] = React.useState("");
   const isSearching = search.trim() !== "";
 
-  const SortableRelationshipMenuItems = isSearching
-    ? FlatSortableRelationshipMenuItems
-    : GroupedSortableRelationshipMenuItem;
+  const sortableFields = useSortableFields(schema);
+  const availableFields = sortableFields.filter(({ field }) => !activeFields.has(field));
 
   const sortableAttributes = (schema.attributes ?? [])
     .filter(isSortableAttribute)
     .filter((attribute) => !activeFields.has(buildAttributeSortField(attribute.name)));
   const sortableRelationships = (schema.relationships ?? []).filter(isSortableRelationship);
-  const metadataFields = NODE_METADATA_SORT_FIELDS.filter(({ field }) => !activeFields.has(field));
+  const metadataFields = METADATA_SORTABLE_FIELDS.filter(({ field }) => !activeFields.has(field));
 
   return (
     <Autocomplete filter={contains} onInputChange={setSearch}>
@@ -204,28 +154,42 @@ export function AddSortPicker({
           </div>
         )}
       >
-        {sortableAttributes.map((attribute) => (
-          <SortableAttributeMenuItem
-            key={attribute.name}
-            attribute={attribute}
-            onSelect={onSelect}
-          />
-        ))}
+        {isSearching ? (
+          availableFields.map(({ field, label }) => (
+            <SortableFieldMenuItem key={field} field={field} onSelect={onSelect}>
+              {label}
+            </SortableFieldMenuItem>
+          ))
+        ) : (
+          <>
+            {sortableAttributes.map((attribute) => (
+              <SortableAttributeMenuItem
+                key={attribute.name}
+                attribute={attribute}
+                onSelect={onSelect}
+              />
+            ))}
 
-        {sortableRelationships.map((relationship) => (
-          <SortableRelationshipMenuItems
-            key={relationship.name}
-            relationship={relationship}
-            activeFields={activeFields}
-            onSelect={onSelect}
-          />
-        ))}
+            {sortableRelationships.map((relationship) => (
+              <GroupedSortableRelationshipMenuItem
+                key={relationship.name}
+                relationship={relationship}
+                activeFields={activeFields}
+                onSelect={onSelect}
+              />
+            ))}
 
-        {metadataFields.map((metadata) => (
-          <SortableFieldMenuItem key={metadata.field} field={metadata.field} onSelect={onSelect}>
-            {metadata.label}
-          </SortableFieldMenuItem>
-        ))}
+            {metadataFields.map((metadata) => (
+              <SortableFieldMenuItem
+                key={metadata.field}
+                field={metadata.field}
+                onSelect={onSelect}
+              >
+                {metadata.label}
+              </SortableFieldMenuItem>
+            ))}
+          </>
+        )}
       </Menu>
     </Autocomplete>
   );

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -116,6 +116,56 @@ function GroupedSortableRelationshipMenuItem({
   );
 }
 
+interface FieldItemsProps {
+  schema: ModelSchema;
+  activeFields: ReadonlySet<SortField>;
+  onSelect: (sort: Sort) => void;
+}
+
+// Flat list of every available field, shown while searching.
+function FlatFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) {
+  const sortableFields = useSortableFields(schema);
+  const availableFields = sortableFields.filter(({ field }) => !activeFields.has(field));
+
+  return availableFields.map(({ field, label }) => (
+    <SortableFieldMenuItem key={field} field={field} onSelect={onSelect}>
+      {label}
+    </SortableFieldMenuItem>
+  ));
+}
+
+// Attributes, then relationships as submenus, then metadata — shown when not searching.
+function GroupedFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) {
+  const sortableAttributes = (schema.attributes ?? [])
+    .filter(isSortableAttribute)
+    .filter((attribute) => !activeFields.has(buildAttributeSortField(attribute.name)));
+  const sortableRelationships = (schema.relationships ?? []).filter(isSortableRelationship);
+  const metadataFields = METADATA_SORTABLE_FIELDS.filter(({ field }) => !activeFields.has(field));
+
+  return (
+    <>
+      {sortableAttributes.map((attribute) => (
+        <SortableAttributeMenuItem key={attribute.name} attribute={attribute} onSelect={onSelect} />
+      ))}
+
+      {sortableRelationships.map((relationship) => (
+        <GroupedSortableRelationshipMenuItem
+          key={relationship.name}
+          relationship={relationship}
+          activeFields={activeFields}
+          onSelect={onSelect}
+        />
+      ))}
+
+      {metadataFields.map((metadata) => (
+        <SortableFieldMenuItem key={metadata.field} field={metadata.field} onSelect={onSelect}>
+          {metadata.label}
+        </SortableFieldMenuItem>
+      ))}
+    </>
+  );
+}
+
 const NO_ACTIVE_FIELDS: ReadonlySet<SortField> = new Set();
 
 export interface AddSortPickerProps {
@@ -133,15 +183,6 @@ export function AddSortPicker({
   const [search, setSearch] = React.useState("");
   const isSearching = search.trim() !== "";
 
-  const sortableFields = useSortableFields(schema);
-  const availableFields = sortableFields.filter(({ field }) => !activeFields.has(field));
-
-  const sortableAttributes = (schema.attributes ?? [])
-    .filter(isSortableAttribute)
-    .filter((attribute) => !activeFields.has(buildAttributeSortField(attribute.name)));
-  const sortableRelationships = (schema.relationships ?? []).filter(isSortableRelationship);
-  const metadataFields = METADATA_SORTABLE_FIELDS.filter(({ field }) => !activeFields.has(field));
-
   return (
     <Autocomplete filter={contains} onInputChange={setSearch}>
       <Menu
@@ -155,40 +196,9 @@ export function AddSortPicker({
         )}
       >
         {isSearching ? (
-          availableFields.map(({ field, label }) => (
-            <SortableFieldMenuItem key={field} field={field} onSelect={onSelect}>
-              {label}
-            </SortableFieldMenuItem>
-          ))
+          <FlatFieldItems schema={schema} activeFields={activeFields} onSelect={onSelect} />
         ) : (
-          <>
-            {sortableAttributes.map((attribute) => (
-              <SortableAttributeMenuItem
-                key={attribute.name}
-                attribute={attribute}
-                onSelect={onSelect}
-              />
-            ))}
-
-            {sortableRelationships.map((relationship) => (
-              <GroupedSortableRelationshipMenuItem
-                key={relationship.name}
-                relationship={relationship}
-                activeFields={activeFields}
-                onSelect={onSelect}
-              />
-            ))}
-
-            {metadataFields.map((metadata) => (
-              <SortableFieldMenuItem
-                key={metadata.field}
-                field={metadata.field}
-                onSelect={onSelect}
-              >
-                {metadata.label}
-              </SortableFieldMenuItem>
-            ))}
-          </>
+          <GroupedFieldItems schema={schema} activeFields={activeFields} onSelect={onSelect} />
         )}
       </Menu>
     </Autocomplete>

--- a/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/add-sort/add-sort-picker.tsx
@@ -12,7 +12,10 @@ import {
   buildRelationshipSortField,
 } from "@/entities/nodes/sort/domain/rules/sort-field";
 import { useSortableFields } from "@/entities/nodes/sort/ui/hooks/use-sortable-fields";
-import { DIRECTION_OPTIONS, METADATA_SORTABLE_FIELDS } from "@/entities/nodes/sort/ui/sort-options";
+import {
+  DIRECTION_OPTIONS,
+  NODE_METADATA_SORT_OPTIONS,
+} from "@/entities/nodes/sort/ui/sort-options";
 import type {
   AttributeSchema,
   ModelSchema,
@@ -140,7 +143,7 @@ function GroupedFieldItems({ schema, activeFields, onSelect }: FieldItemsProps) 
     .filter(isSortableAttribute)
     .filter((attribute) => !activeFields.has(buildAttributeSortField(attribute.name)));
   const sortableRelationships = (schema.relationships ?? []).filter(isSortableRelationship);
-  const metadataFields = METADATA_SORTABLE_FIELDS.filter(({ field }) => !activeFields.has(field));
+  const metadataFields = NODE_METADATA_SORT_OPTIONS.filter(({ field }) => !activeFields.has(field));
 
   return (
     <>

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
@@ -25,7 +25,7 @@ describe("useSort", () => {
     const { result } = await renderHook(() => useSort(schema), { wrapper });
 
     // THEN
-    expect(result.current.sort).toEqual([
+    expect(result.current.customSort).toEqual([
       { field: "name__value", direction: "ASC" },
       { field: "priority__value", direction: "DESC" },
     ]);
@@ -41,7 +41,7 @@ describe("useSort", () => {
     const { result } = await renderHook(() => useSort(schema), { wrapper });
 
     // THEN
-    expect(result.current.sort).toEqual([{ field: "name__value", direction: "DESC" }]);
+    expect(result.current.customSort).toEqual([{ field: "name__value", direction: "DESC" }]);
   });
 
   it("returns null when the query param is absent or carries no valid sort", async () => {
@@ -56,11 +56,11 @@ describe("useSort", () => {
     const hostile = await renderHook(() => useSort(schema), { wrapper: withHostileSort });
 
     // THEN
-    expect(absent.result.current.sort).toBeNull();
-    expect(hostile.result.current.sort).toBeNull();
+    expect(absent.result.current.customSort).toBeNull();
+    expect(hostile.result.current.customSort).toBeNull();
   });
 
-  it("setSort writes the serialized sorts to the URL with history push", async () => {
+  it("setCustomSort writes the serialized sorts to the URL with history push", async () => {
     // GIVEN
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
     const wrapper = withNuqsTestingAdapter({ searchParams: "", onUrlUpdate });
@@ -68,7 +68,7 @@ describe("useSort", () => {
 
     // WHEN
     await hook.act(() => {
-      hook.result.current.setSort([
+      hook.result.current.setCustomSort([
         { field: "priority__value", direction: "DESC" },
         { field: "name__value", direction: "ASC" },
       ]);
@@ -80,7 +80,7 @@ describe("useSort", () => {
     expect(event?.options.history).toBe("push");
   });
 
-  it("setSort with an empty list removes the query param", async () => {
+  it("setCustomSort with an empty list removes the query param", async () => {
     // GIVEN
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
     const wrapper = withNuqsTestingAdapter({
@@ -91,7 +91,7 @@ describe("useSort", () => {
 
     // WHEN
     await hook.act(() => {
-      hook.result.current.setSort([]);
+      hook.result.current.setCustomSort([]);
     });
 
     // THEN

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
@@ -98,4 +98,79 @@ describe("useSort", () => {
     const event = onUrlUpdate.mock.lastCall?.[0];
     expect(event?.searchParams.get("sort")).toBeNull();
   });
+
+  it("derives defaultSort from the schema order_by tokens", async () => {
+    // GIVEN
+    const schemaWithDefaults = generateNodeSchema({
+      ...schema,
+      order_by: ["name__value", "priority__value__desc"],
+    });
+    const wrapper = withNuqsTestingAdapter({ searchParams: "" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schemaWithDefaults), { wrapper });
+
+    // THEN
+    expect(result.current.defaultSort).toEqual([
+      { field: "name__value", direction: "ASC" },
+      { field: "priority__value", direction: "DESC" },
+    ]);
+  });
+
+  it("returns a null defaultSort when the schema defines no order_by", async () => {
+    // GIVEN
+    const schemaWithoutDefaults = generateNodeSchema({ ...schema, order_by: [] });
+    const wrapper = withNuqsTestingAdapter({ searchParams: "" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schemaWithoutDefaults), { wrapper });
+
+    // THEN
+    expect(result.current.defaultSort).toBeNull();
+  });
+
+  it("applies the custom sort over the schema default", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({ searchParams: "?sort=priority__value__desc" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.appliedSort).toEqual([{ field: "priority__value", direction: "DESC" }]);
+  });
+
+  it("applies the schema default when there is no custom sort", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({ searchParams: "" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.appliedSort).toEqual([{ field: "name__value", direction: "ASC" }]);
+  });
+
+  it("applies the schema default when the custom sort has no valid field", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({ searchParams: "?sort=unknown__value__desc" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.appliedSort).toEqual([{ field: "name__value", direction: "ASC" }]);
+  });
+
+  it("applies an empty sort when there is no custom sort nor schema default", async () => {
+    // GIVEN
+    const schemaWithoutDefaults = generateNodeSchema({ ...schema, order_by: [] });
+    const wrapper = withNuqsTestingAdapter({ searchParams: "" });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schemaWithoutDefaults), { wrapper });
+
+    // THEN
+    expect(result.current.appliedSort).toEqual([]);
+  });
 });

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.test.ts
@@ -44,6 +44,19 @@ describe("useSort", () => {
     expect(result.current.customSort).toEqual([{ field: "name__value", direction: "DESC" }]);
   });
 
+  it("keeps only the first occurrence of a field duplicated in the query param", async () => {
+    // GIVEN
+    const wrapper = withNuqsTestingAdapter({
+      searchParams: "?sort=name__value__asc,name__value__desc",
+    });
+
+    // WHEN
+    const { result } = await renderHook(() => useSort(schema), { wrapper });
+
+    // THEN
+    expect(result.current.customSort).toEqual([{ field: "name__value", direction: "ASC" }]);
+  });
+
   it("returns null when the query param is absent or carries no valid sort", async () => {
     // GIVEN
     const withoutSort = withNuqsTestingAdapter({ searchParams: "" });

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sort.ts
@@ -3,6 +3,7 @@ import { createParser, parseAsArrayOf, useQueryState } from "nuqs";
 import { QSP } from "@/shared/config/qsp";
 
 import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
+import { getSchemaDefaultSort } from "@/entities/nodes/sort/domain/rules/get-schema-default-sort";
 import { getValidSorts } from "@/entities/nodes/sort/domain/rules/get-valid-sorts";
 import { parseSortToken, serializeSortToken } from "@/entities/nodes/sort/domain/rules/sort-token";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
@@ -13,8 +14,13 @@ const sortParser = createParser({
 });
 
 type UseSort = (schema: ModelSchema) => {
-  sort: Sort[] | null;
-  setSort: (next: Sort[]) => void;
+  /** The sort the user explicitly chose (URL state), or null when they haven't customized. */
+  customSort: Sort[] | null;
+  setCustomSort: (next: Sort[]) => void;
+  /** The schema's order_by, or null when it defines none. */
+  defaultSort: Sort[] | null;
+  /** The sort effectively applied: custom sort, else schema default, else empty. */
+  appliedSort: Sort[];
 };
 
 export const useSort: UseSort = (schema) => {
@@ -25,8 +31,10 @@ export const useSort: UseSort = (schema) => {
 
   const validSort = getValidSorts(sortInQsp ?? [], schema);
 
-  const sort = validSort.length > 0 ? validSort : null;
-  const setSort = (next: Sort[]) => setSortInQsp(next.length > 0 ? next : null);
+  const customSort = validSort.length > 0 ? validSort : null;
+  const setCustomSort = (next: Sort[]) => setSortInQsp(next.length > 0 ? next : null);
+  const defaultSort = getSchemaDefaultSort(schema);
+  const appliedSort = customSort ?? defaultSort ?? [];
 
-  return { sort, setSort };
+  return { customSort, setCustomSort, defaultSort, appliedSort };
 };

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
@@ -34,14 +34,14 @@ export function useSortableFields(schema: ModelSchema): SortableField[] {
   const profileSchemas = useAtomValue(profileSchemasAtom);
   const templateSchemas = useAtomValue(templateSchemasAtom);
 
-  const attributeFields: SortableField[] = (schema.attributes ?? [])
+  const attributeFields: SortableField[] = sortByOrderWeight(schema.attributes ?? [])
     .filter(isSortableAttribute)
     .map((attribute) => ({
       field: buildAttributeSortField(attribute.name),
       label: attribute.label ?? attribute.name,
     }));
 
-  const relationshipFields: SortableField[] = (schema.relationships ?? [])
+  const relationshipFields: SortableField[] = sortByOrderWeight(schema.relationships ?? [])
     .filter(isSortableRelationship)
     .flatMap((relationship) => {
       const { schema: peerSchema } = resolveSchema(relationship.peer, {

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
@@ -10,7 +10,6 @@ import {
 } from "@/entities/nodes/sort/domain/rules/sort-field";
 import {
   METADATA_SORTABLE_FIELDS,
-  PEER_LABEL_SEPARATOR,
   type SortableField,
 } from "@/entities/nodes/sort/ui/sort-options";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
@@ -21,6 +20,9 @@ import {
   profileSchemasAtom,
   templateSchemasAtom,
 } from "@/entities/schema/stores/schema.atom";
+
+// "Peer › Attribute" separator. En-spaces (U+2002) around the chevron keep it from looking cramped.
+const PEER_LABEL_SEPARATOR = " › ";
 
 /**
  * Flat list of every field a node can be sorted by: its own attributes,

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
@@ -1,0 +1,68 @@
+import { useAtomValue } from "jotai";
+
+import { sortByOrderWeight } from "@/shared/utils/common";
+
+import { isSortableAttribute } from "@/entities/nodes/sort/domain/rules/is-sortable-attribute";
+import { isSortableRelationship } from "@/entities/nodes/sort/domain/rules/is-sortable-relationship";
+import {
+  buildAttributeSortField,
+  buildRelationshipSortField,
+} from "@/entities/nodes/sort/domain/rules/sort-field";
+import {
+  METADATA_SORTABLE_FIELDS,
+  PEER_LABEL_SEPARATOR,
+  type SortableField,
+} from "@/entities/nodes/sort/ui/sort-options";
+import type { ModelSchema } from "@/entities/schema/domain/model/schema";
+import { resolveSchema } from "@/entities/schema/domain/rules/resolve-schema";
+import {
+  genericSchemasAtom,
+  nodeSchemasAtom,
+  profileSchemasAtom,
+  templateSchemasAtom,
+} from "@/entities/schema/stores/schema.atom";
+
+/**
+ * Flat list of every field a node can be sorted by: its own attributes,
+ * attributes reached through cardinality-one relationships, and node metadata.
+ */
+export function useSortableFields(schema: ModelSchema): SortableField[] {
+  const nodeSchemas = useAtomValue(nodeSchemasAtom);
+  const genericSchemas = useAtomValue(genericSchemasAtom);
+  const profileSchemas = useAtomValue(profileSchemasAtom);
+  const templateSchemas = useAtomValue(templateSchemasAtom);
+
+  const attributeFields: SortableField[] = (schema.attributes ?? [])
+    .filter(isSortableAttribute)
+    .map((attribute) => ({
+      field: buildAttributeSortField(attribute.name),
+      label: attribute.label ?? attribute.name,
+    }));
+
+  const relationshipFields: SortableField[] = (schema.relationships ?? [])
+    .filter(isSortableRelationship)
+    .flatMap((relationship) => {
+      const { schema: peerSchema } = resolveSchema(relationship.peer, {
+        nodeSchemas,
+        genericSchemas,
+        profileSchemas,
+        templateSchemas,
+      });
+      if (!peerSchema) return [];
+
+      const relationshipLabel = relationship.label ?? relationship.name;
+      const peerAttributes = (peerSchema.attributes ?? []).filter(isSortableAttribute);
+
+      return sortByOrderWeight(peerAttributes).map((attribute) => {
+        const attributeField = buildAttributeSortField(attribute.name);
+        const attributeLabel = attribute.label ?? attribute.name;
+
+        return {
+          field: buildRelationshipSortField(relationship.name, attributeField),
+          label: `${relationshipLabel}${PEER_LABEL_SEPARATOR}${attributeLabel}`,
+        };
+      });
+    });
+
+  return [...attributeFields, ...relationshipFields, ...METADATA_SORTABLE_FIELDS];
+}

--- a/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/hooks/use-sortable-fields.ts
@@ -9,7 +9,7 @@ import {
   buildRelationshipSortField,
 } from "@/entities/nodes/sort/domain/rules/sort-field";
 import {
-  METADATA_SORTABLE_FIELDS,
+  NODE_METADATA_SORT_OPTIONS,
   type SortableField,
 } from "@/entities/nodes/sort/ui/sort-options";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
@@ -66,5 +66,5 @@ export function useSortableFields(schema: ModelSchema): SortableField[] {
       });
     });
 
-  return [...attributeFields, ...relationshipFields, ...METADATA_SORTABLE_FIELDS];
+  return [...attributeFields, ...relationshipFields, ...NODE_METADATA_SORT_OPTIONS];
 }

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.test.tsx
@@ -18,8 +18,65 @@ describe("SortEditor", () => {
     // GIVEN
     const component = await render(<SortEditor schema={schema} />);
 
+    // WHEN
+    await component.getByRole("button", { name: "Add sort" }).click();
+
     // THEN
     await expect.element(component.getByRole("menuitem", { name: "Description" })).toBeVisible();
     await expect.element(component.getByRole("menuitem", { name: "Name" })).not.toBeInTheDocument();
+  });
+
+  test("shows the schema default sort as a row", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Name", exact: true }))
+      .toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Sort direction for Name" }))
+      .toHaveTextContent("Ascending");
+  });
+
+  test("blocks removing the only row while on the schema default", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Why this sort can't be removed" }))
+      .toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Remove sort" }))
+      .not.toBeInTheDocument();
+  });
+
+  test("changes the sort direction from a row", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Sort direction for Name" }).click();
+    await component.getByRole("option", { name: "Descending" }).click();
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Sort direction for Name" }))
+      .toHaveTextContent("Descending");
+  });
+
+  test("changes the sort field from a row", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Name", exact: true }).click();
+    await component.getByRole("menuitemradio", { name: "Description" }).click();
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Description", exact: true }))
+      .toBeVisible();
   });
 });

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.test.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { render } from "../../../../../tests/components/render";
 import { generateAttributeSchema, generateNodeSchema } from "../../../../../tests/fake/schema";
@@ -13,7 +13,16 @@ const schema = generateNodeSchema({
   relationships: [],
 });
 
+const schemaWithoutDefaultSort = generateNodeSchema({ ...schema, order_by: [] });
+
+const seedSortInUrl = (sort: string) =>
+  window.history.replaceState(null, "", `${window.location.pathname}?sort=${sort}`);
+
 describe("SortEditor", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
   test("hides the schema default sort fields from the picker", async () => {
     // GIVEN
     const component = await render(<SortEditor schema={schema} />);
@@ -26,24 +35,16 @@ describe("SortEditor", () => {
     await expect.element(component.getByRole("menuitem", { name: "Name" })).not.toBeInTheDocument();
   });
 
-  test("shows the schema default sort as a row", async () => {
+  test("shows the schema default as an applied, non-removable row", async () => {
     // GIVEN
     const component = await render(<SortEditor schema={schema} />);
 
     // THEN
+    await expect.element(component.getByText("Default order · applied now")).toBeVisible();
+    await expect.element(component.getByRole("button", { name: "Name Sort field" })).toBeVisible();
     await expect
-      .element(component.getByRole("button", { name: "Name", exact: true }))
-      .toBeVisible();
-    await expect
-      .element(component.getByRole("button", { name: "Sort direction for Name" }))
+      .element(component.getByRole("button", { name: "Sort direction" }))
       .toHaveTextContent("Ascending");
-  });
-
-  test("blocks removing the only row while on the schema default", async () => {
-    // GIVEN
-    const component = await render(<SortEditor schema={schema} />);
-
-    // THEN
     await expect
       .element(component.getByRole("button", { name: "Why this sort can't be removed" }))
       .toBeVisible();
@@ -52,31 +53,147 @@ describe("SortEditor", () => {
       .not.toBeInTheDocument();
   });
 
-  test("changes the sort direction from a row", async () => {
-    // GIVEN
-    const component = await render(<SortEditor schema={schema} />);
-
-    // WHEN
-    await component.getByRole("button", { name: "Sort direction for Name" }).click();
-    await component.getByRole("option", { name: "Descending" }).click();
-
-    // THEN
-    await expect
-      .element(component.getByRole("button", { name: "Sort direction for Name" }))
-      .toHaveTextContent("Descending");
-  });
-
   test("changes the sort field from a row", async () => {
     // GIVEN
     const component = await render(<SortEditor schema={schema} />);
 
     // WHEN
-    await component.getByRole("button", { name: "Name", exact: true }).click();
-    await component.getByRole("menuitemradio", { name: "Description" }).click();
+    await component.getByRole("button", { name: "Name Sort field" }).click();
+    await component.getByRole("option", { name: "Description" }).click();
 
     // THEN
     await expect
-      .element(component.getByRole("button", { name: "Description", exact: true }))
+      .element(component.getByRole("button", { name: "Description Sort field" }))
       .toBeVisible();
+  });
+
+  test("renders only the field picker when there is no sort to edit", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schemaWithoutDefaultSort} />);
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Add sort" }))
+      .not.toBeInTheDocument();
+  });
+
+  test("switches to a custom order when changing the direction", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Sort direction" }).click();
+    await component.getByRole("option", { name: "Descending" }).click();
+
+    // THEN
+    await expect.element(component.getByText("Custom order")).toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Sort direction" }))
+      .toHaveTextContent("Descending");
+  });
+
+  test("resets a custom order back to the default", async () => {
+    // GIVEN
+    seedSortInUrl("name__value__desc");
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Reset to default" }).first().click();
+
+    // THEN
+    await expect.element(component.getByText("Default order · applied now")).toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Sort direction" }))
+      .toHaveTextContent("Ascending");
+  });
+
+  test("offers to clear the sort instead of resetting when the schema has no default", async () => {
+    // GIVEN
+    seedSortInUrl("name__value__desc");
+    const component = await render(<SortEditor schema={schemaWithoutDefaultSort} />);
+
+    // THEN
+    await expect.element(component.getByText("Custom order")).toBeVisible();
+    await expect.element(component.getByRole("button", { name: "Clear sort" })).toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Reset to default" }))
+      .not.toBeInTheDocument();
+  });
+
+  test("clears the custom sort back to the field picker when the schema has no default", async () => {
+    // GIVEN
+    seedSortInUrl("name__value__desc");
+    const component = await render(<SortEditor schema={schemaWithoutDefaultSort} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Clear sort" }).click();
+
+    // THEN
+    await expect.element(component.getByRole("menuitem", { name: "Name" })).toBeVisible();
+  });
+
+  test("adds a sort as a new row", async () => {
+    // GIVEN
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Add sort" }).click();
+    await component.getByRole("menuitem", { name: "Description" }).click();
+    await component.getByRole("menuitem", { name: "Descending" }).click();
+
+    // THEN
+    await expect.element(component.getByText("Custom order")).toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Description Sort field" }))
+      .toBeVisible();
+    await expect
+      .element(component.getByRole("button", { name: "Descending Sort direction" }))
+      .toBeVisible();
+  });
+
+  test("excludes fields used by other rows from a row's field select", async () => {
+    // GIVEN
+    seedSortInUrl("name__value__asc,description__value__desc");
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Name Sort field" }).click();
+
+    // THEN
+    await expect.element(component.getByRole("option", { name: "Name" })).toBeVisible();
+    await expect
+      .element(component.getByRole("option", { name: "Description" }))
+      .not.toBeInTheDocument();
+  });
+
+  test("removes one row of a multi-row custom sort", async () => {
+    // GIVEN
+    seedSortInUrl("name__value__asc,description__value__desc");
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Remove sort" }).first().click();
+
+    // THEN
+    await expect
+      .element(component.getByRole("button", { name: "Name Sort field" }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(component.getByRole("button", { name: "Description Sort field" }))
+      .toBeVisible();
+  });
+
+  test("frames removing the last custom row as a reset to the default", async () => {
+    // GIVEN
+    seedSortInUrl("description__value__desc");
+    const component = await render(<SortEditor schema={schema} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Reset to default" }).nth(1).click();
+
+    // THEN
+    await expect.element(component.getByText("Default order · applied now")).toBeVisible();
+    await expect.element(component.getByRole("button", { name: "Name Sort field" })).toBeVisible();
   });
 });

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -192,6 +192,7 @@ function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
           size="sm"
           shape="square"
           aria-label="Why this sort can't be removed"
+          isDisabledAndFocusable
         >
           <InfoIcon />
         </Button>

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -1,7 +1,28 @@
-import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
+import {
+  Autocomplete,
+  Button,
+  ListBox,
+  Popover,
+  Select,
+  SelectItem,
+  SelectList,
+  SelectTrigger,
+  SortableItem,
+  SortableList,
+  Tooltip,
+} from "@infrahub/ui";
+import { CheckIcon, InfoIcon, RotateCcwIcon, SlidersHorizontalIcon, XIcon } from "lucide-react";
+import type React from "react";
+
+import { Col, Row } from "@/shared/components/container";
+
+import type { Sort, SortDirection, SortField } from "@/entities/nodes/sort/domain/model/sort";
 import { getSchemaDefaultSort } from "@/entities/nodes/sort/domain/rules/get-schema-default-sort";
-import { AddSortPicker } from "@/entities/nodes/sort/ui/add-sort-picker";
+import { AddSortButton } from "@/entities/nodes/sort/ui/add-sort/add-sort-button";
+import { AddSortPicker } from "@/entities/nodes/sort/ui/add-sort/add-sort-picker";
 import { useSort } from "@/entities/nodes/sort/ui/hooks/use-sort";
+import { useSortableFields } from "@/entities/nodes/sort/ui/hooks/use-sortable-fields";
+import { DIRECTION_OPTIONS, type SortableField } from "@/entities/nodes/sort/ui/sort-options";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
 
 interface SortEditorProps {
@@ -21,12 +42,212 @@ export function SortEditor({ schema }: SortEditorProps) {
     return <AddSortPicker schema={schema} onSelect={addSort} />;
   }
 
-  // TODO: managing active sorting, it's a placeholder
   return (
-    <AddSortPicker
-      schema={schema}
-      activeFields={new Set(currentSort.map((sort) => sort.field))}
-      onSelect={addSort}
-    />
+    <Col className="items-start gap-1 p-1">
+      <SortListContainer schema={schema}>
+        <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
+          {(entry) => (
+            <SortableItem id={entry.field} textValue={entry.field}>
+              <SortableItemContent schema={schema} sort={entry} />
+            </SortableItem>
+          )}
+        </SortableList>
+      </SortListContainer>
+
+      <AddSortButton
+        schema={schema}
+        activeFields={new Set(currentSort.map((sort) => sort.field))}
+        onSelect={addSort}
+      />
+    </Col>
+  );
+}
+
+interface SortListContainerProps {
+  schema: ModelSchema;
+  children: React.ReactNode;
+}
+
+function SortListContainer({ schema, children }: SortListContainerProps) {
+  const { sort, setSort } = useSort(schema);
+
+  const isDefaultOrder = sort === null;
+
+  if (isDefaultOrder) {
+    return (
+      <div className="inset-shadow-[0_1px_2px_rgb(255,255,255),0_1px_4px_rgba(0,0,0,0.1)] rounded-lg border border-stone-200 bg-stone-200/50 shadow-[0_1px_1px_rgba(0,0,0,0.02)]">
+        <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
+          <CheckIcon className="size-3.5 text-cyan-600" />
+          Default order · applied now
+        </Row>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-transparent">
+      <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
+        <SlidersHorizontalIcon className="size-3.5" />
+        Custom order
+        <Button variant="ghost" size="xxs" className="ml-auto text-xxs" onPress={() => setSort([])}>
+          {getSchemaDefaultSort(schema) ? (
+            <>
+              <RotateCcwIcon />
+              Reset to default
+            </>
+          ) : (
+            <>
+              <XIcon />
+              Clear sort
+            </>
+          )}
+        </Button>
+      </Row>
+      {children}
+    </div>
+  );
+}
+
+interface SortFieldSelectProps {
+  fields: SortableField[];
+  value: SortField;
+  onChange: (field: SortField) => void;
+}
+
+function SortFieldSelect({ fields, value, onChange }: SortFieldSelectProps) {
+  return (
+    <Select
+      aria-label="Sort field"
+      value={value}
+      onChange={(key) => onChange(String(key) as SortField)}
+      className="flex-1"
+    >
+      <SelectTrigger size="sm" />
+
+      <Popover placement="bottom start">
+        <Autocomplete>
+          <ListBox selectionMode="single" className="max-h-72">
+            {fields.map(({ field, label }) => (
+              <SelectItem key={field} id={field} textValue={label}>
+                {label}
+              </SelectItem>
+            ))}
+          </ListBox>
+        </Autocomplete>
+      </Popover>
+    </Select>
+  );
+}
+
+interface SortDirectionSelectProps {
+  value: SortDirection;
+  onChange: (direction: SortDirection) => void;
+}
+
+function SortDirectionSelect({ value, onChange }: SortDirectionSelectProps) {
+  return (
+    <Select
+      aria-label="Sort direction"
+      value={value}
+      onChange={(key) => onChange(key as SortDirection)}
+      className="w-32"
+    >
+      <SelectTrigger size="sm" />
+
+      <SelectList items={DIRECTION_OPTIONS} matchTriggerWidth={false}>
+        {(option) => <SelectItem>{option.label}</SelectItem>}
+      </SelectList>
+    </Select>
+  );
+}
+
+interface RemoveSortButtonProps {
+  schema: ModelSchema;
+  sort: Sort;
+}
+
+function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
+  const { sort: sortInQsp, setSort } = useSort(schema);
+  const currentSort = sortInQsp ?? getSchemaDefaultSort(schema) ?? [];
+
+  const remove = () => setSort(currentSort.filter((entry) => entry.field !== sort.field));
+
+  // Removing the only row while on the schema default is a no-op (it snaps back), so hide it.
+  const canRemove = !(sortInQsp === null && currentSort.length === 1);
+
+  // Deleting the last remaining row reverts to the schema default, so frame it as a reset.
+  const removeResetsToDefault =
+    canRemove && currentSort.length === 1 && (getSchemaDefaultSort(schema)?.length ?? 0) > 0;
+
+  if (!canRemove) {
+    return (
+      <Tooltip message="This is the default order. Edit it or add a sort to customize.">
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="square"
+          aria-label="Why this sort can't be removed"
+        >
+          <InfoIcon />
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  if (removeResetsToDefault) {
+    return (
+      <Tooltip message="Reset to the default order">
+        <Button
+          variant="ghost"
+          size="sm"
+          shape="square"
+          aria-label="Reset to default"
+          onPress={remove}
+        >
+          <RotateCcwIcon />
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Button variant="ghost" size="sm" shape="square" aria-label="Remove sort" onPress={remove}>
+      <XIcon />
+    </Button>
+  );
+}
+
+interface SortableItemContentProps {
+  schema: ModelSchema;
+  sort: Sort;
+}
+
+function SortableItemContent({ schema, sort }: SortableItemContentProps) {
+  const { sort: sortInQsp, setSort } = useSort(schema);
+  const sortableFields = useSortableFields(schema);
+  const currentSort = sortInQsp ?? getSchemaDefaultSort(schema) ?? [];
+
+  const fieldsUsedByOtherRows = new Set(
+    currentSort.filter((entry) => entry.field !== sort.field).map((entry) => entry.field)
+  );
+  const availableFields = sortableFields.filter((field) => !fieldsUsedByOtherRows.has(field.field));
+
+  const replaceField = (field: SortField) =>
+    setSort(currentSort.map((entry) => (entry.field === sort.field ? { ...entry, field } : entry)));
+
+  const replaceDirection = (direction: SortDirection) =>
+    setSort(
+      currentSort.map((entry) => (entry.field === sort.field ? { ...entry, direction } : entry))
+    );
+
+  return (
+    <>
+      <SortFieldSelect fields={availableFields} value={sort.field} onChange={replaceField} />
+
+      <SortDirectionSelect value={sort.direction} onChange={replaceDirection} />
+
+      <RemoveSortButton schema={schema} sort={sort} />
+    </>
   );
 }

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -17,42 +17,39 @@ import type React from "react";
 import { Col, Row } from "@/shared/components/container";
 
 import type { Sort, SortDirection, SortField } from "@/entities/nodes/sort/domain/model/sort";
-import { getSchemaDefaultSort } from "@/entities/nodes/sort/domain/rules/get-schema-default-sort";
 import { AddSortButton } from "@/entities/nodes/sort/ui/add-sort/add-sort-button";
 import { AddSortPicker } from "@/entities/nodes/sort/ui/add-sort/add-sort-picker";
 import { useSort } from "@/entities/nodes/sort/ui/hooks/use-sort";
 import { useSortableFields } from "@/entities/nodes/sort/ui/hooks/use-sortable-fields";
-import { DIRECTION_OPTIONS, type SortableField } from "@/entities/nodes/sort/ui/sort-options";
+import { DIRECTION_OPTIONS } from "@/entities/nodes/sort/ui/sort-options";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
 
 interface SortEditorProps {
   schema: ModelSchema;
 }
 export function SortEditor({ schema }: SortEditorProps) {
-  const { sort, setSort } = useSort(schema);
-
-  const currentSort: Sort[] = sort ?? getSchemaDefaultSort(schema) ?? [];
+  const { appliedSort, setCustomSort } = useSort(schema);
 
   const addSort = (newSort: Sort) => {
-    const withoutField = currentSort.filter((existing) => existing.field !== newSort.field);
-    setSort([...withoutField, newSort]);
+    const withoutField = appliedSort.filter((existing) => existing.field !== newSort.field);
+    setCustomSort([...withoutField, newSort]);
   };
 
-  if (currentSort.length === 0) {
+  if (appliedSort.length === 0) {
     return <AddSortPicker schema={schema} onSelect={addSort} />;
   }
 
   return (
     <Col className="items-start gap-1 p-1">
       <SortListContainer schema={schema}>
-        <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
+        <SortableList aria-label="Sort keys" items={appliedSort} onReorder={setCustomSort}>
           {(entry) => <SortEditorRow id={entry.field} schema={schema} sort={entry} />}
         </SortableList>
       </SortListContainer>
 
       <AddSortButton
         schema={schema}
-        activeFields={new Set(currentSort.map((sort) => sort.field))}
+        activeFields={new Set(appliedSort.map((sort) => sort.field))}
         onSelect={addSort}
       />
     </Col>
@@ -65,9 +62,9 @@ interface SortListContainerProps {
 }
 
 function SortListContainer({ schema, children }: SortListContainerProps) {
-  const { sort, setSort } = useSort(schema);
+  const { customSort, setCustomSort, defaultSort } = useSort(schema);
 
-  const isDefaultOrder = sort === null;
+  const isDefaultOrder = customSort === null;
 
   if (isDefaultOrder) {
     return (
@@ -86,8 +83,13 @@ function SortListContainer({ schema, children }: SortListContainerProps) {
       <Row className="h-6 pl-2 font-medium text-stone-500 text-xs">
         <SlidersHorizontalIcon className="size-3.5" />
         Custom order
-        <Button variant="ghost" size="xxs" className="ml-auto text-xxs" onPress={() => setSort([])}>
-          {getSchemaDefaultSort(schema) ? (
+        <Button
+          variant="ghost"
+          size="xxs"
+          className="ml-auto text-stone-500"
+          onPress={() => setCustomSort([])}
+        >
+          {defaultSort ? (
             <>
               <RotateCcwIcon />
               Reset to default
@@ -106,12 +108,20 @@ function SortListContainer({ schema, children }: SortListContainerProps) {
 }
 
 interface SortFieldSelectProps {
-  fields: SortableField[];
+  schema: ModelSchema;
   value: SortField;
   onChange: (field: SortField) => void;
 }
 
-function SortFieldSelect({ fields, value, onChange }: SortFieldSelectProps) {
+function SortFieldSelect({ schema, value, onChange }: SortFieldSelectProps) {
+  const { appliedSort } = useSort(schema);
+  const sortableFields = useSortableFields(schema);
+
+  const fieldsUsedByOtherRows = new Set(
+    appliedSort.filter((entry) => entry.field !== value).map((entry) => entry.field)
+  );
+  const fields = sortableFields.filter((field) => !fieldsUsedByOtherRows.has(field.field));
+
   return (
     <Select
       aria-label="Sort field"
@@ -164,17 +174,15 @@ interface RemoveSortButtonProps {
 }
 
 function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
-  const { sort: sortInQsp, setSort } = useSort(schema);
-  const currentSort = sortInQsp ?? getSchemaDefaultSort(schema) ?? [];
+  const { customSort, setCustomSort, appliedSort, defaultSort } = useSort(schema);
 
-  const remove = () => setSort(currentSort.filter((entry) => entry.field !== sort.field));
+  const remove = () => setCustomSort(appliedSort.filter((entry) => entry.field !== sort.field));
 
   // Removing the only row while on the schema default is a no-op (it snaps back), so hide it.
-  const canRemove = !(sortInQsp === null && currentSort.length === 1);
+  const canRemove = customSort !== null && appliedSort.length > 0;
 
   // Deleting the last remaining row reverts to the schema default, so frame it as a reset.
-  const removeResetsToDefault =
-    canRemove && currentSort.length === 1 && (getSchemaDefaultSort(schema)?.length ?? 0) > 0;
+  const willResetsToDefault = canRemove && appliedSort.length === 1 && !!defaultSort?.length;
 
   if (!canRemove) {
     return (
@@ -191,7 +199,7 @@ function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
     );
   }
 
-  if (removeResetsToDefault) {
+  if (willResetsToDefault) {
     return (
       <Tooltip message="Reset to the default order">
         <Button
@@ -222,26 +230,21 @@ interface SortEditorRowProps {
 }
 
 function SortEditorRow({ id, schema, sort }: SortEditorRowProps) {
-  const { sort: sortInQsp, setSort } = useSort(schema);
-  const sortableFields = useSortableFields(schema);
-  const currentSort = sortInQsp ?? getSchemaDefaultSort(schema) ?? [];
-
-  const fieldsUsedByOtherRows = new Set(
-    currentSort.filter((entry) => entry.field !== sort.field).map((entry) => entry.field)
-  );
-  const availableFields = sortableFields.filter((field) => !fieldsUsedByOtherRows.has(field.field));
+  const { setCustomSort, appliedSort } = useSort(schema);
 
   const replaceField = (field: SortField) =>
-    setSort(currentSort.map((entry) => (entry.field === sort.field ? { ...entry, field } : entry)));
+    setCustomSort(
+      appliedSort.map((entry) => (entry.field === sort.field ? { ...entry, field } : entry))
+    );
 
   const replaceDirection = (direction: SortDirection) =>
-    setSort(
-      currentSort.map((entry) => (entry.field === sort.field ? { ...entry, direction } : entry))
+    setCustomSort(
+      appliedSort.map((entry) => (entry.field === sort.field ? { ...entry, direction } : entry))
     );
 
   return (
     <SortableItem id={id} textValue={id}>
-      <SortFieldSelect fields={availableFields} value={sort.field} onChange={replaceField} />
+      <SortFieldSelect schema={schema} value={sort.field} onChange={replaceField} />
 
       <SortDirectionSelect value={sort.direction} onChange={replaceDirection} />
 

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -46,11 +46,7 @@ export function SortEditor({ schema }: SortEditorProps) {
     <Col className="items-start gap-1 p-1">
       <SortListContainer schema={schema}>
         <SortableList aria-label="Sort keys" items={currentSort} onReorder={setSort}>
-          {(entry) => (
-            <SortableItem id={entry.field} textValue={entry.field}>
-              <SortableItemContent schema={schema} sort={entry} />
-            </SortableItem>
-          )}
+          {(entry) => <SortEditorRow id={entry.field} schema={schema} sort={entry} />}
         </SortableList>
       </SortListContainer>
 
@@ -218,12 +214,14 @@ function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
   );
 }
 
-interface SortableItemContentProps {
+interface SortEditorRowProps {
+  // Required on the wrapper itself: the collection keys rows by the rendered element's `id` prop.
+  id: SortField;
   schema: ModelSchema;
   sort: Sort;
 }
 
-function SortableItemContent({ schema, sort }: SortableItemContentProps) {
+function SortEditorRow({ id, schema, sort }: SortEditorRowProps) {
   const { sort: sortInQsp, setSort } = useSort(schema);
   const sortableFields = useSortableFields(schema);
   const currentSort = sortInQsp ?? getSchemaDefaultSort(schema) ?? [];
@@ -242,12 +240,12 @@ function SortableItemContent({ schema, sort }: SortableItemContentProps) {
     );
 
   return (
-    <>
+    <SortableItem id={id} textValue={id}>
       <SortFieldSelect fields={availableFields} value={sort.field} onChange={replaceField} />
 
       <SortDirectionSelect value={sort.direction} onChange={replaceDirection} />
 
       <RemoveSortButton schema={schema} sort={sort} />
-    </>
+    </SortableItem>
   );
 }

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -179,7 +179,7 @@ function RemoveSortButton({ schema, sort }: RemoveSortButtonProps) {
   const remove = () => setCustomSort(appliedSort.filter((entry) => entry.field !== sort.field));
 
   // Removing the only row while on the schema default is a no-op (it snaps back), so hide it.
-  const canRemove = customSort !== null && appliedSort.length > 0;
+  const canRemove = !(customSort === null && appliedSort.length === 1);
 
   // Deleting the last remaining row reverts to the schema default, so frame it as a reset.
   const willResetsToDefault = canRemove && appliedSort.length === 1 && !!defaultSort?.length;

--- a/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
@@ -14,6 +14,3 @@ export const DIRECTION_OPTIONS: { id: SortDirection; label: string }[] = [
   { id: "ASC", label: "Ascending" },
   { id: "DESC", label: "Descending" },
 ];
-
-// "Peer › Attribute" separator. En-spaces (U+2002) around the chevron keep it from looking cramped.
-export const PEER_LABEL_SEPARATOR = " › ";

--- a/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
@@ -1,14 +1,18 @@
-import type { SortDirection, SortField } from "@/entities/nodes/sort/domain/model/sort";
+import type {
+  NodeMetadataSortField,
+  SortDirection,
+  SortField,
+} from "@/entities/nodes/sort/domain/model/sort";
 
 export interface SortableField {
   field: SortField;
   label: string;
 }
 
-export const METADATA_SORTABLE_FIELDS: SortableField[] = [
+export const NODE_METADATA_SORT_OPTIONS: SortableField[] = [
   { field: "node_metadata__created_at", label: "Created at" },
   { field: "node_metadata__updated_at", label: "Updated at" },
-];
+] satisfies { field: NodeMetadataSortField; label: string }[];
 
 export const DIRECTION_OPTIONS: { id: SortDirection; label: string }[] = [
   { id: "ASC", label: "Ascending" },

--- a/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-options.ts
@@ -1,0 +1,19 @@
+import type { SortDirection, SortField } from "@/entities/nodes/sort/domain/model/sort";
+
+export interface SortableField {
+  field: SortField;
+  label: string;
+}
+
+export const METADATA_SORTABLE_FIELDS: SortableField[] = [
+  { field: "node_metadata__created_at", label: "Created at" },
+  { field: "node_metadata__updated_at", label: "Updated at" },
+];
+
+export const DIRECTION_OPTIONS: { id: SortDirection; label: string }[] = [
+  { id: "ASC", label: "Ascending" },
+  { id: "DESC", label: "Descending" },
+];
+
+// "Peer › Attribute" separator. En-spaces (U+2002) around the chevron keep it from looking cramped.
+export const PEER_LABEL_SEPARATOR = " › ";

--- a/frontend/app/src/entities/nodes/sort/ui/sort-picker.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-picker.tsx
@@ -12,13 +12,13 @@ interface SortPickerProps {
 }
 
 export function SortPicker({ schema }: SortPickerProps) {
-  const { sort } = useSort(schema);
+  const { customSort } = useSort(schema);
 
   return (
     <PopoverTrigger>
       <Button variant="outline" size="sm" className="rounded-xl">
         <ArrowUpDownIcon /> Sort
-        {sort !== null && sort.length > 0 && <CountBadge count={sort.length} />}
+        {!!customSort?.length && <CountBadge count={customSort.length} />}
       </Button>
 
       <Popover placement="bottom start">

--- a/frontend/app/tests/e2e/objects/object-sort.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-sort.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+import { ACCOUNT_STATE_PATH } from "../../constants";
+
+test.describe("Object sort", () => {
+  test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
+
+  test("should customize sort, combine multiple sorts, and reset to default", async ({ page }) => {
+    const sortButton = page.getByRole("button", { name: /^Sort( \d+)?$/ });
+    const sortRows = page.getByRole("grid", { name: "Sort keys" }).getByRole("row");
+    const firstRowLink = page.getByTestId("data-table-row").first().getByRole("link").first();
+
+    await test.step("navigate and verify the schema default order", async () => {
+      await page.goto("/objects/InfraDevice");
+      await expect(page.getByRole("heading", { name: "Device" })).toBeVisible();
+      await expect(firstRowLink).toHaveText("atl1-core1");
+    });
+
+    await test.step("open the sort editor showing the schema default", async () => {
+      await sortButton.click();
+      await expect(page.getByText("Default order · applied now")).toBeVisible();
+      await expect(page.getByRole("button", { name: /Sort field/ })).toContainText("Name");
+      await expect(page.getByRole("button", { name: /Sort direction/ })).toContainText("Ascending");
+      await expect(
+        page.getByRole("button", { name: "Why this sort can't be removed" })
+      ).toBeVisible();
+    });
+
+    await test.step("switch the direction to descending", async () => {
+      await page.getByRole("button", { name: /Sort direction/ }).click();
+      await page.getByRole("option", { name: "Descending" }).click();
+
+      await expect(page.getByText("Custom order")).toBeVisible();
+      await expect(page).toHaveURL(/sort=name__value__desc/);
+      await expect(sortButton).toContainText("1");
+      await expect(firstRowLink).toHaveText("ord1-leaf2");
+    });
+
+    await test.step("add a secondary sort on a relationship field", async () => {
+      await page.getByRole("button", { name: "Add sort" }).click();
+
+      await page.getByPlaceholder("Search...").fill("nonexistent field");
+      await expect(page.getByText("No fields match")).toBeVisible();
+      await page.getByPlaceholder("Search...").fill("");
+
+      await page.getByRole("menuitem", { name: "Site" }).click();
+      await page.getByRole("menuitem", { name: "Name", exact: true }).click();
+      await page.getByRole("menuitem", { name: "Ascending" }).click();
+
+      await expect(sortRows).toHaveCount(2);
+      await expect(sortButton).toContainText("2");
+      await expect(page).toHaveURL(/sort=name__value__desc(,|%2C)site__name__value__asc/);
+      // The primary sort is unchanged, so the first row stays the same.
+      await expect(firstRowLink).toHaveText("ord1-leaf2");
+    });
+
+    await test.step("add a metadata sort from the search results", async () => {
+      await page.getByRole("button", { name: "Add sort" }).click();
+      await page.getByPlaceholder("Search...").fill("updated");
+      await page.getByRole("menuitem", { name: "Updated at" }).click();
+      await page.getByRole("menuitem", { name: "Descending" }).click();
+
+      await expect(sortRows).toHaveCount(3);
+      await expect(sortButton).toContainText("3");
+      await expect(page).toHaveURL(
+        /sort=name__value__desc(,|%2C)site__name__value__asc(,|%2C)node_metadata__updated_at__desc/
+      );
+    });
+
+    await test.step("remove the primary and metadata sorts", async () => {
+      await sortRows.first().getByRole("button", { name: "Remove sort" }).click();
+
+      await expect(sortRows).toHaveCount(2);
+      await expect(page).not.toHaveURL(/name__value__desc/);
+      await expect(firstRowLink).toHaveText(/^atl1-/);
+
+      await sortRows.last().getByRole("button", { name: "Remove sort" }).click();
+
+      await expect(sortRows).toHaveCount(1);
+      await expect(sortButton).toContainText("1");
+      await expect(page).toHaveURL(/sort=site__name__value__asc/);
+      await expect(page).not.toHaveURL(/node_metadata__updated_at/);
+    });
+
+    await test.step("change the sort field from the row select", async () => {
+      await page.getByRole("button", { name: /Sort field/ }).click();
+      await page.getByPlaceholder("Search...").fill("name");
+      await page.getByRole("option", { name: "Name", exact: true }).click();
+
+      await expect(page).toHaveURL(/sort=name__value__asc/);
+      await expect(firstRowLink).toHaveText("atl1-core1");
+    });
+
+    await test.step("reset to the default order", async () => {
+      // Both the header button and the row button are named "Reset to default";
+      // the header one comes first in DOM order.
+      await page.getByRole("button", { name: "Reset to default" }).first().click();
+
+      await expect(page.getByText("Default order · applied now")).toBeVisible();
+      await expect(page).not.toHaveURL(/sort=/);
+      await expect(sortButton).not.toContainText("1");
+      await expect(firstRowLink).toHaveText("atl1-core1");
+    });
+  });
+});

--- a/frontend/packages/ui/src/components/button/button.tsx
+++ b/frontend/packages/ui/src/components/button/button.tsx
@@ -62,7 +62,7 @@ const buttonVariants = tv({
       ],
     },
     size: {
-      xxs: "h-6",
+      xxs: "h-6 text-xs",
       xs: "h-7",
       sm: "h-8",
       md: "h-9",

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { CopyIcon, GroupIcon, PencilLineIcon, Trash2Icon } from "lucide-react";
 import React from "react";
 
@@ -20,7 +21,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ColumnLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="font-medium text-neutral-400 text-xxs uppercase tracking-wider">{children}</div>
+  <div className="text-xxs font-medium tracking-wider text-neutral-400 uppercase">{children}</div>
 );
 
 // The menu lives inside a Popover in real usage; this mimics that surface so the  items render against the expected background.
@@ -117,7 +118,7 @@ export const AllVariants: Story = {
             {disabledItems()}
           </Menu>
         </MenuSurface>
-        <p className="text-neutral-400 text-xxs">Hover the disabled item to see the tooltip.</p>
+        <p className="text-xxs text-neutral-400">Hover the disabled item to see the tooltip.</p>
       </div>
       <MenuSurface>
         <Menu aria-label="Picker menu with a disabled item" variant="picker">
@@ -178,7 +179,7 @@ function PickerWithSubmenuRender() {
           </Autocomplete>
         </Popover>
       </MenuTrigger>
-      <p className="text-neutral-500 text-xs">Picked: {picked ?? "—"}</p>
+      <p className="text-xs text-neutral-500">Picked: {picked ?? "—"}</p>
     </div>
   );
 }

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
 import { CopyIcon, GroupIcon, PencilLineIcon, Trash2Icon } from "lucide-react";
-import React, { useState } from "react";
-import { Popover as AriaPopover } from "react-aria-components";
+import React from "react";
 
 import { Autocomplete } from "../autocomplete/autocomplete";
 import { Button } from "../button/button";
+import { Popover } from "../popover/popover";
 import { Menu, MenuItem, MenuSection, MenuTrigger, SubmenuTrigger } from "./menu";
 
 const meta: Meta<typeof Menu> = {
@@ -21,9 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ColumnLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="text-[10px] font-medium tracking-wider text-neutral-400 uppercase">
-    {children}
-  </div>
+  <div className="font-medium text-neutral-400 text-xxs uppercase tracking-wider">{children}</div>
 );
 
 // The menu lives inside a Popover in real usage; this mimics that surface so the  items render against the expected background.
@@ -120,7 +117,7 @@ export const AllVariants: Story = {
             {disabledItems()}
           </Menu>
         </MenuSurface>
-        <p className="text-[10px] text-neutral-400">Hover the disabled item to see the tooltip.</p>
+        <p className="text-neutral-400 text-xxs">Hover the disabled item to see the tooltip.</p>
       </div>
       <MenuSurface>
         <Menu aria-label="Picker menu with a disabled item" variant="picker">
@@ -145,23 +142,25 @@ const DIRECTIONS = [
 ];
 
 function PickerWithSubmenuRender() {
-  const [picked, setPicked] = useState<string | null>(null);
+  const [picked, setPicked] = React.useState<string | null>(null);
   return (
     <div className="flex flex-col items-start gap-3">
       <MenuTrigger>
         <Button variant="outline" size="sm">
           Add sort
         </Button>
-        <AriaPopover
-          placement="bottom start"
-          className="w-56 rounded-lg border border-neutral-300 bg-white shadow-md"
-        >
+        <Popover placement="bottom start" className="w-56">
           <Autocomplete>
-            <Menu variant="picker" aria-label="Sort field" className="max-h-72">
+            <Menu
+              variant="picker"
+              aria-label="Sort field"
+              className="max-h-72"
+              emptyMessage="No fields match"
+            >
               {SORT_FIELDS.map((field) => (
                 <SubmenuTrigger key={field}>
                   <MenuItem textValue={field}>{field}</MenuItem>
-                  <AriaPopover className="rounded-lg border border-neutral-300 bg-white shadow-md">
+                  <Popover>
                     <Menu
                       aria-label={`Direction for ${field}`}
                       onAction={(key) => setPicked(`${field} · ${key}`)}
@@ -172,14 +171,14 @@ function PickerWithSubmenuRender() {
                         </MenuItem>
                       ))}
                     </Menu>
-                  </AriaPopover>
+                  </Popover>
                 </SubmenuTrigger>
               ))}
             </Menu>
           </Autocomplete>
-        </AriaPopover>
+        </Popover>
       </MenuTrigger>
-      <p className="text-xs text-neutral-500">Picked: {picked ?? "—"}</p>
+      <p className="text-neutral-500 text-xs">Picked: {picked ?? "—"}</p>
     </div>
   );
 }

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -14,7 +14,7 @@ import {
   SubmenuTrigger as AriaSubmenuTrigger,
   Collection,
 } from "react-aria-components";
-import { type VariantProps, cn, tv } from "tailwind-variants";
+import { cn, tv, type VariantProps } from "tailwind-variants";
 
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
@@ -24,9 +24,9 @@ export const SubmenuTrigger = AriaSubmenuTrigger;
 
 const menuItemStyles = tv({
   base: [
-    "flex min-w-40 cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden select-none",
+    "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden",
     "data-disabled:pointer-events-none data-disabled:opacity-50",
-    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+    "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   ],
   variants: {
     variant: {
@@ -44,9 +44,16 @@ type MenuVariants = VariantProps<typeof menuItemStyles>;
 
 const MenuVariantContext = React.createContext<MenuVariants["variant"]>("action");
 
-export interface MenuProps<T> extends AriaMenuProps<T>, MenuVariants {}
+export interface MenuProps<T> extends AriaMenuProps<T>, MenuVariants {
+  emptyMessage?: React.ReactNode;
+}
 
-export const Menu = <T extends object>({ className, variant, ...props }: MenuProps<T>) => {
+export const Menu = <T extends object>({
+  className,
+  variant,
+  emptyMessage,
+  ...props
+}: MenuProps<T>) => {
   const resolvedVariant = variant ?? React.use(MenuVariantContext);
 
   return (
@@ -56,9 +63,14 @@ export const Menu = <T extends object>({ className, variant, ...props }: MenuPro
           className,
           cn(
             "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
-            "*:[[role='group']:not(:last-child)]:mb-2",
-          ),
+            "*:[[role='group']:not(:last-child)]:mb-2"
+          )
         )}
+        renderEmptyState={
+          emptyMessage === undefined
+            ? undefined
+            : () => <div className="px-2 py-1 text-neutral-600 text-sm">{emptyMessage}</div>
+        }
         {...props}
       />
     </MenuVariantContext.Provider>
@@ -127,7 +139,7 @@ export const MenuSection = <T extends object>({
 }: MenuSectionProps<T>) => {
   return (
     <AriaMenuSection className={cn("flex flex-col", className)} {...props}>
-      {title && <AriaHeader className="mb-0.5 px-1 text-xs text-stone-500">{title}</AriaHeader>}
+      {title && <AriaHeader className="mb-0.5 px-1 text-stone-500 text-xs">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -24,9 +24,9 @@ export const SubmenuTrigger = AriaSubmenuTrigger;
 
 const menuItemStyles = tv({
   base: [
-    "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden",
+    "flex min-w-40 cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-stone-600 outline-hidden select-none",
     "data-disabled:pointer-events-none data-disabled:opacity-50",
-    "[&_svg:not([class*='size-'])]:size-3.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
   ],
   variants: {
     variant: {
@@ -63,13 +63,13 @@ export const Menu = <T extends object>({
           className,
           cn(
             "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
-            "*:[[role='group']:not(:last-child)]:mb-2"
-          )
+            "*:[[role='group']:not(:last-child)]:mb-2",
+          ),
         )}
         renderEmptyState={
           emptyMessage === undefined
             ? undefined
-            : () => <div className="px-2 py-1 text-neutral-600 text-sm">{emptyMessage}</div>
+            : () => <div className="px-2 py-1 text-sm text-neutral-600">{emptyMessage}</div>
         }
         {...props}
       />
@@ -139,7 +139,7 @@ export const MenuSection = <T extends object>({
 }: MenuSectionProps<T>) => {
   return (
     <AriaMenuSection className={cn("flex flex-col", className)} {...props}>
-      {title && <AriaHeader className="mb-0.5 px-1 text-stone-500 text-xs">{title}</AriaHeader>}
+      {title && <AriaHeader className="mb-0.5 px-1 text-xs text-stone-500">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/components/popover/popover.tsx
+++ b/frontend/packages/ui/src/components/popover/popover.tsx
@@ -18,7 +18,7 @@ const popoverStyles = tv({
   ],
   variants: {
     isEntering: {
-      true: "animate-in fade-in-0 zoom-in-95",
+      true: "pointer-events-none animate-in fade-in-0 zoom-in-95",
     },
     isExiting: {
       true: "animate-out fade-out-0 zoom-out-95",

--- a/frontend/packages/ui/src/components/select/select.stories.tsx
+++ b/frontend/packages/ui/src/components/select/select.stories.tsx
@@ -1,14 +1,30 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Select, SelectItem, SelectList, SelectTrigger } from "./select";
+import {
+  Select,
+  SelectItem,
+  SelectList,
+  SelectTrigger,
+  type SelectTriggerProps,
+  selectTriggerVariants,
+} from "./select";
 
-const meta: Meta<typeof Select> = {
+const SIZES = Object.keys(selectTriggerVariants.variants.size) as SelectTriggerProps["size"][];
+
+const meta: Meta<typeof SelectTrigger> = {
   title: "Components/Select",
-  component: Select,
+  component: SelectTrigger,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: { control: "select", options: SIZES },
+    isDisabled: { control: "boolean" },
+  },
 };
 export default meta;
 
-type Story = StoryObj<typeof Select>;
+type Story = StoryObj<typeof meta>;
 
 const items = [
   { key: "red", label: "Red" },
@@ -16,19 +32,45 @@ const items = [
   { key: "blue", label: "Blue" },
 ];
 
-export const Default: Story = {
-  render: () => (
-    <div className="w-64">
-      <Select placeholder="Pick a color">
-        <SelectTrigger />
-        <SelectList items={items}>
-          {(item) => (
-            <SelectItem key={item.key} textValue={item.label}>
-              {item.label}
-            </SelectItem>
-          )}
-        </SelectList>
-      </Select>
+const SizeLabel = ({ children }: { children: string }) => (
+  <div className="text-xxs font-medium tracking-wider text-neutral-400 uppercase">{children}</div>
+);
+
+const ColorSelect = (props: SelectTriggerProps) => (
+  <div className="w-64">
+    <Select placeholder="Pick a color">
+      <SelectTrigger {...props} />
+      <SelectList items={items}>
+        {(item) => (
+          <SelectItem key={item.key} textValue={item.label}>
+            {item.label}
+          </SelectItem>
+        )}
+      </SelectList>
+    </Select>
+  </div>
+);
+
+export const AllVariants: Story = {
+  argTypes: {
+    size: { table: { disable: true } },
+  },
+  render: ({ isDisabled }) => (
+    <div className="flex flex-col gap-4">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col gap-1">
+          <SizeLabel>{size ?? "md"}</SizeLabel>
+          <ColorSelect size={size} isDisabled={isDisabled} />
+        </div>
+      ))}
     </div>
   ),
+};
+
+export const Playground: Story = {
+  args: {
+    size: "md",
+    isDisabled: false,
+  },
+  render: (args) => <ColorSelect {...args} />,
 };

--- a/frontend/packages/ui/src/components/select/select.stories.tsx
+++ b/frontend/packages/ui/src/components/select/select.stories.tsx
@@ -32,7 +32,7 @@ const items = [
   { key: "blue", label: "Blue" },
 ];
 
-const SizeLabel = ({ children }: { children: string }) => (
+const SizeLabel = ({ children }: { children?: string }) => (
   <div className="text-xxs font-medium tracking-wider text-neutral-400 uppercase">{children}</div>
 );
 
@@ -59,7 +59,7 @@ export const AllVariants: Story = {
     <div className="flex flex-col gap-4">
       {SIZES.map((size) => (
         <div key={size} className="flex flex-col gap-1">
-          <SizeLabel>{size ?? "md"}</SizeLabel>
+          <SizeLabel>{size}</SizeLabel>
           <ColorSelect size={size} isDisabled={isDisabled} />
         </div>
       ))}

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -14,7 +14,7 @@ import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { ListBox, ListBoxItem, type ListBoxItemProps } from "../list-box/list-box";
 import { Popover } from "../popover/popover";
 
-const triggerStyles = tv({
+export const selectTriggerVariants = tv({
   base: [
     "flex w-full items-center gap-2 rounded-lg border border-neutral-300 outline-none",
     "bg-white text-sm placeholder:text-neutral-400",
@@ -33,11 +33,14 @@ const triggerStyles = tv({
 });
 
 export interface SelectTriggerProps
-  extends Omit<AriaButtonProps, "children">, VariantProps<typeof triggerStyles> {}
+  extends Omit<AriaButtonProps, "children">, VariantProps<typeof selectTriggerVariants> {}
 
 export function SelectTrigger({ className, size, ...props }: SelectTriggerProps) {
   return (
-    <AriaButton className={composeAriaClassName(className, triggerStyles({ size }))} {...props}>
+    <AriaButton
+      className={composeAriaClassName(className, selectTriggerVariants({ size }))}
+      {...props}
+    >
       <AriaSelectValue className="truncate data-placeholder:text-neutral-400" />
       <ChevronDownIcon className="ml-auto size-4" />
     </AriaButton>

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -5,7 +5,8 @@ import {
   type ListBoxProps as AriaListBoxProps,
   SelectValue as AriaSelectValue,
 } from "react-aria-components";
-import { tv } from "tailwind-variants";
+import { tv, type VariantProps } from "tailwind-variants";
+
 export { Select } from "react-aria-components";
 
 import { focusVisibleStyle } from "../../styles/focus-visible";
@@ -15,16 +16,29 @@ import { Popover } from "../popover/popover";
 
 const triggerStyles = tv({
   base: [
-    "flex min-h-10 w-full items-center gap-2 rounded-lg border border-neutral-300 outline-none",
-    "bg-white p-2 text-sm placeholder:text-neutral-400",
+    "flex w-full items-center gap-2 rounded-lg border border-neutral-300 outline-none",
+    "bg-white text-sm placeholder:text-neutral-400",
     "disabled:cursor-not-allowed disabled:bg-neutral-100",
     focusVisibleStyle,
   ],
+  variants: {
+    size: {
+      sm: "h-8 px-2",
+      md: "min-h-10 p-2",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
 });
 
-export function SelectTrigger({ className, ...props }: Omit<AriaButtonProps, "children">) {
+export interface SelectTriggerProps
+  extends Omit<AriaButtonProps, "children">,
+    VariantProps<typeof triggerStyles> {}
+
+export function SelectTrigger({ className, size, ...props }: SelectTriggerProps) {
   return (
-    <AriaButton className={composeAriaClassName(className, triggerStyles())} {...props}>
+    <AriaButton className={composeAriaClassName(className, triggerStyles({ size }))} {...props}>
       <AriaSelectValue className="truncate data-placeholder:text-neutral-400" />
       <ChevronDownIcon className="ml-auto size-4" />
     </AriaButton>
@@ -50,7 +64,7 @@ export function SelectItem<T extends object>({ className, ...props }: ListBoxIte
   return (
     <ListBoxItem
       className={composeAriaClassName(className, ({ isSelected }) =>
-        isSelected ? undefined : "pr-8",
+        isSelected ? undefined : "pr-8"
       )}
       {...props}
     />

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -33,8 +33,7 @@ const triggerStyles = tv({
 });
 
 export interface SelectTriggerProps
-  extends Omit<AriaButtonProps, "children">,
-    VariantProps<typeof triggerStyles> {}
+  extends Omit<AriaButtonProps, "children">, VariantProps<typeof triggerStyles> {}
 
 export function SelectTrigger({ className, size, ...props }: SelectTriggerProps) {
   return (
@@ -64,7 +63,7 @@ export function SelectItem<T extends object>({ className, ...props }: ListBoxIte
   return (
     <ListBoxItem
       className={composeAriaClassName(className, ({ isSelected }) =>
-        isSelected ? undefined : "pr-8"
+        isSelected ? undefined : "pr-8",
       )}
       {...props}
     />

--- a/frontend/packages/ui/src/index.ts
+++ b/frontend/packages/ui/src/index.ts
@@ -72,6 +72,7 @@ export {
   SelectList,
   type SelectListProps,
   SelectTrigger,
+  type SelectTriggerProps,
 } from "./components/select/select";
 export { Sheet, type SheetProps } from "./components/sheet/sheet";
 export {

--- a/tests/e2e/objects/test_object_sort.py
+++ b/tests/e2e/objects/test_object_sort.py
@@ -1,0 +1,115 @@
+"""Port of frontend/app/tests/e2e/objects/object-sort.spec.ts.
+
+Sort picker on /objects/InfraDevice: the schema default order, switching to a
+custom direction, stacking sorts through the grouped and searchable pickers,
+removing them again, editing a row's field, and resetting to the schema
+default. Sorting is URL state only (no mutations), so the test runs as Admin
+against main; data_sites provides the demo devices whose names and sites drive
+the expected row order (name ascending starts at atl1-core1, descending at
+ord1-leaf2).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+from playwright.async_api import expect
+
+pytestmark = pytest.mark.shard_sites_a
+
+if TYPE_CHECKING:
+    from data.handles import SitesHandle
+    from playwright.async_api import Page
+
+
+class TestObjectSort:
+    async def test_customize_sort_combine_multiple_sorts_and_reset_to_default(
+        self, admin_page: Page, data_sites: SitesHandle
+    ) -> None:
+        sort_button = admin_page.get_by_role("button", name=re.compile(r"^Sort( \d+)?$"))
+        sort_rows = admin_page.get_by_role("grid", name="Sort keys").get_by_role("row")
+        first_row_link = admin_page.get_by_test_id("data-table-row").first.get_by_role("link").first
+
+        # navigate and verify the schema default order
+        await admin_page.goto("/objects/InfraDevice")
+        await expect(admin_page.get_by_role("heading", name="Device")).to_be_visible()
+        await expect(first_row_link).to_have_text("atl1-core1")
+
+        # open the sort editor showing the schema default
+        await sort_button.click()
+        await expect(admin_page.get_by_text("Default order · applied now")).to_be_visible()
+        await expect(admin_page.get_by_role("button", name=re.compile(r"Sort field"))).to_contain_text("Name")
+        await expect(admin_page.get_by_role("button", name=re.compile(r"Sort direction"))).to_contain_text("Ascending")
+        await expect(admin_page.get_by_role("button", name="Why this sort can't be removed")).to_be_visible()
+
+        # switch the direction to descending
+        await admin_page.get_by_role("button", name=re.compile(r"Sort direction")).click()
+        await admin_page.get_by_role("option", name="Descending").click()
+
+        await expect(admin_page.get_by_text("Custom order")).to_be_visible()
+        await expect(admin_page).to_have_url(re.compile(r"sort=name__value__desc"))
+        await expect(sort_button).to_contain_text("1")
+        await expect(first_row_link).to_have_text("ord1-leaf2")
+
+        # add a secondary sort on a relationship field
+        await admin_page.get_by_role("button", name="Add sort").click()
+
+        await admin_page.get_by_placeholder("Search...").fill("nonexistent field")
+        await expect(admin_page.get_by_text("No fields match")).to_be_visible()
+        await admin_page.get_by_placeholder("Search...").fill("")
+
+        await admin_page.get_by_role("menuitem", name="Site").click()
+        await admin_page.get_by_role("menuitem", name="Name", exact=True).click()
+        await admin_page.get_by_role("menuitem", name="Ascending").click()
+
+        await expect(sort_rows).to_have_count(2)
+        await expect(sort_button).to_contain_text("2")
+        await expect(admin_page).to_have_url(re.compile(r"sort=name__value__desc(,|%2C)site__name__value__asc"))
+        # The primary sort is unchanged, so the first row stays the same.
+        await expect(first_row_link).to_have_text("ord1-leaf2")
+
+        # add a metadata sort from the search results
+        await admin_page.get_by_role("button", name="Add sort").click()
+        await admin_page.get_by_placeholder("Search...").fill("updated")
+        await admin_page.get_by_role("menuitem", name="Updated at").click()
+        await admin_page.get_by_role("menuitem", name="Descending").click()
+
+        await expect(sort_rows).to_have_count(3)
+        await expect(sort_button).to_contain_text("3")
+        await expect(admin_page).to_have_url(
+            re.compile(r"sort=name__value__desc(,|%2C)site__name__value__asc(,|%2C)node_metadata__updated_at__desc")
+        )
+
+        # remove the primary and metadata sorts
+        await sort_rows.first.get_by_role("button", name="Remove sort").click()
+
+        await expect(sort_rows).to_have_count(2)
+        await expect(admin_page).not_to_have_url(re.compile(r"name__value__desc"))
+        await expect(first_row_link).to_have_text(re.compile(r"^atl1-"))
+
+        await sort_rows.last.get_by_role("button", name="Remove sort").click()
+
+        await expect(sort_rows).to_have_count(1)
+        await expect(sort_button).to_contain_text("1")
+        await expect(admin_page).to_have_url(re.compile(r"sort=site__name__value__asc"))
+        await expect(admin_page).not_to_have_url(re.compile(r"node_metadata__updated_at"))
+
+        # change the sort field from the row select
+        await admin_page.get_by_role("button", name=re.compile(r"Sort field")).click()
+        await admin_page.get_by_placeholder("Search...").fill("name")
+        await admin_page.get_by_role("option", name="Name", exact=True).click()
+
+        await expect(admin_page).to_have_url(re.compile(r"sort=name__value__asc"))
+        await expect(first_row_link).to_have_text("atl1-core1")
+
+        # reset to the default order
+        # Both the header button and the row button are named "Reset to default";
+        # the header one comes first in DOM order.
+        await admin_page.get_by_role("button", name="Reset to default").first.click()
+
+        await expect(admin_page.get_by_text("Default order · applied now")).to_be_visible()
+        await expect(admin_page).not_to_have_url(re.compile(r"sort="))
+        await expect(sort_button).not_to_contain_text("1")
+        await expect(first_row_link).to_have_text("atl1-core1")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a sortable editor for node tables to view, edit, reorder, and remove sort rules, with clear “Default order” vs “Custom order” states. Updates sorting to `customSort` with `defaultSort`/`appliedSort`, dedupes duplicate fields, and updates `@infrahub/ui` to support the flow.

- New Features
  - Sort editor: reorder rows; field and direction selects; hides fields used by other rows; shows “Default order · applied now” vs “Custom order”; prevents removing the only default row with an explanation; offers “Reset to default” or “Clear sort”.
  - Add sort: new `AddSortButton`; disables with a tooltip when all fields are in use; picker groups attributes and relationships, orders fields by `order_weight`, flattens with peer labels when searching; hides used fields; omits many‑cardinality and unknown‑peer relationships; includes metadata; shows empty states via menu `emptyMessage`.
  - Hooks and logic: `useSort` exposes `customSort`, `setCustomSort`, `defaultSort`, `appliedSort`; `useSortableFields` returns a flat, order‑weighted list; `getValidSorts` allowlists fields and keeps only the first per field; `ObjectTable` and `SortPicker` now read `customSort`.
  - Tests: unit tests for add button, picker, deduping, and `useSort`; Playwright and pytest e2e cover default/custom, multi‑sort, removal, field edits, reset, URL state, badge count, row order, and search empty states.

- Migration
  - `useSort`: rename `sort` → `customSort`, `setSort` → `setCustomSort`; new `defaultSort` and `appliedSort`.
  - `@infrahub/ui`: `Menu` adds `emptyMessage`; `SelectTrigger` adds `size` (`sm`/`md`) and exports `SelectTriggerProps`; `Button` `xxs` uses smaller text; `Popover` blocks pointer events during enter animations.

<sup>Written for commit 092852d7119ca9c3129b915c3538f15a6cc157a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

