### PR TITLE
fix: recompute relationship on_delete when kind changes away from Component

### DIFF
--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from infrahub import config
-from infrahub.core.constants import RelationshipDirection, RelationshipKind
+from infrahub.core.constants import RelationshipDeleteBehavior, RelationshipDirection, RelationshipKind
 from infrahub.core.query import QueryNode, QueryRel, QueryRelDirection
 from infrahub.core.relationship import Relationship
 from infrahub.exceptions import InitializationError
@@ -14,7 +14,10 @@ from infrahub.exceptions import InitializationError
 from .generated.relationship_schema import GeneratedRelationshipSchema
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from infrahub.core.branch import Branch
+    from infrahub.core.models import HashableModel
     from infrahub.core.query import QueryElement
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.database import InfrahubDatabase
@@ -23,6 +26,28 @@ if TYPE_CHECKING:
 class RelationshipSchema(GeneratedRelationshipSchema):
     _exclude_from_hash: list[str] = ["filters"]
     _sort_by: list[str] = ["name"]
+
+    @staticmethod
+    def default_on_delete_for_kind(kind: RelationshipKind) -> RelationshipDeleteBehavior:
+        """The on_delete behavior implied by a relationship kind when none is set explicitly."""
+        if kind == RelationshipKind.COMPONENT:
+            return RelationshipDeleteBehavior.CASCADE
+        return RelationshipDeleteBehavior.NO_ACTION
+
+    def update(self, other: HashableModel) -> Self:
+        # When the kind changes and the incoming schema does not set on_delete explicitly,
+        # drop an on_delete that merely matches the old kind's default so it is re-derived
+        # from the new kind. Otherwise a CASCADE derived from a former Component kind would
+        # survive a change to a non-cascading kind and keep cascading deletes. An on_delete
+        # that diverges from the old kind's default is a deliberate override and is kept.
+        if (
+            isinstance(other, RelationshipSchema)
+            and other.on_delete is None
+            and other.kind != self.kind
+            and self.on_delete == self.default_on_delete_for_kind(self.kind)
+        ):
+            self.on_delete = None
+        return super().update(other)
 
     @property
     def is_attribute(self) -> bool:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1668,10 +1668,7 @@ class SchemaBranch:
                     schema_to_update = node.duplicate()
 
                 relationship_to_update = schema_to_update.get_relationship(name=relationship.name)
-                if relationship.kind == RelationshipKind.COMPONENT:
-                    relationship_to_update.on_delete = RelationshipDeleteBehavior.CASCADE
-                else:
-                    relationship_to_update.on_delete = RelationshipDeleteBehavior.NO_ACTION
+                relationship_to_update.on_delete = RelationshipSchema.default_on_delete_for_kind(relationship.kind)
 
             if schema_to_update:
                 self.set(name=schema_to_update.kind, schema=schema_to_update)

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -132,6 +132,68 @@ def test_changing_relationship_kind_from_component_recomputes_on_delete() -> Non
     assert updated_rel.on_delete == RelationshipDeleteBehavior.NO_ACTION
 
 
