### PR TITLE
run fewer constraint validators

### DIFF
--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -1,4 +1,3 @@
-import contextlib
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.constants import RelationshipKind, SchemaPathType
@@ -6,7 +5,7 @@ from infrahub.core.constants.schema import UpdateSupport
 from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.models import SchemaUpdateConstraintInfo
 from infrahub.core.path import SchemaPath
-from infrahub.core.schema import AttributeSchema, MainSchemaTypes
+from infrahub.core.schema import AttributePathParsingError, AttributeSchema, MainSchemaTypes
 from infrahub.core.schema.attribute_parameters import AttributeParameters
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -53,10 +52,14 @@ class ConstraintValidatorDeterminer:
         if not node_diffs:
             return constraints
 
-        constraints.extend(await self._get_all_property_constraints())
+        constraints.extend(await self._get_property_constraints_for_impacted_kinds())
 
         for kind in self._node_kinds:
-            schema = self.schema_branch.get(name=kind, duplicate=False)
+            schema = self._get_schema_or_none(kind=kind)
+            if schema is None:
+                # a branch can hold data changes for a kind whose schema it also deletes
+                LOG.info("Skipping constraints for kind absent from the schema", kind=kind)
+                continue
             constraints.extend(await self._get_constraints_for_one_schema(schema))
 
         if not filter_invalid:
@@ -81,18 +84,62 @@ class ConstraintValidatorDeterminer:
         constraints.extend(await self._get_relationship_constraints_for_one_schema(schema=schema))
         return constraints
 
-    async def _get_all_property_constraints(self) -> list[SchemaUpdateConstraintInfo]:
+    def _get_schema_or_none(self, kind: str) -> MainSchemaTypes | None:
+        try:
+            return self.schema_branch.get(name=kind, duplicate=False)
+        except SchemaNotFoundError:
+            return None
+
+    def _get_impacted_kinds(self) -> set[str]:
+        """Kinds with node-level property constraints that could be violated by the data diff.
+
+        Includes the kinds present in the diff and the generics they inherit from, since a
+        generic-level uniqueness check spans every implementing node.
+        """
+        kinds: set[str] = set()
+        for kind in self._node_kinds:
+            schema = self._get_schema_or_none(kind=kind)
+            if schema is None:
+                continue
+            kinds.add(kind)
+            kinds.update(getattr(schema, "inherit_from", None) or [])
+        return kinds
+
+    def _has_uniqueness_constraint_on_peer(self, schema: MainSchemaTypes, peer_kinds: set[str]) -> bool:
+        """Return True if a uniqueness constraint of `schema` reads an attribute of a peer in `peer_kinds`.
+
+        A constraint element such as "owner__name" compares the value of an attribute on the
+        related node, so a data change on the peer kind can create a violation without any
+        change to the constrained kind itself.
+        """
+        for constraint_paths in schema.uniqueness_constraints or []:
+            for constraint_path in constraint_paths:
+                try:
+                    schema_path = schema.parse_schema_path(path=constraint_path, schema=self.schema_branch)
+                except AttributePathParsingError:
+                    continue
+                if (
+                    schema_path.is_type_relationship
+                    and schema_path.attribute_schema is not None
+                    and schema_path.active_relationship_schema.peer in peer_kinds
+                ):
+                    return True
+        return False
+
+    async def _get_property_constraints_for_impacted_kinds(self) -> list[SchemaUpdateConstraintInfo]:
+        impacted_kinds = self._get_impacted_kinds()
+        schemas: list[MainSchemaTypes] = []
+        for kind in impacted_kinds:
+            schema = self._get_schema_or_none(kind=kind)
+            if schema is not None:
+                schemas.append(schema)
+        for schema in self.schema_branch.get_all(duplicate=False).values():
+            if schema.kind in impacted_kinds:
+                continue
+            if self._has_uniqueness_constraint_on_peer(schema=schema, peer_kinds=impacted_kinds):
+                schemas.append(schema)
+
         constraints: list[SchemaUpdateConstraintInfo] = []
