### PR TITLE
fix(regeneration): correct exception catch and subscriber member resolution

### DIFF
--- a/backend/infrahub/core/regeneration/members.py
+++ b/backend/infrahub/core/regeneration/members.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub_sdk.exceptions import NodeNotFoundError
+
 if TYPE_CHECKING:
     import logging
 
@@ -20,13 +22,18 @@ def map_subscriber_ids_by_member(
     """
     subscriber_by_member: dict[str, str] = {}
     for subscriber in existing_subscribers:
-        object_id = subscriber.object.id
-        if object_id is None:
+        try:
+            # Resolve through the peer rather than subscriber.object.id: for some subscriber kinds the
+            # member id is only reachable through the client store, where subscriber.object.id stays None.
+            member_id = subscriber.object.peer.id
+        except (ValueError, NodeNotFoundError):
             log.warning(
                 f"Skipping orphan subscriber {subscriber.id} for definition {definition_name}: object peer unresolvable"
             )
             continue
-        subscriber_by_member[object_id] = subscriber.id
+        if member_id is None:
+            continue
+        subscriber_by_member[member_id] = subscriber.id
     return subscriber_by_member
 
 

--- a/backend/infrahub/core/regeneration/members.py
+++ b/backend/infrahub/core/regeneration/members.py
@@ -23,8 +23,7 @@ def map_subscriber_ids_by_member(
     subscriber_by_member: dict[str, str] = {}
     for subscriber in existing_subscribers:
         try:
-            # Resolve through the peer rather than subscriber.object.id: for some subscriber kinds the
-            # member id is only reachable through the client store, where subscriber.object.id stays None.
+            # The member id lives on the object peer; subscriber.object.id is None for some kinds.
             member_id = subscriber.object.peer.id
         except (ValueError, NodeNotFoundError):
             log.warning(

--- a/backend/infrahub/core/regeneration/models.py
+++ b/backend/infrahub/core/regeneration/models.py
@@ -39,9 +39,7 @@ class RegenerationDefinition(Protocol):
 
     Both the artifact-definition and generator-definition pipeline models satisfy this
     structurally, so the same predicates evaluate either kind without branching on type.
-    ``source_noun`` / ``instance_noun`` carry the kind-correct wording into the reason
-    strings (``transform`` / ``artifacts`` versus ``generator source`` / ``instances``).
-    Declare only what the predicates read.
+    ``source_noun`` / ``instance_noun`` supply the kind-correct wording for the reason strings.
     """
 
     definition_id: str

--- a/backend/infrahub/core/regeneration/predicates.py
+++ b/backend/infrahub/core/regeneration/predicates.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub_sdk.exceptions import NodeNotFoundError
-
 from infrahub.core.constants import DiffAction
+from infrahub.exceptions import NodeNotFoundError
 from infrahub.git.closure_builder.canonicalizer import canonicalize_path
 
 from .models import PredicateOutcome

--- a/backend/tests/unit/core/regeneration/conftest.py
+++ b/backend/tests/unit/core/regeneration/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+
+@pytest.fixture
+def client() -> InfrahubClient:
+    return InfrahubClient(config=Config(address="http://mock"))
+
+
+@pytest.fixture
+def log() -> logging.Logger:
+    return logging.getLogger("test")

--- a/backend/tests/unit/core/regeneration/test_members.py
+++ b/backend/tests/unit/core/regeneration/test_members.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.schema import NodeSchemaAPI, RelationshipSchemaAPI
+from infrahub_sdk.schema.main import RelationshipCardinality, RelationshipKind
+
+from infrahub.core.regeneration.members import map_subscriber_ids_by_member
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+DEFINITION_NAME = "artifact-def"
+
+SUBSCRIBER_SCHEMA = NodeSchemaAPI(
+    name="Subscriber",
+    namespace="Test",
+    relationships=[
+        RelationshipSchemaAPI(
+            name="object",
+            peer="TestMember",
+            kind=RelationshipKind.ATTRIBUTE,
+            cardinality=RelationshipCardinality.ONE,
+        )
+    ],
+)
+MEMBER_SCHEMA = NodeSchemaAPI(name="Member", namespace="Test")
+
+
+def _member(client: InfrahubClient, *, member_id: str | None) -> InfrahubNode:
+    return InfrahubNode(client=client, schema=MEMBER_SCHEMA, data={"__typename": "TestMember", "id": member_id})
+
+
+def _subscriber(client: InfrahubClient, *, subscriber_id: str, object_data: object) -> InfrahubNode:
+    return InfrahubNode(
+        client=client,
+        schema=SUBSCRIBER_SCHEMA,
+        data={"id": subscriber_id, "__typename": "TestSubscriber", "object": object_data},
+    )
+
+
+def test_map_subscriber_ids_by_member_resolves_members_through_the_object_peer(
+    client: InfrahubClient, log: logging.Logger
+) -> None:
+    """Each resolvable subscriber maps its member id (read from the object peer) to its own id."""
+    subscribers = [
+        _subscriber(client, subscriber_id="sub-1", object_data=_member(client, member_id="member-1")),
+        _subscriber(client, subscriber_id="sub-2", object_data=_member(client, member_id="member-2")),
+    ]
+
+    result = map_subscriber_ids_by_member(existing_subscribers=subscribers, definition_name=DEFINITION_NAME, log=log)
+
+    assert result == {"member-1": "sub-1", "member-2": "sub-2"}
+
+
+@dataclass(frozen=True, kw_only=True)
+class UnresolvablePeerCase:
+    name: str
+    object_data: dict[str, object] = field(default_factory=dict)
+
+
+UNRESOLVABLE_PEER_CASES = [
+    # relationship carries no identifier at all -> peer lookup raises ValueError
+    UnresolvablePeerCase(name="no-identifier", object_data={"node": {"__typename": "TestMember"}}),
+    # relationship references a peer absent from the client store -> raises NodeNotFoundError
+    UnresolvablePeerCase(name="store-miss", object_data={"node": {"id": "gone", "__typename": "TestMember"}}),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(c, id=c.name) for c in UNRESOLVABLE_PEER_CASES])
+def test_map_subscriber_ids_by_member_skips_and_warns_when_object_peer_unresolvable(
+    case: UnresolvablePeerCase,
+    client: InfrahubClient,
+    log: logging.Logger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A subscriber whose object peer cannot be resolved is skipped with a warning, not fatal.
+
+    The mapper must keep mapping the remaining subscribers rather than letting the
+    unresolvable-peer exception escape and abort the caller.
+    """
+    subscribers = [
+        _subscriber(client, subscriber_id="orphan", object_data=case.object_data),
+        _subscriber(client, subscriber_id="sub-live", object_data=_member(client, member_id="member-live")),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = map_subscriber_ids_by_member(
+            existing_subscribers=subscribers, definition_name=DEFINITION_NAME, log=log
+        )
+
+    assert result == {"member-live": "sub-live"}
+    assert caplog.messages == [
+        "Skipping orphan subscriber orphan for definition artifact-def: object peer unresolvable"
+    ]
+
+
+def test_map_subscriber_ids_by_member_skips_subscriber_whose_peer_has_no_id(
+    client: InfrahubClient, log: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A resolvable peer that carries no id is skipped silently rather than mapped under ``None``."""
+    subscribers = [
+        _subscriber(client, subscriber_id="sub-empty", object_data=_member(client, member_id=None)),
+        _subscriber(client, subscriber_id="sub-live", object_data=_member(client, member_id="member-live")),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = map_subscriber_ids_by_member(
+            existing_subscribers=subscribers, definition_name=DEFINITION_NAME, log=log
+        )
+
+    assert result == {"member-live": "sub-live"}
+    assert not caplog.text

--- a/backend/tests/unit/core/regeneration/test_predicates.py
+++ b/backend/tests/unit/core/regeneration/test_predicates.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 
 import pytest
 from infrahub_sdk.diff import NodeDiff, NodeDiffElement
 
 from infrahub.core.constants import InfrahubKind
-from infrahub.core.regeneration.predicates import definition_changed, query_changed, transform_changed
-from infrahub.message_bus.types import ProposedChangeArtifactDefinition, ProposedChangeRepository
+from infrahub.core.regeneration.predicates import (
+    definition_changed,
+    query_changed,
+    repo_diff_or_none,
+    transform_changed,
+)
+from infrahub.message_bus.types import (
+    ProposedChangeArtifactDefinition,
+    ProposedChangeBranchDiff,
+    ProposedChangeRepository,
+)
 
 QUERY_ID = "11111111-1111-1111-1111-111111111111"
 DEFINITION_ID = "22222222-2222-2222-2222-222222222222"
@@ -336,3 +346,20 @@ def test_transform_changed(case: TransformChangedCase) -> None:
         files_removed=case.files_removed,
     )
     assert transform_changed(definition=definition, repo_diff=repo_diff).matched is case.expected
+
+
+def test_repo_diff_or_none_returns_matching_repository() -> None:
+    repo_diff = _build_repo_diff()
+    branch_diff = ProposedChangeBranchDiff(repositories=[repo_diff], pipeline_id=uuid.uuid4())
+    assert repo_diff_or_none(branch_diff, repo_diff.repository_id) is repo_diff
+
+
+def test_repo_diff_or_none_returns_none_for_absent_repository() -> None:
+    """A definition may reference a repository with no entry in the branch diff.
+
+    The lookup must degrade to ``None`` so the caller can skip the file-diff
+    predicate, rather than letting the missing-repository exception escape and
+    abort the regeneration task.
+    """
+    branch_diff = ProposedChangeBranchDiff(repositories=[_build_repo_diff()], pipeline_id=uuid.uuid4())
+    assert repo_diff_or_none(branch_diff, "00000000-0000-0000-0000-000000000000") is None

--- a/changelog/+regeneration-missing-repository-lookup.fixed.md
+++ b/changelog/+regeneration-missing-repository-lookup.fixed.md
@@ -1,0 +1,1 @@
+Artifact and generator regeneration during a proposed change no longer fails when a definition references a repository that has no changes in the branch diff; the missing repository is now skipped instead of aborting the task.

--- a/changelog/+regeneration-missing-repository-lookup.fixed.md
+++ b/changelog/+regeneration-missing-repository-lookup.fixed.md
@@ -1,1 +1,1 @@
-Artifact and generator regeneration during a proposed change no longer fails when a definition references a repository that has no changes in the branch diff; the missing repository is now skipped instead of aborting the task.
+Artifact and Generator regeneration during a proposed change no longer fails when a definition references a repository that has no changes in the branch diff; the missing repository is now skipped instead of aborting the task.

--- a/changelog/+regeneration-subscriber-member-peer.fixed.md
+++ b/changelog/+regeneration-subscriber-member-peer.fixed.md
@@ -1,0 +1,1 @@
+Selective regeneration after a merge now narrows Generator instances to the members actually impacted, instead of rerunning every instance in the group.


### PR DESCRIPTION
## Summary

Two bug fixes on the regeneration selection primitives, stacked on top of the extraction refactor (#9928).

Jira: https://opsmill.atlassian.net/browse/IFC-2908

## Fixes

### Repository-diff lookup caught the wrong exception (spotted by Cubic)

#### The issue
The repository-diff lookup helper caught `NodeNotFoundError` from `infrahub_sdk.exceptions`, but the repository lookup raises `infrahub.exceptions.NodeNotFoundError` — an unrelated class — so the `except` never matched. A regeneration definition referencing a repository absent from the branch diff let the exception escape and abort the artifact/generator regeneration task instead of skipping that repository. This is preexisting.

#### What changed
The helper now catches the exception that is actually raised and degrades to `None`, with unit coverage over the absent-repository path.

### Subscriber members resolved to None for generator instances

#### The issue
The shared member mapper read `subscriber.object.id`, which is populated for artifact subscribers but stays `None` for generator instances whose object peer is only reachable through the client store. 


#### What changed
It now resolves through `subscriber.object.peer.id`, so both kinds map their member and generator narrowing works instead of rerunning whole groups after a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two regeneration selection bugs: correct repository diff lookup error handling and resolve subscriber member IDs for generators. Prevents task aborts when a repo is missing and restores generator-level narrowing after merges.

- **Bug Fixes**
  - Repository diff lookup now catches `infrahub.exceptions.NodeNotFoundError` (not `infrahub_sdk.exceptions.NodeNotFoundError`) and returns None when the repo is absent; avoids task failures. Unit tests cover both present and missing repos.
  - Subscriber member mapping reads `subscriber.object.peer.id`, skipping unresolvable peers with a warning (catches `ValueError`/`infrahub_sdk.exceptions.NodeNotFoundError`) and peers with no id; fixes None IDs for generator instances. Tests cover mapping, orphan skip, and no-id cases.

<sup>Written for commit b63ff0886e0a650512f2ee73a7640495e951102c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



