### PR TITLE
chore: add bug analysis/fix/tdd skills

### DIFF
--- a/.agents/skills/opsmill-dev-analyzing-bugs/SKILL.md
+++ b/.agents/skills/opsmill-dev-analyzing-bugs/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: opsmill-dev-analyzing-bugs
+description: >-
+  Performs root-cause analysis of a bug — from a GitHub issue, an issue URL, or a free-text
+  description — before any reproduction or fix is written. TRIGGER when: triaging or diagnosing
+  a bug, investigating why something misbehaves, an issue number/URL handed over for analysis,
+  needing the root cause before touching code. DO NOT TRIGGER when: a failing reproduction test
+  already exists and you are ready to fix → opsmill-dev-fixing-bugs; writing that reproduction test →
+  opsmill-dev-test-driving-bugs; capturing a new bug as a ticket → opsmill-dev-creating-issues.
+argument-hint: <issue number or URL, or a free-text bug description>
+compatibility: >-
+  Works in any git repo; anchors discovery on the OpsMill `dev/` layout with codebase fallback.
+  `gh` is optional, used only for issue numbers/URLs.
+metadata:
+  pipeline: bug-fixing (1 of 3 — analyze → test-drive → fix)
+  version: 0.1.0
+  author: OpsMill
+user-invocable: true
+---
+
+# Bug analyst
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Your role
+
+You are a senior engineer performing root cause analysis. You do **NOT** write fixes or tests.
+Your output will be consumed by `/opsmill-dev-test-driving-bugs` and `/opsmill-dev-fixing-bugs`, so be structured and precise.
+
+## Tool usage
+
+- Use the `Read` tool to read files -- do NOT use `cat` or `head`/`tail` in Bash.
+- Use the `Glob` tool to find files -- do NOT use `find` or `ls -R` in Bash.
+- Use the `Grep` tool to search file contents -- do NOT use `grep` or `rg` in Bash.
+- Reserve Bash for git commands, `gh` CLI, and commands that require shell execution.
+- Shell state does **not** persist across separate Bash calls (variables, `cd`); re-derive or
+  restate anything you need in a later snippet.
+
+## Input
+
+Parse `$ARGUMENTS` to determine what you are analysing:
+
+- **Issue number or URL** (e.g. `4872` or `https://github.com/org/repo/issues/4872`): extract
+  the issue number. If `gh` is available, fetch the issue:
+
+  ```bash
+  gh issue view <number>
+  ```
+
+- **Free-text description**: treat the text itself as the bug report.
+
+Derive a **key** for this analysis (used to name the handoff file and downstream branch/PR):
+
+- If an issue number is present, `<key>` = `<issue_number>-<short-slug>`.
+- Otherwise `<key>` = `<short-slug>` only.
+
+The `<short-slug>` is a lowercase, hyphenated 2--5 word summary of the bug (e.g.
+`internal-groups-dropdown`). Always include the slug so concurrent analyses never collide.
+
+This `<key>` is invented here (the slug is free-form), so it is the **canonical** one for the
+whole pipeline. You will persist it -- and the downstream branch name `ai-bug-pipeline-<key>` --
+into the handoff file below, so `/opsmill-dev-test-driving-bugs` and `/opsmill-dev-fixing-bugs` read them instead of re-deriving a
+slug that could drift (e.g. `internal-groups-dropdown` vs `groups-dropdown-internal`).
+
+If `$ARGUMENTS` is empty or an issue cannot be fetched, inform the developer and **STOP**.
+
+## Discover project context (read what exists, skip what doesn't)
+
+Anchor on the common OpsMill `dev/` structure; fall back to exploration when it is absent.
+**None of these files are required.**
+
+| File | If present, use it for |
+| --- | --- |
+| root `AGENTS.md` | Project map, working agreements, where code lives. |
+| `dev/documentation-architecture.md` | Mapping the bug to the relevant code package(s). |
+| `dev/knowledge/` | Descriptive architecture — how the affected area actually works. |
+| `dev/guidelines/` | Prescriptive rules for the affected area. |
+
+## Investigation
+
+Follow these sections in order.
+
+### Issue clarity check
+
+Verify the report has enough information to work with:
+
+| Required | Description |
+|----------|-------------|
+| **Clear problem statement** | Can you understand what the bug actually is? |
+| **Reproduction path** | Are there steps to reproduce, OR can you infer them from the description? |
+| **Expected vs actual** | Is it clear what should happen vs what happens? |
+
+Rate the clarity:
+
+- **CLEAR**: intent, reproduction scenario, and expected behavior are understandable (even if
+  some details like the affected release are missing).
+- **UNCLEAR**: the intent and reproduction scenario are not understandable.
+
+If the bug is **UNCLEAR**, inform the developer what information is missing and **STOP**.
+
+### Investigate the codebase
+
+1. Read root `AGENTS.md` and `dev/documentation-architecture.md` (if present) to determine which
+   code package(s) relate to the issue. Then:
+   - If you can determine the related code package, rate code identification as **RESOLVED**.
+   - If you cannot, rate it **EXPLORATION REQUIRED** and explore the codebase (use `Glob`/`Grep`)
+     until you locate the affected area.
+
+2. Read the relevant source files in the affected area to understand the current behavior.
+
+3. Identify the most likely root cause(s) -- point to specific files and lines.
+   - If you **cannot** identify a root cause after exploration, inform the developer and **STOP**.
+
+4. Formulate a fix strategy. This is NOT the exact code -- it is the recommended approach:
+   - **Approach:** What should the fixer do and where? Reference existing functions/methods that
+     should be reused rather than reimplemented.
+   - **Scope:** Which files/functions need changes? How large should the change be?
+   - **Do NOT:** List common wrong approaches (e.g., adding a guard clause when the real fix is a
+     missing validation, creating new abstractions when an existing one should be reused).
+
+## Output
+
+Determine the repository's default branch and fetch its latest state, to record what the
+analysis is based on:
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+# Fallback when origin/HEAD is unset (shallow/CI clones, manually-added remotes):
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+[ "$DEFAULT_BRANCH" = "(unknown)" ] && DEFAULT_BRANCH=""   # git prints "(unknown)" when remote HEAD is indeterminate
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+git fetch origin "$DEFAULT_BRANCH" || { echo "Cannot fetch origin/$DEFAULT_BRANCH -- set the default branch manually and retry."; exit 1; }
+git rev-parse "origin/$DEFAULT_BRANCH"
+```
+
+If that fetch fails, **STOP** and report it -- do not write the analysis without a baseline
+commit (the `exit 1` only fails the shell call; you must not continue to the next section).
+
+Write the analysis to `.bug-analysis-<key>.md` in the repo root using the template below. This
+file is a **local working-tree artifact, not committed** -- add `.bug-analysis-*.md` to the
+repo's `.gitignore` if it is not already ignored, and never `git add` it.
+
+Then display the full analysis to the developer in the conversation.
+
+### Analysis template
+
+Replace all `<placeholders>`:
+
+````markdown
+## Root cause analysis for <key>
+
+**Key:** `<key>`
+**Branch:** `ai-bug-pipeline-<key>`
+**Issue:** <issue title or one-line restatement of the description>
+**Based on:** `<commit SHA of origin/<default branch>>`
+**Bug clarity:** CLEAR
+**Code identification:** RESOLVED | EXPLORATION REQUIRED
+
+### Root cause
+
+<one-sentence summary>
+
+### Affected files
+
+- `path/to/file.ext` -- line X: <why this is the culprit>
+
+### Explanation
+
+<detailed reasoning>
+
+## Fix strategy
+
+**Approach:** <recommended fix approach -- explain WHAT to do and WHERE, not the exact code>
+
+**Scope:** <which files/functions should need changes, and roughly how large the change should be>
+
+**Do NOT:**
+
+- <guardrail 1 -- common wrong approach to avoid>
+- <guardrail 2 -- unnecessary refactoring to avoid>
+
+## Notes for downstream steps
+
+<edge cases, risks, or constraints the test-writer and fixer should know about>
+````
+
+## Quality gates
+
+Per `../quality-gates/gates/gate-model.md`. `analyzing-bugs` is **Tier 0** (advisory output).
+
+| Gate | Trigger | Tier | Primitives | Pass criteria | On-fail |
+|---|---|---|---|---|---|
+| Grounded-analysis | before writing the analysis file | T0 | P1 + self-review | Every root-cause claim cites a concrete file:line. | revise before writing |
+
+## Common mistakes
+
+| 🚩 Red flag | Do instead |
+| --- | --- |
+| Writing fix code (or a test) into the analysis | This step does analysis only — describe the fix *strategy*, not the patch; `/opsmill-dev-test-driving-bugs` and `/opsmill-dev-fixing-bugs` do the rest |
+| Analysing an **UNCLEAR** bug or one with no findable root cause | STOP and tell the developer what's missing — a confident-sounding analysis of an unclear bug misleads both later steps |
+| Re-deriving or guessing a slug later in the pipeline | Invent the `<key>` once here and **persist** it (and `ai-bug-pipeline-<key>`) in the handoff header so `/opsmill-dev-test-driving-bugs` / `/opsmill-dev-fixing-bugs` read it instead of drifting |
+| Writing the analysis without a baseline commit | If the default-branch fetch fails, STOP — the `**Based on:**` SHA is what later steps reproduce against |
+| `git add`-ing the `.bug-analysis-*.md` file | It is a local working-tree artifact — never commit it |

--- a/.agents/skills/opsmill-dev-fixing-bugs/SKILL.md
+++ b/.agents/skills/opsmill-dev-fixing-bugs/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: opsmill-dev-fixing-bugs
+description: >-
+  Implements and validates the fix for a bug once a failing reproduction test exists. TRIGGER
+  when: a bug has a failing reproduction test and you are ready to make it pass, implementing
+  the root-cause fix, the final step of the bug-fixing pipeline. DO NOT TRIGGER when: no
+  reproduction test exists yet → opsmill-dev-test-driving-bugs; still diagnosing, or asked to fix a bug with
+  no analysis or reproduction test yet → opsmill-dev-analyzing-bugs.
+argument-hint: <issue number or URL, or bug description>
+compatibility: >-
+  Works in any git repo; detects format/lint/test/changelog commands from the project rather
+  than assuming a toolchain. `gh` and a GitHub remote are needed only for the draft-PR path; the
+  fully-local flow (when `/opsmill-dev-test-driving-bugs` ran without `pr`) needs neither.
+metadata:
+  pipeline: bug-fixing (3 of 3 — analyze → test-drive → fix)
+  version: 0.1.0
+  author: OpsMill
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Bug fixer
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Your role
+
+You are a senior engineer implementing a bug fix. Two prior steps have already completed:
+`/opsmill-dev-analyzing-bugs` identified the root cause, and `/opsmill-dev-test-driving-bugs` wrote a failing test. Your job is to
+fix the root cause. The test is your validation criteria -- it must pass -- but the analyst's
+root cause analysis is what drives your fix, **not** the test.
+
+## Tool usage
+
+- Use the `Read` tool to read files -- do NOT use `cat` or `head`/`tail` in Bash.
+- Use the `Glob` tool to find files -- do NOT use `find` or `ls -R` in Bash.
+- Use the `Grep` tool to search file contents -- do NOT use `grep` or `rg` in Bash.
+- Reserve Bash for git commands, `gh` CLI, and commands that require shell execution.
+- *Shell* state (variables, `cd`) does **not** persist across separate Bash calls -- re-derive
+  shell values you reuse. The pipeline's logical flags like `HAS_PR` are decisions you carry in
+  your own reasoning, not shell variables, so they do persist across steps.
+
+## Input and setup
+
+Start from the analysis artifact, not a reconstructed slug. Discover it with `Glob` for
+`.bug-analysis-*.md` in the repo root:
+
+- **No match:** inform the developer "Run `/opsmill-dev-analyzing-bugs <issue>` first." and **STOP**.
+- **Exactly one match:** use it.
+- **Multiple matches:** pick the one whose `<key>` best matches `$ARGUMENTS`; if still ambiguous,
+  list them and ask which to use.
+
+Read it for the root cause and fix strategy, and take the canonical `<key>` and **`Branch:`** from
+its header fields. (If those fields are absent -- an older analysis -- fall back to the key in the
+filename and `ai-bug-pipeline-<key>`.) Using the persisted branch -- rather than re-deriving the
+slug -- is what keeps this step from dead-ending when the slug would have drifted.
+
+Find the draft PR opened by `/opsmill-dev-test-driving-bugs` on that branch:
+
+```bash
+gh pr list --head "<branch>" --json number,title,body,headRefName --jq '.[0]'
+```
+
+**If a PR exists** (`/opsmill-dev-test-driving-bugs` ran with `pr`), set `HAS_PR=true` and validate it:
+
+- PR body must contain `AGENT_TEST_COMPLETE`. If not, inform the developer:
+  "No `AGENT_TEST_COMPLETE` marker found. Run `/opsmill-dev-test-driving-bugs` first." and **STOP**.
+- PR body must NOT contain `AGENT_FIX_COMPLETE`. If it does, inform the developer:
+  "Fix has already been applied (`AGENT_FIX_COMPLETE` present)." and **STOP**.
+
+**Bind `<branch>` once, here:** set `<branch>` to the PR's `headRefName`. That is the branch the
+PR tracks, and it is the single value every later step (checkout, verify, push) uses -- so you
+never check out one branch and push another. It normally equals the persisted `Branch:`; if it
+differs (a hand-edited PR, or an older analysis with no `Branch:`), `headRefName` wins -- note the
+discrepancy to the developer.
+
+```bash
+git fetch origin
+git checkout "<branch>"   # <branch> is now the PR's headRefName
+```
+
+**If no PR exists**, `/opsmill-dev-test-driving-bugs` was run without `pr` (fully local). Don't dead-end -- check
+whether the branch itself exists:
+
+```bash
+git rev-parse --verify "<branch>" 2>/dev/null || git rev-parse --verify "origin/<branch>" 2>/dev/null
+```
+
+- **Branch exists:** set `HAS_PR=false`, check it out (`git checkout "<branch>"`), and read its
+  diff against the default branch to find the test commit. Proceed -- there is no marker to
+  validate in local mode.
+- **Branch does not exist either:** only now is the test genuinely missing. Inform the developer
+  "Run `/opsmill-dev-test-driving-bugs <issue>` first." and **STOP**.
+
+## Implement the fix
+
+Follow steps 1--9.
+
+### Step 1: Read fix strategy
+
+Read the analyst's fix strategy. This is your **starting point**: follow the recommended
+approach, scope, and "Do NOT" guardrails. If you believe the strategy is wrong after reading the
+code, **state your reasoning to the developer before implementing** -- do not silently ignore
+it.
+
+### Step 2: Read failing test
+
+Read the failing test in the PR diff. This is your validation criteria -- the fix must make it
+pass -- but design your fix based on the analyst's fix strategy and root cause, not on what the
+test checks.
+
+### Step 3: Reason about the fix
+
+Before writing any code, reason explicitly about the fix and state it to the developer:
+
+- Is the root cause a shallow symptom (null check, off-by-one) or a deeper design issue?
+- If shallow: a targeted fix is appropriate.
+- If deeper: a proper fix may require refactoring the affected component. Do it -- do NOT paper
+  over a design flaw with a guard clause.
+
+### Step 4: Implement the fix
+
+- Fix the actual root cause, not just the symptom.
+- Do NOT change the test the test-writer wrote.
+- Do NOT refactor code unrelated to the root cause.
+- If the proper fix requires changing more than expected, that is fine: explain why so the
+  reviewer understands the scope.
+- Stage files **by name** (`git add path/to/file`) -- never `git add .` or `git add -A`.
+- Commit the fix with an explicit commit message.
+
+### Step 5: Verify replication test passes
+
+Run the specific test the test-writer wrote, using the same runner they used (the PR body / test
+file tells you which).
+
+- If the test still FAILS, revisit your fix. Do NOT proceed until it passes.
+- Before continuing, verify `git diff` shows **no changes to the test file(s)** from the
+  test-writer's PR. If you accidentally modified a test file, revert those changes.
+
+> **Gate (T2-verify · P1):** paste the actual test-run output proving PASS. Do not write "the
+> test passes" without it. See `../quality-gates/gates/primitives/evidence-before-done.md`.
+
+### Step 6: Pre-CI checks
+
+Run the project's pre-CI checks before pushing. **Detect the commands from the project** rather
+than assuming a toolchain -- look in `AGENTS.md`, a `Makefile`/`invoke`/`tasks` file,
+`pyproject.toml`, or `package.json` scripts. Apply them in this order, fixing and committing
+issues as separate commits (do NOT amend previous commits):
+
+1. **Auto-format** (e.g. `uv run invoke format`, `ruff format`, `npx biome check --write .`,
+   `prettier --write`). If formatting changed source files, re-run the later phases.
+2. **Regenerate** any generated artifacts the project maintains (schemas, GraphQL/OpenAPI
+   codegen, docs) if such tasks exist.
+3. **Lint** (e.g. `ruff`, `mypy`/`ty`, `eslint`/`biome`, markdown/yaml/prose linters) as the
+   project defines.
+4. **Unit tests** for the affected area (e.g. `uv run invoke backend.test-unit`,
+   `npm run test`). Run the broader suite the project expects for a change of this size.
+
+Stage any files changed by generation by name -- never `git add .` / `git add -A`.
+
+**Changelog:** if the project has a changelog mechanism, add an entry for this fix:
+
+- towncrier (a `[tool.towncrier]` config or a `changelog.d`/`newsfragments` dir): create a
+  fragment named after the issue, e.g.
+  `uv run towncrier create -c "<user-facing description>" <issue_number>.fixed.md`. When there is
+  no issue number (free-text bug), towncrier has no number to anchor on -- use its issue-less
+  form with a `+` prefix, e.g. `+<key>.fixed.md` (in the free-text case `<key>` is the slug, with
+  no issue prefix).
+- a `dev/guidelines/changelog.md` describing another process: follow it.
+- otherwise a top-level `CHANGELOG.md`: add a line under the appropriate section.
+
+Write changelog text from the user's perspective, past tense, one sentence, no jargon. Commit
+the generated/edited file. If the project has no changelog mechanism, skip this and note it.
+
+> **Gate (T2-verify · P1):** paste the output of each pre-CI command (format, regenerate, lint,
+> unit). A claim of "clean" without output fails the gate.
+
+### Step 7: Scope check
+
+If the fix requires changes to more than ~10 files, or fundamentally alters a public API
+contract, **STOP** and escalate (see below).
+
+### Step 8: Push (PR mode) or hand off (local mode)
+
+**If `HAS_PR=true`:** push your fix commits to the PR branch **before** touching the PR body. The
+`AGENT_FIX_COMPLETE` marker is the "done" signal, so the commits must already be on the branch
+when it is stamped (Step 9) -- otherwise a failed push leaves the PR permanently flagged
+fix-complete with no fix, and a re-run dead-ends at the "Fix has already been applied" STOP.
+
+```bash
+git push -u origin "<branch>"
+```
+
+`<branch>` is the value bound during setup (the PR's `headRefName`) -- the same branch you checked
+out, so the push always lands on the branch the PR tracks.
+
+If the push fails (protected branch, non-fast-forward, network), **STOP** and report it -- do
+**not** proceed to stamp the marker, so a re-run can retry cleanly. Otherwise continue to Step 9.
+
+**If `HAS_PR=false` (local mode):** do NOT push. Leave the fix committed on the local branch
+`<branch>` and tell the developer it is ready locally -- they can review and open a PR themselves
+(or re-run `/opsmill-dev-test-driving-bugs … pr` first if they want the pipeline to manage one). You are done -- skip
+Step 9.
+
+### Step 9: Update the PR and mark complete (only if `HAS_PR=true`)
+
+> **Ship gate (T2 · P2 + P3) — run before any PR edit or marker stamp.**
+> Run the ship gate per `../quality-gates/gates/primitives/independent-judge.md` (judge → on-FAIL
+> STOP → R2 degrade → write receipt on PASS, all defined there). R1 criteria: the
+> `.bug-analysis-<key>.md` file verbatim (the root cause + fix strategy — NOT your summary).
+> Artifact: `git diff <default-branch>...HEAD`. Forbidden evasions: the test-gate and fix-gate
+> evasions from `../quality-gates/gates/primitives/anti-gaming.md`.
+
+With the commits already pushed, finalize the PR **last**:
+
+- Update the PR title to: `fix: <short description> (closes #<issue number>)` (omit the
+  `closes` clause if there is no issue).
+- Update the PR body: if `.github/pull_request_template.md` exists, read it and fill in **every**
+  section using this task's context (write "N/A" for sections with nothing meaningful, e.g.
+  Screenshots -- do not skip or invent). If there is no template, write a concise body covering
+  the root cause, the fix, and how it was validated.
+- Ensure the hidden marker `<!-- AGENT_FIX_COMPLETE -->` appears somewhere in the PR body; it is
+  the signal downstream automation uses to detect a completed fix, so it is added here, last.
+- Use `gh pr edit` to apply the title and body.
+- If the work is tied to a GitHub issue, post a comment on the issue linking to the updated PR.
+
+## Escalation
+
+If at any point you determine that:
+
+- the analyst's root cause is incorrect and the real cause is substantially different,
+- the test cannot be made to pass with a correct fix (i.e. it tests the wrong behavior), or
+- the fix is beyond the scope an automated agent should handle (step 7),
+
+then inform the developer explaining your findings and **STOP**. Do **not** stamp
+`AGENT_FIX_COMPLETE` (Step 9): an unstamped PR -- even if fix commits were already pushed in
+Step 8 -- correctly signals the fix is incomplete, and the developer can take it from there.
+
+## Quality gates
+
+Gates for this skill follow `../quality-gates/gates/gate-model.md`. `fixing-bugs` is **Tier 2** — it
+ships a fix and stamps a completion marker.
+
+| Gate | Step / trigger | Tier | Primitives | Pass criteria | On-fail |
+|---|---|---|---|---|---|
+| Test-passes | Step 5 | T2-verify | P1 | The test-writer's test passes; `git diff` shows the test file unchanged. Paste the test run. | STOP; revisit fix |
+| Pre-CI | Step 6 | T2-verify | P1 | Format/lint/unit all clean. Paste each command's output. | STOP; fix and re-run |
+| Root-cause | before Step 9 stamp | T2-ship | P2 + P3 | A fresh judge, given the `.bug-analysis-<key>.md` verbatim (R1) and `git diff <base>...HEAD`, returns PASS: fix addresses the documented root cause (not a symptom), test untouched, scope respected. | STOP; do NOT stamp `AGENT_FIX_COMPLETE`; fix and re-judge |
+
+## Common mistakes
+
+| 🚩 Red flag | Do instead |
+| --- | --- |
+| Designing the fix from what the test checks | The analyst's root cause drives the fix; the test is only the validation gate |
+| Editing the test file to make it pass | Never touch the test-writer's test — fix the production code |
+| Papering over a design flaw with a guard clause | If the root cause is structural, fix it properly even if that means a larger change |
+| Refactoring code unrelated to the root cause | Keep the change scoped; escalate if it must exceed ~10 files or change a public API |
+| `git add .` / `git add -A` | Stage changed files by name |
+| Stamping `AGENT_FIX_COMPLETE` before the push lands | In PR mode, push in Step 8 before stamping; the marker is the "done" signal, written last in Step 9 |

