### PR TITLE
fix(graphql): normalize non-str node_type in NodeNotFoundError (closes #9926)

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -876,7 +876,8 @@ class NodeManager:
             branch_agnostic=branch_agnostic,
         )
         if not node:
-            raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
+            kind_str = get_schema(db=db, branch=branch, node_schema=kind).kind
+            raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
         return node
 
     @overload
@@ -1059,7 +1060,8 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
+                kind_str = get_schema(db=db, branch=branch, node_schema=kind).kind if kind else "Node"
+                raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
             return None
 
         node = result[id]

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -84,6 +84,16 @@ def get_schema[SchemaProtocol](
     return node_schema
 
 
+def get_kind_str(kind: str | type | MainSchemaTypes | None) -> str:
+    if isinstance(kind, str):
+        return kind
+    if isinstance(kind, type) and issubclass(kind, CoreNode):
+        return kind.__name__
+    if isinstance(kind, MainSchemaTypes):
+        return kind.kind
+    return "Unknown kind"
+
+
 class NodeManager:
     @overload
     @classmethod
@@ -876,8 +886,7 @@ class NodeManager:
             branch_agnostic=branch_agnostic,
         )
         if not node:
-            kind_str = get_schema(db=db, branch=branch, node_schema=kind).kind
-            raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
+            raise NodeNotFoundError(branch_name=branch.name, node_type=get_kind_str(kind), identifier=id)
         return node
 
     @overload
@@ -1060,8 +1069,7 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                kind_str = get_schema(db=db, branch=branch, node_schema=kind).kind if kind else "Node"
-                raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=id)
+                raise NodeNotFoundError(branch_name=branch.name, node_type=get_kind_str(kind), identifier=id)
             return None
 
         node = result[id]

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -244,12 +244,15 @@ class NodeNotFoundError(Error):
     HTTP_CODE: int = 404
 
     def __init__(
-        self, node_type: str, identifier: str, branch_name: str | None = None, message: str | None = None
+        self, node_type: str | type, identifier: str, branch_name: str | None = None, message: str | None = None
     ) -> None:
-        self.node_type = node_type
+        # Callers may pass a schema/protocol class as the kind rather than its kind string;
+        # normalize to a string so downstream consumers (e.g. error payload serialization)
+        # always see a plain kind name.
+        self.node_type = node_type if isinstance(node_type, str) else getattr(node_type, "__name__", str(node_type))
         self.identifier = identifier
         self.branch_name = branch_name
-        self.message = message or f"Unable to find the node {identifier} / {node_type} in the database."
+        self.message = message or f"Unable to find the node {identifier} / {self.node_type} in the database."
         super().__init__(self.message)
 
     def __str__(self) -> str:

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -244,15 +244,12 @@ class NodeNotFoundError(Error):
     HTTP_CODE: int = 404
 
     def __init__(
-        self, node_type: str | type, identifier: str, branch_name: str | None = None, message: str | None = None
+        self, node_type: str, identifier: str, branch_name: str | None = None, message: str | None = None
     ) -> None:
-        # Callers may pass a schema/protocol class as the kind rather than its kind string;
-        # normalize to a string so downstream consumers (e.g. error payload serialization)
-        # always see a plain kind name.
-        self.node_type = node_type if isinstance(node_type, str) else getattr(node_type, "__name__", str(node_type))
+        self.node_type = node_type
         self.identifier = identifier
         self.branch_name = branch_name
-        self.message = message or f"Unable to find the node {identifier} / {self.node_type} in the database."
+        self.message = message or f"Unable to find the node {identifier} / {node_type} in the database."
         super().__init__(self.message)
 
     def __str__(self) -> str:

--- a/backend/infrahub/graphql/error_formatter.py
+++ b/backend/infrahub/graphql/error_formatter.py
@@ -49,7 +49,10 @@ def _build_payload(exc: BaseException | None, code: str) -> dict[str, Any]:
     payload: BaseModel = UndefinedErrorData()
     match code:
         case "NODE_NOT_FOUND" if isinstance(exc, NodeNotFoundError):