-        schemas = list(self.schema_branch.get_all(duplicate=False).values())
-        # added here to check their uniqueness constraints
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaNode", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaGeneric", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaAttribute", duplicate=False))
-        with contextlib.suppress(SchemaNotFoundError):
-            schemas.append(self.schema_branch.get_node(name="SchemaRelationship", duplicate=False))
         for schema in schemas:
             constraints.extend(await self._get_property_constraints_for_one_schema(schema=schema))
         return constraints
@@ -127,9 +174,14 @@ class ConstraintValidatorDeterminer:
             )
             constraint_name = f"node.{prop_name}.update"
 
+            checker = CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+            if checker is not None and not checker.triggered_by_data_change:
+                # a data change cannot violate a constraint whose checker only compares the
+                # candidate schema against the current one; that case belongs to the schema diff
+                continue
+
             do_constraint_validation = prop_field_update == UpdateSupport.VALIDATE_CONSTRAINT.value or (
-                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value
-                and CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value and checker
             )
             if not do_constraint_validation:
                 continue
@@ -193,9 +245,14 @@ class ConstraintValidatorDeterminer:
                 path_type = SchemaPathType.RELATIONSHIP
                 constraint_name = f"relationship.{prop_name}.update"
 
+            checker = CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+            if checker is not None and not checker.triggered_by_data_change:
+                # a data change cannot violate a constraint whose checker only compares the
+                # candidate schema against the current one; that case belongs to the schema diff
+                continue
+
             do_constraint_validation = prop_field_update == UpdateSupport.VALIDATE_CONSTRAINT.value or (
-                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value
-                and CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value and checker
             )
             if not do_constraint_validation:
                 continue

--- a/backend/infrahub/core/validators/interface.py
+++ b/backend/infrahub/core/validators/interface.py
@@ -10,6 +10,10 @@ if TYPE_CHECKING:
 
 
 class ConstraintCheckerInterface(ABC):
+    # Whether a change to instance data (as opposed to schema) can cause this constraint to be
+    # violated. If the checker only compares schemas, it should set this False.
+    triggered_by_data_change: bool = True
+
     @property
     @abstractmethod
     def name(self) -> str: ...

--- a/backend/infrahub/core/validators/node/generate_profile.py
+++ b/backend/infrahub/core/validators/node/generate_profile.py
@@ -60,6 +60,9 @@ class NodeGenerateProfileValidatorQuery(SchemaValidatorQuery):
 
 class NodeGenerateProfileChecker(ConstraintCheckerInterface):
     query_classes = [NodeGenerateProfileValidatorQuery]
+    # Only fires when generate_profile is turned off while profiles still exist; instance data
+    # changes cannot flip that schema flag, so a data diff can never trigger it.
+    triggered_by_data_change = False
 
     def __init__(self, db: InfrahubDatabase, branch: Branch | None = None) -> None:
         self.db = db

--- a/backend/infrahub/core/validators/node/inherit_from.py
+++ b/backend/infrahub/core/validators/node/inherit_from.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 
 
 class NodeInheritFromChecker(ConstraintCheckerInterface):
+    # Only fires when a generic is removed from a node schema's inherit_from list.
+    triggered_by_data_change = False
+
     def __init__(self, db: InfrahubDatabase, branch: Branch | None = None) -> None:
         self.db = db
         self.branch = branch

--- a/backend/tests/component/core/constraint_validators/test_determiner.py
+++ b/backend/tests/component/core/constraint_validators/test_determiner.py
@@ -12,17 +12,23 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.core.validators.enum import ConstraintIdentifier
 
+RELATIONSHIP_PROPERTIES = ("peer", "cardinality", "optional", "min_count", "max_count")
 
