### PR TITLE
fix(frontend): order proposed changes list newest-first

### DIFF
--- a/changelog/+proposed-changes-list-order.fixed.md
+++ b/changelog/+proposed-changes-list-order.fixed.md
@@ -1,0 +1,1 @@
+The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.

--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import { EnumType, jsonToGraphQLQuery } from "json-to-graphql-query";
 
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import {
@@ -43,6 +43,9 @@ export const getProposedChangesFromApi = async ({
         __args: {
           limit,
           offset,
+          order: {
+            by: [{ field: "node_metadata__created_at", direction: new EnumType("DESC") }],
+          },
           ...(filters ? addFiltersToRequest(filters) : {}),
         },
         count: true,

--- a/tests/e2e/proposed-changes/test_proposed_changes_ordering.py
+++ b/tests/e2e/proposed-changes/test_proposed_changes_ordering.py
@@ -1,0 +1,99 @@
+"""/proposed-changes list ordering.
+
+The proposed-changes list (both the Opened and Closed tabs) must be ordered by
+creation date, newest first. Regression guard for the list previously coming
+back in an arbitrary (node-uuid) order, which buried recently created proposed
+changes.
+
+The test owns all of its data: it creates three throwaway branches and one
+proposed change per branch through the SDK, so it needs neither the demo
+dataset nor the demo-edge repository.
+
+Note on the Closed tab: ordering is by *creation* time, not by when each
+proposed change was closed. The test closes the proposed changes in reverse
+creation order to prove the list still comes back newest-created-first (the
+most recently closed one is not floated to the top).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import pytest
+from helpers import generate_random_branch_name
+from playwright.async_api import expect
+
+pytestmark = pytest.mark.shard_branches_repo
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from infrahub_sdk import InfrahubClient
+    from infrahub_sdk.node import InfrahubNode
+    from playwright.async_api import Page
+
+
+async def _rendered_pc_order(page: Page) -> list[str]:
+    """Return the proposed-change ids in the order they are rendered in the list."""
+    listbox = page.get_by_role("listbox")
+    hrefs = await listbox.locator('a[href*="/proposed-changes/"]').evaluate_all(
+        "els => els.map((e) => e.getAttribute('href'))"
+    )
+    order: list[str] = []
+    for href in hrefs:
+        pc_id = href.split("/proposed-changes/", 1)[1].split("?", 1)[0].split("/", 1)[0]
+        if pc_id and pc_id not in order:
+            order.append(pc_id)
+    return order
+
+
+class TestProposedChangesOrdering:
+    @pytest.fixture
+    async def proposed_changes(
+        self,
+        infrahub_client: InfrahubClient,
+        schema_base: None,
+    ) -> AsyncGenerator[list[InfrahubNode], None]:
+        """Create three proposed changes, oldest first, each on its own branch."""
+        created: list[tuple[InfrahubNode, str]] = []
+        try:
+            for index in range(3):
+                branch_name = generate_random_branch_name(f"pc-order-{index}")
+                await infrahub_client.branch.create(branch_name=branch_name, sync_with_git=False)
+                pc = await infrahub_client.create(
+                    kind="CoreProposedChange",
+                    name=generate_random_branch_name(f"pc-order-e2e-{index}"),
+                    source_branch=branch_name,
+                    destination_branch="main",
+                )
+                await pc.save()
+                created.append((pc, branch_name))
+            yield [pc for pc, _ in created]
+        finally:
+            for pc, branch_name in created:
+                with contextlib.suppress(Exception):
+                    await pc.delete()
+                with contextlib.suppress(Exception):
+                    await infrahub_client.branch.delete(branch_name=branch_name)
+
+    async def test_list_is_ordered_newest_first(self, admin_page: Page, proposed_changes: list[InfrahubNode]) -> None:
+        oldest, middle, newest = proposed_changes
+        expected = [newest.id, middle.id, oldest.id]
+
+        # Opened tab (default): newest created proposed change on top.
+        await admin_page.goto("/proposed-changes")
+        await expect(admin_page.locator(f'a[href*="/proposed-changes/{newest.id}"]')).to_be_visible()
+        opened_order = await _rendered_pc_order(admin_page)
+        assert [pc_id for pc_id in opened_order if pc_id in expected] == expected
+
+        # Close them in reverse creation order to prove ordering ignores close time.
+        for pc in (newest, middle, oldest):
+            pc.state.value = "closed"
+            await pc.save()
+
+        # Closed tab: still ordered by creation date, newest first.
+        await admin_page.goto("/proposed-changes?pr_state=closed")
+        await expect(admin_page.locator(f'a[href*="/proposed-changes/{newest.id}"]')).to_be_visible()
+        closed_order = await _rendered_pc_order(admin_page)
+        assert [pc_id for pc_id in closed_order if pc_id in expected] == expected


### PR DESCRIPTION
# Why

The proposed changes list came back in an arbitrary order (node UUID), so
recently created proposed changes were buried instead of appearing at the top —
most visible on the Closed tab. Neither the `ProposedChange` schema nor the list
query specified any ordering.

Goal: list proposed changes newest-first on both the Opened and Closed tabs.

Non-goals: does not add a user-facing sort/filter control, and does not add
date-based *filtering* (the other half of the issue) — only default ordering.

Refs #9915

## What changed

- Proposed changes now display newest-first (by creation date) on both the
  Opened and Closed tabs, and in the homepage widget.
- Implemented by requesting `order: { by: [{ field: node_metadata__created_at,
  direction: DESC }] }` in the list query builder.

Implementation notes:
- Frontend-only — consumes the existing GraphQL `order` argument, so **no
  schema change** and no change to ordering for any other API/SDK consumer.
- Ordering is by *creation* time, not close time, so it's stable against later
  edits; on the Closed tab the most-recently-*closed* item is not floated to
  the top (accepted tradeoff).
- Pagination stays stable — the backend still appends `n.uuid` as a tiebreaker.

## How to test

```bash
# e2e (needs a local image built from this branch)
INFRAHUB_IMAGE_VER=e2e-pytest uv run invoke dev.build
INFRAHUB_TESTING_IMAGE_VER=e2e-pytest INFRAHUB_TESTING_DOCKER_PULL=false \
  uv run pytest -c tests/e2e/pytest.ini \
  tests/e2e/proposed-changes/test_proposed_changes_ordering.py -m shard_branches_repo
```

Verified locally: the new e2e test passes (`1 passed`) — it creates three
proposed changes, asserts newest-first on the Opened tab, closes them in reverse
order, and asserts the Closed tab is still newest-created-first.

## Impact & rollout

- **Backward compatibility:** no breaking changes; UI-only ordering.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated (e2e)
- [x] Changelog entry added
- [ ] External docs updated (n/a — no documented behavior contract changes)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Order proposed changes by creation date (newest first) on the Opened and Closed tabs and the homepage widget, fixing the previous arbitrary order. Addresses #9915.

- **Bug Fixes**
  - Added explicit GraphQL order by `node_metadata__created_at DESC` in the list query (using `json-to-graphql-query` `EnumType`).
  - Applies across Opened/Closed tabs and the homepage widget; UI-only with no schema changes.
  - Added e2e test to verify newest-first on both tabs, independent of close time.

<sup>Written for commit 19863f6f15dbac04e44d6f742e5721fee1743c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