-            payload = NodeNotFoundData(node_kind=exc.node_type, identifier=exc.identifier)
+            # ``node_type`` is normally a kind string, but guard against a non-str value
+            # so formatting an error can never itself raise.
+            node_kind = exc.node_type if isinstance(exc.node_type, str) else getattr(exc.node_type, "__name__", None)
+            payload = NodeNotFoundData(node_kind=node_kind or str(exc.node_type), identifier=exc.identifier)
         case "AUTHENTICATION_REQUIRED":
             payload = AuthenticationRequiredData()
         case "TOKEN_EXPIRED":

--- a/backend/infrahub/graphql/error_formatter.py
+++ b/backend/infrahub/graphql/error_formatter.py
@@ -49,10 +49,7 @@ def _build_payload(exc: BaseException | None, code: str) -> dict[str, Any]:
     payload: BaseModel = UndefinedErrorData()
     match code:
         case "NODE_NOT_FOUND" if isinstance(exc, NodeNotFoundError):
-            # ``node_type`` is normally a kind string, but guard against a non-str value
-            # so formatting an error can never itself raise.
-            node_kind = exc.node_type if isinstance(exc.node_type, str) else getattr(exc.node_type, "__name__", None)
-            payload = NodeNotFoundData(node_kind=node_kind or str(exc.node_type), identifier=exc.identifier)
+            payload = NodeNotFoundData(node_kind=str(exc.node_type), identifier=exc.identifier)
         case "AUTHENTICATION_REQUIRED":
             payload = AuthenticationRequiredData()
         case "TOKEN_EXPIRED":

--- a/backend/tests/unit/core/test_manager.py
+++ b/backend/tests/unit/core/test_manager.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from infrahub.core.manager import get_kind_str
+from infrahub.core.protocols import CoreMenuItem
+from infrahub.core.schema import NodeSchema
+
+
+def test_get_kind_str_returns_string_unchanged() -> None:
+    assert get_kind_str("BuiltinTag") == "BuiltinTag"
+
+
+def test_get_kind_str_resolves_protocol_class_to_name() -> None:
+    assert get_kind_str(CoreMenuItem) == "CoreMenuItem"
+
+
+def test_get_kind_str_reads_kind_from_schema_object() -> None:
+    assert get_kind_str(NodeSchema(name="Widget", namespace="Test")) == "TestWidget"
+
+
+def test_get_kind_str_falls_back_for_unknown_input() -> None:
+    assert get_kind_str(None) == "Unknown kind"

--- a/backend/tests/unit/graphql/test_error_formatter.py
+++ b/backend/tests/unit/graphql/test_error_formatter.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from graphql import GraphQLError
 