-def node_uniqueness_constraint(kind: str) -> SchemaUpdateConstraintInfo:
+
+def node_constraint(kind: str, property_name: str) -> SchemaUpdateConstraintInfo:
     return SchemaUpdateConstraintInfo(
-        constraint_name="node.uniqueness_constraints.update",
+        constraint_name=f"node.{property_name}.update",
         path=SchemaPath(
             path_type=SchemaPathType.NODE,
             schema_kind=kind,
-            field_name="uniqueness_constraints",
-            property_name="uniqueness_constraints",
+            field_name=property_name,
+            property_name=property_name,
         ),
     )
+
+
+def node_uniqueness_constraint(kind: str) -> SchemaUpdateConstraintInfo:
+    return node_constraint(kind, "uniqueness_constraints")
 
 
 def attribute_constraint(kind: str, field_name: str, property_name: str) -> SchemaUpdateConstraintInfo:
@@ -30,6 +36,18 @@ def attribute_constraint(kind: str, field_name: str, property_name: str) -> Sche
         constraint_name=f"attribute.{property_name}.update",
         path=SchemaPath(
             path_type=SchemaPathType.ATTRIBUTE,
+            schema_kind=kind,
+            field_name=field_name,
+            property_name=property_name,
+        ),
+    )
+
+
+def relationship_constraint(kind: str, field_name: str, property_name: str) -> SchemaUpdateConstraintInfo:
+    return SchemaUpdateConstraintInfo(
+        constraint_name=f"relationship.{property_name}.update",
+        path=SchemaPath(
+            path_type=SchemaPathType.RELATIONSHIP,
             schema_kind=kind,
             field_name=field_name,
             property_name=property_name,
@@ -298,3 +316,32 @@ class TestConstraintDeterminer:
         for kind in internal_kinds:
             assert node_uniqueness_constraint(kind) in set(constraints)
         assert {c.path.schema_kind for c in constraints} == {"TestPerson", *internal_kinds}
+
+    async def test_hierarchy_constraints_selected_for_both_endpoint_kinds(
+        self,
+        hierarchical_location_schema_simple: SchemaRoot,
+        default_branch: Branch,
+    ) -> None:
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        # A hierarchy edge change surfaces on both endpoints: the child (LocationRack) records its
+        # `parent` change and the parent (LocationSite) records its `children` change.
+        node_diffs = [
+            NodeDiffFieldSummary(kind="LocationRack", relationship_names={"parent"}),
+            NodeDiffFieldSummary(kind="LocationSite", relationship_names={"children"}),
+        ]
+        expected = {
+            node_constraint("LocationRack", "parent"),
+            node_constraint("LocationRack", "children"),
+            node_uniqueness_constraint("LocationRack"),
+            node_constraint("LocationSite", "parent"),
+            node_constraint("LocationSite", "children"),
+            node_uniqueness_constraint("LocationSite"),
+            node_uniqueness_constraint("LocationGeneric"),
+            *(relationship_constraint("LocationRack", "parent", p) for p in RELATIONSHIP_PROPERTIES),
+            *(relationship_constraint("LocationSite", "children", p) for p in RELATIONSHIP_PROPERTIES),
+        }
+
+        constraints = await determiner.get_constraints(node_diffs=node_diffs)
+
+        assert set(constraints) == expected

--- a/backend/tests/component/core/constraint_validators/test_determiner.py
+++ b/backend/tests/component/core/constraint_validators/test_determiner.py
@@ -7,9 +7,34 @@ from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.models import SchemaUpdateConstraintInfo
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot, internal_schema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.core.validators.enum import ConstraintIdentifier
+
+
+def node_uniqueness_constraint(kind: str) -> SchemaUpdateConstraintInfo:
+    return SchemaUpdateConstraintInfo(
+        constraint_name="node.uniqueness_constraints.update",
+        path=SchemaPath(
+            path_type=SchemaPathType.NODE,
+            schema_kind=kind,
+            field_name="uniqueness_constraints",
+            property_name="uniqueness_constraints",
+        ),
+    )
+
+
+def attribute_constraint(kind: str, field_name: str, property_name: str) -> SchemaUpdateConstraintInfo:
+    return SchemaUpdateConstraintInfo(
+        constraint_name=f"attribute.{property_name}.update",
+        path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE,
+            schema_kind=kind,
+            field_name=field_name,
+            property_name=property_name,
+        ),
+    )
 
 
 @pytest.fixture
@@ -44,24 +69,6 @@ def person_name_node_diff(
                 schema_kind="TestPerson",
                 field_name="name",
                 property_name="unique",
-            ),
-        ),
-        SchemaUpdateConstraintInfo(
-            constraint_name="node.inherit_from.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestPerson",
-                field_name="inherit_from",
-                property_name="inherit_from",
-            ),
-        ),
-        SchemaUpdateConstraintInfo(
-            constraint_name="node.inherit_from.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestCar",
-                field_name="inherit_from",
-                property_name="inherit_from",
             ),
         ),
     }
