### PR TITLE
fix(frontend): keep IPAM namespace context on IP links from namespace relationship tabs

### DIFF
--- a/changelog/9892.fixed.md
+++ b/changelog/9892.fixed.md
@@ -1,1 +1,1 @@
-Following an IP prefix or address link from an IPAM namespace's relationship tabs now keeps you in that namespace, instead of redirecting to the default namespace.
+Following an IP prefix or address link from the relationship tabs of an IPAM namespace now keeps you in that namespace, instead of redirecting to the default namespace.

--- a/changelog/9892.fixed.md
+++ b/changelog/9892.fixed.md
@@ -1,0 +1,1 @@
+Following an IP prefix or address link from an IPAM namespace's relationship tabs now keeps you in that namespace, instead of redirecting to the default namespace.

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
@@ -1,6 +1,7 @@
 import { LinkButton } from "@infrahub/ui";
 import type { PressEvent } from "react-aria-components";
 
+import type { overrideQueryParams } from "@/shared/api/rest/fetch";
 import { Checkbox } from "@/shared/components/aria/checkbox";
 
 import { useAuth } from "@/entities/authentication/ui/useAuth";
@@ -13,6 +14,7 @@ export interface TableIdentifierCellProps {
   label: React.ReactNode;
   isSelected?: boolean;
   onClickCheckbox?: (e: PressEvent) => void;
+  overrideParams?: overrideQueryParams[];
 }
 
 export function TableIdentifierCell({
@@ -21,6 +23,7 @@ export function TableIdentifierCell({
   label,
   isSelected,
   onClickCheckbox,
+  overrideParams,
 }: TableIdentifierCellProps) {
   const { isAuthenticated } = useAuth();
   return (
@@ -36,7 +39,7 @@ export function TableIdentifierCell({
       <LinkButton
         variant="ghost"
         size="sm"
-        href={getObjectDetailsUrl(objectKind, objectId)}
+        href={getObjectDetailsUrl(objectKind, objectId, overrideParams)}
         className="-mx-1 truncate rounded-xl px-2 text-custom-blue-700 hover:underline"
       >
         {label}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
@@ -1,6 +1,7 @@
 import type { PopoverTriggerProps } from "@radix-ui/react-popover";
 import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
+import type { overrideQueryParams } from "@/shared/api/rest/fetch";
 import { FROM_RESOURCE_POOL_SUFFIX } from "@/shared/components/form/constants";
 import { TableCell } from "@/shared/components/table/table-cell";
 import { sortByOrderWeight } from "@/shared/utils/common";
@@ -34,7 +35,8 @@ import { isGenericSchema } from "@/entities/schema/utils/is-generic-schema";
 const columnHelper = createColumnHelper<NodeObject>();
 
 export function getObjectIdentifierColumns(
-  schema: ModelSchema
+  schema: ModelSchema,
+  identifierOverrideParams?: overrideQueryParams[]
 ): Array<ColumnDef<NodeObject, string>> {
   return [
     columnHelper.accessor((node) => getNodeLabel(node), {
@@ -59,6 +61,7 @@ export function getObjectIdentifierColumns(
             label={label}
             isSelected={row.getIsSelected()}
             onClickCheckbox={getToggleSelectedRowHandler({ row, table })}
+            overrideParams={identifierOverrideParams}
           />
         );
       },
@@ -145,10 +148,11 @@ export function getObjectFieldsColumns(
 
 export const getObjectTableColumns = (
   schema: ModelSchema,
-  headerProps?: PopoverTriggerProps
+  headerProps?: PopoverTriggerProps,
+  identifierOverrideParams?: overrideQueryParams[]
 ): Array<ColumnDef<NodeObject>> => {
   return [
-    ...getObjectIdentifierColumns(schema),
+    ...getObjectIdentifierColumns(schema, identifierOverrideParams),
     ...getObjectGenericColumns(schema),
     ...getObjectFieldsColumns(schema, headerProps),
   ] as Array<ColumnDef<NodeObject>>;

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
@@ -3,6 +3,7 @@ import { DataTable } from "@/shared/components/table/data-table";
 import { InfiniteScroll } from "@/shared/components/utils/infinite-scroll";
 import useFilters from "@/shared/hooks/useFilters";
 
+import { IP_NAMESPACE_GENERIC, IPAM_QSP } from "@/entities/ipam/constants";
 import { ObjectTableEmpty } from "@/entities/nodes/object/ui/object-table/object-table-empty";
 import { getObjectTableColumns } from "@/entities/nodes/object/ui/object-table/utils/get-object-table-columns";
 import {
@@ -15,6 +16,7 @@ import { ToolbarDissociateAction } from "@/entities/nodes/relationships/ui/relat
 import { canDissociateRelationship } from "@/entities/nodes/relationships/utils/can-dissociate-relationship";
 import { useGetObjectPermissions } from "@/entities/permission/ui/queries/get-object-permissions.query";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
+import { isOfKind } from "@/entities/schema/utils/is-of-kind";
 
 export interface RelationshipTableProps extends UseObjectRelationshipsParams {}
 
@@ -49,8 +51,18 @@ export function RelationshipTable({
   }
 
   const flatData = data?.pages?.flat() ?? [];
+
+  // On an IP namespace's relationship tabs (e.g. its prefixes/addresses), the active
+  // namespace lives in the route path, not the `namespace` query param that IPAM links
+  // rely on. Forward it explicitly so child IP links stay in this namespace instead of
+  // falling back to the default one.
+  const identifierOverrideParams =
+    parentSchema && isOfKind(IP_NAMESPACE_GENERIC, parentSchema)
+      ? [{ name: IPAM_QSP.NAMESPACE, value: parentId }]
+      : undefined;
+
   const columns = [
-    ...getObjectTableColumns(relationshipSchema, { disabled: true }),
+    ...getObjectTableColumns(relationshipSchema, { disabled: true }, identifierOverrideParams),
     getRelationshipActionsColumn({
       parentId,
       parentKind,

--- a/frontend/app/src/entities/nodes/utils.test.ts
+++ b/frontend/app/src/entities/nodes/utils.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import { IP_PREFIX_GENERIC, IPAM_QSP } from "@/entities/ipam/constants";
+import { getObjectDetailsUrl } from "@/entities/nodes/utils";
+import {
+  genericSchemasAtom,
+  nodeSchemasAtom,
+  profileSchemasAtom,
+  templateSchemasAtom,
+} from "@/entities/schema/stores/schema.atom";
+
+import { generateNodeSchema } from "../../../tests/fake/schema";
+
+const ipPrefixSchema = generateNodeSchema({
+  kind: "BuiltinIPPrefix",
+  name: "IPPrefix",
+  namespace: "Builtin",
+  inherit_from: [IP_PREFIX_GENERIC],
+});
+
+describe("getObjectDetailsUrl", () => {
+  afterEach(() => {
+    store.set(nodeSchemasAtom, []);
+    store.set(genericSchemasAtom, []);
+    store.set(profileSchemasAtom, []);
+    store.set(templateSchemasAtom, []);
+  });
+
+  it("keeps the namespace context for an IP prefix link when passed as an override param", () => {
+    store.set(nodeSchemasAtom, [ipPrefixSchema]);
+
+    const url = getObjectDetailsUrl("BuiltinIPPrefix", "prefix-1", [
+      { name: IPAM_QSP.NAMESPACE, value: "namespace-1" },
+    ]);
+
+    expect(url).toContain("/ipam/BuiltinIPPrefix/prefix-1");
+    expect(url).toContain(`${IPAM_QSP.NAMESPACE}=namespace-1`);
+  });
+
+  it("does not add a namespace param to an IP prefix link when none is provided", () => {
+    store.set(nodeSchemasAtom, [ipPrefixSchema]);
+
+    const url = getObjectDetailsUrl("BuiltinIPPrefix", "prefix-1");
+
+    expect(url).toBe("/ipam/BuiltinIPPrefix/prefix-1");
+  });
+});


### PR DESCRIPTION
Closes #9892

## Problem

When viewing an IPAM namespace object and its relationship tabs (e.g. `/ipam/namespaces/IpamNamespace/<id>/ip_prefixes`), clicking an IP prefix/address link dropped the namespace context and the target resolved to the **default** namespace.

Those pages render through the generic object-relationship table, whose links are built by `getObjectDetailsUrl` with no namespace context. IPAM links preserve the active namespace via the `?namespace=<id>` query param, but on a namespace object detail page the namespace lives in the **route path**, not that query param — so there was nothing to preserve and the link fell back to the default namespace.

## Fix

Thread an optional `identifierOverrideParams` through the relationship table column builder (`getObjectTableColumns` → `getObjectIdentifierColumns` → `TableIdentifierCell`). `RelationshipTable` injects `namespace=<parentId>` only when the relationship's parent object is an IP namespace (`isOfKind(IP_NAMESPACE_GENERIC, parentSchema)`). All params are optional/additive, so other object tables are unaffected.

## Scope note

This fixes the entry point from a namespace object's relationship tabs. Once you land on the IP detail page with `?namespace=<id>`, the existing `IpNamespaceProvider` keeps that namespace for subsequent links. Other places that link to an IP without namespace context (e.g. an IP relationship shown on a Device page) are out of scope for this change.

## Testing

- Added `src/entities/nodes/utils.test.ts` covering `getObjectDetailsUrl` with/without a namespace override for IP prefix kinds.
- `biome check` clean on touched files; touched files are type-clean under `tsc --noEmit`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IPAM links on a namespace’s relationship tabs so they keep the current namespace instead of jumping to the default. Clicking an IP prefix or address now stays in the same namespace.

- **Bug Fixes**
  - Pass the parent namespace into child links via `?namespace=<id>` when the relationship parent is an IP namespace.
  - Thread optional `overrideParams` through `getObjectTableColumns` → `getObjectIdentifierColumns` → `TableIdentifierCell` to `getObjectDetailsUrl`.
  - Add tests covering `getObjectDetailsUrl` with and without a namespace override.

<sup>Written for commit 231f2930bb0efde4cddd0b7f973169f70313b293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

