### PR TITLE
chore(sdk): bump python_sdk to latest infrahub-develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,28 @@ cd frontend/app && pnpm build         # Build frontend
 cd docs && npm run build              # Build documentation
 ```
 
+## Submodules
+
+- `python_sdk/` → [opsmill/infrahub-sdk-python](https://github.com/opsmill/infrahub-sdk-python)
+- `frontend/packages/schema-visualizer/` → [opsmill/infrahub-schema-visualizer](https://github.com/opsmill/infrahub-schema-visualizer)
+
+The `python_sdk` submodule tracks the SDK branch **named after** the current
+Infrahub branch, not the SDK's own same-named branch:
+
+- Infrahub `develop` → SDK `infrahub-develop`
+- Infrahub `stable` → SDK `stable`
+
+The SDK repo also has its own `develop` branch. It is **not** the counterpart of
+Infrahub `develop` — do not use it to update the submodule. When updating
+`python_sdk` from Infrahub `develop`, pin `origin/infrahub-develop`.
+
+You can modify code inside a submodule, but the changes live in a separate
+repository. Before opening a PR on this repository, push the submodule commit
+upstream and open a separate PR on the submodule repo first. Only once that is
+merged (or the commit is otherwise available upstream) should the submodule
+pointer bump land here — a pointer to an unpushed commit breaks every other
+checkout.
+
 ## Coding Standards
 
 - Backend: `dev/guidelines/backend/python.md`


### PR DESCRIPTION
# Why

Keep the bundled Python SDK in sync with the tip of its `infrahub-develop`
branch so develop builds and tests run against the current SDK.

## What changed

- Bump `python_sdk` submodule to `25cf939` (tip of the SDK's `infrahub-develop`).
- Add a **Submodules** section to `AGENTS.md` documenting the branch mapping
  (Infrahub `develop` → SDK `infrahub-develop`, `stable` → `stable`), warning
  against the SDK's decoy `develop` branch, and requiring a separate upstream
  submodule PR before the pointer bumps here.

No schema, API, or backend behavior changes — submodule pointer + docs only.

## How to test

```bash
git submodule status python_sdk   # -> 25cf9394... (v1.13.2-1096-g25cf939)
```

CI on `develop` is the real validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the bundled `python_sdk` submodule to the latest `infrahub-develop` so `develop` builds and tests use the current SDK. Adds a Submodules section in `AGENTS.md` with branch mapping (Infrahub `develop` → SDK `infrahub-develop`, `stable` → `stable`) and an upstream-first update workflow.

<sup>Written for commit 7c62bae943c05f55ffda807e997d5d2025d6e8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

