### PR TITLE
fix(docker): restore uv in the runtime container image

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -132,13 +132,17 @@ ENV PREFECT_WORKER_QUERY_SECONDS="2" \
     PREFECT_SERVER_API_MAX_PARAMETER_SIZE=0
 
 # Runtime-only OS packages: tini (init/entrypoint), git (repository sync), curl (healthcheck).
-# No build-essential/pkg-config/uv — those exist only in the builder stage.
+# No build-essential/pkg-config — the compiler toolchain exists only in the builder stage.
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y tini git curl ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
+
+# Ship the uv/uvx standalone binaries (not the compiler toolchain) so downstream images built
+# `FROM` this one can install extra Python packages into /.venv when extending Infrahub.
+COPY --from=base /root/.local/bin/uv /root/.local/bin/uvx /usr/local/bin/
 
 RUN mkdir /prom_shared /remote && \
     mkdir -p /opt/infrahub/git /opt/infrahub/storage /opt/infrahub/source /opt/infrahub/frontend/app/dist /opt/infrahub/workflow


### PR DESCRIPTION
## Problem

PR #9868 split the Dockerfile into a `builder` stage (compiler toolchain + `uv`) and a slim `backend` runtime stage that copies only the prebuilt `/.venv`. That dropped `uv` from the shipped image, breaking downstream images built `FROM` the Infrahub image that install extra Python packages into the environment.

## Fix

Copy just the `uv`/`uvx` standalone binaries from the `base` toolchain stage into the runtime image's `/usr/local/bin` (already on `PATH`). This keeps the size win from #9868 — the ~290 MB compiler stack (`build-essential`, `pkg-config`) stays out of the runtime image — while restoring the ability to extend the environment.

## Verification

The change is isolated to the `backend` stage, so I verified it by mirroring that stage (`python:3.14.3-slim` + `ENV PATH="/.venv/bin:${PATH}"` + the exact `COPY`):

- `uv` and `uvx` resolve on `PATH` in a fresh shell (`/usr/local/bin/{uv,uvx}`)
- `uv venv` + `uv pip install` into a new venv succeeds — i.e. the downstream "build a custom image on top of Infrahub" flow works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `uv` and `uvx` in the runtime Docker image so downstream images can install Python packages into the shipped `/.venv` again. The image stays slim by excluding the compiler toolchain.

- **Bug Fixes**
  - Copy `uv` and `uvx` from the `base` stage into `/usr/local/bin` in the runtime stage.
  - Verified `uv` is on PATH and downstream installs into `/.venv` succeed.

<sup>Written for commit 7887ea2cf31b1842946525ad22d8942e0450dc94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

