### PR TITLE
fix(ci): use correct opsmill-bug-pipeline bot slug in bug-pipeline gates

### DIFF
--- a/.github/workflows/bug-agent-fix.lock.yml
+++ b/.github/workflows/bug-agent-fix.lock.yml
@@ -577,7 +577,7 @@ jobs:
 
           if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
             REQ=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+              --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
                 and (.body | contains("AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED")))] | length')
             if [ "$REQ" = "0" ]; then
               fail "Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer."
@@ -590,7 +590,7 @@ jobs:
           fi
 
           APPROVED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+            --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
               and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
           if [ "$APPROVED" = "0" ]; then
             fail "Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict."

--- a/.github/workflows/bug-agent-fix.md
+++ b/.github/workflows/bug-agent-fix.md
@@ -45,7 +45,7 @@ steps:
 
       if [[ "$PR_BODY" == *"AGENT_FIX_COMPLETE"* ]]; then
         REQ=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-          --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+          --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
             and (.body | contains("AGENT_REVIEW_VERDICT: FIX_CHANGES_REQUESTED")))] | length')
         if [ "$REQ" = "0" ]; then
           fail "Cannot run /bug-fix: fix already complete and no FIX_CHANGES_REQUESTED verdict from reviewer."
@@ -58,7 +58,7 @@ steps:
       fi
 
       APPROVED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-        --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+        --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
           and (.body | contains("AGENT_REVIEW_VERDICT: TEST_APPROVED")))] | length')
       if [ "$APPROVED" = "0" ]; then
         fail "Cannot run /bug-fix: test not yet approved by reviewer. Wait for TEST_APPROVED verdict."

--- a/.github/workflows/bug-agent-review.lock.yml
+++ b/.github/workflows/bug-agent-review.lock.yml
@@ -56,7 +56,7 @@
 name: "Bug reviewer agent"
 on:
   # bots: # Bots processed as bot check in pre-activation job
-  # - infrahub-bug-pipeline[bot] # Bots processed as bot check in pre-activation job
+  # - opsmill-bug-pipeline[bot] # Bots processed as bot check in pre-activation job
   # github-app: # GitHub App used to mint token for reactions and status comments in activation
     # client-id: ${{ secrets.GH_AW_APP_ID }}
     # private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
@@ -264,7 +264,7 @@ jobs:
         id: sanitized
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
-          GH_AW_ALLOWED_BOTS: "infrahub-bug-pipeline[bot]"
+          GH_AW_ALLOWED_BOTS: "opsmill-bug-pipeline[bot]"
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
         with:
           script: |
@@ -540,7 +540,7 @@ jobs:
           fi
 
           COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq "[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
+            --jq "[.[] | select((.user.login == \"opsmill-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
               and (.body | contains(\"$MARKER\")))] | length")
 
           if [ "$COUNT" -gt 0 ]; then
@@ -1713,7 +1713,7 @@ jobs:
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-          GH_AW_ALLOWED_BOTS: "infrahub-bug-pipeline[bot]"
+          GH_AW_ALLOWED_BOTS: "opsmill-bug-pipeline[bot]"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/bug-agent-review.md
+++ b/.github/workflows/bug-agent-review.md
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - "**/*.md"
   bots:
-    - "infrahub-bug-pipeline[bot]"
+    - "opsmill-bug-pipeline[bot]"
   github-app:
     client-id: ${{ secrets.GH_AW_APP_ID }}
     private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
@@ -56,7 +56,7 @@ steps:
       fi
 
       COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-        --jq "[.[] | select((.user.login == \"infrahub-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
+        --jq "[.[] | select((.user.login == \"opsmill-bug-pipeline[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"claude[bot]\")
           and (.body | contains(\"$MARKER\")))] | length")
 
       if [ "$COUNT" -gt 0 ]; then

--- a/.github/workflows/bug-agent-test.lock.yml
+++ b/.github/workflows/bug-agent-test.lock.yml
@@ -584,7 +584,7 @@ jobs:
             fi
 
             REQ=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-              --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+              --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
                 and (.body | contains("AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED")))] | length')
             if [ "$REQ" = "0" ]; then
               fail "Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on."
