### PR TITLE
chore(observability): update cAdvisor to v0.60.5 and switch to ghcr.io

### DIFF
--- a/development/docker-compose-observability-standalone.yml
+++ b/development/docker-compose-observability-standalone.yml
@@ -129,7 +129,7 @@ services:
     - "9100:9100"
 
   infrahub-cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    image: ghcr.io/google/cadvisor:v0.60.5
     privileged: true
     volumes:
     - /:/rootfs:ro

--- a/development/docker-compose-observability.yml
+++ b/development/docker-compose-observability.yml
@@ -136,7 +136,7 @@ services:
 
   infrahub-cadvisor:
     profiles: [debug]
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    image: ghcr.io/google/cadvisor:v0.60.5
     privileged: true
     volumes:
       - /:/rootfs:ro


### PR DESCRIPTION
## Summary

Updates cAdvisor in the observability docker-compose stack:

- Bumps the image from `v0.52.1` to the latest **`v0.60.5`**.
- Switches the registry from `gcr.io/cadvisor/cadvisor` to **`ghcr.io/google/cadvisor`**.

Applied to both variants of the observability stack:

- `development/docker-compose-observability.yml`
- `development/docker-compose-observability-standalone.yml`

## Notes

The testcontainers test stacks (`python_testcontainers/.../docker-compose*.test.yml`) also reference cAdvisor (`v0.51.0`), but they are out of scope for this change — this PR targets the observability stack only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update cAdvisor in the observability stack to `ghcr.io/google/cadvisor:v0.60.5`, moving from `gcr.io/cadvisor/cadvisor:v0.52.1` to use the maintained registry and latest fixes.
Applied to both `development/docker-compose-observability.yml` and `development/docker-compose-observability-standalone.yml`.

<sup>Written for commit ae25c1cf017727c621b4f075ba1a2bea2d83cac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

