### PR TITLE
fix(schema): keep the cached derived-value filter for own-id recomputes

### DIFF
--- a/backend/infrahub/core/schema/schema_branch_display.py
+++ b/backend/infrahub/core/schema/schema_branch_display.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -125,9 +125,10 @@ class DisplayLabels:
         for applicable_kinds in relationship_trigger.attributes.values():
             for relationship_identifier in applicable_kinds:
                 if target_kind == relationship_identifier.kind:
-                    template_label = self.get_template_node(kind=target_kind)
-                    template_label.filter_key = relationship_identifier.filter_key
-                    return template_label
+                    # Copy so the cached template keeps its own-id filter for self recomputes.
+                    return replace(
+                        self.get_template_node(kind=target_kind), filter_key=relationship_identifier.filter_key
+                    )
 
         raise ValueError(
             f"Unable to find registered template for {target_kind} registered on related node {related_kind}"

--- a/backend/infrahub/core/schema/schema_branch_hfid.py
+++ b/backend/infrahub/core/schema/schema_branch_hfid.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -111,9 +111,10 @@ class HFIDs:
         for applicable_kinds in relationship_trigger.attributes.values():
             for relationship_identifier in applicable_kinds:
                 if target_kind == relationship_identifier.kind:
-                    template_label = self.get_node_definition(kind=target_kind)
-                    template_label.filter_key = relationship_identifier.filter_key
-                    return template_label
+                    # Copy so the cached definition keeps its own-id filter for self recomputes.
+                    return replace(
+                        self.get_node_definition(kind=target_kind), filter_key=relationship_identifier.filter_key
+                    )
 
         raise ValueError(
             f"Unable to find registered template for {target_kind} registered on related node {related_kind}"

--- a/backend/tests/unit/core/schema/test_schema_branch_derived_filter_key.py
+++ b/backend/tests/unit/core/schema/test_schema_branch_derived_filter_key.py
@@ -1,0 +1,43 @@
+"""Resolving a cross-node derived value must not corrupt the cached own-id filter.
+
+Display labels and HFIDs cache one template per kind. The self getter and the related (cross-node)
+getter share that cached instance, so the related getter must return a copy rather than overwrite the
+cached ``filter_key`` - otherwise a later own-id recompute queries with the relationship filter and
+silently matches nothing.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from infrahub.core.schema.schema_branch import SchemaBranch
+from tests.helpers.merge_recompute.dataset import PROFILE_NODE_KIND, PROFILE_PEER_KIND, build_profile_schema
+
+
+def _profile_schema_branch(*, hfid_reads_peer: bool = False) -> SchemaBranch:
+    schema = deepcopy(build_profile_schema())
+    if hfid_reads_peer:
+        node = next(node for node in schema.nodes if node.kind == PROFILE_NODE_KIND)
+        node.human_friendly_id = ["name__value", "peer__name__value"]
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema)
+    schema_branch.process()
+    return schema_branch
+
+
+def test_get_related_template_does_not_mutate_cached_filter_key() -> None:
+    display_labels = _profile_schema_branch().display_labels
+
+    related = display_labels.get_related_template(related_kind=PROFILE_PEER_KIND, target_kind=PROFILE_NODE_KIND)
+
+    assert related.filter_key == "peer__ids"
+    assert display_labels.get_template_node(kind=PROFILE_NODE_KIND).filter_key == "ids"
+
+
+def test_get_related_definition_does_not_mutate_cached_filter_key() -> None:
+    hfids = _profile_schema_branch(hfid_reads_peer=True).hfids
+
+    related = hfids.get_related_definition(related_kind=PROFILE_PEER_KIND, target_kind=PROFILE_NODE_KIND)
+
+    assert related.filter_key == "peer__ids"
+    assert hfids.get_node_definition(kind=PROFILE_NODE_KIND).filter_key == "ids"

--- a/changelog/+display-label-hfid-own-id-filter.fixed.md
+++ b/changelog/+display-label-hfid-own-id-filter.fixed.md
@@ -1,0 +1,1 @@
+Fixed display labels and human-friendly ids that read across a relationship not refreshing when they were recomputed by their own id. Resolving a cross-node template overwrote the cached own-id filter in place, so a later self recompute queried with the relationship filter, matched no node, and left the stored value stale.


### PR DESCRIPTION
## Why

A node's display label and human-friendly id can include a value taken from a related node (read across a relationship). When Infrahub had to rebuild that value for the node itself, it sometimes did not update and kept showing the old value.

## How it was found

This turned up while working on #9845 (refresh a reader when its read peer is deleted). After deleting a peer and merging, the reader's computed attribute refreshed, but its display label kept naming the deleted peer. The real cause was a separate, older bug in how display labels and HFIDs are rebuilt, so it gets its own fix here.

## The bug

Each kind keeps one cached template for its display label and one for its HFID. Two paths share that cached template: one rebuilds the node by its own id, the other rebuilds it because a related node changed. The related-node path changed a lookup setting on the shared template and never reset it. So once a related-node rebuild had run, the own-id path used the wrong lookup, matched no node, and left the stored value stale.

## The fix

The related-node path now works on a copy instead of editing the shared cached template, so the own-id path keeps its correct lookup.

## Why this is separate from #9845 and does not replace it

They fix different bugs in different places:

- #9845 fixes the merge itself. When a peer is deleted, the old code looked for readers starting from the deleted peer and found none, so it never asked to rebuild them. #9845 makes the merge ask for the rebuild by the reader's own id. That alone fixes the main case (the computed attribute), so #9845 is worth merging on its own.
- This PR fixes an older, unrelated bug in how display labels and HFIDs are rebuilt, in a different part of the code. It is wrong with or without #9845.

So this PR does not supersede #9845. #9845 stays the main fix; this one clears the remaining display label gap. The delete-peer display label refresh only works once both are in.

## Tests

- New unit test: rebuilding from a related node must not change the cached own-id lookup. It fails on the current code and passes with the fix.
- Checked end to end with #9845 applied on top: after a related-node change followed by a peer delete, the reader's display label refreshes (`dnode via beta` becomes `dnode via None`) instead of staying stale.
