### PR TITLE
docs(frontend): gate authenticated-query providers on auth (RequireAuth is not a gate)

### DIFF
--- a/dev/guidelines/frontend/route-architecture.md
+++ b/dev/guidelines/frontend/route-architecture.md
@@ -293,11 +293,36 @@ The path-based tab routing migration left `Pill`, `TASK_TAB`, and `DIFF_TABS` or
 
 Add `pnpm knip` to your verification commands any time a PR deletes a component, switches a switch-on-QSP to nested routes, or otherwise removes the last importer of a helper. Fix in the same PR — orphaned exports compound and become harder to delete with confidence as time passes.
 
+## Authenticated data providers mount under `RequireAuth`
+
+A React context provider whose data comes from an **authenticated** query (`BranchesProvider`,
+`SchemaProvider`, `DatePreferencesProvider`, …) must mount **inside `RequireAuth`** in
+`app/router.tsx`, not at the app root in `app.tsx`.
+
+```tsx
+<RequireAuth>
+  <DatePreferencesProvider>
+    <BranchesProvider>
+      <SchemaProvider>
+        <Outlet />
+```
+
+Mounting such a provider above the router means its query also runs on the **login page**, before a
+token exists. The resulting 401 trips Apollo's `errorLink` → `redirectToLogin`, which races the
+just-submitted login back to `/login` — intermittently, so it surfaces as a flaky E2E auth-setup
+timeout rather than an obvious error. Placement is the fix; **prefer it over a runtime `enabled`
+flag**, which leaves the provider mounted (and coupled to auth state) on pages that don't need it.
+
+This came from PR #9930: `DatePreferencesProvider` was mounted at the root and broke the read-write
+E2E login. Scope a provider by *where it mounts*, mirroring the sibling providers already under
+`RequireAuth`.
+
 ## Anti-patterns observed in past PRs
 
 | Anti-pattern | Replacement |
 |---|---|
 | `?tab=foo` URL state for tab navigation | Nested child routes + `LinkTab` + `<Outlet />` |
+| App-level provider with an authenticated query mounted in `app.tsx` | Mount under `RequireAuth` in `router.tsx` |
 | Tab bar without `<nav aria-label="Tabs">` | Always wrap; E2E selectors and screen readers depend on it |
 | Children re-calling the same parent query | `<Outlet context>` + typed hook with runtime guard |
 | `useParams() as { foo: string }` for guaranteed params | `useRequiredParams("foo")` |

--- a/dev/guidelines/frontend/route-architecture.md
+++ b/dev/guidelines/frontend/route-architecture.md
@@ -293,36 +293,42 @@ The path-based tab routing migration left `Pill`, `TASK_TAB`, and `DIFF_TABS` or
 
 Add `pnpm knip` to your verification commands any time a PR deletes a component, switches a switch-on-QSP to nested routes, or otherwise removes the last importer of a helper. Fix in the same PR — orphaned exports compound and become harder to delete with confidence as time passes.
 
-## Authenticated data providers mount under `RequireAuth`
+## An authenticated-query provider must gate its own fetch on auth
 
-A React context provider whose data comes from an **authenticated** query (`BranchesProvider`,
-`SchemaProvider`, `DatePreferencesProvider`, …) must mount **inside `RequireAuth`** in
-`app/router.tsx`, not at the app root in `app.tsx`.
+A context provider whose data comes from an **authenticated** query (`DatePreferencesProvider`, …)
+must not fire that query for a logged-out user. Gate the fetch on `isAuthenticated` by **not mounting
+the query-calling component** until authenticated:
 
 ```tsx
-<RequireAuth>
-  <DatePreferencesProvider>
-    <BranchesProvider>
-      <SchemaProvider>
-        <Outlet />
+export function DatePreferencesProvider({ children }) {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) return children;              // logged out → no query, browser fallback
+  return <AuthenticatedDatePreferences>{children}</AuthenticatedDatePreferences>;
+}
 ```
 
-Mounting such a provider above the router means its query also runs on the **login page**, before a
-token exists. The resulting 401 trips Apollo's `errorLink` → `redirectToLogin`, which races the
-just-submitted login back to `/login` — intermittently, so it surfaces as a flaky E2E auth-setup
-timeout rather than an obvious error. Placement is the fix; **prefer it over a runtime `enabled`
-flag**, which leaves the provider mounted (and coupled to auth state) on pages that don't need it.
+Why this matters, and why **`RequireAuth` is not the gate**: `RequireAuth` renders its children when
+`isAuthenticated || config.main.allow_anonymous_access`, so with anonymous access enabled the whole
+authenticated route tree — and any provider mounted in it — renders for **logged-out** users. An
+ungated authenticated query then 401s, Apollo's `errorLink` calls `redirectToLogin`, and the user is
+bounced to `/login`. Because it depends on timing/anonymous-access it surfaces as a **flaky E2E
+failure** (auth-setup timeout, or "not logged in" specs), not an obvious error.
 
-This came from PR #9930: `DatePreferencesProvider` was mounted at the root and broke the read-write
-E2E login. Scope a provider by *where it mounts*, mirroring the sibling providers already under
-`RequireAuth`.
+Prefer the mount gate above over react-query `enabled: isAuthenticated` — it keeps the query hook
+itself auth-agnostic (the "authenticated" concern is a distinct component that simply doesn't exist
+when logged out). Do **not** rely on placement under `RequireAuth`; do **not** read the auth token
+from a `domain/` use-case (that breaks the FSD layer rule — auth state stays in `ui/`).
+
+This came from PR #9930: `DatePreferencesProvider` first mounted at the app root, then under
+`RequireAuth` — both fired the query for logged-out users and broke E2E. The fix was to gate the
+mount on `isAuthenticated`.
 
 ## Anti-patterns observed in past PRs
 
 | Anti-pattern | Replacement |
 |---|---|
 | `?tab=foo` URL state for tab navigation | Nested child routes + `LinkTab` + `<Outlet />` |
-| App-level provider with an authenticated query mounted in `app.tsx` | Mount under `RequireAuth` in `router.tsx` |
+| Authenticated-query provider that fetches for logged-out users (relies on `RequireAuth` or mounts unconditionally) | Gate the fetch on `isAuthenticated` — don't mount the query-calling component when logged out |
 | Tab bar without `<nav aria-label="Tabs">` | Always wrap; E2E selectors and screen readers depend on it |
 | Children re-calling the same parent query | `<Outlet context>` + typed hook with runtime guard |
 | `useParams() as { foo: string }` for guaranteed params | `useRequiredParams("foo")` |


### PR DESCRIPTION
## What

Adds a route-architecture rule: a context provider backed by an **authenticated** query must gate its own fetch on `isAuthenticated` (don't mount the query-calling component when logged out).

## Why

`RequireAuth` renders its children when `isAuthenticated || config.main.allow_anonymous_access`, so with anonymous access enabled the authenticated route tree — and any provider mounted in it — renders for **logged-out** users. An ungated authenticated query then 401s, Apollo's `errorLink` calls `redirectToLogin`, and the user is bounced to `/login`. It's timing/anonymous-dependent, so it shows up as a **flaky E2E failure**, not an obvious error.

Rule: gate the fetch by not mounting the query-calling component until authenticated. Prefer that over react-query `enabled` (keeps the query hook auth-agnostic), and never read the auth token from a `domain/` use-case (FSD layer rule).

From a retrospective on PR #9930, where a `DatePreferencesProvider` fetched for logged-out users and broke E2E.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)