### PR TITLE
fix: skip merged branches during git repository sync

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -14,6 +14,7 @@ from prefect.cache_policies import NONE
 from pydantic import Field
 
 from infrahub import config
+from infrahub.core.branch.enums import TERMINAL_BRANCH_STATUSES
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus, RepositoryOperationalStatus
 from infrahub.exceptions import (
     CommitNotFoundError,
@@ -159,6 +160,10 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         # TODO need to handle properly the situation when a branch is not valid.
         if self.internal_status == RepositoryInternalStatus.ACTIVE.value:
+            # A branch that has been merged (or is being deleted) is read-only: recording its commit
+            # would be rejected by the graph and abort the whole sync, so drop those branches here.
+            new_branches, updated_branches = await self._exclude_read_only_branches(new_branches, updated_branches)
+
             for branch_name in new_branches:
                 is_valid = self.validate_remote_branch(branch_name=branch_name)
                 if not is_valid:
@@ -225,6 +230,22 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             await self._collect_staging_imports(staging_branch=staging_branch, updated_branches=updated_branches)
         )
         return CollectedImports(imports=imports, failed_imports=failed_imports)
+
+    async def _exclude_read_only_branches(
+        self, new_branches: list[str], updated_branches: list[str]
+    ) -> tuple[list[str], list[str]]:
+        """Drop branches whose Infrahub branch is in a terminal status (merged or being deleted).
+
+        Such branches are read-only, so recording their commit is rejected by the graph. The default
+        branch is never terminal, so filtering here does not affect the staging-import path.
+        """
+        terminal_status_values = {status.value for status in TERMINAL_BRANCH_STATUSES}
+        graph_branches = await self.sdk.branch.all()
+        read_only = {name for name, branch in graph_branches.items() if branch.status.value in terminal_status_values}
+        return (
+            [name for name in new_branches if self._get_mapped_target_branch(branch_name=name) not in read_only],
+            [name for name in updated_branches if self._get_mapped_target_branch(branch_name=name) not in read_only],
+        )
 
     async def _collect_staging_imports(
         self, staging_branch: str | None, updated_branches: list[str]

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -2,6 +2,7 @@ import re
 import shutil
 from pathlib import Path
 from typing import Any, Generator
+from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
@@ -31,6 +32,13 @@ from tests.helpers.test_client import dummy_async_request
 @pytest.fixture
 def client() -> InfrahubClient:
     return InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
+
+
+@pytest.fixture
+def mock_branch_all() -> Generator[AsyncMock]:
+    """Git sync queries all branches to skip merged/read-only ones; stub the SDK call with no such branches."""
+    with patch("infrahub_sdk.branch.InfrahubBranchManager.all", new_callable=AsyncMock, return_value={}) as mock:
+        yield mock
 
 
 @pytest.fixture

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -546,6 +547,13 @@ async def _sync(repo: InfrahubRepository, staging_branch: str | None = None) -> 
     await syncer.sync(repo, staging_branch=staging_branch)
 
 
+@pytest.fixture
+def mock_branch_all() -> Generator[AsyncMock]:
+    """Git sync queries all branches to skip merged/read-only ones; stub the SDK call with no such branches."""
+    with patch("infrahub_sdk.branch.InfrahubBranchManager.all", new_callable=AsyncMock, return_value={}) as mock:
+        yield mock
+
+
 async def test_sync_no_update(git_repo_02: InfrahubRepository) -> None:
     repo = git_repo_02
     await _sync(repo)
@@ -560,6 +568,7 @@ async def test_sync_new_branch(
     git_repo_03: InfrahubRepository,
     httpx_mock: HTTPXMock,
     mock_add_branch01_query: HTTPXMock,
+    mock_branch_all: AsyncMock,
 ) -> None:
     repo = git_repo_03
 
@@ -598,7 +607,9 @@ async def test_sync_new_branch(
     assert len(worktrees) == 4
 
 
-async def test_sync_updated_branch(prefect_test_fixture: None, git_repo_04: InfrahubRepository) -> None:
+async def test_sync_updated_branch(
+    prefect_test_fixture: None, git_repo_04: InfrahubRepository, mock_branch_all: AsyncMock
+) -> None:
     repo = git_repo_04
 
     branch = Branch(name="branch01", uuid=uuid4())
@@ -621,7 +632,7 @@ async def test_sync_updated_branch(prefect_test_fixture: None, git_repo_04: Infr
 
 
 async def test_sync_continues_after_branch_pull_failure(
-    prefect_test_fixture: None, git_repo_07: InfrahubRepository
+    prefect_test_fixture: None, git_repo_07: InfrahubRepository, mock_branch_all: AsyncMock
 ) -> None:
     """A branch whose pull fails must not prevent the synchronization of the remaining branches."""
     repo = git_repo_07

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1,6 +1,5 @@
 import re
 import shutil
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -545,13 +544,6 @@ async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData) -> 
 async def _sync(repo: InfrahubRepository, staging_branch: str | None = None) -> None:
     syncer = RepositorySyncer(lock_registry=InfrahubLockRegistry(local_only=True), importer=RepositoryFileImporter())
     await syncer.sync(repo, staging_branch=staging_branch)
-
-
-@pytest.fixture
-def mock_branch_all() -> Generator[AsyncMock]:
-    """Git sync queries all branches to skip merged/read-only ones; stub the SDK call with no such branches."""
-    with patch("infrahub_sdk.branch.InfrahubBranchManager.all", new_callable=AsyncMock, return_value={}) as mock:
-        yield mock
 
 
 async def test_sync_no_update(git_repo_02: InfrahubRepository) -> None:

--- a/backend/tests/component/git/test_sync_lock_scope.py
+++ b/backend/tests/component/git/test_sync_lock_scope.py
@@ -1,3 +1,4 @@
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 from infrahub.core.branch import Branch
@@ -8,7 +9,7 @@ from tests.adapters.lock import LockTimeline, RecordingImporter, RecordingLockRe
 
 
 async def test_repository_lock_scopes_import_build_and_apply(
-    prefect_test_fixture: None, git_repo_04: InfrahubRepository
+    prefect_test_fixture: None, git_repo_04: InfrahubRepository, mock_branch_all: AsyncMock
 ) -> None:
     """The build phase of an import must run outside the lock and the apply phase inside it.
 

--- a/backend/tests/integration/git/test_sync_merged_branch.py
+++ b/backend/tests/integration/git/test_sync_merged_branch.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from git.repo import Repo
+
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.git import InfrahubRepository
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+    from tests.helpers.file_repo import FileRepo
+
+MERGED_BRANCH = "description-field"
+
+
+class TestSyncMergedBranch(TestInfrahubApp):
+    async def test_sync_skips_merged_branch(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        git_repo_car_dealership: FileRepo,
+        git_repos_dir: Path,
+    ) -> None:
+        """A merged (read-only) branch lingering on the remote must be skipped by the sync.
+
+        Recording its commit issues CoreRepositoryUpdate, which is rejected for a merged branch. That
+        rejection is not isolated per branch, so it aborts the whole sync instead of skipping the one
+        branch.
+        """
+        obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)
+        await obj.new(
+            db=db,
+            name=git_repo_car_dealership.name,
+            description="test repository",
+            location=git_repo_car_dealership.path,
+        )
+        await obj.save(db=db)
+
+        repo = await InfrahubRepository.new(
+            id=obj.id,
+            name=git_repo_car_dealership.name,
+            location=git_repo_car_dealership.path,
+            client=client,
+        )
+
+        # The branch has been merged: it is read-only but its branch object persists in the graph.
+        branch = await create_branch(branch_name=MERGED_BRANCH, db=db)
+        branch.status = BranchStatus.MERGED
+        await branch.save(db=db)
+
+        # The corresponding git branch is not deleted on merge, so it lingers on the remote and the
+        # local clone does not have it, making the sync treat it as a new branch to record.
+        Repo(git_repo_car_dealership.path).git.branch(MERGED_BRANCH, "main")
+
+        collected = await repo.collect_pending_imports()
+
+        assert MERGED_BRANCH not in [pending.infrahub_branch_name for pending in collected.imports]

--- a/changelog/9931.fixed.md
+++ b/changelog/9931.fixed.md
@@ -1,0 +1,1 @@
+Fixed git repository synchronization halting when a branch that had been merged still existed on the remote.


### PR DESCRIPTION
# Why

The recurring `git_repositories_sync` flow records each branch's commit via
`CoreRepositoryUpdate`. When a git branch still present on the remote maps to an
Infrahub branch that has already been merged (and is therefore read-only), the
mutation is rejected. That `GraphQLError` was isolated by neither the per-branch
handler nor any enclosing frame, so a single merged-but-undeleted branch aborted
the **entire** recurring flow every cron cycle — freezing sync for the affected
repository and every repository iterated after it until the branch was deleted.

Goal: a merged/read-only branch lingering on the remote no longer breaks sync.

Non-goals: no change to the server-side read-only guard (rejecting writes to a
merged branch is correct); no broader rework of the sync error-handling model.

Closes #9931

## What changed

- Recurring git sync now skips branches whose Infrahub branch is in a terminal
  status (merged / being deleted) instead of trying to record their commit —
  so one merged branch can no longer stall the whole sync.

Implementation: `collect_pending_imports` filters both the new- and updated-branch
lists through a new `_exclude_read_only_branches` helper, which reads branch
statuses once via `branch.all()` and drops any whose mapped Infrahub branch is in
`TERMINAL_BRANCH_STATUSES`. No new per-branch queries; reuses the existing enum.

What stayed the same: the staging-import path is unaffected (the default branch is
never terminal). No schema, GraphQL, or SDK changes.

## How to test

```bash
INFRAHUB_USE_TEST_CONTAINERS=true uv run pytest \
  backend/tests/integration/git/test_sync_merged_branch.py -v
```

Without the fix the test errors with the `GraphQLError` from the issue; with it the
sync completes and the merged branch is skipped. Regression-checked against
`backend/tests/component/git/test_sync_repository.py` and `backend/tests/unit/git/`.

## Impact & rollout

- **Backward compatibility:** no breaking changes; behavior-only fix.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated — N/A (internal sync behavior)
- [x] Internal .md docs reviewed — no update needed (`branch-status.md` documents the read-only *enforcement* points; this fix is a consumer honoring them)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip branches mapped to merged/read-only Infrahub branches during recurring git repository sync so a lingering merged branch no longer halts the whole flow. Fixes #9931.

- **Bug Fixes**
  - Filter `new_branches` and `updated_branches` via `_exclude_read_only_branches` using `TERMINAL_BRANCH_STATUSES` to drop terminal (merged/deleting) branches.
  - Added integration test to confirm merged branches are skipped and sync completes.
  - Stubbed `infrahub_sdk.branch.InfrahubBranchManager.all` in component test `conftest` and applied across sync and lock-scope tests to avoid the dummy SDK KeyError.

<sup>Written for commit e13fab8a28b6f5fe15f3ef32d7c93c0bde544d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