--- a/.agents/skills/opsmill-dev-test-driving-bugs/SKILL.md
+++ b/.agents/skills/opsmill-dev-test-driving-bugs/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: opsmill-dev-test-driving-bugs
+description: >-
+  Writes a single failing test that reproduces a bug after its root-cause analysis is complete,
+  before any fix is written. TRIGGER when: a bug has a completed root-cause analysis and you need
+  the failing reproduction test, writing a test that proves a bug exists, the second step of the
+  bug-fixing pipeline. DO NOT TRIGGER when: still triaging or diagnosing the bug → opsmill-dev-analyzing-bugs;
+  implementing the fix once the test exists → opsmill-dev-fixing-bugs; general feature test-first work →
+  superpowers test-driven-development.
+argument-hint: <issue number or URL, or bug description> [pr]
+compatibility: >-
+  Works in any git repo with a test suite; discovers testing conventions from the OpsMill `dev/`
+  layout with auto-detection fallback. The draft-PR step needs `gh` and a GitHub remote.
+metadata:
+  pipeline: bug-fixing (2 of 3 — analyze → test-drive → fix)
+  version: 0.1.0
+  author: OpsMill
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Bug test-writer
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Your role
+
+You are a senior QA engineer writing a targeted failing test that reproduces a confirmed bug.
+`/opsmill-dev-analyzing-bugs` has already identified the root cause. Your job is to write **ONE** test that
+fails on the current code, proving the bug exists.
+
+## Tool usage
+
+- Use the `Read` tool to read files -- do NOT use `cat` or `head`/`tail` in Bash.
+- Use the `Glob` tool to find files -- do NOT use `find` or `ls -R` in Bash.
+- Use the `Grep` tool to search file contents -- do NOT use `grep` or `rg` in Bash.
+- Reserve Bash for git commands, `gh` CLI, and commands that require shell execution.
+- *Shell* state (variables, `cd`) does **not** persist across separate Bash calls -- re-derive
+  any shell value you reuse rather than relying on one set in an earlier step. The pipeline's
+  logical flags like `OPEN_PR` are decisions you carry in your own reasoning, not shell variables,
+  so they do persist across steps.
+
+## Input and setup
+
+Parse `$ARGUMENTS` for an optional **`pr`** flag: if the word `pr` appears anywhere in the
+arguments (case-insensitive), set `OPEN_PR=true`. Otherwise `OPEN_PR=false`. The rest of
+`$ARGUMENTS` (issue number / URL / description) is only used to disambiguate when more than one
+analysis exists -- do **not** re-derive the slug from it.
+
+Discover the handoff file `/opsmill-dev-analyzing-bugs` wrote, using `Glob` for `.bug-analysis-*.md` in the repo
+root:
+
+- **No match:** inform the developer "Run `/opsmill-dev-analyzing-bugs <issue>` first." and **STOP**.
+- **Exactly one match:** use it.
+- **Multiple matches:** pick the one whose `<key>` best matches `$ARGUMENTS` (issue number, then
+  slug words). If still ambiguous, list them and ask the developer which to use.
+
+Read the full analysis. Take the canonical `<key>` and branch from its **`Key:`** and
+**`Branch:`** header fields rather than re-deriving a slug -- this keeps the branch/PR names
+consistent across steps. (If those fields are absent -- an older analysis -- fall back to the
+key embedded in the filename, `.bug-analysis-<key>.md`, and `ai-bug-pipeline-<key>`.)
+
+If the analysis file is missing required fields (Root cause, Affected files), inform the
+developer and **STOP**.
+
+## Write the test
+
+Follow steps 0--9 below. **Step 10 (draft PR) runs only when `OPEN_PR=true`.** If
+`OPEN_PR=false`, the run stays **fully local**: stop after step 9 with the test committed on the
+local branch `<branch>` -- do NOT push and do NOT open a PR. Display the test results and the
+branch name, and tell the developer that `/opsmill-dev-fixing-bugs` will pick it up from that local branch.
+
+### Step 0: Create working branch
+
+Detect the default branch and create a working branch from it:
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+# Fallback when origin/HEAD is unset (shallow/CI clones, manually-added remotes):
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
+[ "$DEFAULT_BRANCH" = "(unknown)" ] && DEFAULT_BRANCH=""   # git prints "(unknown)" when remote HEAD is indeterminate
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+git fetch origin "$DEFAULT_BRANCH" || { echo "Cannot fetch origin/$DEFAULT_BRANCH -- set the default branch manually and retry."; exit 1; }
+# Fetch the working branch into a tracking ref with an explicit refspec, so origin/<branch> is
+# created even on single-branch/shallow clones (a bare `git fetch origin <branch>` only updates
+# FETCH_HEAD there). Silently a no-op when the branch doesn't exist on the remote yet.
+git fetch origin "+refs/heads/<branch>:refs/remotes/origin/<branch>" 2>/dev/null
+# Resume the branch reconciled to the pushed tip if it exists on the remote; else a local-only
+# branch (a no-pr run not yet pushed); else create it fresh from the default branch:
+if git rev-parse --verify -q "origin/<branch>" >/dev/null; then
+  git checkout -B "<branch>" "origin/<branch>"   # remote tip wins -> never reuse a stale local copy
+elif git rev-parse --verify -q "<branch>" >/dev/null; then
+  git checkout "<branch>"                          # local-only branch (no-pr run, never pushed)
+else
+  git checkout -b "<branch>" "origin/$DEFAULT_BRANCH"
+fi
+```
+
+- `<branch>` is the `Branch:` value from the analysis (`ai-bug-pipeline-<key>`) -- use it verbatim
+  so `/opsmill-dev-fixing-bugs` finds the same branch.
+- Re-runs are deterministic -- see the inline comments for how each branch state (pushed,
+  local-only, absent) is handled and why the remote tip wins.
+- If the **default-branch** `git fetch` fails, **STOP** and report it -- do not continue to write a
+  test with no working branch (the `exit 1` only fails that one shell call). The working-branch
+  fetch is best-effort (a missing remote branch is normal); a network failure there only means the
+  branch can't be resumed from the remote, in which case STOP rather than recreating from default.
+
+### Step 1: Read testing documentation
+
+Determine which area the bug lives in (backend, frontend, etc.) and read the project's testing
+conventions. Anchor on the `dev/` layout, falling back to detection:
+
+- Read root `AGENTS.md` and `dev/documentation-architecture.md` (if present) to map the bug to a
+  code package.
+- Backend testing docs, if present: `dev/knowledge/**/testing.md` and `dev/guidelines/**/testing.md`.
+- Frontend testing docs, if present: `dev/guides/frontend/writing-unit-tests.md`,
+  `writing-component-tests.md`, `writing-e2e-tests.md`.
+- **Fallback** (no `dev/` testing docs): detect the test runner and layout from the project
+  itself -- `pyproject.toml` / `tox.ini` / `pytest.ini` (pytest), `package.json` scripts
+  (vitest / jest / playwright), or a `Makefile` / `AGENTS.md` documenting the test command.
+
+### Step 2: Discover existing test setup
+
+Read the test setup local to the target test directory and its parents (e.g. `conftest.py`
+files up the tree for pytest, shared setup/`setup.ts` for JS suites). Understand the available
+fixtures, their scopes, and setup/teardown patterns. Do NOT reinvent setup logic that already
+exists.
+
+### Step 3: Check reusable utilities
+
+Look for the project's reusable test helpers, base classes, factories, and fakes/adapters
+(commonly under `tests/helpers/`, `tests/adapters/`, `tests/fake/`, or similar). Use these
+instead of writing your own test infrastructure.
+
+### Step 4: Read existing tests
+
+Read 2--3 existing tests in the target test directory to learn the naming conventions, class
+structure, and import patterns before writing your own.
+
+### Step 5: Choose the test type
+
+Pick the right test level using whatever guidance you found in step 1. Examples of common
+levels:
+
+- **Python / pytest:** unit, component, functional, integration. Reuse existing schema fixtures
+  and helpers when available.
+- **Frontend:** unit/component (e.g. Vitest, colocated `.test.ts`), E2E (e.g. Playwright). Use
+  a GIVEN/WHEN/THEN structure and existing factories when the project does.
+
+### Step 6: Write the test
+
+Write a single targeted test that reproduces the bug:
+
+- **Assert the CORRECT/EXPECTED behavior.** The test fails because the bug prevents the expected
+  behavior. Do NOT assert that the buggy behavior succeeds. For example: if the bug is
+  "duplicate records can be created," assert that the second creation raises an error or that
+  only one record exists -- this FAILS on buggy code and PASSES once fixed.
+- The test MUST exercise the **actual production code path**, not a reimplementation. Call the
+  real functions/classes from the source. Do NOT copy production logic into the test.
+- Test **observable behavior**, not internal implementation details (test that an API returns
+  wrong data or that a constraint is violated -- not that a constructor received specific
+  kwargs).
+- **Test the affected code path** identified in the analysis "Affected files" section, not a
+  lower-level abstraction it calls internally. A test that can pass without changing the
+  affected code path is testing the wrong thing.
+- Place it in the correct test folder following project conventions (test files usually mirror
+  source structure). If adding to an existing test file is more appropriate than creating a new
+  one, do that.
+
+### Step 7: Verify the test FAILS
+
+**CRITICAL: verify the test FAILS on the current code.** Run just this test using the project's
+detected runner (e.g. `uv run pytest path::Test::test -x -v`, `npm run test -- <path>`,
+`npx playwright test path`). Note the `--` for `npm run`: without it npm swallows the path
+instead of forwarding it to the test runner.
+
+- If a test run takes more than ~5 minutes, kill it and investigate why.
+- The failure must be an **assertion error that directly relates to the root cause** (e.g.
+  `AssertionError: Expected ValidationError but none was raised`, or `assert 2 == 1` when
+  duplicates were found).
+- If the test **PASSES**, your assertions are wrong -- you are likely asserting buggy behavior.
+  Flip them to assert what SHOULD happen.
+- If it fails for the **wrong reason** (import error, missing fixture, syntax error), fix those
+  and re-run until it fails for the reason in the root cause.
+
+> **Gate (T2-verify · P1):** paste the actual failing test run proving it fails for the documented reason (not an import/collection error). See `../quality-gates/gates/primitives/evidence-before-done.md`.
+
+### Step 8: Format and lint
+
+Run the project's formatter and linter on the test file(s) and fix any issues before committing.
+Use whatever the project defines (e.g. `uv run invoke format` / `uv run invoke lint`,
+`npx biome check --write .`, `ruff format`, `prettier`/`eslint`). Detect these from
+`AGENTS.md` / `Makefile` / `pyproject.toml` / `package.json`.
+
+### Step 9: Commit test files
+
+Commit ONLY the test file(s). Do NOT touch production code. Stage files **by name**
+(`git add path/to/test_file`) -- never `git add .` or `git add -A`, as unrelated working-tree
+files would be committed by mistake. Commit message: `test: add failing test for <key>`.
+
+### Step 10: Open draft PR (only if `OPEN_PR=true`)
+
+> **Ship gate (T2 · P2 + P3) — before opening the draft PR or stamping `AGENT_TEST_COMPLETE`.** Run the ship gate per `../quality-gates/gates/primitives/independent-judge.md` (judge → on-FAIL STOP → R2 degrade → write receipt on PASS, all defined there). R1 criteria: the `.bug-analysis-<key>.md` verbatim (the root cause the test must prove — NOT your summary). Artifact: the test diff. Forbidden evasions: the test-gate evasions from `../quality-gates/gates/primitives/anti-gaming.md`. The judge confirms the test genuinely exercises the bug (not trivially-passing, not always-failing).
+
+Push the branch and open a **draft** Pull Request against the repo's default branch:
+
+```bash
+git push -u origin "<branch>" || { echo "Push rejected (non-fast-forward / protected / network). STOP and resolve before retrying -- do not open or edit a PR."; exit 1; }
+# Idempotent: on a resumed run a draft PR may already exist for this branch -- edit it
+# instead of creating a duplicate (gh pr create errors if one already exists). Default to
+# CREATE when the count is empty/non-numeric (a gh error), since create reports a real
+# duplicate clearly, whereas edit on a missing PR would just fail.
+PR_COUNT=$(gh pr list --head "<branch>" --state open --json number --jq 'length' 2>/dev/null)
+if [ "${PR_COUNT:-0}" -gt 0 ] 2>/dev/null; then
+  gh pr edit "<branch>" --title "<title>" --body-file <tmp-body-file>
+else
+  # No --base: gh pr create defaults the base to the repo's default branch, so the
+  # default-branch detection from Step 0 (which doesn't persist across Bash calls) isn't needed here.
+  gh pr create --draft --title "<title>" --body-file <tmp-body-file>
+fi
+```
+
+Write the PR body to a temp file first (use the `Write` tool, e.g. under the system temp dir),
+then pass it via `--body-file`.
+
+- Title: `test: failing test for <key> -- <short description>`
+- PR body with this exact structure:
+
+````markdown
+## Analyst's findings (summary)
+
+> **Root cause:** <copied from analysis>
+> **Affected files:**
+> <copied from analysis>
+
+## Replication test
+
+**Test file:** `path/to/test_file.ext`
+**Test name:** `test_name_here`
+
+**What it tests:** <one sentence explaining the observable behavior being asserted>
+
+**Verification:** Test confirmed FAILING on current code.
+**Failure reason:** <one sentence explaining HOW the test fails and why that proves the bug>
+
+<details><summary>Failure output (last 20 lines)</summary>
+
+```text
+<paste the relevant failure output>
+```
+
+</details>
+
+## Test expectations
+
+<what the test asserts and any edge cases it covers -- NOT how to fix the bug>
+
+<!-- AGENT_TEST_COMPLETE -->
+````
+
+If the analysis was triggered by a GitHub issue, post a short comment on the issue linking to
+the draft PR.
+
+## Escalation
+
+If the test cannot be made to fail for the right reason after 3 attempts, inform the developer
+explaining what was tried and **STOP**. Do NOT open a PR or include the `AGENT_TEST_COMPLETE`
+marker.
+
+## Quality gates
+
+Gates for this skill follow `../quality-gates/gates/gate-model.md`. `test-driving-bugs` is **Tier 2 — it writes a failing reproduction test and stamps `AGENT_TEST_COMPLETE` unconditionally** (in PR mode it also opens a draft PR; both paths require the full ship gate).
+
+| Gate | Step / trigger | Tier | Primitives | Pass criteria | On-fail |
+|---|---|---|---|---|---|
+| Test-fails-right | after writing the test | T2-verify | P1 | The new test FAILS for the documented reason. Paste the failing run. | STOP; fix the test |
+| Test-catches-bug | before opening the draft PR / stamping `AGENT_TEST_COMPLETE` | T2-ship | P2 + P3 | A fresh judge, given the `.bug-analysis-<key>.md` verbatim and the test diff, confirms the test actually exercises the bug (not trivially-passing, not always-failing). | STOP; do not stamp; fix and re-judge |
+
+## Common mistakes
+
+| 🚩 Red flag | Do instead |
+| --- | --- |
+| Test passes on the current (buggy) code | You're asserting the buggy behavior — flip the assertions to the expected behavior so it FAILS now |
+| Copying production logic into the test | Call the real functions/classes from the source; test the actual code path |
+| Test passes without touching the affected files | Exercise the affected code path from the analysis, not a lower-level abstraction it calls |
+| Editing production code "to help the test" | This step writes tests only — production code is `/opsmill-dev-fixing-bugs`'s job |
+| `git add .` / `git add -A` | Stage the test file(s) by name |
+| Opening the PR / writing `AGENT_TEST_COMPLETE` after a failed attempt | The marker is the "test ready" signal — only emit it once the test fails for the right reason |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -31,6 +31,24 @@
       "skillPath": "opsmill-dev/skills/monitoring-pull-requests/SKILL.md",
       "computedHash": "b52cf3902ca8a290aa3167ff5e6b0a54068a45187357e342e5967f18fb00d854"
     },
+    "opsmill-dev-analyzing-bugs": {
+      "source": "opsmill/opsmill-skills",
+      "sourceType": "github",
+      "skillPath": "opsmill-dev/skills/analyzing-bugs/SKILL.md",
+      "computedHash": "b1280c4b1eeae4dfd6c1b47078ba44586b23842ec27551a64e40217003fd66b2"
+    },
+    "opsmill-dev-fixing-bugs": {
+      "source": "opsmill/opsmill-skills",
+      "sourceType": "github",
+      "skillPath": "opsmill-dev/skills/fixing-bugs/SKILL.md",
+      "computedHash": "9b08acdd7fccf8a279a837fd4a6e74bca93802970c7a4d06cfe7fea87ac5b11f"
+    },
+    "opsmill-dev-test-driving-bugs": {
+      "source": "opsmill/opsmill-skills",
+      "sourceType": "github",
+      "skillPath": "opsmill-dev/skills/test-driving-bugs/SKILL.md",
+      "computedHash": "1a9514502876e98d188f00b7aef80efb8621d06813c3485968755a14969284fa"
+    },
     "pr": {
       "source": "opsmill/opsmill-skills",
       "sourceType": "github",


### PR DESCRIPTION
# Why

The opsmill-dev bug-workflow skills weren't vendored into this repo, so the
guided bug triage → reproduce → fix flow wasn't available to agents here.

## What changed

- Adds three `opsmill-dev` skills under `.agents/skills/`:
  - `analyzing-bugs` — root-cause analysis before any code is touched
  - `test-driving-bugs` — writes the failing reproduction test
  - `fixing-bugs` — implements the fix against that failing test
- Pins all three in `skills-lock.json` (source, path, content hash).

No code, schema, or user-facing behaviour changes — agent tooling only.

## How to test

No changelog fragment needed (agent tooling only — `ci/skip-changelog`).
CI validates the skill lockfile is consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendored `opsmill-dev` bug workflow skills into `.agents/skills` and pinned them in `skills-lock.json` to enable the analyze → test-drive → fix pipeline for agents (`analyzing-bugs`, `test-driving-bugs`, `fixing-bugs`). No code or user-facing changes; CI validates the lockfile.

<sup>Written for commit 84510dc3e32a0d13b5452ab97deee543a22221b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