@@ -183,24 +190,6 @@ class TestConstraintDeterminer:
         car_schema.uniqueness_constraints = [["owner", "color__value"]]
         determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
         node_diff, constraint_info_set = person_name_node_diff
-        person_uniqueness_constraint_info = SchemaUpdateConstraintInfo(
-            constraint_name="node.uniqueness_constraints.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestPerson",
-                field_name="uniqueness_constraints",
-                property_name="uniqueness_constraints",
-            ),
-        )
-        car_uniqueness_constraint_info = SchemaUpdateConstraintInfo(
-            constraint_name="node.uniqueness_constraints.update",
-            path=SchemaPath(
-                path_type=SchemaPathType.NODE,
-                schema_kind="TestCar",
-                field_name="uniqueness_constraints",
-                property_name="uniqueness_constraints",
-            ),
-        )
         max_length_param_constraint_info = SchemaUpdateConstraintInfo(
             constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MAX_LENGTH_UPDATE.value,
             path=SchemaPath(
@@ -210,16 +199,102 @@ class TestConstraintDeterminer:
                 property_name="parameters.max_length",
             ),
         )
-        constraint_info_set.add(person_uniqueness_constraint_info)
-        constraint_info_set.add(car_uniqueness_constraint_info)
+        constraint_info_set.add(node_uniqueness_constraint("TestPerson"))
         constraint_info_set.add(max_length_param_constraint_info)
 
         constraints = await determiner.get_constraints(node_diffs=[node_diff])
 
