### PR TITLE
docs(audit-docs): clarify skill scope and input priority

### DIFF
--- a/.agents/skills/audit-docs/SKILL.md
+++ b/.agents/skills/audit-docs/SKILL.md
@@ -30,7 +30,7 @@ Treat `$ARGUMENTS` as what to audit. It will be one of:
 - A **commit range or branch name** — audit all changes in that range. Run `git log <range> --oneline --stat` to understand every change. The input in order of importance is:
   - PR description (if the branch corresponds to a PR or if a PR is provided)
   - Pull Request review comments, resolved and unresolved. Usually this is GOLD information to be included in the internal docs (if the branch corresponds to a PR or if a PR is provided)
-  - Any a changelog fragment and spec link. If missing, flag it as a gap.
+  - Any changelog fragment and spec link. If missing, flag it as a gap.
   - The source code diffs themselves.
 - A **subject** (e.g. "webhooks", "computed attributes", "IPAM") — audit documentation for that topic across the codebase, regardless of branch. Use Grep/Glob to find all related code and docs, then assess coverage against `dev/knowledge/`, `docs/docs/`, `dev/specs/`, `backend/AGENTS.md`, `frontend/app/AGENTS.md`, and the code itself.
 - A **set of doc paths** (e.g. `docs/docs/guides/installation.mdx dev/knowledge/backend/templates.md`) — audit only those files. Read each one, identify the feature/topic it covers, then search the codebase for the corresponding implementation to confirm the doc is current and complete, and check whether the code has drifted from what the doc describes.

--- a/.agents/skills/audit-docs/SKILL.md
+++ b/.agents/skills/audit-docs/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: audit-docs
 description: >-
-  Audits documentation completeness for a feature branch, subject, or set of existing docs — maps
-  changes across Infrahub's documentation layers, reports gaps, and optionally applies the fixes.
-  TRIGGER when: the user wants to audit or check documentation coverage, find doc gaps after a
-  feature branch, or verify docs are still current for a subject or specific files.
-  DO NOT TRIGGER when: authoring new documentation from scratch → use the add-docs flow; only
-  linting/formatting Markdown → run `uv run invoke docs.lint`.
+  Audits internal (dev/) and external (docs/) documentation completeness for a feature, subject, or set of existing docs, maps changes indicated by the user, across Infrahub's documentation layers, reports gaps, and optionally applies the fixes. TRIGGER when: the user wants to audit or check documentation coverage, find doc gaps after a feature branch, or verify docs are still current for a subject or specific files. DO NOT TRIGGER when: authoring new documentation from scratch → use the add-docs flow; only linting/formatting Markdown → run `uv run invoke docs.lint`.
 argument-hint: <commit-range, branch name, subject, or doc paths to audit>
 compatibility: Requires the Infrahub repository checked out. Commit-range and branch audits additionally require Git history.
 metadata:
@@ -32,7 +27,11 @@ Audit documentation completeness — after a feature branch, for a subject, or a
 
 Treat `$ARGUMENTS` as what to audit. It will be one of:
 
-- A **commit range or branch name** — audit all changes in that range. Run `git log <range> --oneline --stat` to understand every change.
+- A **commit range or branch name** — audit all changes in that range. Run `git log <range> --oneline --stat` to understand every change. The input in order of importance is:
+  - PR description (if the branch corresponds to a PR or if a PR is provided)
+  - Pull Request review comments, resolved and unresolved. Usually this is GOLD information to be included in the internal docs (if the branch corresponds to a PR or if a PR is provided)
+  - Any a changelog fragment and spec link. If missing, flag it as a gap.
+  - The source code diffs themselves.
 - A **subject** (e.g. "webhooks", "computed attributes", "IPAM") — audit documentation for that topic across the codebase, regardless of branch. Use Grep/Glob to find all related code and docs, then assess coverage against `dev/knowledge/`, `docs/docs/`, `dev/specs/`, `backend/AGENTS.md`, `frontend/app/AGENTS.md`, and the code itself.
 - A **set of doc paths** (e.g. `docs/docs/guides/installation.mdx dev/knowledge/backend/templates.md`) — audit only those files. Read each one, identify the feature/topic it covers, then search the codebase for the corresponding implementation to confirm the doc is current and complete, and check whether the code has drifted from what the doc describes.
 


### PR DESCRIPTION
# Why

The `audit-docs` skill description didn't make clear it covers both internal (`dev/`) and external (`docs/`) documentation, and the branch/PR audit step didn't tell the skill which inputs matter most.

## What changed

- Description now states the skill audits both internal (`dev/`) and external (`docs/`) docs.
- Branch/PR audits get an explicit input priority order: PR description → PR review comments (resolved and unresolved) → changelog fragment + spec link (flag if missing) → source diffs.

No behavioral code changes — this only edits `.agents/skills/audit-docs/SKILL.md`.

## How to test

Not applicable — Markdown-only change to a skill definition.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the `audit-docs` skill scope to cover both internal `dev/` and external `docs/` docs, and set the input priority for branch/PR audits: PR description, review comments, changelog/spec link, then source diffs. Also fixes a minor typo; Markdown-only edit to `.agents/skills/audit-docs/SKILL.md` with no behavior changes.

<sup>Written for commit 4eeee3128e94036141bed31cfab941ed7783f3ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

