### PR TITLE
fix: git-sync import no longer aborts on a blocked cleanup-delete (closes #9934)

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -11,7 +11,7 @@ import ujson
 import yaml
 from infrahub_sdk import InfrahubClient  # noqa: TC002
 from infrahub_sdk.exceptions import Error as InfrahubSdkError
-from infrahub_sdk.exceptions import ValidationError
+from infrahub_sdk.exceptions import GraphQLError, ValidationError
 from infrahub_sdk.graphql.query_renderer import render_query
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import (
@@ -362,6 +362,24 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             )
         )
 
+    async def _delete_object_removed_from_repository(self, node: InfrahubNode, object_label: str, name: str) -> None:
+        """Delete a repository-managed object that is no longer defined in the repository config.
+
+        The delete can be rejected when a historical node still holds the object through a
+        mandatory relationship (for example a validator that evaluated a check definition and
+        pins it after the check is renamed or removed). Such a blocked cleanup must not abort
+        the whole import: log a warning and leave the object in place so the rest of the import
+        completes and the commit advances.
+        """
+        log = get_run_logger()
+        try:
+            await node.delete()
+        except GraphQLError as exc:
+            log.warning(
+                f"Unable to delete {object_label} {name!r} because it is still referenced by another node; "
+                f"leaving it in place. ({exc})"
+            )
+
     @task(name="import-jinja2-transforms", task_run_name="Import Jinja2 transform", cache_policy=NONE)
     async def import_jinja2_transforms(
         self,
@@ -466,7 +484,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for transform_name in only_graph:
             log.info(f"Jinja2 Transform '{transform_name}' not found locally in branch {branch_name}, deleting")
-            await transforms_in_graph[transform_name].delete()
+            await self._delete_object_removed_from_repository(
+                node=transforms_in_graph[transform_name], object_label="Jinja2 Transform", name=transform_name
+            )
 
     async def create_jinja2_transform(self, branch_name: str, data: InfrahubRepositoryJinja2) -> CoreTransformJinja2:
         schema = await self.sdk.schema.get(kind=InfrahubKind.TRANSFORMJINJA2, branch=branch_name)
@@ -854,7 +874,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         for query_name in only_graph:
             graph_query = queries_in_graph[query_name]
             log.info(f"Graphql Query {query_name!r} not found locally, deleting")
-            await graph_query.delete()
+            await self._delete_object_removed_from_repository(
+                node=graph_query, object_label="Graphql Query", name=query_name
+            )
 
     async def create_graphql_query(self, branch_name: str, name: str, query_string: str) -> CoreGraphQLQuery:
         data = {"name": name, "query": query_string, "repository": self.id}
@@ -974,7 +996,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for check_name in only_graph:
             log.info(f"CheckDefinition '{check_name!r}' not found locally, deleting")
-            await check_definition_in_graph[check_name].delete()
+            await self._delete_object_removed_from_repository(
+                node=check_definition_in_graph[check_name], object_label="CheckDefinition", name=check_name
+            )
 
     @task(name="import-generator-definitions", task_run_name="Import Generator Definitions", cache_policy=NONE)
     async def import_generator_definitions(
@@ -1056,7 +1080,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for generator_name in only_graph:
             log.info(f"GeneratorDefinition '{generator_name!r}' not found locally, deleting")
-            await generator_definition_in_graph[generator_name].delete()
+            await self._delete_object_removed_from_repository(
+                node=generator_definition_in_graph[generator_name],
+                object_label="GeneratorDefinition",
+                name=generator_name,
+            )
 
     async def _generator_requires_update(
         self,
@@ -1204,7 +1232,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         for transform_name in only_graph:
             log.info(f"TransformPython {transform_name!r} not found locally, deleting")
-            await transform_definition_in_graph[transform_name].delete()
+            await self._delete_object_removed_from_repository(
+                node=transform_definition_in_graph[transform_name], object_label="TransformPython", name=transform_name
+            )
 
     async def _load_yamlfile_from_disk(self, paths: list[Path], file_type: type[YamlFileVar]) -> list[YamlFileVar]:
         data_files = file_type.load_from_disk(paths=paths)

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -315,6 +315,65 @@ class TestInfrahubClient:
         with pytest.raises(NodeNotFoundError):
             await client.get(kind=CoreTransformJinja2, id=obj.id)
 
+    async def test_import_check_definition_pinned_by_validator(
+        self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, query_99: Node
+    ) -> None:
+        """A check definition still referenced by a user validator must not abort the import.
+
+        When a check definition is dropped from the repository config but a historical
+        user validator still pins it through the mandatory check_definition relationship,
+        the reconcile must tolerate the blocked delete and leave the check in place
+        instead of failing the whole import.
+        """
+        commit = repo.get_commit_value(branch_name="main")
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[call-overload]
+        assert config_file
+
+        # A check definition present in the graph but not in the repository config, so the
+        # reconcile treats it as removed and attempts to delete it.
+        check = await Node.init(schema=InfrahubKind.CHECKDEFINITION, db=db)
+        await check.new(
+            db=db,
+            name="pinned_check",
+            query=str(query_99.id),
+            file_path="check.py",
+            class_name="MyCheck",
+            repository=str(repo.id),
+        )
+        await check.save(db=db)
+
+        # A historical proposed change and the user validator that evaluated the check. The
+        # validator holds the check through the mandatory check_definition relationship, so
+        # deleting the check is rejected.
+        proposed_change = await Node.init(schema=InfrahubKind.PROPOSEDCHANGE, db=db)
+        await proposed_change.new(
+            db=db,
+            name="pinning-change",
+            source_branch="feature",
+            destination_branch="main",
+        )
+        await proposed_change.save(db=db)
+
+        validator = await Node.init(schema=InfrahubKind.USERVALIDATOR, db=db)
+        await validator.new(
+            db=db,
+            proposed_change=proposed_change.id,
+            check_definition=check.id,
+            repository=str(repo.id),
+        )
+        await validator.save(db=db)
+
+        # Drop every check definition from the config so the pinned check is the only entry
+        # the reconcile tries to delete.
+        config_file.check_definitions = []
+
+        # The reconcile must complete: the blocked delete is tolerated, not fatal to the import.
+        await repo.import_python_check_definitions(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[call-overload]
+
+        # The pinned check is left in place because it could not be deleted.
+        remaining = await client.get(kind=CoreCheckDefinition, id=check.id)
+        assert remaining.id == check.id
+
 
 class TestGetMissingFile(TestInfrahubApp):
     async def test_get_missing_file(

--- a/changelog/9934.fixed.md
+++ b/changelog/9934.fixed.md
@@ -1,0 +1,1 @@
+Fixed a repository import failure when a check definition removed from a repository was still referenced by a previously executed proposed change, which left the repository stuck on the old commit.


### PR DESCRIPTION
# Why

When a git-sourced check definition (or transform, generator, or GraphQL query) was renamed or removed from `.infrahub.yml`, repository import tried to delete the stale graph node during cleanup. If that node was still pinned by a historical record — e.g. a `CoreUserValidator` that evaluated the check and references it through the **mandatory `check_definition` relationship** — the backend correctly rejected the delete, but the importer let that single failure abort the **entire** import. The repository landed in `sync_status: error-import` and stayed stuck on the old commit; every subsequent sync re-hit the same delete and failed identically, so the repository never advanced. The only workaround was manually deleting validator records belonging to (often already-merged) proposed changes.

Goal: a removed/renamed git-sourced object should never freeze the import. If its delete is blocked because a historical node still holds it, the import completes anyway and the commit advances.

Non-goals: not cascade-deleting or detaching the historical validator records (those belong to real proposed changes), and not introducing soft-deprecation of check definitions.

Closes #9934

## What changed

- Repository import no longer aborts when a repository-managed object removed from `.infrahub.yml` cannot be deleted because a historical record still references it through a mandatory relationship. The blocked delete is logged as a warning, the object is left in place, and the rest of the import completes so the commit advances.
- The same tolerance applies to every reconcile cleanup-delete: check definitions, Jinja2 transforms, GraphQL queries, generator definitions, and Python transforms.

Implementation notes: the five `only_graph` delete loops in `InfrahubRepositoryIntegrator` now route through a single helper, `_delete_object_removed_from_repository`, which catches the `infrahub_sdk.exceptions.GraphQLError` raised by a blocked delete. The catch is narrow (only `GraphQLError`, not bare `Exception`) so genuine failures still surface and fail the import.

What stayed the same: no schema changes, no GraphQL/API contract changes. The backend delete-validation that rejects the delete is unchanged — only the importer's handling of that rejection changed.

## How to review

- `backend/infrahub/git/integrator.py` — the new `_delete_object_removed_from_repository` helper and the five call sites that replaced the raw `await …delete()` calls.
- The delete-rejection itself lives in `backend/infrahub/core/node/delete_validator.py` and is intentionally untouched.

## How to test

```bash
cd backend
uv run pytest tests/integration/git/test_git_repository.py::TestInfrahubClient::test_import_check_definition_pinned_by_validator -x
```

The test creates a check definition pinned by a `CoreUserValidator`, drops it from the repository config, and runs `import_python_check_definitions`. It fails on the previous code with `GraphQLError: Cannot delete CoreCheckDefinition … linked to mandatory relationship check_definition on node CoreUserValidator …` and passes with this fix (the import completes and the check is left in place).

## Impact & rollout

- **Backward compatibility:** no breaking changes; no migration steps.
- **Performance:** negligible (one `try/except` per cleanup-delete).
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) — N/A, internal git-sync behavior
- [ ] Internal .md docs updated — N/A, no existing knowledge doc covers reconcile-delete behavior
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes import freezes when a cleanup delete is blocked by a mandatory relationship (e.g., a validator pinning a check). The importer now logs a warning, keeps the object, and completes the sync so the commit advances. Closes #9934.

- **Bug Fixes**
  - All cleanup deletes now use `_delete_object_removed_from_repository`, which catches `GraphQLError`, warns, and skips the delete instead of aborting the import.
  - Applies to CheckDefinitions, Python/Jinja2 transforms, generators, and GraphQL queries.
  - Added an integration test for a check definition pinned by a `CoreUserValidator`; no schema or API changes.

<sup>Written for commit 737c6bd30af4dd31e16f5b2ae3b406f873b570e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