+from infrahub.core.protocols import CoreMenuItem
 from infrahub.errors.exceptions import (
     AttributeConstraintViolationError,
     AttributeInvalidTypeError,
@@ -131,6 +132,19 @@ def test_build_catalogue_extensions_per_code(case: CodeCase) -> None:
     assert extensions["code"] == case.expected_code
     assert extensions["http_status"] == case.expected_http_status
     assert extensions["data"] == case.expected_data
+
+
+def test_build_catalogue_extensions_handles_class_node_type() -> None:
+    exc = NodeNotFoundError(node_type=CoreMenuItem, identifier="x")
+
+    extensions = build_catalogue_extensions(exc)
+
+    assert extensions["code"] == "NODE_NOT_FOUND"
+    assert extensions["http_status"] == 404
+    assert extensions["data"]["identifier"] == "x"
+    node_kind = extensions["data"]["node_kind"]
+    assert isinstance(node_kind, str)
+    assert "CoreMenuItem" in node_kind
 
 
 def test_undefined_error_for_uncatalogued_error_with_http_code() -> None:

--- a/backend/tests/unit/graphql/test_error_formatter.py
+++ b/backend/tests/unit/graphql/test_error_formatter.py
@@ -135,7 +135,10 @@ def test_build_catalogue_extensions_per_code(case: CodeCase) -> None:
 
 
 def test_build_catalogue_extensions_handles_class_node_type() -> None:
-    exc = NodeNotFoundError(node_type=CoreMenuItem, identifier="x")
+    # A class kind here deliberately violates the str-typed API to prove the formatter
+    # still produces a valid payload rather than raising.
+    kwargs: dict[str, Any] = {"node_type": CoreMenuItem, "identifier": "x"}
+    exc = NodeNotFoundError(**kwargs)
 
     extensions = build_catalogue_extensions(exc)
 

--- a/changelog/9926.fixed.md
+++ b/changelog/9926.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where some GraphQL requests could return an unexpected HTTP 500 error instead of a proper node-not-found response.


### PR DESCRIPTION
## Analyst's findings (summary)

> **Root cause:** `NodeNotFoundError.node_type` can hold a schema/protocol **class** (`type[SchemaProtocol]`) rather than a string. The GraphQL error formatter feeds it straight into `NodeNotFoundData(node_kind=...)`, whose `node_kind` field is typed `str`, so pydantic raises a `ValidationError` **inside** the error-formatting path — turning a would-be `NODE_NOT_FOUND` (404) response into an uncaught ASGI 500.
>
> **Affected files:**
> - `backend/infrahub/graphql/error_formatter.py` — `_build_payload()` builds `NodeNotFoundData(node_kind=exc.node_type, ...)` with no coercion (the crash site).
> - `backend/infrahub/errors/payloads.py` — `NodeNotFoundData.node_kind: str` (`extra="forbid", frozen=True`).
> - `backend/infrahub/exceptions.py` — `NodeNotFoundError.__init__` annotates `node_type: str` but stores it verbatim with no coercion.
> - `backend/infrahub/core/manager.py` — `get_one` and `get_one_by_id_or_default_filter` raise with an unresolved class `kind`, unlike sibling sites that resolve to `kind_str` first.

## Replication test

**Test file:** `backend/tests/unit/graphql/test_error_formatter.py`
**Test name:** `test_build_catalogue_extensions_handles_class_node_type`

**What it tests:** Formatting a `NodeNotFoundError` whose `node_type` is a class produces a normal catalogued `NODE_NOT_FOUND` / 404 payload with a string `node_kind`, instead of raising.

**Verification:** Test confirmed FAILING on the pre-fix code.
**Failure reason:** `build_catalogue_extensions` raised a pydantic `ValidationError` on `node_kind` inside `_build_payload`, proving the formatter can itself crash while formatting an error.

<details><summary>Failure output (last 20 lines)</summary>

```
backend/tests/unit/graphql/test_error_formatter.py:140: in test_build_catalogue_extensions_handles_class_node_type
    extensions = build_catalogue_extensions(exc)
backend/infrahub/graphql/error_formatter.py:127: in build_catalogue_extensions
    "data": _build_payload(exc, code),
backend/infrahub/graphql/error_formatter.py:52: in _build_payload
    payload = NodeNotFoundData(node_kind=exc.node_type, identifier=exc.identifier)
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for NodeNotFoundData
E   node_kind
E     Input should be a valid string [type=string_type, input_value=<class 'infrahub.core.protocols.CoreMenuItem'>, input_type=type]
E       For further information visit https://errors.pydantic.dev/2.12/v/string_type
```

</details>

## Test expectations

The test asserts the observable behavior of the error formatter for a class-valued `node_type`: it must not raise, and it must return `code == "NODE_NOT_FOUND"`, `http_status == 404`, `data["identifier"] == "x"`, and a string `data["node_kind"]` that conveys the kind name. The `node_kind` assertion is deliberately tolerant of the exact coercion strategy (kind name vs. repr) so it validates the contract without over-constraining the fix.

<!-- AGENT_TEST_COMPLETE -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the GraphQL error formatter when `NodeNotFoundError` carried a non-string `node_type`, which returned a 500 instead of a 404. The formatter now always returns a `NODE_NOT_FOUND` payload with a string `node_kind`.

- **Bug Fixes**
  - Normalize kinds at `NodeManager` raise sites (`get_one`, `get_one_by_id_or_default_filter`) using a new `get_kind_str` helper to always pass a string into `NodeNotFoundError`.
  - Coerce `node_kind` with `str()` in `_build_payload` so formatting never raises; added unit tests for class-valued `node_type` and for `get_kind_str`.

<sup>Written for commit f2fe776885929295507997e03e2c33f33cfc56a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