@@ -593,7 +593,7 @@ jobs:
           fi
 
           ANALYSIS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-            --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+            --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
               and (.body | contains("AGENT_ANALYSIS_COMPLETE")))] | length')
           if [ "$ANALYSIS" = "0" ]; then
             fail "Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first."

--- a/.github/workflows/bug-agent-test.md
+++ b/.github/workflows/bug-agent-test.md
@@ -51,7 +51,7 @@ steps:
         fi
 
         REQ=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-          --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+          --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
             and (.body | contains("AGENT_REVIEW_VERDICT: TEST_CHANGES_REQUESTED")))] | length')
         if [ "$REQ" = "0" ]; then
           fail "Cannot run /bug-tdd: no TEST_CHANGES_REQUESTED verdict from reviewer to act on."
@@ -60,7 +60,7 @@ steps:
       fi
 
       ANALYSIS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
-        --jq '[.[] | select((.user.login == "infrahub-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
+        --jq '[.[] | select((.user.login == "opsmill-bug-pipeline[bot]" or .user.login == "github-actions[bot]" or .user.login == "claude[bot]")
           and (.body | contains("AGENT_ANALYSIS_COMPLETE")))] | length')
       if [ "$ANALYSIS" = "0" ]; then
         fail "Cannot run /bug-tdd: no AGENT_ANALYSIS_COMPLETE comment from analyst. Run /bug-analyze first."


### PR DESCRIPTION
## What

The bug-pipeline stage gates key off the pipeline GitHub App's comments to
confirm the previous stage ran. They reference the bot slug
`infrahub-bug-pipeline[bot]`, but the installed App posts as
**`opsmill-bug-pipeline[bot]`** (the `infrahub-bug-pipeline[bot]` account does
not exist). The author filter therefore never matches a real comment, so every
gated stage refuses to proceed with a misleading "run the previous step first"
error.

This replaces the slug with `opsmill-bug-pipeline[bot]` in all three gated
workflows so each stage recognises the prior stage's marker comment:

- `bug-agent-test` — `/bug-tdd` gate requiring `AGENT_ANALYSIS_COMPLETE`
- `bug-agent-fix` — `/bug-fix` gate requiring `TEST_APPROVED` / `FIX_CHANGES_REQUESTED`
- `bug-agent-review` — reviewer `GH_AW_ALLOWED_BOTS` and the marker-count gate

Both the `.md` sources and the generated `.lock.yml` files are updated with the
identical string swap. The lock files were edited directly rather than via a
full `gh aw compile` to avoid unrelated action-pin churn from a stale local
gh-aw action database; a future recompile will regenerate them cleanly.

## Origin

Introduced as I renamed the bot pipeline during https://github.com/opsmill/opsmill-cicd-workflows/pull/36 implementation.

## Evidence

Observed on #9931: `/bug-analyze` completed and `opsmill-bug-pipeline[bot]`
posted the `AGENT_ANALYSIS_COMPLETE` comment, but `/bug-tdd`
([run 29509109255](https://github.com/opsmill/infrahub/actions/runs/29509109255))
failed the gate with "no AGENT_ANALYSIS_COMPLETE comment from analyst".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the correct bot slug `opsmill-bug-pipeline[bot]` in bug-pipeline gates so `/bug-tdd`, `/bug-fix`, and reviewer stages detect prior-step comments and proceed.

- **Bug Fixes**
  - Replaced `infrahub-bug-pipeline[bot]` with `opsmill-bug-pipeline[bot]` in gates for `bug-agent-test`, `bug-agent-fix`, and `bug-agent-review` (`.md` and `.lock.yml`).
  - Updated reviewer allowlist `GH_AW_ALLOWED_BOTS` and marker checks to accept comments from `opsmill-bug-pipeline[bot]`.

<sup>Written for commit a693dabad1f170c8c2264bc366cbb03c82b677df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

