### PR TITLE
fix(docker): build venv against the base image's system Python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 script.py
 node_modules
 .venv
+**/.venv
 .ruff_cache
 **/.ruff_cache
 .mypy_cache
@@ -15,6 +16,10 @@ node_modules
 coverage.xml
 # Exclude git dotfiles but NOT .git/ itself — the Dockerfile bind-mounts .git/ at build time so
 # hatch-vcs can resolve the version. .git/ is kept out of the image by COPY --exclude=.git.
+# .python-version pins 3.12 for local dev; keep it out of the build so uv does not rebuild the
+# venv against a different interpreter than the base image (see UV_PYTHON_* in development/Dockerfile).
+.python-version
+
 .gitignore
 .gitmodules
 .gitattributes

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -12,6 +12,13 @@ ENV PYTHONUNBUFFERED=1
 # uv installs to /root/.local/bin
 ENV PATH="${PATH}:/root/.local/bin"
 
+# Force uv to build the virtualenv against this image's own system Python and never download a
+# managed interpreter. A managed CPython would live under /root/.local/share/uv/python — a path the
+# runtime `backend` stage does not copy — leaving /.venv's interpreter dangling and every console
+# script (uvicorn, gunicorn, prefect, ...) failing to exec.
+ENV UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON_PREFERENCE=only-system
+
 # Build toolchain only: build-essential/pkg-config compile any dependency that has no wheel,
 # uv installs the dependencies. None of this is needed at runtime — the final `backend` stage
 # copies only the built virtualenv, so this bloat stays out of the shipped image.


### PR DESCRIPTION
## Summary

Local `dev.build` / `dev.start` off `develop` currently fails: every service running a virtualenv console script (`task-manager`, workers, server) crashes on startup with `exec uvicorn failed: No such file or directory` (exit 127). This makes the dev stack unstartable for anyone building the image locally.

## Root Cause

The recent stage-split refactor (`fd44a86a7a build(docker): split Dockerfile into builder and runtime stages`) copies only `/.venv` and `/source` from the builder into the runtime stage. But uv was building the venv against a **downloaded, uv-managed** CPython under `/root/.local/share/uv/python/...` — a path the runtime stage never copies. That left `/.venv/bin/python` a dangling symlink, so the kernel failed to exec the interpreter named in every console-script shebang.

Two things drove uv to a managed interpreter instead of the base image's own Python:
- uv's default `python-preference` downloads a managed interpreter.
- `.python-version` (pinned to `3.12` for local dev) gets copied into the build context, so the second `uv sync` rebuilt the venv against 3.12 even though the base image is `python:3.13-slim`.

## Key Changes

- **The dev stack builds and starts cleanly again** — the venv is now built against the image's own system Python (`/usr/local/bin/python3.13`), which is present in both the builder and runtime stages.
- Force uv to use system Python and never download a managed interpreter (`UV_PYTHON_DOWNLOADS=never`, `UV_PYTHON_PREFERENCE=only-system`).
- Keep `.python-version` out of the build context so the second `uv sync` no longer switches interpreters.
- Add `**/.venv` to `.dockerignore` so nested local virtualenvs (e.g. `python_testcontainers/.venv`) can't break `COPY` with dangling host symlinks.

## Follow-up (not addressed here)

The build's Python version is specified in three places that disagree: `.python-version` (`3.12`), the `dev.build` default (`3.13`), and the Dockerfile ARG default (`3.14.3`). This PR pins the build to its own base image and sidesteps the conflict, but the team may want to reconcile those separately.

## Test Plan

```bash
uv run inv dev.destroy dev.build dev.start
```

All containers reach `Healthy`/`Started`, including `infrahub-task-manager-1` (previously exit 127). Verified in-image:

```bash
docker run --rm --entrypoint sh registry.opsmill.io/opsmill/infrahub:local -c 'readlink -f /.venv/bin/python; uvicorn --version'
# /usr/local/bin/python3.13
# Running uvicorn 0.32.1 with CPython 3.13.14 on Linux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the virtualenv against the base image’s system Python to fix broken console scripts and restore the dev stack. This resolves startup failures (`exit 127`) for services running `uvicorn` and similar tools.

- **Bug Fixes**
  - Force `uv` to use system Python only (`UV_PYTHON_DOWNLOADS=never`, `UV_PYTHON_PREFERENCE=only-system`).
  - Exclude `.python-version` from the Docker build context to prevent interpreter switching.
  - Add `**/.venv` to `.dockerignore` to keep nested local envs out of the build context.

<sup>Written for commit b6b754520a9bc589a16fc4b7c00f18a2570d5101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