-        relevant_constraints = [
-            c
-            for c in constraints
-            if c.constraint_name != "node.generate_profile.update" and c.path.schema_kind in {"TestCar", "TestPerson"}
-        ]
-        assert len(relevant_constraints) == len(constraint_info_set)
-        assert set(relevant_constraints) == constraint_info_set
+        assert set(constraints) == constraint_info_set
+
+    async def test_uniqueness_constraint_on_peer_attribute_included(
+        self,
+        car_person_schema: SchemaBranch,
+        default_branch: Branch,
+        person_name_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
+    ) -> None:
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        car_schema = schema_branch.get(name="TestCar", duplicate=False)
+        car_schema.uniqueness_constraints = [["owner__name", "color__value"]]
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        node_diff, constraint_info_set = person_name_node_diff
+        constraint_info_set.add(node_uniqueness_constraint("TestPerson"))
+        # TestCar's constraint reads the name attribute of the related TestPerson, so a TestPerson
+        # data change can violate it even though TestCar itself has no diff
+        constraint_info_set.add(node_uniqueness_constraint("TestCar"))
+
+        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+
+        assert set(constraints) == constraint_info_set
+
+    async def test_generic_of_changed_kind_included(
+        self,
+        car_person_schema_generics_simple: SchemaRoot,
+        default_branch: Branch,
+    ) -> None:
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        generic_schema = schema_branch.get(name="TestCar", duplicate=False)
+        generic_schema.uniqueness_constraints = [["name__value"]]
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        node_diff = NodeDiffFieldSummary(kind="TestElectricCar", attribute_names={"nbr_engine"})
+        # a generic-level uniqueness check spans every implementing node, so a data change on an
+        # implementation must trigger the check on the generic (TestCar) as well as the implementation
+        constraint_info_set = {
+            node_uniqueness_constraint("TestCar"),
+            node_uniqueness_constraint("TestElectricCar"),
+            attribute_constraint("TestElectricCar", "nbr_engine", "kind"),
+            attribute_constraint("TestElectricCar", "nbr_engine", "optional"),
+            attribute_constraint("TestElectricCar", "nbr_engine", "unique"),
+        }
+
+        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+
+        assert set(constraints) == constraint_info_set
+
+    async def test_kind_missing_from_schema_is_skipped(
+        self,
+        car_person_schema: SchemaBranch,
+        default_branch: Branch,
+        person_name_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
+    ) -> None:
+        schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        node_diff, constraint_info_set = person_name_node_diff
+        constraint_info_set.add(node_uniqueness_constraint("TestPerson"))
+
+        constraints = await determiner.get_constraints(
+            node_diffs=[NodeDiffFieldSummary(kind="TestDeleted", attribute_names={"name"}), node_diff]
+        )
+
+        # TestDeleted is absent from the schema, so it contributes nothing; only TestPerson remains
+        assert set(constraints) == constraint_info_set
+
+    async def test_internal_schema_kinds_only_when_in_diff(
+        self,
+        car_person_schema: SchemaBranch,
+        default_branch: Branch,
+        person_name_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
+    ) -> None:
+        schema_branch = registry.schema.register_schema(
+            schema=SchemaRoot(**internal_schema), branch=default_branch.name
+        )
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        node_diff, constraint_info_set = person_name_node_diff
+        constraint_info_set.add(node_uniqueness_constraint("TestPerson"))
+
+        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        # internal schema kinds are absent from the diff, so none contribute constraints
+        assert set(constraints) == constraint_info_set
+
+        internal_kinds = {"SchemaNode", "SchemaGeneric", "SchemaAttribute", "SchemaRelationship"}
+        determiner = ConstraintValidatorDeterminer(schema_branch=schema_branch)
+        constraints = await determiner.get_constraints(
+            node_diffs=[
+                node_diff,
+                *(NodeDiffFieldSummary(kind=kind, attribute_names={"name"}) for kind in internal_kinds),
+            ]
+        )
+        # once an internal schema kind is in the diff, its uniqueness constraint must be validated
+        # (this is what catches duplicate schema elements when a branch is merged)
+        for kind in internal_kinds:
+            assert node_uniqueness_constraint(kind) in set(constraints)
+        assert {c.path.schema_kind for c in constraints} == {"TestPerson", *internal_kinds}

