### PR TITLE
fix(backend): resolve NodeNotFoundError node_type to a string

### DIFF
--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -43,6 +43,6 @@ Where IDs *do* belong:
 
 ## What good documentation looks like
 
-- Explains *why* the code exists when the why is non-obvious (a constraint, an invariant, a workaround for a specific upstream bug).
+- Comment the *why*, never the *what*: a constraint, an invariant, a workaround, a deliberate deviation from the obvious approach. Never paraphrase the line below it or restate the type signature.
 - Documents the contract of a public function (inputs, outputs, errors raised) when it crosses a module boundary.
-- Stays silent by default. A comment that restates the code is worse than no comment — it adds noise and rots the moment the code changes.
+- Stays silent by default. If code needs a comment to explain *what* it does, rename or extract until it doesn't. A comment that restates the code is worse than none — noise that rots the moment the code changes.

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -344,7 +344,7 @@ class NodeManager:
                 data=peer,
             )
             if fetch_peers:
-                result.set_peer(value=peer_nodes[peer.peer_id])
+                result.set_peer(value=peer_nodes[str(peer.peer_id)])
             results.append(result)
 
         return results

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -163,7 +163,7 @@ class NodeManager:
             node = await cls.get_one_by_hfid(
                 db=db,
                 hfid=filters["hfid"],
-                kind=schema,
+                kind=node_schema.kind,
                 fields=fields,
                 at=at,
                 branch=branch,
@@ -318,7 +318,7 @@ class NodeManager:
             return []
 
         if fetch_peers:
-            peer_ids = [peer.peer_id for peer in peers_info]
+            peer_ids = [str(peer.peer_id) for peer in peers_info]
             peer_nodes = await cls.get_many(
                 db=db,
                 ids=peer_ids,
@@ -336,7 +336,7 @@ class NodeManager:
                 branch=branch,
                 source_kind=peer.source_kind,
                 at=at,
-                node_id=peer.source_id,
+                node_id=str(peer.source_id),
             ).load(
                 db=db,
                 id=peer.rel_node_id,
@@ -864,10 +864,11 @@ class NodeManager:
         if node:
             return node
 
-        node = await cls.get_one_by_default_filter(
+        return await cls.get_one_by_default_filter(
             db=db,
             id=id,
             kind=kind,
+            raise_on_error=True,
             fields=fields,
             at=at,
             branch=branch,
@@ -875,9 +876,6 @@ class NodeManager:
             prefetch_relationships=prefetch_relationships,
             branch_agnostic=branch_agnostic,
         )
-        if not node:
-            raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
-        return node
 
     @overload
     @classmethod
@@ -1059,7 +1057,11 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                raise NodeNotFoundError(branch_name=branch.name, node_type=kind, identifier=id)
+                # `kind` is a protocol class, a kind string, or None because callers look nodes up
+                # in all three ways; derive the name from it directly, since resolving it through the
+                # schema could raise on the not-found path we are already handling.
+                node_kind = kind.__name__ if isinstance(kind, type) else (kind or "Node")
+                raise NodeNotFoundError(branch_name=branch.name, node_type=node_kind, identifier=id)
             return None
 
         node = result[id]
@@ -1175,7 +1177,7 @@ class NodeManager:
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)
             item = await node_class.init(schema=node.schema, branch=node_branch, at=at, db=db)
-            await item.load(**new_node_data, db=db)
+            await item.load(**new_node_data, db=db)  # type: ignore[arg-type]  # mypy cannot match a heterogeneous **dict splat against load()'s typed params
             item._set_created_at(node.created_at)
             item._set_created_by(node.created_by)
             item._set_updated_at(node.updated_at)
@@ -1303,9 +1305,9 @@ class NodeManager:
             if insert_peer_node:
                 rel_peers: list[Node | str] = []
                 for peer_id in peer_ids:
-                    peer = nodes_by_id.get(peer_id)
-                    if peer:
-                        rel_peers.append(peer)
+                    peer_node = nodes_by_id.get(peer_id)
+                    if peer_node:
+                        rel_peers.append(peer_node)
             # if only getting some relationships, make sure we want THIS relationship for THIS node schema
             elif cardinality_one_identifiers_by_kind:
                 required_direction = cardinality_one_identifiers_by_kind.get(node_schema.kind, {}).get(
@@ -1342,7 +1344,8 @@ class NodeManager:
                 rel_peers_with_metadata.append(peer_with_metadata)
 
             rel_manager.has_fetched_relationships = True
-            await rel_manager.update(db=db, data=rel_peers_with_metadata)
+            # invariant list parameter; update() only reads data, so the narrower element type is safe
+            await rel_manager.update(db=db, data=rel_peers_with_metadata)  # type: ignore[arg-type]
 
     @classmethod
     async def delete(

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1057,9 +1057,7 @@ class NodeManager:
 
         if not result:
             if raise_on_error:
-                # `kind` is a protocol class, a kind string, or None because callers look nodes up
-                # in all three ways; derive the name from it directly, since resolving it through the
-                # schema could raise on the not-found path we are already handling.
+                # Avoid resolving kind via the schema here: it can raise on the not-found path.
                 node_kind = kind.__name__ if isinstance(kind, type) else (kind or "Node")
                 raise NodeNotFoundError(branch_name=branch.name, node_type=node_kind, identifier=id)
             return None

--- a/backend/tests/component/api/test_20_graphql.py
+++ b/backend/tests/component/api/test_20_graphql.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
 from infrahub.core.initialization import create_branch
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
 
 
@@ -184,6 +186,39 @@ async def test_graphql_endpoint_generics(
     assert sorted(result_per_name.keys()) == ["Jane", "John"]
     assert len(result_per_name["John"]["cars"]) == 2
     assert len(result_per_name["Jane"]["cars"]) == 1
+
+
+async def test_graphql_menu_delete_missing_returns_node_not_found(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers: dict[str, str],
+    default_branch: Branch,
+    create_test_admin: Node,
+    register_core_models_schema: SchemaBranch,
+) -> None:
+    """A menu mutation targeting a missing id must return NODE_NOT_FOUND, not an HTTP 500."""
+    missing_id = str(UUIDT())
+    mutation = """
+    mutation ($id: String!) {
+        CoreMenuItemDelete(data: { id: $id }) {
+            ok
+        }
+    }
+    """
+
+    # Must execute in a with block to execute the startup/shutdown events
+    with client:
+        response = client.post(
+            "/graphql",
+            json={"query": mutation, "variables": {"id": missing_id}},
+            headers=admin_headers,
+        )
+
+    assert response.status_code == 200
+    errors = response.json()["errors"]
+    assert errors[0]["extensions"]["code"] == "NODE_NOT_FOUND"
+    assert errors[0]["extensions"]["http_status"] == 404
+    assert errors[0]["extensions"]["data"]["node_kind"] == "CoreMenuItem"
 
 
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])

--- a/backend/tests/component/core/test_manager_node.py
+++ b/backend/tests/component/core/test_manager_node.py
@@ -9,6 +9,7 @@ from infrahub.core.constants import MetadataOptions
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager, identify_node_class
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreMenuItem
 from infrahub.core.protocols_base import CoreNode
 from infrahub.core.query.node import NodeToProcess
 from infrahub.core.registry import registry
@@ -224,6 +225,49 @@ async def test_get_one_by_id_or_default_filter(
     )
     assert isinstance(node2, Node)
     assert node2.id == criticality_low.id
+
+
+async def test_get_one_missing_class_kind_reports_str_node_type(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    # Passing a schema/protocol class as ``kind`` must surface the kind name as a string on the
+    # raised error; leaving it as the class object broke error serialization downstream.
+    missing_id = str(UUIDT())
+
+    with pytest.raises(
+        NodeNotFoundError, match=rf"Unable to find the node {missing_id} / CoreMenuItem in the database\."
+    ) as exc_info:
+        await NodeManager.get_one(db=db, id=missing_id, kind=CoreMenuItem, raise_on_error=True)
+
+    assert exc_info.value.node_type == "CoreMenuItem"
+    assert isinstance(exc_info.value.node_type, str)
+
+
+async def test_get_one_by_id_or_default_filter_missing_class_kind_reports_str_node_type(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    missing_id = str(UUIDT())
+
+    with pytest.raises(
+        NodeNotFoundError, match=rf"Unable to find the node {missing_id} / CoreMenuItem in the database\."
+    ) as exc_info:
+        await NodeManager.get_one_by_id_or_default_filter(db=db, id=missing_id, kind=CoreMenuItem)
+
+    assert exc_info.value.node_type == "CoreMenuItem"
+    assert isinstance(exc_info.value.node_type, str)
+
+
+async def test_get_one_missing_without_kind_reports_str_node_type(db: InfrahubDatabase, default_branch: Branch) -> None:
+    # With no kind supplied, node_type falls back to a plain string, never None.
+    missing_id = str(UUIDT())
+
+    with pytest.raises(
+        NodeNotFoundError, match=rf"Unable to find the node {missing_id} / Node in the database\."
+    ) as exc_info:
+        await NodeManager.get_one(db=db, id=missing_id, raise_on_error=True)
+
+    assert exc_info.value.node_type == "Node"
+    assert isinstance(exc_info.value.node_type, str)
 
 
 async def test_get_one_by_hfid(

--- a/changelog/9926.fixed.md
+++ b/changelog/9926.fixed.md
@@ -1,0 +1,1 @@
+Fixed some GraphQL requests returning an unexpected HTTP 500 error instead of a proper node-not-found (404) response.

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -271,6 +271,16 @@ To branch on or read from a typed object, use `isinstance` so the type checker c
 
 When a JSON string feeds a hash, fingerprint, or cache key, its output must be deterministic. Do **not** pass `default=str` to `json.dumps` there: it silently serializes unexpected types via `str()`, which can embed run-specific data (memory addresses) and break determinism. Serialize an explicit, canonical shape (sorted keys, known field types) and let unknown types raise instead of being coerced.
 
+### When a wrong-type bug slips through
+
+`mypy` and `ty` both gate CI, but modules opt out of checks — mypy via per-module `disable_error_code` in `pyproject.toml`, ty via directory `[[tool.ty.overrides]]` (`invalid-argument-type` is currently ignored tree-wide). These suppressions hide real bugs.
+
+So when a bug is caused by a **wrong type being passed** (e.g. a class where a `str` was expected), the checker should have caught it — treat it as a gap to close, not just a runtime fix:
+
+1. Find why it was missed — usually `arg-type` / `invalid-argument-type` is suppressed for that module.
+2. Re-enable the rule for that module and fix the whole typing chain it surfaces. Grandfather unrelated pre-existing violations with a scoped `# type: ignore[code]  # reason`, not by leaving the rule off.
+3. Fix the source. Never widen a parameter's type to silence the checker when the real contract is narrower — that entrenches the defect. mypy enforces argument types by default (modules opt out), so fix there; re-enabling ty's `invalid-argument-type` is a deliberate directory-wide effort, not a per-file exception.
+
 ## Python Version Compatibility
 
 The `python_testcontainers` package supports Python 3.10+, while the main backend requires Python 3.12+. When writing code that may be shared or used in `python_testcontainers`, be mindful of version-specific features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,6 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "infrahub.core.manager"
 disable_error_code = [
-    "arg-type",
     "assignment",
     "attr-defined",
     "index",


### PR DESCRIPTION
# Why

A GraphQL request that produced a `NodeNotFoundError` whose `node_type` was a schema/protocol **class** (not a kind string) crashed the error formatter itself — pydantic rejected the non-`str` `node_kind`, the exception escaped the formatter, and the request returned an uncaught **HTTP 500** instead of a normal `NODE_NOT_FOUND` (404). Observed in production as thousands of uncaught 500s.

Closes #9926

Supersedes #9952, which took a different approach: widening `NodeNotFoundError.node_type` to accept a class plus a defensive `str()` guard in the formatter. This PR instead fixes the two raise sites at the source and keeps the exception's `str` contract.

## What changed

**Behavioral:** a node-not-found lookup now always returns a catalogued `NODE_NOT_FOUND` (404) GraphQL error, whether the internal `kind` was a string or a class.

**Implementation:**

- `NodeManager.get_one` and `get_one_by_id_or_default_filter` resolve `kind` to its kind string at the raise site, so `NodeNotFoundError.node_type` is always a plain string (the sibling lookup methods already did this).
- Re-enabled mypy `arg-type` on `infrahub.core.manager` so a non-`str` `node_type` is caught at type-check time; fixed the pre-existing violations it surfaced (or scoped the two genuine type-system limitations with a documented `# type: ignore`).
- Documented the practice ("a wrong-type bug means a checker was suppressed — re-enable it and fix the typing chain") in `dev/guidelines/backend/python.md`, and tightened comment guidance in `.agents/rules/code-doc-style.md`.

**Unchanged:** `NodeNotFoundError.node_type` keeps its `str` contract (not widened to accept a class); the error formatter is untouched — the fix is at the source, not a defensive coercion.

## How to review

- Start with `backend/infrahub/core/manager.py` — the two raise sites.
- `pyproject.toml` — one line: `arg-type` re-enabled for `infrahub.core.manager`.
- Tests: `test_manager_node.py` (3 raise-site cases) and `test_20_graphql.py` (end-to-end 404).

## How to test

```bash
uv run pytest backend/tests/component/core/test_manager_node.py -k reports_str_node_type
uv run pytest backend/tests/component/api/test_20_graphql.py -k menu_delete_missing
uv run invoke backend.lint   # arg-type now enforced on manager
```

## Impact & rollout

Backend-only. No schema, API-contract, or migration changes.

A remaining hardening follow-up — two other modules (`infrahub.core.node`, `infrahub.graphql.mutations.main`) raise `NodeNotFoundError` with `arg-type` still disabled, both passing `str` today — is tracked in INBOX-1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GraphQL requests that returned HTTP 500 when a missing node used a class kind. Missing nodes now return `NODE_NOT_FOUND` (404), and stricter typing prevents regressions; also fixes a `fetch_peers` KeyError by normalizing peer IDs.

- **Bug Fixes**
  - Resolve `kind` to a string at raise sites in `NodeManager.get_one` and `get_one_by_id_or_default_filter`; ensure lookups pass kind strings (e.g., `get_one_by_hfid`).
  - Normalize peer IDs to `str` on both sides of `fetch_peers` mapping to prevent `KeyError`.
  - Re-enabled `mypy` `arg-type` for `infrahub.core.manager`; added targeted `# type: ignore[...]`; `NodeNotFoundError.node_type` stays `str`.
  - Tests: GraphQL `CoreMenuItemDelete` with a missing ID returns `NODE_NOT_FOUND` (404); manager errors assert string `node_type`. Updated backend guidelines and `.agents/rules/code-doc-style.md`; added changelog entry.

- **Refactors**
  - Trimmed the `get_one` kind-normalization comment to keep only the non-obvious why.

<sup>Written for commit f115a2bfcbee3fbd17964682b12f0c83e27efbff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

