### PR TITLE
small fixes from cubic feedback

### DIFF
--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -12,7 +12,7 @@ from infrahub.core.diff.query.summary_counts_enricher import (
 )
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, retry_db_transaction
-from infrahub.exceptions import ResourceNotFoundError
+from infrahub.exceptions import ResourceMultipleFoundError, ResourceNotFoundError
 from infrahub.log import get_logger
 
 from ..model.field_specifiers_map import NodeFieldSpecifierMap
@@ -246,7 +246,7 @@ class DiffRepository:
         if len(enriched_diffs) == 0:
             raise ResourceNotFoundError(f"Cannot find diff for {error_str}")
         if len(enriched_diffs) > 1:
-            raise ResourceNotFoundError(f"Multiple diffs for {error_str}")
+            raise ResourceMultipleFoundError(f"Multiple diffs for {error_str}")
         return enriched_diffs[0]
 
     def _get_node_create_request_batch(

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -9,10 +9,18 @@ if TYPE_CHECKING:
     from infrahub.core.validators.model import SchemaViolation
 
 
-def _rebuild_error(cls: type[Error], args: tuple[Any, ...], state: dict[str, Any]) -> Error:
+def _rebuild_error(cls: type[Error], args: tuple[Any, ...], state: Any) -> Error:
     obj = cls.__new__(cls)
     obj.args = args
-    obj.__dict__.update(state)
+    # Mirror object.__setstate__: state is a dict of instance attributes, or a
+    # (dict_state, slots_state) tuple for subclasses that define __slots__, or None.
+    if state is not None:
+        dict_state, slots_state = state if isinstance(state, tuple) else (state, None)
+        if dict_state:
+            obj.__dict__.update(dict_state)
+        if slots_state:
+            for key, value in slots_state.items():
+                setattr(obj, key, value)
     return obj
 
 
@@ -23,12 +31,12 @@ class Error(Exception):
     errors: list | None = None
 
     def __reduce__(self) -> tuple[Any, ...]:
-        # BaseException.__reduce__ rebuilds via cls(*self.args), replaying only the message and
-        # dropping any additional required constructor arguments, so subclasses with extra
-        # parameters fail to unpickle. Rebuild via __new__ + instance state instead so every
-        # subclass round-trips regardless of its __init__ signature (errors are pickled when they
-        # cross the workflow engine).
-        return (_rebuild_error, (self.__class__, self.args, self.__dict__))
+        # BaseException.__reduce__ rebuilds via cls(*self.args), dropping any additional required
+        # constructor arguments, so subclasses with extra parameters fail to unpickle. Rebuild via
+        # __new__ + instance state instead so every subclass round-trips regardless of its
+        # __init__ signature. __getstate__ captures both __dict__ and __slots__ state so
+        # slotted subclasses round-trip too.
+        return (_rebuild_error, (self.__class__, self.args, self.__getstate__()))
 
     def api_response(self) -> dict[str, Any]:
         """Return error response."""

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -259,6 +259,14 @@ class ResourceNotFoundError(Error):
         super().__init__(self.message)
 
 
+class ResourceMultipleFoundError(Error):
+    HTTP_CODE: int = 500
+
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message or "Multiple matching resources were found"
+        super().__init__(self.message)
+
+
 class AuthorizationError(Error):
     HTTP_CODE: int = 401
     message: str = "Access to the requested resource was denied"

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -585,7 +585,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             from_time=Timestamp("2024-06-15T10:00:00Z"),
             to_time=Timestamp("2024-06-15T11:00:00Z"),
             nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
-            tracking_id=None,
+            tracking_id=NameTrackingId(name="diff-one"),
         )
         await self._save_single_diff(diff_repository=diff_repository, enriched_diff=first_diff, do_summary_counts=False)
         second_diff = EnrichedRootFactory.build(
@@ -594,7 +594,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             from_time=Timestamp("2024-06-15T12:00:00Z"),
             to_time=Timestamp("2024-06-15T13:00:00Z"),
             nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
-            tracking_id=None,
+            tracking_id=NameTrackingId(name="diff-two"),
         )
         await self._save_single_diff(
             diff_repository=diff_repository, enriched_diff=second_diff, do_summary_counts=False

--- a/backend/tests/component/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/component/core/diff/repository/test_diff_repository.py
@@ -22,7 +22,7 @@ from infrahub.core.diff.repository.deserializer import EnrichedDiffDeserializer
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
-from infrahub.exceptions import ResourceNotFoundError
+from infrahub.exceptions import ResourceMultipleFoundError, ResourceNotFoundError
 
 from ..factories import (
     EnrichedAttributeFactory,
@@ -574,6 +574,36 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
                 tracking_id=BranchTrackingId(name="not a branch"),
                 diff_branch_name=self.diff_branch_name,
             )
+
+    async def test_get_one_multiple_results_raises_distinct_error(
+        self, diff_repository: DiffRepository, reset_database: None
+    ) -> None:
+        # two diffs for the same branch with distinct, non-overlapping time ranges
+        first_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=Timestamp("2024-06-15T10:00:00Z"),
+            to_time=Timestamp("2024-06-15T11:00:00Z"),
+            nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
+            tracking_id=None,
+        )
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=first_diff, do_summary_counts=False)
+        second_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=Timestamp("2024-06-15T12:00:00Z"),
+            to_time=Timestamp("2024-06-15T13:00:00Z"),
+            nodes=self._build_nodes(num_nodes=1, num_sub_fields=1),
+            tracking_id=None,
+        )
+        await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=second_diff, do_summary_counts=False
+        )
+
+        # a "multiple results" case must not masquerade as "not found"
+        with pytest.raises(ResourceMultipleFoundError, match="Multiple diffs for"):
+            await diff_repository.get_one(diff_branch_name=self.diff_branch_name)
+        assert not issubclass(ResourceMultipleFoundError, ResourceNotFoundError)
 
     async def test_get_node_field_summaries(self, diff_repository: DiffRepository) -> None:
         diff_nodes = self._build_nodes(num_nodes=5, num_sub_fields=2)