--- a/backend/tests/component/core/test_initialization.py
+++ b/backend/tests/component/core/test_initialization.py
@@ -16,23 +16,6 @@ async def test_first_time_initialization(db: InfrahubDatabase, default_branch: B
     assert True
 
 
-async def test_first_time_initialization_converges_core_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
-    """A fresh installation must persist the schema shape the upgrade flow builds as its candidate.
-
-    The candidate includes the deprecated overlay, so the core-schema diff starts out empty.
-    """
-    await first_time_initialization(db=db)
-
-    branch_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
-    candidate_schema = branch_schema.duplicate()
-    candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
-    candidate_schema.load_schema(schema=SchemaRoot(**core_models))
-    candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
-    candidate_schema.process()
-
-    assert branch_schema.diff(other=candidate_schema).all == []
-
-
 async def test_first_time_initialization_does_not_seed_preferences(
     db: InfrahubDatabase, delete_all_nodes_in_db: None
 ) -> None:

--- a/backend/tests/component/core/test_initialization.py
+++ b/backend/tests/component/core/test_initialization.py
@@ -16,6 +16,23 @@ async def test_first_time_initialization(db: InfrahubDatabase, default_branch: B
     assert True
 
 
+async def test_first_time_initialization_converges_core_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """A fresh installation must persist the schema shape the upgrade flow builds as its candidate.
+
+    The candidate includes the deprecated overlay, so the core-schema diff starts out empty.
+    """
+    await first_time_initialization(db=db)
+
+    branch_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+    candidate_schema = branch_schema.duplicate()
+    candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
+    candidate_schema.load_schema(schema=SchemaRoot(**core_models))
+    candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
+    candidate_schema.process()
+
+    assert branch_schema.diff(other=candidate_schema).all == []
+
+
 async def test_first_time_initialization_does_not_seed_preferences(
     db: InfrahubDatabase, delete_all_nodes_in_db: None
 ) -> None:

--- a/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/component/message_bus/operations/requests/test_proposed_change.py
@@ -131,9 +131,11 @@ async def test_get_proposed_change_schema_integrity_constraints(
         schema=schema, diff_summary=branch_diff_01_summary
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
-    # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 249
-    assert len(non_generate_profile_constraints) == 151
+    assert len(constraints) == 12
+    assert len(non_generate_profile_constraints) == 12
+    # node-level property constraints must be scoped to the kinds present in the diff
+    node_constraint_kinds = {c.path.schema_kind for c in constraints if c.path.path_type is SchemaPathType.NODE}
+    assert node_constraint_kinds == {"TestPerson"}
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",
@@ -223,46 +225,6 @@ async def test_get_proposed_change_schema_integrity_constraints(
             "property_name": "unique",
             "schema_id": None,
             "schema_kind": "TestPerson",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.parent.update",
-        "path": {
-            "field_name": "parent",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "parent",
-            "schema_id": None,
-            "schema_kind": "CoreStandardGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.children.update",
-        "path": {
-            "field_name": "children",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "children",
-            "schema_id": None,
-            "schema_kind": "CoreStandardGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.parent.update",
-        "path": {
-            "field_name": "parent",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "parent",
-            "schema_id": None,
-            "schema_kind": "CoreGraphQLQueryGroup",
-        },
-    } in dumped_constraints
-    assert {
-        "constraint_name": "node.children.update",
-        "path": {
-            "field_name": "children",
-            "path_type": SchemaPathType.NODE,
-            "property_name": "children",
-            "schema_id": None,
-            "schema_kind": "CoreGraphQLQueryGroup",
         },
     } in dumped_constraints
 

--- a/changelog/2592.fixed.md
+++ b/changelog/2592.fixed.md
@@ -1,0 +1,1 @@
+Branches containing only data changes no longer trigger every validator across every kind in the schema. Schema diffs between identical branches now come back empty, and constraint validation is scoped to the kinds with changed data or schemas.


### PR DESCRIPTION
# Why

Merging, rebasing, or running proposed-change checks on a branch that only
changed *data* used to select every constraint validator against every kind in
the schema, even kinds the change never touched. That work grows with the size
of the schema, not the size of the change, and dominates merge/rebase time on
large schemas.

**Goal:** scope constraint validation to the kinds a change can actually
affect, so a data-only branch validates only the kinds whose data changed plus
the few kinds that transitively depend on them.

**Non-goals:** no change to what any validator checks, nor to the set of
validators that exist. This only changes *which* validators are selected to run
for a given diff.

Closes #9246 

## What changed

**Behavioral changes:**

- A branch with only data changes no longer triggers constraint validators for
  unrelated kinds. Node-level property constraints are scoped to the kinds
  present in the data diff, the generics they inherit from, and any peer whose
  uniqueness constraint reads an attribute of a changed kind (e.g. a
  `owner__name` uniqueness on `Car` when `Person` data changes).
- Schema-transition-only checkers (`node.generate_profile.update`,
  `node.inherit_from.update`) are no longer run from the data-diff path. A data
  change cannot violate them — they only fire when the schema property itself
  changes — so they stay covered by the schema-diff path and are dropped from
  the data path.
- Internal schema kinds (`SchemaNode`/`SchemaGeneric`/`SchemaAttribute`/
  `SchemaRelationship`) are validated when they appear in the diff (i.e. when a
  schema is edited on the branch) rather than being appended unconditionally.

**Implementation notes:**

- New `triggered_by_data_change` flag on `ConstraintCheckerInterface`
  (defaults `True`), set `False` on `NodeGenerateProfileChecker` and
  `NodeInheritFromChecker`. The determiner consults `CONSTRAINT_VALIDATOR_MAP`
  and skips any constraint whose checker is not data-triggered — the
  classification lives with the checker that embodies it, and a new checker is
  forced to answer the question rather than silently defaulting into the data
  path.
- `ConstraintValidatorDeterminer` computes an "impacted kinds" set (diff kinds +
  inherited generics + peers whose uniqueness reads them) and scopes node-level
  property constraints to it instead of iterating every kind.
- Peer-uniqueness detection uses `parse_schema_path` for a structured view of
  each constraint element instead of string partitioning.
- A kind that is absent from the schema (e.g. a kind whose schema the branch
  also deletes) is skipped instead of raising.

**What stayed the same:** the validators themselves are unchanged; schema-diff
constraint selection is unchanged; every caller still unions data-diff
constraints with schema-diff constraints, so selection is only ever *narrowed*
for data changes and never for schema changes.

## How to review

Suggested order:

1. `backend/infrahub/core/validators/determiner.py` — the scoping logic
   (`_get_impacted_kinds`, `_get_property_constraints_for_impacted_kinds`, and
   the `triggered_by_data_change` filter in the per-schema/per-field helpers).
2. `interface.py` + `node/generate_profile.py` + `node/inherit_from.py` — the
   new flag and where it is set `False`.
3. `test_determiner.py` — each scenario asserts the **exact** constraint set the
   determiner returns.

The risk to scrutinize is *under*-selection: narrowing which validators run at
merge/rebase/PC-check time must not drop a validator a change could actually
violate. The integration test `test_schema_duplicate_merge` (duplicate schema →
`SchemaNode` uniqueness violation at merge) and the exact-set unit tests guard
this.

## Impact & rollout

- **Backward compatibility:** no API or schema changes; validation is narrowed
  only for data-only diffs, never for schema diffs.
- **Performance:** the motivating win — fewer validators dispatched on data-only
  branch merges, rebases, and proposed-change checks; the count no longer scales
  with total schema size.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added
- [ ] External docs updated (n/a — internal validation behavior)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes schema integrity validators to only the kinds impacted by data or schema changes and skips schema-only checks on data diffs. Fixes schema diffing and first-time init so identical branches start with an empty core-schema diff; addresses IFC-2604 by cutting full-DB uniqueness scans and speeding up PC pipelines.

- **Bug Fixes**
  - Scope node-level constraints to changed kinds, their generics, and peers referenced by uniqueness paths; skip kinds absent from the schema.
  - Add `triggered_by_data_change` on checkers and mark `node.generate_profile.update` and `node.inherit_from.update` as schema-only so data-only PCs don’t run them.
  - Use `parse_schema_path` to detect peer-attribute uniqueness checks and include those schemas only when needed.
  - Compare id-less schema elements by value; remove `PYTEST_RUNNING` shortcut; preserve empty optional text fields; load `deprecated_models` on first init; add tests for empty core-schema diff, reduced validator set, and hierarchy edge diffs selecting both endpoints.

<sup>Written for commit e1896d50789e4e0ec7496a56ea9be406c18d2fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



