### PR TITLE
fix(schema): handle node removal during branch merge migration (closes #9899)

### DIFF
--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -191,6 +191,12 @@ class SchemaUpdateValidationResult(BaseModel):
             )
 
         for schema_name, schema_diff in self.diff.changed.items():
+            # A node can appear in both `removed` and `changed` of a merged 3-way diff
+            # when it is removed on one side and modified on the other. Its removal is
+            # already handled above, and the post-merge target schema no longer holds it,
+            # so processing it as a changed element would raise SchemaNotFoundError.
+            if schema_name in self.diff.removed:
+                continue
             schema_node = schema.get(name=schema_name, duplicate=False)
             if "inherit_from" in schema_diff.changed:
                 self.migrations.append(

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -295,6 +295,12 @@ class SchemaNotFoundError(Error):
         self.message = message or f"Unable to find the schema {identifier} in the database."
         super().__init__(self.message)
 
+    def __reduce__(self) -> tuple[type[SchemaNotFoundError], tuple[str, str, str]]:
+        # The default pickling only preserves `args` (the message), but __init__ requires
+        # branch_name and identifier, so a round-trip through pickle (e.g. Prefect) would
+        # otherwise fail with a missing-argument TypeError.
+        return (self.__class__, (self.branch_name, self.identifier, self.message))
+
     def __str__(self) -> str:
         return f"""
         {self.message}

--- a/backend/tests/unit/core/test_models.py
+++ b/backend/tests/unit/core/test_models.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from infrahub.core.constants import UpdateValidationErrorType
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.models import SchemaUpdateValidationResult
+from infrahub.core.schema import AttributeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 
 WIDGET_GADGET_SCHEMA: dict[str, Any] = {
@@ -57,3 +58,39 @@ async def test_relationship_identifier_update_is_not_supported() -> None:
     assert error.path.field_name == "gadgets"
     assert error.path.property_name == "identifier"
     assert result.migrations == []
+
+
+async def test_process_diff_node_removed_and_changed() -> None:
+    """A node removed on one side and changed on the other must be treated as a removal.
+
+    Such a node appears in both `removed` and `changed` of the merged 3-way diff. The
+    migration calculation runs against the post-merge target schema, from which the node
+    is already gone, so processing it as a changed element would raise SchemaNotFoundError.
+    """
+    initial = _build_schema()
+
+    # Source side removes the node entirely.
+    source = initial.duplicate()
+    source.delete(name="TestWidget")
+    source.process()
+
+    # Destination side keeps the node but modifies it, so it lands in `changed`.
+    destination = initial.duplicate()
+    widget = destination.get_node(name="TestWidget", duplicate=True)
+    widget.attributes.append(AttributeSchema(name="color", kind="Text", optional=True))
+    destination.set(name="TestWidget", schema=widget)
+    destination.process()
+
+    diff_3way = initial.diff(other=source) + initial.diff(other=destination)
+    assert "TestWidget" in diff_3way.removed
+    assert "TestWidget" in diff_3way.changed
+
+    # The post-merge target schema no longer contains the removed node.
+    target = destination.duplicate()
+    target.delete(name="TestWidget")
+    target.process()
+
+    result = SchemaUpdateValidationResult.init(diff=diff_3way, schema=target)
+
+    migrations = {(migration.path.schema_kind, migration.migration_name) for migration in result.migrations}
+    assert ("TestWidget", "node.remove") in migrations

--- a/backend/tests/unit/test_exceptions.py
+++ b/backend/tests/unit/test_exceptions.py
@@ -1,0 +1,20 @@
+import pickle  # noqa: S403
+
+from infrahub.exceptions import SchemaNotFoundError
+
+
+def test_schema_not_found_error_is_picklable() -> None:
+    """SchemaNotFoundError must survive a pickle round-trip.
+
+    It is transported across process boundaries (e.g. by Prefect); if it cannot be
+    unpickled, the real error is masked by a TypeError from its own constructor.
+    """
+    error = SchemaNotFoundError(branch_name="main", identifier="TestingWidget")
+
+    restored = pickle.loads(pickle.dumps(error))  # noqa: S301
+
+    assert isinstance(restored, SchemaNotFoundError)
+    assert restored.branch_name == error.branch_name
+    assert restored.identifier == error.identifier
+    assert restored.message == error.message
+    assert str(restored) == str(error)

--- a/changelog/9899.fixed.md
+++ b/changelog/9899.fixed.md
@@ -1,0 +1,1 @@
+Merging a branch that removes a schema node no longer fails during migration calculation with a `SchemaNotFoundError`.


### PR DESCRIPTION
# Why

Merging a branch that removes any schema node failed. Both integrity validators passed and the proposed change was reported "eligible to be merged", but the merge task then failed during migration calculation and rolled back with:

```
SchemaNotFoundError: Unable to find the schema '<NodeKind>' in the registry
```

Closes #9899

## What changed

**Behavioral change:** merging a branch that removes a schema node now completes instead of failing and rolling back.

**Root cause.** Migration calculation builds a 3-way schema diff (`initial ↔ source` + `initial ↔ destination`). A removed node lands in the `removed` set from the source side, but also appears in the `changed` set from the destination side, because `load_schema_from_db(at=created_at)` does not byte-for-byte match the live in-memory schema. `process_diff` then looked the node up in the post-merge target schema — where it has already been deleted — and raised `SchemaNotFoundError`.

- `process_diff` now skips any node already present in the diff's `removed` set when iterating `changed`. The removal is fully handled by the `removed` loop; field-level migrations for a node that is disappearing are moot.
- `SchemaNotFoundError` is now picklable (`__reduce__`). Its `__init__` requires `branch_name`/`identifier`, so the default pickle round-trip (args = message only) raised `TypeError: __init__() missing 1 required positional argument: 'identifier'`, masking the real error when transported between processes (e.g. Prefect).

**What stayed the same:** no schema or API changes. Nodes that are only *changed* (not removed) still produce their migrations exactly as before — verified by the existing `test_merge_update_schema` component test.

## How to review

1. `backend/infrahub/core/models.py` — the guard in `process_diff`.
2. `backend/infrahub/exceptions.py` — `SchemaNotFoundError.__reduce__`.
3. Tests: `backend/tests/unit/core/test_models.py::test_process_diff_node_removed_and_changed` reproduces the original crash (node in both `removed` and `changed`, target schema missing the node); `backend/tests/unit/test_exceptions.py` guards the pickle round-trip.

## Test Plan

```bash
uv run pytest backend/tests/unit/core/test_models.py backend/tests/unit/test_exceptions.py -q
uv run pytest backend/tests/component/core/test_branch_merge.py::test_merge_update_schema -q
```

Both green. The unit test fails on `stable` with the exact reported traceback (`models.py` → `schema_branch.py` `SchemaNotFoundError`) and passes with the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a merge crash when a branch removes a schema node by correctly handling nodes that show up as both removed and changed. Also makes `SchemaNotFoundError` picklable so real errors aren’t masked when crossing process boundaries.

- **Bug Fixes**
  - Skip nodes found in `diff.removed` when iterating `diff.changed` in `process_diff` to avoid looking up a node that no longer exists.
  - Add `SchemaNotFoundError.__reduce__` to support pickle round-trips (e.g., Prefect) and preserve error context.
  - Added targeted unit tests; no schema or API changes, and migrations for non-removed nodes are unchanged.

<sup>Written for commit 52556ca4526d5c69fc70edb353ca48be1d233f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