--- a/backend/tests/unit/test_exceptions.py
+++ b/backend/tests/unit/test_exceptions.py
@@ -24,6 +24,16 @@ def _round_trip(error: Error) -> Error:
     return pickle.loads(pickle.dumps(error))  # noqa: S301
 
 
+class SlottedError(Error):
+    """Error subclass that stores state in __slots__ instead of __dict__."""
+
+    __slots__ = ("detail",)
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
 @dataclass
 class ErrorPickleCase:
     name: str
@@ -63,6 +73,10 @@ ERROR_PICKLE_CASES = [
         name="list_arg",
         error=GraphQLQueryError(errors=[{"message": "bad query"}]),
     ),
+    ErrorPickleCase(
+        name="slotted_state",
+        error=SlottedError(detail="slot-value"),
+    ),
 ]
 
 
@@ -86,6 +100,15 @@ def test_pickle_preserves_extra_constructor_attributes() -> None:
     assert isinstance(restored, SchemaNotFoundError)
     assert restored.branch_name == "main"
     assert restored.identifier == "TestingReproSolo"
+
+
+def test_pickle_preserves_slot_state() -> None:
+    error = SlottedError(detail="slot-value")
+
+    restored = _round_trip(error)
+
+    assert isinstance(restored, SlottedError)
+    assert restored.detail == "slot-value"
 
 
 def test_reconstructed_error_can_be_raised_and_caught() -> None:


### PR DESCRIPTION
cubic suggested some small changes in #9917. they are implemented here

1. new `ResourceMultipleFoundError` to go with `ResourceNotFoundError`. uses in diff retrieval in case there are multiple diffs for a given set of parameters
2. support for `__slots__` when rebuilding an error in the pickle -> unpickle path Prefect uses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a distinct error for duplicate diff results and fix error serialization for slotted exceptions. This clarifies API behavior and prevents state loss during pickle/unpickle.

- **Bug Fixes**
  - Diff retrieval now raises `ResourceMultipleFoundError` when multiple diffs match, instead of `ResourceNotFoundError`.
  - Error pickling/unpickling preserves both `__dict__` and `__slots__` state via `__getstate__` and improved rebuild logic.

<sup>Written for commit 18602714c57e664324402636047c15958316722f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

