### PR TITLE
docs(frontend): document the full CI gate + browser-test dep gotcha

### DIFF
--- a/frontend/app/AGENTS.md
+++ b/frontend/app/AGENTS.md
@@ -19,6 +19,27 @@ cd frontend/app && pnpm biome:fix  # Format and lint
 cd frontend/app && pnpm codegen    # Generate GraphQL types
 ```
 
+## Before pushing (run the full CI gate locally)
+
+`pnpm biome:fix` alone is **not** the CI gate. The `frontend-lint` job runs three checks and
+`frontend-tests` runs the browser test suite. Run all of them before pushing — they each fail CI
+independently:
+
+```bash
+cd frontend/app && pnpm exec biome ci .   # format + lint (same as CI)
+cd frontend/app && pnpm knip              # unused exports/files/deps
+cd frontend/app && pnpm exec betterer ci  # TypeScript-regression gate (NOT plain tsc)
+cd frontend/app && pnpm test              # vitest (browser mode)
+```
+
+- **`betterer`** ratchets ~200 tracked pre-existing TS errors (`.betterer.results`); the count must
+  never grow. **After a rebase, or when moving/editing a file with tracked errors, refresh it**:
+  `pnpm betterer`, then commit `.betterer.results`. See `dev/guidelines/frontend/typescript.md`.
+- **Browser-test flakes**: tests run in real Chromium. A new npm dependency that Vite's initial scan
+  can't see (reached only via `React.lazy`/dynamic import) must be added to
+  `vitest.config.ts` → `optimizeDeps.include`, or CI fails with
+  `[vitest] Vite unexpectedly reloaded a test`.
+
 ## See Also
 
 ### Guidelines (How to write code)

--- a/frontend/app/AGENTS.md
+++ b/frontend/app/AGENTS.md
@@ -32,14 +32,6 @@ cd frontend/app && pnpm exec betterer ci  # TypeScript-regression gate (NOT plai
 cd frontend/app && pnpm test              # vitest (browser mode)
 ```
 
-- **`betterer`** ratchets ~200 tracked pre-existing TS errors (`.betterer.results`); the count must
-  never grow. **After a rebase, or when moving/editing a file with tracked errors, refresh it**:
-  `pnpm betterer`, then commit `.betterer.results`. See `dev/guidelines/frontend/typescript.md`.
-- **Browser-test flakes**: tests run in real Chromium. A new npm dependency that Vite's initial scan
-  can't see (reached only via `React.lazy`/dynamic import) must be added to
-  `vitest.config.ts` → `optimizeDeps.include`, or CI fails with
-  `[vitest] Vite unexpectedly reloaded a test`.
-
 ## See Also
 
 ### Guidelines (How to write code)


### PR DESCRIPTION
## What

`frontend/app/AGENTS.md` implied `pnpm biome:fix` was the lint step, but the `frontend-lint` CI job actually runs **three** checks (`biome ci` + `knip` + `betterer ci`) and `frontend-tests` runs the browser suite. Adds a **"Before pushing"** section so agents/contributors run the full gate locally.

Also documents two gotchas that cost real CI cycles:
- **betterer** must be refreshed (`pnpm betterer`, commit `.betterer.results`) after a rebase or when moving/editing a file with tracked errors.
- A new npm dep reached only via `React.lazy`/dynamic import must go in `vitest.config.ts` → `optimizeDeps.include`, or browser tests flake with `[vitest] Vite unexpectedly reloaded a test`.

## Why

Came out of a retrospective on PR #9930, where each of these was found by CI one push at a time instead of locally up front.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `frontend/app/AGENTS.md` to document the full frontend CI gate and streamline the “Before pushing” steps so contributors can run the same checks locally (`biome ci`, `knip`, `betterer ci`, and browser tests).

- **Migration**
  - Run before pushing: `pnpm exec biome ci .`, `pnpm knip`, `pnpm exec betterer ci`, `pnpm test` (browser mode).

<sup>Written for commit c8529ec3f6a55503a3888937a5dd340683d10e9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