+def test_changing_relationship_kind_preserves_explicit_on_delete_override() -> None:
+    """An on_delete that diverges from the kind default is an explicit override and must survive a kind change."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Gadget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                ),
+                NodeSchema(
+                    name="Widget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="gadgets",
+                            peer="TestingGadget",
+                            kind=RelationshipKind.GENERIC,
+                            cardinality=RelationshipCardinality.MANY,
+                            optional=True,
+                            on_delete=RelationshipDeleteBehavior.CASCADE,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    schema.process()
+
+    widget = schema.get(name="TestingWidget", duplicate=False)
+    assert widget.get_relationship(name="gadgets").on_delete == RelationshipDeleteBehavior.CASCADE
+
+    # Change the kind but do not restate on_delete. Because CASCADE diverges from the Generic
+    # default (NO_ACTION), it is a deliberate override and must be kept.
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="gadgets",
+                            peer="TestingGadget",
+                            kind=RelationshipKind.ATTRIBUTE,
+                            cardinality=RelationshipCardinality.MANY,
+                            optional=True,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    schema.process()
+
+    widget = schema.get(name="TestingWidget", duplicate=False)
+    assert widget.get_relationship(name="gadgets").on_delete == RelationshipDeleteBehavior.CASCADE
+
+
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:
     """Proves that schema processing produces the peer/hierarchical values in an expected manner."""
 

--- a/backend/tests/unit/core/schema/test_schema_branch.py
+++ b/backend/tests/unit/core/schema/test_schema_branch.py
@@ -1,5 +1,6 @@
 import pytest
 
+from infrahub.core.constants import RelationshipCardinality, RelationshipDeleteBehavior, RelationshipKind
 from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 
@@ -66,6 +67,69 @@ def test_validate_names_rejects_double_underscore_in_relationship_name() -> None
         match=r"TestingUnderscore: 'peer__link' cannot be used as a relationship name",
     ):
         schema.validate_names()
+
+
+def test_changing_relationship_kind_from_component_recomputes_on_delete() -> None:
+    """Changing a relationship's kind away from Component must recompute on_delete to NO_ACTION."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Gadget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                ),
+                NodeSchema(
+                    name="Widget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="gadgets",
+                            peer="TestingGadget",
+                            kind=RelationshipKind.COMPONENT,
+                            cardinality=RelationshipCardinality.MANY,
+                            optional=True,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    schema.process()
+
+    widget = schema.get(name="TestingWidget", duplicate=False)
+    assert widget.get_relationship(name="gadgets").on_delete == RelationshipDeleteBehavior.CASCADE
+
+    # Change the relationship kind from Component to Attribute, mirroring an in-place schema
+    # update. on_delete is intentionally left unset — it is a derived field users do not set.
+    schema.load_schema(
+        schema=SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Widget",
+                    namespace="Testing",
+                    attributes=[AttributeSchema(name="name", kind="Text")],
+                    relationships=[
+                        RelationshipSchema(
+                            name="gadgets",
+                            peer="TestingGadget",
+                            kind=RelationshipKind.ATTRIBUTE,
+                            cardinality=RelationshipCardinality.MANY,
+                            optional=True,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    schema.process()
+
+    widget = schema.get(name="TestingWidget", duplicate=False)
+    updated_rel = widget.get_relationship(name="gadgets")
+    assert updated_rel.kind == RelationshipKind.ATTRIBUTE
+    assert updated_rel.on_delete == RelationshipDeleteBehavior.NO_ACTION
 
 
 class TestHierarchySchemaProcessingSetsCorrectPeerAndHierarchical:

--- a/changelog/+relationship-on-delete-kind-change.fixed.md
+++ b/changelog/+relationship-on-delete-kind-change.fixed.md
@@ -1,0 +1,1 @@
+Fixed relationships continuing to cascade deletes to their related nodes after their kind was changed away from "Component".


### PR DESCRIPTION
# Why

A relationship's cascade-on-delete behavior is derived from its `kind` (a `Component` relationship implies `on_delete=CASCADE`). Once that value was derived and persisted, it was never recomputed when the kind later changed. So a relationship switched from `Component` to `Attribute` kept cascading deletes to its related nodes as if it were still a Component — observed at a customer.

Goal: changing a relationship's kind away from `Component` stops the cascade, while still honoring an explicit `on_delete` the user set on purpose.

Non-goal: this does not retroactively repair schemas that are already in the stale state (see Impact & rollout).

## What changed

Behavioral changes:
- Changing a relationship's `kind` away from `Component` — without restating `on_delete` — now recomputes the delete behavior from the new kind, so deletes stop cascading.
- An explicit `on_delete` that diverges from the kind's default (e.g. a `Generic` relationship deliberately set to cascade, as the built-in `artifacts` relationship does) is preserved across a kind change.

Implementation notes:
- `on_delete` is reconciled at schema-merge time in `RelationshipSchema.update`, the only layer that sees both the old kind/value and the incoming kind. A stored value that matches the *old* kind's default is treated as auto-derived and cleared so it re-derives from the new kind; a divergent value is kept as a deliberate override.
- Derivation is centralized in `RelationshipSchema.default_on_delete_for_kind` and reused by `SchemaBranch.process_relationships` (single source of truth).

What stayed the same: no database-schema or GraphQL-contract changes; cascade deletes still key off `on_delete`.

## How to review

- `backend/infrahub/core/schema/relationship_schema.py` — the `update` override and the derivation helper; this is the core of the fix and the part worth extra scrutiny (the "auto-derived vs. explicit override" heuristic).
- `backend/infrahub/core/schema/schema_branch.py` — `process_relationships` now calls the shared helper.
- `backend/tests/unit/core/schema/test_schema_branch.py` — the reproduction test plus a guard that an explicit override survives a kind change.

## How to test

```bash
uv run pytest backend/tests/unit/core/schema/test_schema_branch.py -v
uv run pytest backend/tests/component/core/schema_manager/test_manager_schema.py -k on_delete -v
```

Regression suites run locally and green: schema unit (60) + migrations (7), `schema_manager` component (200), node delete/cascade component (17).

## Impact & rollout

- **Backward compatibility:** fixes the bug going forward. Schemas *already* corrupted (kind already switched away from `Component` while the stale `CASCADE` is persisted) are **not** auto-healed — the stale value is now indistinguishable from an intentional override. Remediation is to set `on_delete: no-action` explicitly on the affected relationship, or a follow-up data migration.
- **Performance:** no impact.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added
- [ ] External docs updated (N/A — no user-facing doc change)
- [ ] Internal .md docs updated (N/A)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale cascade deletes when a relationship’s kind changes away from Component. We now recompute on_delete from the new kind unless an explicit override exists.

- **Bug Fixes**
  - Recompute on_delete on kind change to stop unwanted cascades.
  - Keep explicit on_delete overrides intact.
  - Centralize default derivation in RelationshipSchema.default_on_delete_for_kind and use it in SchemaBranch.
  - Add unit tests for both cases.

- **Migration**
  - Existing schemas already persisting CASCADE won’t auto-heal. Set on_delete: no-action on affected relationships or run a data migration.

<sup>Written for commit a87bef53851c3d095c734e1992999b1a4817faa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

