### PR TITLE
docs: harvest frontend review lessons + document the .agents/rules layer (stacked on #9951)

### DIFF
--- a/.agents/rules/frontend-conventions.md
+++ b/.agents/rules/frontend-conventions.md
@@ -46,4 +46,4 @@ Before building anything generic (a row/layout wrapper, a combobox, a modal vari
 
 ## Naming
 
-File and hook names follow `dev/guidelines/frontend/naming-conventions.md`. Hook names match the operation (`useUpsert…` not `useUpdate…` for an upsert) and predicate hooks read as a question (`useHasX`).
+File and hook names follow `dev/guidelines/frontend/naming-conventions.md` — see its File Naming and Hook Naming sections.

--- a/.agents/rules/frontend-conventions.md
+++ b/.agents/rules/frontend-conventions.md
@@ -21,7 +21,7 @@ Full detail: `dev/knowledge/frontend/entities-structure.md`.
 ## React Query
 
 - Build query keys from the entity's key factory (`{noun}.query-keys.ts` → `{noun}QueryKeys`); never hardcode a key array.
-- Cache invalidation lives inside the `useMutation` hook (`onSuccess`/`onSettled`), not at the call site.
+- Cache invalidation lives inside the `useMutation` hook (`onSuccess`/`onSettled`) by default. Call-site invalidation is allowed only when the key needs context the hook lacks — mark it with an `invalidation-at-callsite` comment (see `naming-conventions.md#mutation-invalidation`).
 - Do not set Apollo `fetchPolicy` at a call site — the default is `no-cache` and TanStack Query is the only server-state cache.
 
 See `dev/guidelines/frontend/naming-conventions.md` and `dev/knowledge/frontend/entities-structure.md`.

--- a/.agents/rules/frontend-conventions.md
+++ b/.agents/rules/frontend-conventions.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "frontend/app/src/**/*.ts"
+  - "frontend/app/src/**/*.tsx"
+---
+
+# Frontend conventions
+
+Applies when writing or changing frontend code under `frontend/app/src/`. These are the conventions reviewers raise most often; the fuller reference lives in `dev/guidelines/frontend/` and `dev/knowledge/frontend/`.
+
+## Entity layers: api → domain → ui
+
+Each entity has three layers with one-way imports (`ui/ → domain/ → api/`):
+
+- **`api/`** — transport only: make the network/GraphQL call and return the raw response. No business logic, no React.
+- **`domain/`** — pure TypeScript business logic: orchestration, decisions, validation, mapping. A domain async function does `call api → check for errors → validate → map to domain types`, and *answers the business question* (e.g. `hasGlobalPermission()`), not just "fetch data". Extract reusable pure logic into a `domain/` rule module so it is unit-testable on its own — don't bury it in a component.
+- **`ui/`** — React + TanStack Query wiring only. `queryOptions`/`useQuery`/`useMutation` live in `ui/queries/`; keep business logic out of `useQuery`'s `select` (call a domain function instead).
+
+Full detail: `dev/knowledge/frontend/entities-structure.md`.
+
+## React Query
+
+- Build query keys from the entity's key factory (`{noun}.query-keys.ts` → `{noun}QueryKeys`); never hardcode a key array.
+- Cache invalidation lives inside the `useMutation` hook (`onSuccess`/`onSettled`), not at the call site.
+- Do not set Apollo `fetchPolicy` at a call site — the default is `no-cache` and TanStack Query is the only server-state cache.
+
+See `dev/guidelines/frontend/naming-conventions.md` and `dev/knowledge/frontend/entities-structure.md`.
+
+## React (compiler enabled)
+
+Do **not** use `useMemo`, `useCallback`, or `memo()` — React Compiler memoizes automatically (`dev/knowledge/frontend/react.md`). Derive state during render instead of syncing it with effects.
+
+## Types
+
+- No `any`, no `!` (non-null assertion), no `as` — narrow with a guard or early return.
+- Prefer generated types/enums (e.g. `DateFormat` from the generated GraphQL types) over `string`; model nullability to the backend reality rather than making everything optional.
+- Return `null` for an intentional empty value, `undefined` for absent/not-provided.
+
+## Comments
+
+Do not add comments that narrate what the code is doing. Explain a non-obvious *why* only; a comment that restates the code is noise and rots. (Same bar as the backend `code-doc-style` rule.)
+
+## Reuse first
+
+Before building anything generic (a row/layout wrapper, a combobox, a modal variant), check `dev/knowledge/frontend/shared-components.md` and the `@infrahub/ui` design system — compose existing primitives instead of hand-rolling.
+
+## Naming
+
+File and hook names follow `dev/guidelines/frontend/naming-conventions.md`. Hook names match the operation (`useUpsert…` not `useUpdate…` for an upsert) and predicate hooks read as a question (`useHasX`).

--- a/dev/guidelines/frontend/naming-conventions.md
+++ b/dev/guidelines/frontend/naming-conventions.md
@@ -66,6 +66,12 @@ export type GetDiffSummaryResponse = { /* ... */ };
 
 Do not use `*Response`, `*Output`, `*Outcome`, or `*Data` suffixes — `*Result` is the only sanctioned name.
 
+## Hook Naming
+
+- A hook that reads or writes through the API takes a CRUD/verb prefix that **matches the operation**: `useGet…`, `useCreate…`, `useUpsert…`, `useDelete…`, `useMerge…`. Do not call an upsert `useUpdate…` — the verb should read the same as the domain function it wraps.
+- A hook that answers a yes/no question reads as one: `useHasGlobalPermission`, `useCanEditX` — not `useGlobalPermission`.
+- Match the shape of the entity's existing hooks (`useGetBranches`, `useMergeBranch`); don't invent a parallel suffix.
+
 ## Query Keys
 
 Build query keys from a single object, not positional spreads. Object-shaped keys are easier to read in devtools, easier to invalidate by partial match, and easier to diff.

--- a/dev/guidelines/frontend/naming-conventions.md
+++ b/dev/guidelines/frontend/naming-conventions.md
@@ -68,7 +68,9 @@ Do not use `*Response`, `*Output`, `*Outcome`, or `*Data` suffixes — `*Result`
 
 ## Hook Naming
 
-- A hook that reads or writes through the API takes a CRUD/verb prefix that **matches the operation**: `useGet…`, `useCreate…`, `useUpsert…`, `useDelete…`, `useMerge…`. Do not call an upsert `useUpdate…` — the verb should read the same as the domain function it wraps.
+Applies to **new** hooks — some legacy hooks (e.g. `useMenu`) predate this and are not worth churning.
+
+- A new hook that reads or writes through the API takes a CRUD/verb prefix that **matches the operation**: `useGet…`, `useCreate…`, `useUpsert…`, `useDelete…`, `useMerge…`. Do not call an upsert `useUpdate…` — the verb should read the same as the domain function it wraps.
 - A hook that answers a yes/no question reads as one: `useHasGlobalPermission`, `useCanEditX` — not `useGlobalPermission`.
 - Match the shape of the entity's existing hooks (`useGetBranches`, `useMergeBranch`); don't invent a parallel suffix.
 

--- a/dev/guidelines/frontend/typescript.md
+++ b/dev/guidelines/frontend/typescript.md
@@ -26,8 +26,8 @@ type LinkProps =
 ## Hooks
 
 - Prefix: `use*`
-- Let TypeScript infer return types (annotate only when complex)
-- Include all deps in useEffect/useCallback/useMemo arrays
+- Let TypeScript infer return types (annotate only when complex) — this includes `useMutation`/`useQuery` callbacks; don't hand-type them
+- Include all deps in `useEffect` arrays. Do **not** use `useMemo`/`useCallback`/`memo` — React Compiler memoizes automatically (see [react.md](../../knowledge/frontend/react.md))
 
 ## Type Safety
 
@@ -45,6 +45,10 @@ if (isUserData(response)) {
   const data = response; // TS knows type
 }
 ```
+
+### `null` vs `undefined`
+
+Distinguish them by intent: return `null` for a value that is *intentionally empty*, and `undefined` for one that is *absent / not provided*. A domain function that resolves to "no value" should return `null`, not `undefined`.
 
 ### `optional?.x!` is always wrong
 

--- a/dev/guidelines/repository-organization.md
+++ b/dev/guidelines/repository-organization.md
@@ -122,6 +122,44 @@ Each directory in `dev/` serves a specific purpose and follows a content lifecyc
 
 **Naming**: Use descriptive, kebab-case names that clearly indicate the topic.
 
+**Relationship to `.agents/rules/`**: Guidelines are the *full* rulebook. The lean subset of these rules that must be in front of an agent while it writes code — auto-injected every turn — lives in `.agents/rules/` (see below). Both are rules; the only difference is how they load.
+
+### rules/
+
+**Purpose**: "What must I always/never do while writing this code?"
+
+**Content Lifecycle**: Stable. The lean, always-loaded subset of the coding rules in `guidelines/`.
+
+**Primary Target**: AI
+
+**Location**: Rules live in `.agents/rules/` (the vendor-neutral canonical source), not under `dev/`. Tool adapters symlink here (e.g. `.claude/rules → ../.agents/rules`).
+
+**File Size Guidelines**: As small as possible — terse always/never bullets, no long examples or tables.
+
+**Rules vs. guidelines — same content, different delivery.** Both hold prescriptive rules; they are not "rules vs. not-rules". The difference is how each is loaded:
+
+- A file in `.agents/rules/` carries a `paths:` glob in its frontmatter and is **auto-injected into every agent turn** that touches a matching file. It is paid for on every such turn, so it must stay lean.
+- `dev/guidelines/**` is the **full rulebook** — the same rules with tables, ✅/❌ examples, and enforcement scripts — loaded **on demand** when the relevant `AGENTS.md` router points an agent at it.
+
+So `.agents/rules/` is not "the rules" as opposed to the guidelines; it is the always-on *index* of the highest-value rules, each pointing to its fuller home in `dev/guidelines/`.
+
+**What earns a rule slot** (all three must hold — every rule costs tokens on every matching turn):
+
+1. It is a terse always/never an author can follow without opening anything else.
+2. It applies broadly across files matching the glob, not to one narrow task.
+3. The cost of an agent *not* knowing it — a repeated review nit or a real bug — outweighs the per-turn tokens.
+
+**Keep rules as pointers, not copies.** A rule line states the imperative and points to the guideline for the detail (examples, enforcement scripts). When a rule would restate a guideline at the same depth, shrink it to a pointer — the guideline stays the single source of truth.
+
+**Example Files**:
+
+- `code-doc-style.md` — comment and docstring rules (backend)
+- `backend-component-design.md` — SOLID/DI for new backend components
+- `testing-python.md` — backend test rules
+- `frontend-conventions.md` — the always-on frontend conventions, pointing into `dev/guidelines/frontend/`
+
+**Naming**: Use descriptive, kebab-case names that indicate the domain or concern (e.g. `python-module-layout.md`).
+
 ### knowledge/
 
 **Purpose**: "How does this work?"
@@ -533,7 +571,7 @@ Maintain a single source of truth with symlinks for tool compatibility, since mo
 rm -rf .claude/commands .claude/skills
 
 # Create tool directories
-mkdir -p .claude 
+mkdir -p .claude
 
 # Create symlinks to canonical source
 ln -s ../.agents/commands .claude/commands

--- a/dev/guidelines/repository-organization.md
+++ b/dev/guidelines/repository-organization.md
@@ -128,7 +128,7 @@ Each directory in `dev/` serves a specific purpose and follows a content lifecyc
 
 **Purpose**: "What must I always/never do while writing this code?"
 
-**Content Lifecycle**: Stable. The lean, always-loaded subset of the coding rules in `guidelines/`.
+**Content Lifecycle**: Stable. The lean, always-loaded subset of the coding rules; the fuller reference lives in `guidelines/` (or `knowledge/` when the detail is how-it-works context).
 
 **Primary Target**: AI
 
@@ -141,7 +141,7 @@ Each directory in `dev/` serves a specific purpose and follows a content lifecyc
 - A file in `.agents/rules/` carries a `paths:` glob in its frontmatter and is **auto-injected into every agent turn** that touches a matching file. It is paid for on every such turn, so it must stay lean.
 - `dev/guidelines/**` is the **full rulebook** — the same rules with tables, ✅/❌ examples, and enforcement scripts — loaded **on demand** when the relevant `AGENTS.md` router points an agent at it.
 
-So `.agents/rules/` is not "the rules" as opposed to the guidelines; it is the always-on *index* of the highest-value rules, each pointing to its fuller home in `dev/guidelines/`.
+So `.agents/rules/` is not "the rules" as opposed to the guidelines; it is the always-on *index* of the highest-value rules, each pointing to its fuller home in `dev/guidelines/` (or `dev/knowledge/` for how-it-works detail).
 
 **What earns a rule slot** (all three must hold — every rule costs tokens on every matching turn):
 
@@ -568,14 +568,15 @@ Maintain a single source of truth with symlinks for tool compatibility, since mo
 
 ```bash
 # Remove old directories if they exist
-rm -rf .claude/commands .claude/skills
+rm -rf .claude/commands .claude/skills .claude/rules
 
 # Create tool directories
 mkdir -p .claude
 
 # Create symlinks to canonical source
 ln -s ../.agents/commands .claude/commands
-
+ln -s ../.agents/skills .claude/skills
+ln -s ../.agents/rules .claude/rules
 ```
 
 ## Best Practices

--- a/dev/knowledge/frontend/entities-structure.md
+++ b/dev/knowledge/frontend/entities-structure.md
@@ -48,6 +48,19 @@ Page (thin route wrapper)
 
 Global state (branch, date, schema) is injected at the ui/ layer and passed as parameters to domain/ functions. Domain functions never read global state directly.
 
+## What goes in a domain function
+
+The `api/` function is a thin transport call. The `domain/` function is where the work happens, in this order:
+
+1. **Call** the `api/` function.
+2. **Check for errors** — throw on failure (don't return an unread `ok` flag that a caller might ignore).
+3. **Validate** the response shape.
+4. **Map** to domain types.
+
+A domain function should *answer the business question*, not just "fetch data": expose `hasGlobalPermission(action)` rather than `getGlobalPermissions()` + a check the caller has to repeat. Keep that decision in `domain/`; the `ui/queries/` hook only wires TanStack Query — don't put business logic in `useQuery`'s `select`.
+
+Reusable pure logic (list transforms, sort/merge rules, permission resolution) belongs in a `domain/` rule module so it can be unit-tested on its own, not inlined in a component where it is only reachable through the UI.
+
 ## queryOptions Live in ui/queries/
 
 queryOptions factories and useQuery/useMutation hooks live in `ui/queries/`, not in domain/. Domain's public API is async functions and types only.
@@ -163,3 +176,7 @@ Do not enable Apollo's normalized cache, do not pass `fetchPolicy: "cache-first"
 ### Mutation invalidation
 
 Mutations own their cache invalidation. Place `onSuccess`/`onSettled` inside the `useMutation` hook in `ui/queries/*.mutation.ts`. See `dev/guidelines/frontend/naming-conventions.md#mutation-invalidation` for the convention and the audit script.
+
+### Avoiding double error toasts
+
+The Apollo error link already surfaces a toast for a failed request. If a mutation also renders its own error toast (in `onError` or a `catch`), the user sees two. Suppress the automatic one for that call by passing `context: { processErrorMessage: () => {} }` to the mutation so only the component's toast shows.


### PR DESCRIPTION
## What

Second accumulative run of the `harvesting-review` skill, over the review threads of **5 merged PRs** — #9871, #9867, #9754, #9880, #9890 (mostly frontend). **Stacked on #9951** (batch 1); GitHub will retarget this to `stable` once #9951 merges.

It also documents the `.agents/rules/` layer itself (see the last section) — a gap that surfaced directly out of the review discussion on this PR.

## Why

The same frontend conventions get re-flagged on **every** frontend PR — layering, query-key builders, no-`useMemo`, hook naming — even though they're already written down in `dev/guidelines/frontend/` and `dev/knowledge/frontend/`. The reason is structural: **there was no auto-injected `.agents/rules` for frontend at all** (backend has four; frontend had zero), so nothing surfaced these conventions while an author is writing frontend code. This PR closes that gap and fills the few genuinely-missing specifics.

## Frontend conventions harvested

- **New `.agents/rules/frontend-conventions.md`** — auto-injected on `frontend/app/src`, terse always/never with pointers to the fuller guidelines: api→domain→ui layering, React Query (query-key factory, invalidation-in-hook with the documented call-site carve-out, no `fetchPolicy`), no `useMemo`/`useCallback` (React Compiler), types (generated enums, `null` vs `undefined`), no narration comments, reuse-first, hook naming.
- **`typescript.md`** — corrected the Hooks bullet that still referenced `useMemo`/`useCallback` deps (it contradicted `react.md`); noted `useMutation`/`useQuery` callbacks are inferred; added the `null` vs `undefined` intent convention.
- **`entities-structure.md`** — added "What goes in a domain function" (*call → check error → validate → map*; answer the business question; keep logic out of `useQuery.select`; pure logic → a testable domain rule) and an "Avoiding double error toasts" note (`context.processErrorMessage`).
- **`naming-conventions.md`** — added a Hook Naming section (verb matches the operation — `useUpsert…` not `useUpdate…`; predicate hooks read as a question — `useHasX`), scoped to new hooks.

## Also: documents the `.agents/rules` layer

The review discussion surfaced that `repository-organization.md` never defined `.agents/rules/` at all — making it look like a second, competing "rules" concept next to `dev/guidelines/` (which the doc itself calls "rules").

- Added a `rules/` section: **both layers hold rules; the difference is delivery.** `.agents/rules` auto-injects on every matching turn (so it stays lean); `dev/guidelines` is the full on-demand rulebook. It's the always-on *index* pointing into the guidelines, not a competing ruleset.
- Documented **what earns a rule slot** (a 3-part test) and **"keep rules as pointers, not copies."**
- Applied that principle: slimmed the frontend rule's Naming bullet from a restatement down to a pure pointer.

## Notes

- **Held one lesson:** a backend "parse external ids → raise `ValidationError`" note (from #9754). Its natural home — `python.md`'s Exception Handling section — is develop-only and absent on this stable base; mis-homing it would conflict when develop merges to stable. Better placed on a develop-based change.
- Deliberately did **not** assert a `*Mutation` hook suffix that cubic suggested — the codebase's own hooks (`useMergeBranch`, `useGetBranches`) carry no such suffix.
- Docs-only; no code or generated files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)