### PR TITLE
capture previous metadata during schema migration to support rollback

### DIFF
--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -114,7 +114,16 @@ class AttributeAddQuery(Query):
         CALL (a, n) {
             WITH a, n
             WHERE $set_metadata
+            // The Attribute vertex is created here, so it has no prior metadata to snapshot for rollback
             SET a.created_at = $current_time, a.created_by = $user_id, a.updated_at = $current_time, a.updated_by = $user_id
+            SET n.previous_updated_at = CASE
+                    WHEN n.updated_at IS NULL OR n.updated_at <> $current_time THEN n.updated_at
+                    ELSE n.previous_updated_at
+                END,
+                n.previous_updated_by = CASE
+                    WHEN n.updated_at IS NULL OR n.updated_at <> $current_time THEN n.updated_by
+                    ELSE n.previous_updated_by
+                END
             SET n.updated_at = $current_time, n.updated_by = $user_id
         }
         FOREACH (i in CASE WHEN has_attr_e.status = "deleted" THEN [1] ELSE [] END |

--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -142,7 +142,23 @@ class AttributeRemoveQuery(Query):
         CALL (active_attr, active_node) {
             WITH active_attr, active_node
             WHERE $set_metadata
+            SET active_attr.previous_updated_at = CASE
+                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $current_time THEN active_attr.updated_at
+                    ELSE active_attr.previous_updated_at
+                END,
+                active_attr.previous_updated_by = CASE
+                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $current_time THEN active_attr.updated_by
+                    ELSE active_attr.previous_updated_by
+                END
             SET active_attr.updated_at = $current_time, active_attr.updated_by = $user_id
+            SET active_node.previous_updated_at = CASE
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                    ELSE active_node.previous_updated_at
+                END,
+                active_node.previous_updated_by = CASE
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                    ELSE active_node.previous_updated_by
+                END
             SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
         }
         RETURN DISTINCT active_attr

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -190,8 +190,17 @@ class AttributeRenameQuery(Query):
             CALL (new_attr, active_node) {
                 WITH new_attr, active_node
                 WHERE $set_metadata
+                // The renamed Attribute vertex is created here, so it has no prior metadata to snapshot
                 SET new_attr.created_at = $current_time, new_attr.created_by = $user_id
                 SET new_attr.updated_at = $current_time, new_attr.updated_by = $user_id
+                SET active_node.previous_updated_at = CASE
+                        WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                        ELSE active_node.previous_updated_at
+                    END,
+                    active_node.previous_updated_by = CASE
+                        WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                        ELSE active_node.previous_updated_by
+                    END
                 SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
             }
             RETURN DISTINCT new_attr

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -158,7 +158,6 @@ class NodeDuplicateQuery(Query):
 
         self.add_to_query(self.render_match())
 
-        # ruff: noqa: E501
         query = """
         CALL (node) {
             MATCH (root:Root)<-[r:IS_PART_OF]-(node)
@@ -169,7 +168,9 @@ class NodeDuplicateQuery(Query):
         }
         WITH active_node
         WHERE is_active = TRUE
-        CREATE (new_node:Node:%(labels)s { uuid: active_node.uuid, kind: $new_node.kind, namespace: $new_node.namespace, branch_support: $new_node.branch_support })
+        CREATE (new_node:Node:%(labels)s {
+            uuid: active_node.uuid, kind: $new_node.kind, namespace: $new_node.namespace, branch_support: $new_node.branch_support
+        })
         WITH active_node, new_node
         // Set metadata on new Node vertex
         CALL (active_node, new_node) {
@@ -178,7 +179,16 @@ class NodeDuplicateQuery(Query):
             WITH active_node, new_node
             // set updated_by/at if we're on the default/global branch
             WHERE $set_metadata
+            SET active_node.previous_updated_at = CASE
+                WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                ELSE active_node.previous_updated_at
+            END,
+            active_node.previous_updated_by = CASE
+                WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                ELSE active_node.previous_updated_by
+            END
             SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+            // new_node is created here, so it has no prior metadata to snapshot for rollback
             SET new_node.updated_at = $current_time, new_node.updated_by = $user_id
         }
 

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -147,7 +147,11 @@ CALL (has_value_e) {
 CALL (attr, n) {
     WITH attr, n
     WHERE $set_metadata
+    SET attr.previous_updated_at = CASE WHEN attr.updated_at IS NULL OR attr.updated_at <> $at THEN attr.updated_at ELSE attr.previous_updated_at END,
+        attr.previous_updated_by = CASE WHEN attr.updated_at IS NULL OR attr.updated_at <> $at THEN attr.updated_by ELSE attr.previous_updated_by END
     SET attr.updated_at = $at, attr.updated_by = $user_id
+    SET n.previous_updated_at = CASE WHEN n.updated_at IS NULL OR n.updated_at <> $at THEN n.updated_at ELSE n.previous_updated_at END,
+        n.previous_updated_by = CASE WHEN n.updated_at IS NULL OR n.updated_at <> $at THEN n.updated_by ELSE n.previous_updated_by END
     SET n.updated_at = $at, n.updated_by = $user_id
 }
         """ % {

--- a/backend/infrahub/core/migrations/schema/node_relationship_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_relationship_remove.py
@@ -129,7 +129,23 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
         CALL (active_node, rel) {
             WITH active_node, rel
             WHERE $set_metadata
+            SET rel.previous_updated_at = CASE
+                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $current_time THEN rel.updated_at
+                    ELSE rel.previous_updated_at
+                END,
+                rel.previous_updated_by = CASE
+                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $current_time THEN rel.updated_by
+                    ELSE rel.previous_updated_by
+                END
             SET rel.updated_at = $current_time, rel.updated_by = $user_id
+            SET active_node.previous_updated_at = CASE
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                    ELSE active_node.previous_updated_at
+                END,
+                active_node.previous_updated_by = CASE
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                    ELSE active_node.previous_updated_by
+                END
             SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
         }
 
@@ -166,6 +182,14 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
         CALL (peer) {
             WITH peer
             WHERE $set_metadata AND peer:Node
+            SET peer.previous_updated_at = CASE
+                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $current_time THEN peer.updated_at
+                    ELSE peer.previous_updated_at
+                END,
+                peer.previous_updated_by = CASE
+                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $current_time THEN peer.updated_by
+                    ELSE peer.previous_updated_by
+                END
             SET peer.updated_at = $current_time, peer.updated_by = $user_id
         }
 

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -114,6 +114,14 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     CALL (peer_node) {
         WITH peer_node
         WHERE $set_metadata
+        SET peer_node.previous_updated_at = CASE
+                WHEN peer_node.updated_at IS NULL OR peer_node.updated_at <> $current_time THEN peer_node.updated_at
+                ELSE peer_node.previous_updated_at
+            END,
+            peer_node.previous_updated_by = CASE
+                WHEN peer_node.updated_at IS NULL OR peer_node.updated_at <> $current_time THEN peer_node.updated_by
+                ELSE peer_node.previous_updated_by
+            END
         SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
     }
 
@@ -236,6 +244,14 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     CALL (active_node) {
         WITH active_node
         WHERE $set_metadata
+        SET active_node.previous_updated_at = CASE
+                WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                ELSE active_node.previous_updated_at
+            END,
+            active_node.previous_updated_by = CASE
+                WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                ELSE active_node.previous_updated_by
+            END
         SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
     }
 
@@ -261,6 +277,14 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     CALL (peer_node) {
         WITH peer_node
         WHERE $set_metadata AND (peer_node:Attribute OR peer_node:Relationship)
+        SET peer_node.previous_updated_at = CASE
+                WHEN peer_node.updated_at IS NULL OR peer_node.updated_at <> $current_time THEN peer_node.updated_at
+                ELSE peer_node.previous_updated_at
+            END,
+            peer_node.previous_updated_by = CASE
+                WHEN peer_node.updated_at IS NULL OR peer_node.updated_at <> $current_time THEN peer_node.updated_by
+                ELSE peer_node.previous_updated_by
+            END
         SET peer_node.updated_at = $current_time, peer_node.updated_by = $user_id
     }
 

--- a/backend/tests/component/core/migrations/graph/test_040.py
+++ b/backend/tests/component/core/migrations/graph/test_040.py
@@ -43,10 +43,6 @@ class TestMigration040:
         )
         assert not migration_errors
 
-        # Fabricate the error state a concurrent migration race used to produce: for every node that just
-        # gained the attribute, copy the HAS_ATTRIBUTE path and the attribute's HAS_VALUE/IS_PROTECTED paths
-        # onto a second Attribute vertex (fresh uuid) pointing at the same value vertices. Deterministic,
-        # unlike racing the migration against itself, which does not reliably duplicate under CI load.
         await self._duplicate_attribute(db=db, branch=branch, attr_name="smell")
 
         # validate the error state

--- a/backend/tests/component/core/migrations/graph/test_040.py
+++ b/backend/tests/component/core/migrations/graph/test_040.py
@@ -26,7 +26,7 @@ class TestMigration040:
         new_schema_branch = previous_schema_branch.duplicate()
         new_schema_branch.set(name="TestCar", schema=new_car_schema)
 
-        # reproduces the error state by running the same migration concurrently so that the attribute is duplicated
+        # add the "smell" attribute once through the normal migration
         migration_errors = await schema_apply_migrations(
             message=SchemaApplyMigrationData(
                 branch=branch,
@@ -37,18 +37,45 @@ class TestMigration040:
                         path=SchemaPath(schema_kind="TestCar", path_type=SchemaPathType.ATTRIBUTE, field_name="smell"),
                         migration_name="node.attribute.add",
                     )
-                ]
-                * 3,
+                ],
                 at=Timestamp(),
             )
         )
         assert not migration_errors
+
+        # Fabricate the error state a concurrent migration race used to produce: for every node that just
+        # gained the attribute, copy the HAS_ATTRIBUTE path and the attribute's HAS_VALUE/IS_PROTECTED paths
+        # onto a second Attribute vertex (fresh uuid) pointing at the same value vertices. Deterministic,
+        # unlike racing the migration against itself, which does not reliably duplicate under CI load.
+        await self._duplicate_attribute(db=db, branch=branch, attr_name="smell")
 
         # validate the error state
         errors = await validate_no_duplicate_attributes(db=db, branch=branch)
         assert errors
 
         registry.schema.set(name="TestCar", branch=branch.name, schema=new_car_schema)
+
+    async def _duplicate_attribute(self, db: InfrahubDatabase, branch: Branch, attr_name: str) -> None:
+        query = """
+        MATCH (n:Node)-[hae:HAS_ATTRIBUTE {branch: $branch_name, status: "active"}]->(a:Attribute {name: $attr_name})
+        WHERE hae.to IS NULL
+        CALL (n, hae, a) {
+            CREATE (dup:Attribute)
+            SET dup = properties(a)
+            CREATE (n)-[new_hae:HAS_ATTRIBUTE]->(dup)
+            SET new_hae = properties(hae)
+            SET dup.uuid = randomUUID()
+            RETURN dup
+        }
+        WITH dup, a
+        MATCH (a)-[e {branch: $branch_name, status: "active"}]->(peer)
+        WHERE e.to IS NULL
+        CALL (dup, e, peer) {
+            CREATE (dup)-[new_e:$(type(e))]->(peer)
+            SET new_e = properties(e)
+        }
+        """
+        await db.execute_query(query=query, params={"branch_name": branch.name, "attr_name": attr_name})
 
     async def test_clean_duplicated_attributes(
         self,

--- a/backend/tests/component/core/migrations/schema/metadata_helpers.py
+++ b/backend/tests/component/core/migrations/schema/metadata_helpers.py
@@ -51,16 +51,11 @@ async def get_node_vertex_metadata(db: InfrahubDatabase, node_uuid: str) -> Vert
 async def get_attribute_vertex_metadata(
     db: InfrahubDatabase, node_uuid: str, attribute_name: str, edge_from: str
 ) -> VertexMetadata:
-    """Return the vertex metadata for the attribute whose HAS_ATTRIBUTE edge opened at ``edge_from``.
-
-    Filtering on the edge's ``from`` time uniquely selects a freshly-(re)created attribute even when an
-    earlier same-named attribute still exists on the node (e.g. a remove-then-add, or a rename). Pass the
-    migration timestamp (``Timestamp.to_string()``).
-    """
+    """Return the vertex metadata for the attribute whose HAS_ATTRIBUTE edge opened at ``edge_from``."""
     results = await db.execute_query(
         query=(
-            "MATCH (n:Node {uuid: $node_uuid})-[e:HAS_ATTRIBUTE]->(a:Attribute {name: $attribute_name}) "
-            "WHERE e.from = $edge_from "
+            'MATCH (n:Node {uuid: $node_uuid})-[e:HAS_ATTRIBUTE {status: "active"}]->(a:Attribute {name: $attribute_name}) '
+            "WHERE e.from = $edge_from AND e.to IS NULL "
             "RETURN a.updated_at AS updated_at, a.updated_by AS updated_by, "
             "a.previous_updated_at AS previous_updated_at, a.previous_updated_by AS previous_updated_by"
         ),
@@ -75,6 +70,35 @@ async def get_attribute_vertex_metadata(
         updated_by=row["updated_by"],
         previous_updated_at=row["previous_updated_at"],
         previous_updated_by=row["previous_updated_by"],
+    )
+
+
+async def branch_metadata_fingerprint(db: InfrahubDatabase, branch_name: str) -> list[tuple]:
+    """Snapshot the user-timestamp metadata of every Node/Attribute/Relationship vertex on a branch.
+
+    The vertex-metadata analogue of ``branch_edge_fingerprint``: two snapshots compare equal only when
+    every vertex's ``updated_at``/``updated_by`` and ``previous_updated_at``/``previous_updated_by`` are
+    identical, so an empty diff between a pre-change and a post-rollback snapshot proves the rollback
+    restored the metadata that a schema migration or merge bumped (and cleared the snapshot).
+    """
+    results = await db.execute_query(
+        query=(
+            "MATCH (v)-[{branch: $branch}]-() "
+            "WHERE v:Node OR v:Attribute OR v:Relationship "
+            "RETURN DISTINCT elementId(v) AS id, v.updated_at AS updated_at, v.updated_by AS updated_by, "
+            "v.previous_updated_at AS previous_updated_at, v.previous_updated_by AS previous_updated_by"
+        ),
+        params={"branch": branch_name},
+    )
+    return sorted(
+        (
+            row["id"],
+            row["updated_at"] or "",
+            row["updated_by"] or "",
+            row["previous_updated_at"] or "",
+            row["previous_updated_by"] or "",
+        )
+        for row in results
     )
 
 

--- a/backend/tests/component/core/migrations/schema/metadata_helpers.py
+++ b/backend/tests/component/core/migrations/schema/metadata_helpers.py
@@ -1,0 +1,105 @@
+"""Shared helpers for the schema-migration metadata tests.
+
+These assert how a schema migration bumps the user-timestamp metadata (``updated_at``/``updated_by``)
+stored on Node/Attribute/Relationship vertices, snapshots the prior values into
+``previous_updated_at``/``previous_updated_by``, and how a merge-failure rollback restores them.
+"""
+
+from dataclasses import dataclass
+
+from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class VertexMetadata:
+    """The user-timestamp metadata stored directly on a Node/Attribute/Relationship vertex.
+
+    ``previous_updated_at``/``previous_updated_by`` hold the snapshot a schema migration or merge
+    records before bumping ``updated_at``/``updated_by``, so a merge-failure rollback can restore them.
+    """
+
+    updated_at: str | None = None
+    updated_by: str | None = None
+    previous_updated_at: str | None = None
+    previous_updated_by: str | None = None
+
+
+async def get_node_vertex_metadata(db: InfrahubDatabase, node_uuid: str) -> VertexMetadata:
+    """Return the vertex metadata for the single Node vertex identified by ``node_uuid``.
+
+    Expects exactly one Node vertex with the uuid; callers that duplicate a node (e.g. a kind change
+    that leaves two same-uuid vertices) must disambiguate themselves rather than use this helper.
+    """
+    results = await db.execute_query(
+        query=(
+            "MATCH (n:Node {uuid: $node_uuid}) "
+            "RETURN n.updated_at AS updated_at, n.updated_by AS updated_by, "
+            "n.previous_updated_at AS previous_updated_at, n.previous_updated_by AS previous_updated_by"
+        ),
+        params={"node_uuid": node_uuid},
+    )
+    assert len(results) == 1, f"Expected exactly one Node vertex for {node_uuid}, found {len(results)}"
+    row = results[0]
+    return VertexMetadata(
+        updated_at=row["updated_at"],
+        updated_by=row["updated_by"],
+        previous_updated_at=row["previous_updated_at"],
+        previous_updated_by=row["previous_updated_by"],
+    )
+
+
+async def get_attribute_vertex_metadata(
+    db: InfrahubDatabase, node_uuid: str, attribute_name: str, edge_from: str
+) -> VertexMetadata:
+    """Return the vertex metadata for the attribute whose HAS_ATTRIBUTE edge opened at ``edge_from``.
+
+    Filtering on the edge's ``from`` time uniquely selects a freshly-(re)created attribute even when an
+    earlier same-named attribute still exists on the node (e.g. a remove-then-add, or a rename). Pass the
+    migration timestamp (``Timestamp.to_string()``).
+    """
+    results = await db.execute_query(
+        query=(
+            "MATCH (n:Node {uuid: $node_uuid})-[e:HAS_ATTRIBUTE]->(a:Attribute {name: $attribute_name}) "
+            "WHERE e.from = $edge_from "
+            "RETURN a.updated_at AS updated_at, a.updated_by AS updated_by, "
+            "a.previous_updated_at AS previous_updated_at, a.previous_updated_by AS previous_updated_by"
+        ),
+        params={"node_uuid": node_uuid, "attribute_name": attribute_name, "edge_from": edge_from},
+    )
+    assert len(results) == 1, (
+        f"Expected exactly one '{attribute_name}' attribute opened at {edge_from} for {node_uuid}, found {len(results)}"
+    )
+    row = results[0]
+    return VertexMetadata(
+        updated_at=row["updated_at"],
+        updated_by=row["updated_by"],
+        previous_updated_at=row["previous_updated_at"],
+        previous_updated_by=row["previous_updated_by"],
+    )
+
+
+async def branch_edge_fingerprint(db: InfrahubDatabase, branch_name: str) -> list[tuple]:
+    """Snapshot every edge on a branch, keyed on endpoints, timestamps and status.
+
+    Two snapshots compare equal only when the branch's edges are identical, so an empty diff between a
+    pre-change and a post-rollback snapshot proves the rollback restored the branch exactly.
+    """
+    results = await db.execute_query(
+        query=(
+            "MATCH (src)-[r {branch: $branch}]->(dst) "
+            "RETURN type(r) AS edge_type, elementId(src) AS src, elementId(dst) AS dst, "
+            "r.from AS edge_from, r.to AS edge_to, r.status AS status"
+        ),
+        params={"branch": branch_name},
+    )
+    return sorted(
+        (
+            row["edge_type"],
+            row["src"],
+            row["dst"],
+            row["edge_from"] or "",
+            row["edge_to"] or "",
+            row["status"] or "",
+        )
+        for row in results
+    )

--- a/backend/tests/component/core/migrations/schema/test_all_migrations_rollback.py
+++ b/backend/tests/component/core/migrations/schema/test_all_migrations_rollback.py
@@ -1,0 +1,256 @@
+"""Merge a branch carrying every schema-migration type, then roll the merge back on the default branch.
+
+Data is created on the default branch, a branch applies all migration types, the branch is merged into
+the default (bringing the migrated structure and its metadata onto the default branch), and the merge is
+then rolled back. The default branch must end byte-for-byte identical to its pre-merge state.
+
+This test does not validate the precise per-node effect of each migration. It only asserts that the
+merge changed the default branch and that the rollback fully undid it.
+"""
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import (
+    HashableModelState,
+    RelationshipCardinality,
+    RelationshipDirection,
+    RelationshipKind,
+    SchemaPathType,
+)
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.initialization import create_branch
+from infrahub.core.migrations.schema.attribute_kind_update import AttributeKindUpdateMigration
+from infrahub.core.migrations.schema.attribute_name_update import AttributeNameUpdateMigration
+from infrahub.core.migrations.schema.node_attribute_add import NodeAttributeAddMigration
+from infrahub.core.migrations.schema.node_attribute_remove import NodeAttributeRemoveMigration
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.schema.node_relationship_remove import NodeRelationshipRemoveMigration
+from infrahub.core.migrations.schema.node_remove import NodeRemoveMigration
+from infrahub.core.migrations.shared import MigrationInput, SchemaMigration
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+from tests.component.core.migrations.schema.metadata_helpers import branch_edge_fingerprint, branch_metadata_fingerprint
+from tests.helpers.db_validation import verify_graph
+from tests.helpers.schema import load_schema
+
+BRANCH_USER_ID = "branch_user"
+
+ALL_MIGRATIONS_SCHEMA = SchemaRoot(
+    version="1.0",
+    nodes=[
+        NodeSchema(
+            name="Widget",
+            namespace="Test",
+            attributes=[
+                AttributeSchema(name="name", kind="Text", unique=True),
+                AttributeSchema(name="color", kind="Text", optional=True),  # renamed -> new_color
+                AttributeSchema(name="weight", kind="Number", optional=True),  # removed
+                AttributeSchema(name="notes", kind="Text", optional=True),  # kind changed Text -> TextArea
+            ],
+            relationships=[
+                RelationshipSchema(
+                    name="keeper",
+                    peer="TestKeeper",
+                    kind=RelationshipKind.ATTRIBUTE,
+                    optional=True,
+                    cardinality=RelationshipCardinality.ONE,
+                    direction=RelationshipDirection.OUTBOUND,
+                    identifier="widget__keeper",
+                ),  # relationship removed
+            ],
+        ),
+        NodeSchema(
+            name="Keeper",
+            namespace="Test",
+            attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            relationships=[
+                RelationshipSchema(
+                    name="widgets",
+                    peer="TestWidget",
+                    optional=True,
+                    cardinality=RelationshipCardinality.MANY,
+                    direction=RelationshipDirection.INBOUND,
+                    identifier="widget__keeper",
+                ),
+            ],
+        ),
+        NodeSchema(  # node kind updated
+            name="Morph",
+            namespace="Test",
+            attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            relationships=[
+                RelationshipSchema(
+                    name="companion",
+                    peer="TestKeeper",
+                    kind=RelationshipKind.ATTRIBUTE,
+                    optional=True,
+                    cardinality=RelationshipCardinality.ONE,
+                    identifier="morph__companion",
+                ),
+            ],
+        ),
+        NodeSchema(  # schema to be deleted
+            name="Doomed",
+            namespace="Test",
+            attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            relationships=[
+                RelationshipSchema(
+                    name="guard",
+                    peer="TestKeeper",
+                    kind=RelationshipKind.ATTRIBUTE,
+                    optional=True,
+                    cardinality=RelationshipCardinality.ONE,
+                    identifier="doomed__guard",
+                ),
+            ],
+        ),
+    ],
+)
+
+
+async def _apply_all_migrations_on_branch(db: InfrahubDatabase, branch: Branch) -> None:
+    """Apply every schema-migration type on ``branch`` in a single schema update, then run each migration."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
+
+    # Capture the pre-change node schemas (the ``previous`` side of each migration).
+    original_widget = schema.get(name="TestWidget", duplicate=True)
+    original_morph = schema.get(name="TestMorph", duplicate=True)
+    original_doomed = schema.get(name="TestDoomed", duplicate=True)
+
+    # Make every schema change on the candidate branch schema, then process + persist once.
+    widget = schema.get(name="TestWidget", duplicate=True)
+    widget.attributes.append(AttributeSchema(name="extra", kind="Text", optional=True))  # attribute add
+    widget.get_attribute(name="weight").state = HashableModelState.ABSENT  # attribute remove
+    widget.get_attribute(name="color").name = "new_color"  # attribute rename (id preserved)
+    widget.get_attribute(name="notes").kind = "TextArea"  # attribute kind update
+    widget.get_relationship(name="keeper").state = HashableModelState.ABSENT  # relationship remove
+    schema.set(name="TestWidget", schema=widget)
+
+    keeper = schema.get(name="TestKeeper", duplicate=True)  # remove the other side of the shared identifier
+    keeper.get_relationship(name="widgets").state = HashableModelState.ABSENT
+    schema.set(name="TestKeeper", schema=keeper)
+
+    morph = schema.get(name="TestMorph", duplicate=True)  # node kind update TestMorph -> Test2Morph
+    schema.delete(name="TestMorph")
+    morph.namespace = "Test2"
+    schema.set(name="Test2Morph", schema=morph)
+
+    schema.delete(name="TestDoomed")  # node remove
+
+    schema.process()
+    await registry.schema.update_schema_branch(
+        db=db,
+        branch=branch,
+        schema=schema,
+        limit=["TestWidget", "TestKeeper", "TestMorph", "Test2Morph", "TestDoomed"],
+        update_db=True,
+    )
+
+    new_widget = schema.get(name="TestWidget")
+    migration_input = MigrationInput(db=db, at=Timestamp(), user_id=BRANCH_USER_ID)
+    migrations: list[SchemaMigration] = [
+        NodeAttributeAddMigration(
+            previous_node_schema=original_widget,
+            new_node_schema=new_widget,
+            schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestWidget", field_name="extra"),
+        ),
+        NodeAttributeRemoveMigration(
+            previous_node_schema=original_widget,
+            new_node_schema=new_widget,
+            schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestWidget", field_name="weight"),
+        ),
+        AttributeNameUpdateMigration(
+            previous_node_schema=original_widget,
+            new_node_schema=new_widget,
+            schema_path=SchemaPath(
+                path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestWidget", field_name="new_color"
+            ),
+        ),
+        AttributeKindUpdateMigration(
+            previous_node_schema=original_widget,
+            new_node_schema=new_widget,
+            schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestWidget", field_name="notes"),
+        ),
+        NodeRelationshipRemoveMigration(
+            previous_node_schema=original_widget,
+            new_node_schema=new_widget,
+            schema_path=SchemaPath(
+                path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestWidget", field_name="keeper"
+            ),
+        ),
+        NodeKindUpdateMigration(
+            previous_node_schema=original_morph,
+            new_node_schema=schema.get(name="Test2Morph"),
+            schema_path=SchemaPath(
+                path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2Morph", field_name="namespace"
+            ),
+        ),
+        NodeRemoveMigration(
+            previous_node_schema=original_doomed,
+            new_node_schema=None,
+            schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDoomed"),
+        ),
+    ]
+    for migration in migrations:
+        result = await migration.execute(migration_input=migration_input, branch=branch)
+        assert not result.errors, f"{migration.name} failed: {result.errors}"
+
+
+async def test_merge_then_rollback_with_all_migrations(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Merging a branch that applied every migration type, then rolling it back, restores the default branch."""
+    await load_schema(db=db, schema=ALL_MIGRATIONS_SCHEMA, update_db=True)
+
+    # Data on the default branch: every kind gets an attribute value and a relationship.
+    keeper = await Node.init(db=db, schema="TestKeeper")
+    await keeper.new(db=db, name="k1")
+    await keeper.save(db=db)
+    widget = await Node.init(db=db, schema="TestWidget")
+    await widget.new(db=db, name="w1", color="red", weight=5, notes="hello", keeper=keeper.id)
+    await widget.save(db=db)
+    morph = await Node.init(db=db, schema="TestMorph")
+    await morph.new(db=db, name="m1", companion=keeper.id)
+    await morph.save(db=db)
+    doomed = await Node.init(db=db, schema="TestDoomed")
+    await doomed.new(db=db, name="d1", guard=keeper.id)
+    await doomed.save(db=db)
+
+    pre_merge_edges = await branch_edge_fingerprint(db=db, branch_name=default_branch.name)
+    pre_merge_metadata = await branch_metadata_fingerprint(db=db, branch_name=default_branch.name)
+
+    # Apply every migration type on a branch.
+    branch = await create_branch(branch_name="all-migrations", db=db)
+    await _apply_all_migrations_on_branch(db=db, branch=branch)
+
+    # Merge the branch into the default branch.
+    merge_at = Timestamp()
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await diff_merger.merge_graph(at=merge_at)
+
+    # The merge changed the default branch, so its edges and the vertex metadata must differ
+    # from the pre-merge state.
+    assert await branch_edge_fingerprint(db=db, branch_name=default_branch.name) != pre_merge_edges
+    assert await branch_metadata_fingerprint(db=db, branch_name=default_branch.name) != pre_merge_metadata
+
+    # Roll the merge back on the default branch.
+    await diff_merger.rollback(merge_started_at=merge_at)
+
+    await verify_graph(db=db)
+
+    # The default branch is byte-for-byte identical to its pre-merge state: both the edges and the vertex
+    # metadata (updated_at/by restored, previous_* snapshots cleared) match the pre-merge snapshots.
+    assert await branch_edge_fingerprint(db=db, branch_name=default_branch.name) == pre_merge_edges
+    assert await branch_metadata_fingerprint(db=db, branch_name=default_branch.name) == pre_merge_metadata

--- a/backend/tests/component/core/migrations/schema/test_attribute_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_kind_update.py
@@ -1,6 +1,11 @@
+from dataclasses import dataclass
+
+import pytest
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.migrations.schema.attribute_kind_update import (
     AttributeKindUpdateMigration,
     AttributeKindUpdateMigrationQuery,
@@ -8,10 +13,13 @@ from infrahub.core.migrations.schema.attribute_kind_update import (
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import VertexMetadata, branch_edge_fingerprint
 from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import load_schema
 
@@ -28,6 +36,41 @@ CAR_SCHEMA_TEXT = {
         }
     ],
 }
+
+
+async def _get_car_and_description_metadata(
+    db: InfrahubDatabase, node_uuid: str
+) -> tuple[VertexMetadata, VertexMetadata]:
+    """Return the vertex metadata for a TestCar node and its ``description`` attribute.
+
+    The kind-update migration reuses the existing Attribute vertex rather than creating a new one, so
+    the ``description`` Attribute is reachable regardless of whether the migration has run yet.
+    """
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})-[:HAS_ATTRIBUTE]->(a:Attribute {name: "description"})
+        RETURN n.updated_at AS node_updated_at, n.updated_by AS node_updated_by,
+            n.previous_updated_at AS node_previous_updated_at, n.previous_updated_by AS node_previous_updated_by,
+            a.updated_at AS attr_updated_at, a.updated_by AS attr_updated_by,
+            a.previous_updated_at AS attr_previous_updated_at, a.previous_updated_by AS attr_previous_updated_by
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"node_uuid": node_uuid},
+    )
+    row = results[0]
+    node_metadata = VertexMetadata(
+        updated_at=row["node_updated_at"],
+        updated_by=row["node_updated_by"],
+        previous_updated_at=row["node_previous_updated_at"],
+        previous_updated_by=row["node_previous_updated_by"],
+    )
+    attr_metadata = VertexMetadata(
+        updated_at=row["attr_updated_at"],
+        updated_by=row["attr_updated_by"],
+        previous_updated_at=row["attr_previous_updated_at"],
+        previous_updated_by=row["attr_previous_updated_by"],
+    )
+    return node_metadata, attr_metadata
 
 
 async def check_attribute_value_vertices(db: InfrahubDatabase, value: str) -> tuple[int, int]:
@@ -147,3 +190,178 @@ async def test_migration_edge_timestamps(db: InfrahubDatabase, default_branch: B
     # 4. Validate edge timestamps
     after_snapshot = await snapshotter.snapshot()
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
+
+
+@dataclass
+class _AttributeKindUpdate:
+    """State captured around a single ``description`` kind-update migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    attr_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeKindUpdate:
+    """Run the ``description`` Text->TextArea kind-update migration on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration vertex metadata and branch edge fingerprint so callers can assert the
+    snapshot (default/global branch) and a rollback's restore.
+    """
+    node_before, attr_before = await _get_car_and_description_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "migration_user"
+    migration_time = Timestamp()
+
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    # Change description from Text (indexed) to TextArea (not indexed) so the migration runs.
+    new_car_schema.get_attribute(name="description").kind = "TextArea"
+
+    migration = AttributeKindUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="description"),
+    )
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
+    )
+    assert not execution_result.errors
+
+    return _AttributeKindUpdate(
+        branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        attr_before=attr_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, update: _AttributeKindUpdate) -> None:
+    """Assert the kind update's metadata effect, which differs by branch.
+
+    On every branch the change is reflected through the edges: a new active non-indexed HAS_VALUE edge
+    is written with the migration's user/timestamp. Vertex-level metadata is maintained only on the
+    default/global branch, so only there does the migration bump ``updated_at``/``by`` on the reused
+    Attribute and its Node and snapshot the prior values into ``previous_*``; on a user branch the
+    shared vertices are left untouched.
+    """
+    # The migration writes a new active HAS_VALUE edge to a non-indexed AttributeValue on the branch.
+    edge_results = await db.execute_query(
+        query="""
+        MATCH (:TestCar {uuid: $node_uuid})-[:HAS_ATTRIBUTE]->(a:Attribute {name: "description"})
+        MATCH (a)-[r:HAS_VALUE {branch: $branch, status: "active"}]->(av:AttributeValue)
+        WHERE r.from = $at AND r.to IS NULL
+        RETURN r.from_user_id AS from_user_id, r.from AS from_time,
+            "AttributeValueIndexed" IN labels(av) AS is_indexed
+        """,
+        params={"node_uuid": update.node_id, "branch": update.branch.name, "at": update.migration_time.to_string()},
+    )
+    assert len(edge_results) == 1, "Expected at least one new active HAS_VALUE edge"
+    assert edge_results[0]["from_user_id"] == update.user_id
+    assert edge_results[0]["from_time"] == update.migration_time.to_string()
+    assert edge_results[0]["is_indexed"] is False
+
+    node_after, attr_after = await _get_car_and_description_metadata(db=db, node_uuid=update.node_id)
+    if update.branch.is_default or update.branch.is_global:
+        # The bump snapshots the pre-migration values so a merge-failure rollback can restore them. The
+        # Attribute vertex is reused (not recreated) and survives a rollback, so it too needs a snapshot.
+        assert node_after.updated_at == update.migration_time.to_string()
+        assert node_after.updated_by == update.user_id
+        assert node_after.previous_updated_at == update.node_before.updated_at
+        assert node_after.previous_updated_by == update.node_before.updated_by
+        assert attr_after.updated_at == update.migration_time.to_string()
+        assert attr_after.updated_by == update.user_id
+        assert attr_after.previous_updated_at == update.attr_before.updated_at
+        assert attr_after.previous_updated_by == update.attr_before.updated_by
+    else:
+        # A user-branch migration leaves the shared vertices untouched and records no snapshot.
+        assert node_after == update.node_before
+        assert attr_after == update.attr_before
+        assert node_after.previous_updated_at is None
+        assert attr_after.previous_updated_at is None
+
+
+class TestAttributeKindUpdateMetadata:
+    """On the default branch, a kind update snapshots vertex metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def update(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+    ) -> _AttributeKindUpdate:
+        await load_schema(db=db, schema=SchemaRoot(**CAR_SCHEMA_TEXT), branch_name=default_branch_scope_class.name)
+
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="Accord", description="A nice car")
+        await car.save(db=db)
+
+        return await _run_kind_update_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, update: _AttributeKindUpdate) -> None:
+        """The kind update bumps updated_at/by on the Node and Attribute and snapshots the prior values."""
+        await _assert_migration_metadata(db=db, update=update)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, update: _AttributeKindUpdate) -> None:
+        """RollbackQuery undoes the migration: the branch edges and vertex metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=update.branch,
+                at=update.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+
+        # The vertex metadata is restored to its pre-migration values and the snapshot is cleared.
+        node_after, attr_after = await _get_car_and_description_metadata(db=db, node_uuid=update.node_id)
+        assert node_after.updated_at == update.node_before.updated_at
+        assert node_after.updated_by == update.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+        assert attr_after.updated_at == update.attr_before.updated_at
+        assert attr_after.updated_by == update.attr_before.updated_by
+        assert attr_after.previous_updated_at is None
+        assert attr_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        node_again, attr_again = await _get_car_and_description_metadata(db=db, node_uuid=update.node_id)
+        assert node_again == node_after
+        assert attr_again == attr_after
+
+
+async def test_migration_metadata_non_default_branch(db: InfrahubDatabase, default_branch: Branch) -> None:
+    """On a user branch the kind update is reflected through edges but records no vertex-metadata snapshot."""
+    await load_schema(db=db, schema=SchemaRoot(**CAR_SCHEMA_TEXT))
+
+    car = await Node.init(db=db, schema="TestCar")
+    await car.new(db=db, name="Accord", description="A nice car")
+    await car.save(db=db)
+
+    branch = await create_branch(branch_name="branch-attr-kind-update", db=db)
+    update = await _run_kind_update_migration(db=db, branch=branch, node_uuid=car.id)
+    await _assert_migration_metadata(db=db, update=update)

--- a/backend/tests/component/core/migrations/schema/test_attribute_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_kind_update.py
@@ -17,7 +17,11 @@ from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
-from tests.component.core.migrations.schema.metadata_helpers import VertexMetadata, branch_edge_fingerprint
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    branch_metadata_fingerprint,
+)
 from tests.db_snapshot import DbSnapshotter
 from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
@@ -203,6 +207,7 @@ class _AttributeKindUpdate:
     node_before: VertexMetadata
     attr_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeKindUpdate:
@@ -213,6 +218,7 @@ async def _run_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_
     """
     node_before, attr_before = await _get_car_and_description_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "migration_user"
     migration_time = Timestamp()
@@ -242,6 +248,7 @@ async def _run_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_
         node_before=node_before,
         attr_before=attr_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -333,6 +340,7 @@ class TestAttributeKindUpdateMetadata:
 
         # The branch edges are restored exactly to their pre-migration state.
         assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_metadata
 
         # The vertex metadata is restored to its pre-migration values and the snapshot is cleared.
         node_after, attr_after = await _get_car_and_description_metadata(db=db, node_uuid=update.node_id)
@@ -349,6 +357,7 @@ class TestAttributeKindUpdateMetadata:
         await _run_rollback()
         await verify_graph(db=db)
         assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_metadata
         node_again, attr_again = await _get_car_and_description_metadata(db=db, node_uuid=update.node_id)
         assert node_again == node_after
         assert attr_again == attr_after

--- a/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass
 
 import pytest
 
@@ -17,6 +18,7 @@ from infrahub.core.migrations.schema.attribute_name_update import (
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.template import core_object_template
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -24,6 +26,13 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    get_attribute_vertex_metadata,
+    get_node_vertex_metadata,
+    verify_graph,
+)
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
@@ -179,8 +188,31 @@ async def test_migration(
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
-async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
-    """Test that metadata is set correctly when renaming an attribute."""
+@dataclass
+class _AttributeRename:
+    """State captured around a single ``color`` -> ``new_color`` rename migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_attribute_rename_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeRename:
+    """Run the ``color`` -> ``new_color`` rename migration on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration Node vertex metadata and branch edge fingerprint so callers can assert the
+    snapshot (default/global branch) and a rollback's restore. The renamed attribute vertex does not exist
+    before the migration, so only the pre-existing Node is snapshotted here.
+    """
+    node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "migration_user"
+    migration_time = Timestamp()
+
     schema = registry.schema.get_schema_branch(name=branch.name)
     prev_car_schema = schema.get(name="TestCar")
     prev_attr = prev_car_schema.get_attribute(name="color")
@@ -191,40 +223,146 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
     new_attr.name = "new_color"
     new_attr.id = prev_attr.id
 
-    test_user_id = "test-metadata-user"
-    migration_time = Timestamp()
-
     migration = AttributeNameUpdateMigration(
         previous_node_schema=prev_car_schema,
         new_node_schema=new_car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new_color"),
     )
     execution_result = await migration.execute(
-        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
     )
     assert not execution_result.errors
 
-    schema_branch = registry.schema.get_schema_branch(name=branch.name)
-    car_schema = schema_branch.get(name="TestCar", duplicate=False)
-    color_attr = car_schema.get_attribute(name="color")
-    color_attr.name = "new_color"
+    # Reflect the rename in the in-place branch schema so the ORM can resolve the ``new_color`` field.
+    car_schema = schema.get(name="TestCar", duplicate=False)
+    car_schema.get_attribute(name="color").name = "new_color"
 
+    return _AttributeRename(
+        branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, context: _AttributeRename) -> None:
+    """Assert the rename's metadata effect, which differs by branch.
+
+    On every branch the change is reflected through the edges (the new HAS_ATTRIBUTE edge and the ORM's
+    edge-derived timestamps). Vertex-level metadata is maintained only on the default/global branch, so
+    only there does the rename bump ``updated_at``/``by`` on the Node and set it on the freshly-created
+    ``new_color`` Attribute; on a user branch the shared Node vertex is left untouched.
+    """
     updated_car = await NodeManager.get_one(
         db=db,
-        branch=branch,
-        id=car_accord_main.id,
+        branch=context.branch,
+        id=context.node_id,
         include_metadata=MetadataQueryOptions(
             node_level=MetadataOptions.USER_TIMESTAMPS, attribute_level=MetadataOptions.USER_TIMESTAMPS
         ),
         fields={"new_color": True},
     )
-    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_at() < context.migration_time
     assert updated_car._get_created_by() == SYSTEM_USER_ID
-    assert updated_car._get_updated_at() == migration_time
-    assert updated_car._get_updated_by() == test_user_id
+    assert updated_car._get_updated_at() == context.migration_time
+    assert updated_car._get_updated_by() == context.user_id
 
-    new_attr = updated_car.new_color
-    assert new_attr._get_created_at() == migration_time
-    assert new_attr._get_created_by() == test_user_id
-    assert new_attr._get_updated_at() == migration_time
-    assert new_attr._get_updated_by() == test_user_id
+    new_color_attr = updated_car.get_attribute("new_color")
+    assert new_color_attr._get_created_at() == context.migration_time
+    assert new_color_attr._get_created_by() == context.user_id
+    assert new_color_attr._get_updated_at() == context.migration_time
+    assert new_color_attr._get_updated_by() == context.user_id
+
+    node_after = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
+    if context.branch.is_default or context.branch.is_global:
+        # The bump snapshots the pre-migration Node values so a merge-failure rollback can restore them.
+        assert node_after.updated_at == context.migration_time.to_string()
+        assert node_after.updated_by == context.user_id
+        assert node_after.previous_updated_at == context.node_before.updated_at
+        assert node_after.previous_updated_by == context.node_before.updated_by
+        # The renamed Attribute vertex is created by this migration, so its metadata is set to the
+        # migration timestamp but there is no prior value to snapshot into previous_*.
+        new_color_after = await get_attribute_vertex_metadata(
+            db=db, node_uuid=context.node_id, attribute_name="new_color", edge_from=context.migration_time.to_string()
+        )
+        assert new_color_after.updated_at == context.migration_time.to_string()
+        assert new_color_after.updated_by == context.user_id
+        assert new_color_after.previous_updated_at is None
+    else:
+        # A user-branch migration leaves the shared Node vertex untouched and records no snapshot.
+        assert node_after == context.node_before
+        assert node_after.previous_updated_at is None
+
+
+class TestAttributeNameUpdateMetadata:
+    """On the default branch, renaming an attribute snapshots Node metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def rename(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _AttributeRename:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", color="#123456", owner=person.id)
+        await car.save(db=db)
+
+        return await _run_attribute_rename_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, rename: _AttributeRename) -> None:
+        """The rename bumps updated_at/by on the Node, snapshots its prior values, and sets the new vertex."""
+        await _assert_migration_metadata(db=db, context=rename)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, rename: _AttributeRename) -> None:
+        """RollbackQuery undoes the migration: the branch edges and Node metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=rename.branch,
+                at=rename.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert await branch_edge_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_fingerprint
+
+        # The Node metadata is restored to its pre-migration values and the snapshot is cleared. The
+        # freshly-created new_color Attribute vertex is deleted by the rollback rather than restored.
+        node_after = await get_node_vertex_metadata(db=db, node_uuid=rename.node_id)
+        assert node_after.updated_at == rename.node_before.updated_at
+        assert node_after.updated_by == rename.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert await branch_edge_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_fingerprint
+        node_again = await get_node_vertex_metadata(db=db, node_uuid=rename.node_id)
+        assert node_again == node_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node
+) -> None:
+    """On a user branch the rename is reflected through edges but records no Node vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-attr-rename", db=db)
+    context = await _run_attribute_rename_migration(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, context=context)

--- a/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
@@ -28,6 +28,7 @@ from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
+    branch_metadata_fingerprint,
     get_attribute_vertex_metadata,
     get_node_vertex_metadata,
 )
@@ -198,6 +199,7 @@ class _AttributeRename:
     user_id: str
     node_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_attribute_rename_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeRename:
@@ -209,6 +211,7 @@ async def _run_attribute_rename_migration(db: InfrahubDatabase, branch: Branch, 
     """
     node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "migration_user"
     migration_time = Timestamp()
@@ -244,6 +247,7 @@ async def _run_attribute_rename_migration(db: InfrahubDatabase, branch: Branch, 
         user_id=user_id,
         node_before=node_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -342,6 +346,7 @@ class TestAttributeNameUpdateMetadata:
 
         # The branch edges are restored exactly to their pre-migration state.
         assert await branch_edge_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_metadata
 
         # The Node metadata is restored to its pre-migration values and the snapshot is cleared. The
         # freshly-created new_color Attribute vertex is deleted by the rollback rather than restored.
@@ -355,6 +360,7 @@ class TestAttributeNameUpdateMetadata:
         await _run_rollback()
         await verify_graph(db=db)
         assert await branch_edge_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=rename.branch.name) == rename.pre_migration_metadata
         node_again = await get_node_vertex_metadata(db=db, node_uuid=rename.node_id)
         assert node_again == node_after
 

--- a/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
+++ b/backend/tests/component/core/migrations/schema/test_attribute_name_update.py
@@ -25,14 +25,14 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
-from tests.db_snapshot import DbSnapshotter
-from tests.helpers.db_validation import (
+from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
     get_attribute_vertex_metadata,
     get_node_vertex_metadata,
-    verify_graph,
 )
+from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -6,7 +6,6 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import (
-    SYSTEM_USER_ID,
     BranchSupportType,
     HashableModelState,
     InfrahubKind,
@@ -16,7 +15,6 @@ from infrahub.core.constants import (
 )
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
-from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_add import (
     NodeAttributeAddMigration,
     NodeAttributeAddMigrationQuery01,
@@ -40,6 +38,7 @@ from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
+    branch_metadata_fingerprint,
     get_attribute_vertex_metadata,
     get_node_vertex_metadata,
 )
@@ -233,7 +232,6 @@ async def test_migration(
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
-SETUP_USER_ID = "setup_user"
 MIGRATION_USER_ID = "migration_user"
 
 
@@ -247,39 +245,29 @@ class _AttributeAdd:
     user_id: str
     node_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_attribute_add_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeAdd:
-    """Remove and then re-add the ``color`` attribute on ``branch``, capturing the surrounding state.
-
-    The removal runs first so the add has something to recreate. The pre-add vertex metadata and branch
-    edge fingerprint are captured after the removal but before the add, so callers can assert the
-    snapshot (default/global branch) and a rollback's restore of the state just before the add.
-    """
-    schema = registry.schema.get_schema_branch(name=branch.name)
-    car_schema = schema.get_node(name="TestCar")
-
-    remove_migration = NodeAttributeRemoveMigration(
-        previous_node_schema=car_schema,
-        new_node_schema=car_schema,
-        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
-    )
-    # The removal runs as a distinct user so the pre-add updated_by differs from the migration's,
-    # making the add's updated_by bump and its rollback revert unambiguous on the default branch.
-    await remove_migration.execute(
-        migration_input=MigrationInput(db=db, at=Timestamp(), user_id=SETUP_USER_ID), branch=branch
-    )
-
+    """Add a brand-new ``doors`` attribute on ``branch``."""
     node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = MIGRATION_USER_ID
     migration_time = Timestamp()
 
+    candidate_schema = registry.schema.get_schema_branch(name=branch.name).duplicate()
+    car_schema = candidate_schema.get(name="TestCar")
+    car_schema.attributes.append(AttributeSchema(name="doors", kind="Number", optional=True))
+    candidate_schema.set(name="TestCar", schema=car_schema)
+    candidate_schema.process()
+    car_schema = candidate_schema.get(name="TestCar")
+
     migration = NodeAttributeAddMigration(
         new_node_schema=car_schema,
         previous_node_schema=car_schema,
-        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="doors"),
     )
     execution_result = await migration.execute(
         migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
@@ -293,42 +281,21 @@ async def _run_attribute_add_migration(db: InfrahubDatabase, branch: Branch, nod
         user_id=user_id,
         node_before=node_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
 async def _assert_migration_metadata(db: InfrahubDatabase, context: _AttributeAdd) -> None:
     """Assert the add's metadata effect, which differs by branch.
 
-    On every branch the ORM reflects the migration's user/timestamp through the edges. Vertex-level
-    metadata is maintained only on the default/global branch, so only there does the add bump
-    ``updated_at``/``by`` on the pre-existing node (snapshotting the prior values into ``previous_*``)
-    and stamp the freshly-created attribute vertex. On a user branch the shared node is left untouched
-    and the new attribute vertex is created without vertex metadata.
+    Vertex metadata is maintained only on the default/global branch, so only there does the add bump
+    ``updated_at``/``by`` on the pre-existing node (snapshotting the prior values into ``previous_*``) and
+    stamp the freshly-created attribute vertex. On a user branch the shared node is left untouched and the
+    new attribute vertex is created without vertex metadata.
     """
-    updated_car = await NodeManager.get_one(
-        db=db,
-        branch=context.branch,
-        id=context.node_id,
-        include_metadata=MetadataQueryOptions(
-            node_level=MetadataOptions.USER_TIMESTAMPS,
-            attribute_level=MetadataOptions.USER_TIMESTAMPS,
-        ),
-        fields={"color": True},
-    )
-    assert updated_car._get_created_at() < context.migration_time
-    assert updated_car._get_created_by() == SYSTEM_USER_ID
-    assert updated_car._get_updated_at() == context.migration_time
-    assert updated_car._get_updated_by() == context.user_id
-
-    added_attr = updated_car.get_attribute("color")
-    assert added_attr._get_created_at() == context.migration_time
-    assert added_attr._get_created_by() == context.user_id
-    assert added_attr._get_updated_at() == context.migration_time
-    assert added_attr._get_updated_by() == context.user_id
-
     node_after = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
     attr_after = await get_attribute_vertex_metadata(
-        db=db, node_uuid=context.node_id, attribute_name="color", edge_from=context.migration_time.to_string()
+        db=db, node_uuid=context.node_id, attribute_name="doors", edge_from=context.migration_time.to_string()
     )
     if context.branch.is_default or context.branch.is_global:
         # The pre-existing node is bumped and its prior values snapshotted so a rollback can restore them.
@@ -344,6 +311,7 @@ async def _assert_migration_metadata(db: InfrahubDatabase, context: _AttributeAd
         # A user-branch add leaves the shared node untouched and creates the attribute without metadata.
         assert node_after == context.node_before
         assert node_after.previous_updated_at is None
+        assert attr_after == VertexMetadata()
         assert attr_after == VertexMetadata()
 
 
@@ -391,12 +359,15 @@ class TestNodeAttributeAddMetadata:
         await _run_rollback()
         await verify_graph(db=db)
 
-        # The branch edges are restored exactly to their state just before the add.
+        # The branch edges and vertex metadata are restored exactly to the pristine pre-setup state.
         assert (
             await branch_edge_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_fingerprint
         )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_metadata
+        )
 
-        # The node metadata is restored to its pre-add values and the snapshot is cleared.
+        # The node metadata is restored to its pre-setup values and the snapshot is cleared.
         node_after = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
         assert node_after.updated_at == context.node_before.updated_at
         assert node_after.updated_by == context.node_before.updated_by
@@ -408,6 +379,9 @@ class TestNodeAttributeAddMetadata:
         await verify_graph(db=db)
         assert (
             await branch_edge_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_fingerprint
+        )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_metadata
         )
         node_again = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
         assert node_again == node_after

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -37,8 +37,14 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    get_attribute_vertex_metadata,
+    get_node_vertex_metadata,
+)
 from tests.db_snapshot import DbSnapshotter
-from tests.helpers.db_validation import VertexMetadata, branch_edge_fingerprint, verify_graph
+from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
@@ -231,49 +237,6 @@ SETUP_USER_ID = "setup_user"
 MIGRATION_USER_ID = "migration_user"
 
 
-async def _get_car_metadata(db: InfrahubDatabase, node_uuid: str) -> VertexMetadata:
-    """Return the vertex metadata stored on a TestCar node."""
-    query = """
-        MATCH (n:TestCar {uuid: $node_uuid})
-        RETURN n.updated_at AS updated_at, n.updated_by AS updated_by,
-            n.previous_updated_at AS previous_updated_at, n.previous_updated_by AS previous_updated_by
-    """
-    results = await db.execute_query(query=query, params={"node_uuid": node_uuid})
-    row = results[0]
-    return VertexMetadata(
-        updated_at=row["updated_at"],
-        updated_by=row["updated_by"],
-        previous_updated_at=row["previous_updated_at"],
-        previous_updated_by=row["previous_updated_by"],
-    )
-
-
-async def _get_added_color_metadata(db: InfrahubDatabase, node_uuid: str, migration_time: Timestamp) -> VertexMetadata:
-    """Return the vertex metadata of the freshly-added ``color`` attribute.
-
-    The added attribute is matched through the HAS_ATTRIBUTE edge opened at the migration timestamp,
-    which distinguishes it from the earlier removed ``color`` attribute on the same node.
-    """
-    query = """
-        MATCH (n:TestCar {uuid: $node_uuid})-[e:HAS_ATTRIBUTE]->(a:Attribute {name: "color"})
-        WHERE e.from = $migration_time
-        RETURN a.updated_at AS updated_at, a.updated_by AS updated_by,
-            a.previous_updated_at AS previous_updated_at, a.previous_updated_by AS previous_updated_by
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": node_uuid, "migration_time": migration_time.to_string()},
-    )
-    assert len(results) == 1, "Expected exactly one freshly-added color attribute"
-    row = results[0]
-    return VertexMetadata(
-        updated_at=row["updated_at"],
-        updated_by=row["updated_by"],
-        previous_updated_at=row["previous_updated_at"],
-        previous_updated_by=row["previous_updated_by"],
-    )
-
-
 @dataclass
 class _AttributeAdd:
     """State captured around a single ``color`` attribute-add migration on one branch."""
@@ -307,7 +270,7 @@ async def _run_attribute_add_migration(db: InfrahubDatabase, branch: Branch, nod
         migration_input=MigrationInput(db=db, at=Timestamp(), user_id=SETUP_USER_ID), branch=branch
     )
 
-    node_before = await _get_car_metadata(db=db, node_uuid=node_uuid)
+    node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
 
     user_id = MIGRATION_USER_ID
@@ -363,9 +326,9 @@ async def _assert_migration_metadata(db: InfrahubDatabase, context: _AttributeAd
     assert added_attr._get_updated_at() == context.migration_time
     assert added_attr._get_updated_by() == context.user_id
 
-    node_after = await _get_car_metadata(db=db, node_uuid=context.node_id)
-    attr_after = await _get_added_color_metadata(
-        db=db, node_uuid=context.node_id, migration_time=context.migration_time
+    node_after = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
+    attr_after = await get_attribute_vertex_metadata(
+        db=db, node_uuid=context.node_id, attribute_name="color", edge_from=context.migration_time.to_string()
     )
     if context.branch.is_default or context.branch.is_global:
         # The pre-existing node is bumped and its prior values snapshotted so a rollback can restore them.
@@ -434,7 +397,7 @@ class TestNodeAttributeAddMetadata:
         )
 
         # The node metadata is restored to its pre-add values and the snapshot is cleared.
-        node_after = await _get_car_metadata(db=db, node_uuid=context.node_id)
+        node_after = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
         assert node_after.updated_at == context.node_before.updated_at
         assert node_after.updated_by == context.node_before.updated_by
         assert node_after.previous_updated_at is None
@@ -446,7 +409,7 @@ class TestNodeAttributeAddMetadata:
         assert (
             await branch_edge_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_fingerprint
         )
-        node_again = await _get_car_metadata(db=db, node_uuid=context.node_id)
+        node_again = await get_node_vertex_metadata(db=db, node_uuid=context.node_id)
         assert node_again == node_after
 
 

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_add.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass
 
 import pytest
 
@@ -13,6 +14,7 @@ from infrahub.core.constants import (
     NumberPoolType,
     SchemaPathType,
 )
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_add import (
@@ -27,6 +29,7 @@ from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.definitions.core.template import core_object_template
@@ -35,6 +38,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes
 from infrahub.database import InfrahubDatabase
 from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import VertexMetadata, branch_edge_fingerprint, verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 
@@ -223,20 +227,90 @@ async def test_migration(
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
-async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
-    """Test that vertex metadata is set correctly when adding an attribute."""
+SETUP_USER_ID = "setup_user"
+MIGRATION_USER_ID = "migration_user"
+
+
+async def _get_car_metadata(db: InfrahubDatabase, node_uuid: str) -> VertexMetadata:
+    """Return the vertex metadata stored on a TestCar node."""
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})
+        RETURN n.updated_at AS updated_at, n.updated_by AS updated_by,
+            n.previous_updated_at AS previous_updated_at, n.previous_updated_by AS previous_updated_by
+    """
+    results = await db.execute_query(query=query, params={"node_uuid": node_uuid})
+    row = results[0]
+    return VertexMetadata(
+        updated_at=row["updated_at"],
+        updated_by=row["updated_by"],
+        previous_updated_at=row["previous_updated_at"],
+        previous_updated_by=row["previous_updated_by"],
+    )
+
+
+async def _get_added_color_metadata(db: InfrahubDatabase, node_uuid: str, migration_time: Timestamp) -> VertexMetadata:
+    """Return the vertex metadata of the freshly-added ``color`` attribute.
+
+    The added attribute is matched through the HAS_ATTRIBUTE edge opened at the migration timestamp,
+    which distinguishes it from the earlier removed ``color`` attribute on the same node.
+    """
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})-[e:HAS_ATTRIBUTE]->(a:Attribute {name: "color"})
+        WHERE e.from = $migration_time
+        RETURN a.updated_at AS updated_at, a.updated_by AS updated_by,
+            a.previous_updated_at AS previous_updated_at, a.previous_updated_by AS previous_updated_by
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"node_uuid": node_uuid, "migration_time": migration_time.to_string()},
+    )
+    assert len(results) == 1, "Expected exactly one freshly-added color attribute"
+    row = results[0]
+    return VertexMetadata(
+        updated_at=row["updated_at"],
+        updated_by=row["updated_by"],
+        previous_updated_at=row["previous_updated_at"],
+        previous_updated_by=row["previous_updated_by"],
+    )
+
+
+@dataclass
+class _AttributeAdd:
+    """State captured around a single ``color`` attribute-add migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_attribute_add_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeAdd:
+    """Remove and then re-add the ``color`` attribute on ``branch``, capturing the surrounding state.
+
+    The removal runs first so the add has something to recreate. The pre-add vertex metadata and branch
+    edge fingerprint are captured after the removal but before the add, so callers can assert the
+    snapshot (default/global branch) and a rollback's restore of the state just before the add.
+    """
     schema = registry.schema.get_schema_branch(name=branch.name)
     car_schema = schema.get_node(name="TestCar")
 
-    # Remove the color attribute first so we can re-add it
     remove_migration = NodeAttributeRemoveMigration(
         previous_node_schema=car_schema,
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
-    await remove_migration.execute(migration_input=MigrationInput(db=db, at=Timestamp()), branch=branch)
+    # The removal runs as a distinct user so the pre-add updated_by differs from the migration's,
+    # making the add's updated_by bump and its rollback revert unambiguous on the default branch.
+    await remove_migration.execute(
+        migration_input=MigrationInput(db=db, at=Timestamp(), user_id=SETUP_USER_ID), branch=branch
+    )
 
-    test_user_id = "test-metadata-user"
+    node_before = await _get_car_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = MIGRATION_USER_ID
     migration_time = Timestamp()
 
     migration = NodeAttributeAddMigration(
@@ -245,31 +319,144 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
     execution_result = await migration.execute(
-        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
     )
     assert not execution_result.errors
 
-    nodes = await NodeManager.get_many(
-        db=db,
-        ids=[car_accord_main.id],
+    return _AttributeAdd(
         branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, context: _AttributeAdd) -> None:
+    """Assert the add's metadata effect, which differs by branch.
+
+    On every branch the ORM reflects the migration's user/timestamp through the edges. Vertex-level
+    metadata is maintained only on the default/global branch, so only there does the add bump
+    ``updated_at``/``by`` on the pre-existing node (snapshotting the prior values into ``previous_*``)
+    and stamp the freshly-created attribute vertex. On a user branch the shared node is left untouched
+    and the new attribute vertex is created without vertex metadata.
+    """
+    updated_car = await NodeManager.get_one(
+        db=db,
+        branch=context.branch,
+        id=context.node_id,
         include_metadata=MetadataQueryOptions(
             node_level=MetadataOptions.USER_TIMESTAMPS,
             attribute_level=MetadataOptions.USER_TIMESTAMPS,
         ),
+        fields={"color": True},
     )
-    node = nodes[car_accord_main.id]
-    assert node._get_created_at() < migration_time
-    assert node._get_created_by() == SYSTEM_USER_ID
-    assert node._get_updated_at() == migration_time
-    assert node._get_updated_by() == test_user_id
+    assert updated_car._get_created_at() < context.migration_time
+    assert updated_car._get_created_by() == SYSTEM_USER_ID
+    assert updated_car._get_updated_at() == context.migration_time
+    assert updated_car._get_updated_by() == context.user_id
 
-    # Verify attribute metadata via the Node object
-    attr = node.color
-    assert attr._get_created_at() == migration_time
-    assert attr._get_created_by() == test_user_id
-    assert attr._get_updated_at() == migration_time
-    assert attr._get_updated_by() == test_user_id
+    added_attr = updated_car.get_attribute("color")
+    assert added_attr._get_created_at() == context.migration_time
+    assert added_attr._get_created_by() == context.user_id
+    assert added_attr._get_updated_at() == context.migration_time
+    assert added_attr._get_updated_by() == context.user_id
+
+    node_after = await _get_car_metadata(db=db, node_uuid=context.node_id)
+    attr_after = await _get_added_color_metadata(
+        db=db, node_uuid=context.node_id, migration_time=context.migration_time
+    )
+    if context.branch.is_default or context.branch.is_global:
+        # The pre-existing node is bumped and its prior values snapshotted so a rollback can restore them.
+        assert node_after.updated_at == context.migration_time.to_string()
+        assert node_after.updated_by == context.user_id
+        assert node_after.previous_updated_at == context.node_before.updated_at
+        assert node_after.previous_updated_by == context.node_before.updated_by
+        # The attribute vertex is created here, so it is stamped but has no prior value to snapshot.
+        assert attr_after.updated_at == context.migration_time.to_string()
+        assert attr_after.updated_by == context.user_id
+        assert attr_after.previous_updated_at is None
+    else:
+        # A user-branch add leaves the shared node untouched and creates the attribute without metadata.
+        assert node_after == context.node_before
+        assert node_after.previous_updated_at is None
+        assert attr_after == VertexMetadata()
+
+
+class TestNodeAttributeAddMetadata:
+    """On the default branch, adding an attribute stamps vertex metadata and a rollback removes it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def context(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _AttributeAdd:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", color="#123456", owner=person.id)
+        await car.save(db=db)
+
+        return await _run_attribute_add_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, context: _AttributeAdd) -> None:
+        """The add stamps the node and the new attribute vertex and snapshots the node's prior values."""
+        await _assert_migration_metadata(db=db, context=context)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, context: _AttributeAdd) -> None:
+        """RollbackQuery undoes the migration: the added attribute is deleted and the node restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=context.branch,
+                at=context.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their state just before the add.
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_fingerprint
+        )
+
+        # The node metadata is restored to its pre-add values and the snapshot is cleared.
+        node_after = await _get_car_metadata(db=db, node_uuid=context.node_id)
+        assert node_after.updated_at == context.node_before.updated_at
+        assert node_after.updated_by == context.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=context.branch.name) == context.pre_migration_fingerprint
+        )
+        node_again = await _get_car_metadata(db=db, node_uuid=context.node_id)
+        assert node_again == node_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node
+) -> None:
+    """On a user branch the add is reflected through edges but records no vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-attr-add-meta", db=db)
+    context = await _run_attribute_add_migration(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, context=context)
 
 
 # -----------------------------------------------------------------------------

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
@@ -23,7 +23,11 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
-from tests.component.core.migrations.schema.metadata_helpers import VertexMetadata, branch_edge_fingerprint
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    branch_metadata_fingerprint,
+)
 from tests.db_snapshot import DbSnapshotter
 from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
@@ -227,6 +231,7 @@ class _AttributeRemoval:
     node_before: VertexMetadata
     attr_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_removal_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeRemoval:
@@ -237,6 +242,7 @@ async def _run_removal_migration(db: InfrahubDatabase, branch: Branch, node_uuid
     """
     node_before, attr_before = await _get_car_and_color_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "test-metadata-user"
     migration_time = Timestamp()
@@ -263,6 +269,7 @@ async def _run_removal_migration(db: InfrahubDatabase, branch: Branch, node_uuid
         node_before=node_before,
         attr_before=attr_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -366,6 +373,9 @@ class TestAttributeRemoveMetadata:
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
         )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
+        )
 
         # The vertex metadata is restored to its pre-migration values and the snapshot is cleared.
         node_after, attr_after = await _get_car_and_color_metadata(db=db, node_uuid=removal.node_id)
@@ -383,6 +393,9 @@ class TestAttributeRemoveMetadata:
         await verify_graph(db=db)
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
         )
         node_again, attr_again = await _get_car_and_color_metadata(db=db, node_uuid=removal.node_id)
         assert node_again == node_after

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import SYSTEM_USER_ID, HashableModelState, MetadataOptions, SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.metadata.model import MetadataQueryOptions
 from infrahub.core.migrations.schema.node_attribute_remove import (
@@ -14,6 +16,7 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.definitions.core.template import core_object_template
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -21,7 +24,41 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 from tests.db_snapshot import DbSnapshotter
+from tests.helpers.db_validation import VertexMetadata, branch_edge_fingerprint, verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
+
+
+async def _get_car_and_color_metadata(db: InfrahubDatabase, node_uuid: str) -> tuple[VertexMetadata, VertexMetadata]:
+    """Return the vertex metadata for a TestCar node and its ``color`` attribute.
+
+    The HAS_ATTRIBUTE edge is traversed regardless of its status, so this works both before the
+    removal (edge active) and after it (edge closed).
+    """
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})-[:HAS_ATTRIBUTE]->(a:Attribute {name: "color"})
+        RETURN n.updated_at AS node_updated_at, n.updated_by AS node_updated_by,
+            n.previous_updated_at AS node_previous_updated_at, n.previous_updated_by AS node_previous_updated_by,
+            a.updated_at AS attr_updated_at, a.updated_by AS attr_updated_by,
+            a.previous_updated_at AS attr_previous_updated_at, a.previous_updated_by AS attr_previous_updated_by
+    """
+    results = await db.execute_query(
+        query=query,
+        params={"node_uuid": node_uuid},
+    )
+    row = results[0]
+    node_metadata = VertexMetadata(
+        updated_at=row["node_updated_at"],
+        updated_by=row["node_updated_by"],
+        previous_updated_at=row["node_previous_updated_at"],
+        previous_updated_by=row["node_previous_updated_by"],
+    )
+    attr_metadata = VertexMetadata(
+        updated_at=row["attr_updated_at"],
+        updated_by=row["attr_updated_by"],
+        previous_updated_at=row["attr_previous_updated_at"],
+        previous_updated_by=row["attr_previous_updated_by"],
+    )
+    return node_metadata, attr_metadata
 
 
 @pytest.fixture
@@ -178,51 +215,183 @@ async def test_migration(
     assert_edge_timestamps(before_snapshot, after_snapshot, at_str)
 
 
-async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
-    """Test that metadata is set correctly when removing an attribute."""
+@dataclass
+class _AttributeRemoval:
+    """State captured around a single ``color`` attribute-removal migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    attr_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_removal_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _AttributeRemoval:
+    """Run the ``color``-attribute removal migration on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration vertex metadata and branch edge fingerprint so callers can assert the
+    snapshot (default/global branch) and a rollback's restore.
+    """
+    node_before, attr_before = await _get_car_and_color_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "test-metadata-user"
+    migration_time = Timestamp()
+
     schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
-    car_schema = candidate_schema.get(name="TestCar")
-    attr = car_schema.get_attribute(name="color")
-    attr.state = HashableModelState.ABSENT
-
-    test_user_id = "test-metadata-user"
-    migration_time = Timestamp()
+    candidate_schema.get(name="TestCar").get_attribute(name="color").state = HashableModelState.ABSENT
 
     migration = NodeAttributeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
-        new_node_schema=car_schema,
+        new_node_schema=candidate_schema.get(name="TestCar"),
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
     )
     execution_result = await migration.execute(
-        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
     )
     assert not execution_result.errors
 
+    return _AttributeRemoval(
+        branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        attr_before=attr_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, removal: _AttributeRemoval) -> None:
+    """Assert the removal's metadata effect, which differs by branch.
+
+    On every branch the change is reflected through the edges (the closed HAS_ATTRIBUTE edge and the
+    ORM's edge-derived timestamps). Vertex-level metadata is maintained only on the default/global
+    branch, so only there does the removal bump ``updated_at``/``by`` on the vertices and snapshot the
+    prior values into ``previous_*``; on a user branch the shared vertices are left untouched.
+    """
     updated_car = await NodeManager.get_one(
         db=db,
-        branch=branch,
-        id=car_accord_main.id,
+        branch=removal.branch,
+        id=removal.node_id,
         include_metadata=MetadataQueryOptions(node_level=MetadataOptions.USER_TIMESTAMPS),
         fields={"color": True},
     )
-    assert updated_car._get_created_at() < migration_time
+    assert updated_car._get_created_at() < removal.migration_time
     assert updated_car._get_created_by() == SYSTEM_USER_ID
-    assert updated_car._get_updated_at() == migration_time
-    assert updated_car._get_updated_by() == test_user_id
+    assert updated_car._get_updated_at() == removal.migration_time
+    assert updated_car._get_updated_by() == removal.user_id
 
-    # Query for the deleted attribute edges and verify metadata
-    query = """
-    MATCH (n:TestCar {uuid: $node_uuid})-[r:HAS_ATTRIBUTE {branch: $branch, status: "deleted"}]->(attr:Attribute {name: "color"})
-    RETURN r.from_user_id as from_user_id, r.from as from_time, n.updated_at as updated_at, n.updated_by as updated_by
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": car_accord_main.id, "branch": branch.name},
+    # The removal closes the HAS_ATTRIBUTE edge with the migration's user/timestamp.
+    edge_results = await db.execute_query(
+        query="""
+        MATCH (:TestCar {uuid: $node_uuid})-[r:HAS_ATTRIBUTE {branch: $branch, status: "deleted"}]->(:Attribute {name: "color"})
+        RETURN r.from_user_id as from_user_id, r.from as from_time
+        """,
+        params={"node_uuid": removal.node_id, "branch": removal.branch.name},
     )
-    assert len(results) > 0, "Expected at least one deleted HAS_ATTRIBUTE edge"
-    assert results[0]["from_user_id"] == test_user_id
-    assert results[0]["from_time"] == migration_time.to_string()
-    if branch.is_default:
-        assert results[0]["updated_at"] == migration_time.to_string()
-        assert results[0]["updated_by"] == test_user_id
+    assert len(edge_results) > 0, "Expected at least one deleted HAS_ATTRIBUTE edge"
+    assert edge_results[0]["from_user_id"] == removal.user_id
+    assert edge_results[0]["from_time"] == removal.migration_time.to_string()
+
+    node_after, attr_after = await _get_car_and_color_metadata(db=db, node_uuid=removal.node_id)
+    if removal.branch.is_default or removal.branch.is_global:
+        # The bump snapshots the pre-migration values so a merge-failure rollback can restore them. The
+        # Attribute vertex being removed is pre-existing and survives a rollback, so it too needs a snapshot.
+        assert node_after.updated_at == removal.migration_time.to_string()
+        assert node_after.updated_by == removal.user_id
+        assert node_after.previous_updated_at == removal.node_before.updated_at
+        assert node_after.previous_updated_by == removal.node_before.updated_by
+        assert attr_after.updated_at == removal.migration_time.to_string()
+        assert attr_after.updated_by == removal.user_id
+        assert attr_after.previous_updated_at == removal.attr_before.updated_at
+        assert attr_after.previous_updated_by == removal.attr_before.updated_by
+    else:
+        # A user-branch migration leaves the shared vertices untouched and records no snapshot.
+        assert node_after == removal.node_before
+        assert attr_after == removal.attr_before
+        assert node_after.previous_updated_at is None
+        assert attr_after.previous_updated_at is None
+
+
+class TestAttributeRemoveMetadata:
+    """On the default branch, removing an attribute snapshots vertex metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def removal(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _AttributeRemoval:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", color="#123456", owner=person.id)
+        await car.save(db=db)
+
+        return await _run_removal_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, removal: _AttributeRemoval) -> None:
+        """The removal bumps updated_at/by on the Node and Attribute and snapshots the prior values."""
+        await _assert_migration_metadata(db=db, removal=removal)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, removal: _AttributeRemoval) -> None:
+        """RollbackQuery undoes the migration: the branch edges and vertex metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=removal.branch,
+                at=removal.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+
+        # The vertex metadata is restored to its pre-migration values and the snapshot is cleared.
+        node_after, attr_after = await _get_car_and_color_metadata(db=db, node_uuid=removal.node_id)
+        assert node_after.updated_at == removal.node_before.updated_at
+        assert node_after.updated_by == removal.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+        assert attr_after.updated_at == removal.attr_before.updated_at
+        assert attr_after.updated_by == removal.attr_before.updated_by
+        assert attr_after.previous_updated_at is None
+        assert attr_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        node_again, attr_again = await _get_car_and_color_metadata(db=db, node_uuid=removal.node_id)
+        assert node_again == node_after
+        assert attr_again == attr_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node
+) -> None:
+    """On a user branch the removal is reflected through edges but records no vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-attr-remove", db=db)
+    removal = await _run_removal_migration(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, removal=removal)

--- a/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_attribute_remove.py
@@ -23,8 +23,9 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import VertexMetadata, branch_edge_fingerprint
 from tests.db_snapshot import DbSnapshotter
-from tests.helpers.db_validation import VertexMetadata, branch_edge_fingerprint, verify_graph
+from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 
 

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -23,6 +23,7 @@ from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
+    branch_metadata_fingerprint,
     get_node_vertex_metadata,
 )
 from tests.constants import TestKind
@@ -299,6 +300,7 @@ class _NodeKindUpdate:
     car_created_at: Timestamp
     node_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_node_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _NodeKindUpdate:
@@ -319,6 +321,7 @@ async def _run_node_kind_update_migration(db: InfrahubDatabase, branch: Branch, 
 
     node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "migration_user"
     migration_time = Timestamp()
@@ -351,6 +354,7 @@ async def _run_node_kind_update_migration(db: InfrahubDatabase, branch: Branch, 
         car_created_at=car_created_at,
         node_before=node_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -484,6 +488,7 @@ class TestNodeKindUpdateMetadata:
 
         # The branch edges are restored exactly to their pre-migration state.
         assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_metadata
 
         # The rollback deletes the new Test2NewCar vertex and reopens the original, restoring its metadata.
         node_after = await get_node_vertex_metadata(db=db, node_uuid=update.node_id)
@@ -496,6 +501,7 @@ class TestNodeKindUpdateMetadata:
         await _run_rollback()
         await verify_graph(db=db)
         assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        assert await branch_metadata_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_metadata
         node_again = await get_node_vertex_metadata(db=db, node_uuid=update.node_id)
         assert node_again == node_after
 

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update.py
@@ -1,4 +1,7 @@
+from dataclasses import dataclass
 from typing import Any
+
+import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -11,13 +14,24 @@ from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
 from infrahub.core.query.node import NodeGetHierarchyQuery
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    get_node_vertex_metadata,
+)
 from tests.constants import TestKind
 from tests.db_snapshot import DbSnapshotter
-from tests.helpers.db_validation import validate_node_relationships, verify_no_duplicate_paths
+from tests.helpers.db_validation import (
+    validate_node_relationships,
+    verify_graph,
+    verify_no_duplicate_paths,
+)
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import LOCATION_SCHEMA, load_schema
 
@@ -252,9 +266,63 @@ async def test_inheritance_migration_on_branch_and_main(
     await verify_no_duplicate_paths(db=db)
 
 
-async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
-    """Test that metadata is set correctly when updating node kind."""
-    car_created_at = car_accord_main._get_created_at()
+async def _get_original_car_metadata(db: InfrahubDatabase, node_uuid: str, branch_name: str) -> VertexMetadata:
+    """Return the metadata of the ORIGINAL ``:TestCar`` vertex after the migration.
+
+    The kind change creates a new ``:Test2NewCar`` vertex sharing the uuid, so the original is
+    disambiguated by its now-deleted IS_PART_OF edge on ``branch_name``. The original vertex is the one
+    that survives a rollback and holds the meaningful ``previous_*`` snapshot.
+    """
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})-[:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root)
+        RETURN n.updated_at AS updated_at, n.updated_by AS updated_by,
+            n.previous_updated_at AS previous_updated_at, n.previous_updated_by AS previous_updated_by
+    """
+    results = await db.execute_query(query=query, params={"node_uuid": node_uuid, "branch": branch_name})
+    row = results[0]
+    return VertexMetadata(
+        updated_at=row["updated_at"],
+        updated_by=row["updated_by"],
+        previous_updated_at=row["previous_updated_at"],
+        previous_updated_by=row["previous_updated_by"],
+    )
+
+
+@dataclass
+class _NodeKindUpdate:
+    """State captured around a single ``TestCar`` -> ``Test2NewCar`` kind-update migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    car_created_at: Timestamp
+    node_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_node_kind_update_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _NodeKindUpdate:
+    """Rename ``TestCar`` to ``Test2NewCar`` on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration node created_at, vertex metadata and branch edge fingerprint so callers
+    can assert the snapshot (default/global branch) and a rollback's restore.
+    """
+    car_before = await NodeManager.get_one(
+        db=db,
+        branch=branch,
+        id=node_uuid,
+        include_metadata=MetadataQueryOptions(node_level=MetadataOptions.USER_TIMESTAMPS),
+    )
+    assert car_before is not None
+    car_created_at = car_before._get_created_at()
+    assert car_created_at is not None
+
+    node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "migration_user"
+    migration_time = Timestamp()
+
     schema = registry.schema.get_schema_branch(name=branch.name)
     candidate_schema = schema.duplicate()
     car_schema = candidate_schema.get(name="TestCar")
@@ -263,25 +331,43 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
     car_schema.namespace = "Test2"
     candidate_schema.set(name="Test2NewCar", schema=car_schema)
 
-    test_user_id = "test-metadata-user"
-    migration_time = Timestamp()
-
     migration = NodeKindUpdateMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
     )
     execution_result = await migration.execute(
-        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
     )
     assert not execution_result.errors
 
     registry.schema.set_schema_branch(name=branch.name, schema=candidate_schema)
 
+    return _NodeKindUpdate(
+        branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        car_created_at=car_created_at,
+        node_before=node_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, update: _NodeKindUpdate) -> None:
+    """Assert the kind-update's metadata effect, which differs by branch.
+
+    On every branch the change is reflected through the ORM view of the migrated node and through the
+    edges (a new active edge set on the ``:Test2NewCar`` vertex and the closed edge on the original
+    ``:TestCar`` vertex, both stamped with the migration's user). Vertex-level metadata is maintained
+    only on the default/global branch, so only there does the migration bump ``updated_at``/``by`` on the
+    surviving original vertex and snapshot the prior values into ``previous_*``; on a user branch the
+    shared vertex is left untouched.
+    """
     updated_car = await NodeManager.get_one(
         db=db,
-        branch=branch,
-        id=car_accord_main.id,
+        branch=update.branch,
+        id=update.node_id,
         include_metadata=MetadataQueryOptions(
             node_level=MetadataOptions.USER_TIMESTAMPS,
             attribute_level=MetadataOptions.USER_TIMESTAMPS,
@@ -289,43 +375,135 @@ async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, b
         ),
         prefetch_relationships=True,
     )
-    assert updated_car._get_created_at() == car_created_at
+    assert updated_car._get_created_at() == update.car_created_at
     assert updated_car._get_created_by() == SYSTEM_USER_ID
-    assert updated_car._get_updated_at() == migration_time
-    assert updated_car._get_updated_by() == test_user_id
-    for attr_name in car_schema.attribute_names:
+    assert updated_car._get_updated_at() == update.migration_time
+    assert updated_car._get_updated_by() == update.user_id
+    for attr_name in updated_car.get_schema().attribute_names:
         attr = updated_car.get_attribute(name=attr_name)
-        assert attr._get_created_at() == car_created_at
+        assert attr._get_created_at() == update.car_created_at
         assert attr._get_created_by() == SYSTEM_USER_ID
         assert attr._get_updated_at() == attr._get_created_at()
         assert attr._get_updated_by() == SYSTEM_USER_ID
     rel_manager = updated_car.get_relationship(name="owner")
-    rel = await rel_manager.get(db=db)
-    assert rel._get_created_at() == car_created_at
+    rels = await rel_manager.get_relationships(db=db)
+    assert len(rels) == 1
+    rel = rels[0]
+    assert rel._get_created_at() == update.car_created_at
     assert rel._get_created_by() == SYSTEM_USER_ID
     assert rel._get_updated_at() == rel._get_created_at()
     assert rel._get_updated_by() == SYSTEM_USER_ID
 
-    # Query for the NEW active node edges and verify metadata
-    query = """
-    MATCH (n:Test2NewCar {uuid: $node_uuid})-[r {branch: $branch, status: "active", from: $migration_time}]-()
-    RETURN DISTINCT r.from_user_id as from_user_id
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": car_accord_main.id, "branch": branch.name, "migration_time": migration_time.to_string()},
+    # The NEW active edges on the migrated node carry the migration's user/timestamp.
+    new_edge_results = await db.execute_query(
+        query="""
+        MATCH (:Test2NewCar {uuid: $node_uuid})-[r {branch: $branch, status: "active", from: $migration_time}]-()
+        RETURN DISTINCT r.from_user_id AS from_user_id
+        """,
+        params={
+            "node_uuid": update.node_id,
+            "branch": update.branch.name,
+            "migration_time": update.migration_time.to_string(),
+        },
     )
-    assert len(results) == 1, "Expected exactly one active edge on migrated node"
-    assert results[0]["from_user_id"] == test_user_id
+    assert len(new_edge_results) == 1, "Expected exactly one active edge on migrated node"
+    assert new_edge_results[0]["from_user_id"] == update.user_id
 
-    # Query for the OLD deleted node edges and verify metadata
-    query = """
-    MATCH (n:TestCar {uuid: $node_uuid})-[r {branch: $branch, status: "deleted", from: $migration_time}]-()
-    RETURN DISTINCT r.from_user_id as from_user_id
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": car_accord_main.id, "branch": branch.name, "migration_time": migration_time.to_string()},
+    # The OLD deleted edges on the original node carry the same migration user/timestamp.
+    old_edge_results = await db.execute_query(
+        query="""
+        MATCH (:TestCar {uuid: $node_uuid})-[r {branch: $branch, status: "deleted", from: $migration_time}]-()
+        RETURN DISTINCT r.from_user_id AS from_user_id
+        """,
+        params={
+            "node_uuid": update.node_id,
+            "branch": update.branch.name,
+            "migration_time": update.migration_time.to_string(),
+        },
     )
-    assert len(results) == 1, "Expected exactly one deleted edge on old node"
-    assert results[0]["from_user_id"] == test_user_id
+    assert len(old_edge_results) == 1, "Expected exactly one deleted edge on old node"
+    assert old_edge_results[0]["from_user_id"] == update.user_id
+
+    original_after = await _get_original_car_metadata(db=db, node_uuid=update.node_id, branch_name=update.branch.name)
+    if update.branch.is_default or update.branch.is_global:
+        # The kind change replaces the node with a new vertex; the original (now deleted) vertex keeps the
+        # pre-migration snapshot so a merge-failure rollback can restore it after deleting the new one.
+        assert original_after.updated_at == update.migration_time.to_string()
+        assert original_after.updated_by == update.user_id
+        assert original_after.previous_updated_at == update.node_before.updated_at
+        assert original_after.previous_updated_by == update.node_before.updated_by
+    else:
+        # A user-branch migration leaves the shared vertex untouched and records no snapshot.
+        assert original_after.previous_updated_at is None
+        assert original_after.previous_updated_by is None
+
+
+class TestNodeKindUpdateMetadata:
+    """On the default branch, updating a node's kind snapshots vertex metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def update(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _NodeKindUpdate:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", nbr_seats=5, is_electric=False, owner=person.id)
+        await car.save(db=db)
+
+        return await _run_node_kind_update_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, update: _NodeKindUpdate) -> None:
+        """The kind change bumps updated_at/by on the surviving original vertex and snapshots the prior values."""
+        await _assert_migration_metadata(db=db, update=update)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, update: _NodeKindUpdate) -> None:
+        """RollbackQuery undoes the migration: the branch edges and vertex metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=update.branch,
+                at=update.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+
+        # The rollback deletes the new Test2NewCar vertex and reopens the original, restoring its metadata.
+        node_after = await get_node_vertex_metadata(db=db, node_uuid=update.node_id)
+        assert node_after.updated_at == update.node_before.updated_at
+        assert node_after.updated_by == update.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert await branch_edge_fingerprint(db=db, branch_name=update.branch.name) == update.pre_migration_fingerprint
+        node_again = await get_node_vertex_metadata(db=db, node_uuid=update.node_id)
+        assert node_again == node_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node
+) -> None:
+    """On a user branch the kind change is reflected through edges but records no vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-kind-update-meta", db=db)
+    update = await _run_node_kind_update_migration(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, update=update)

--- a/backend/tests/component/core/migrations/schema/test_node_relationship_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_relationship_remove.py
@@ -12,6 +12,10 @@ post-removal schema with every side of the identifier removed, matching what the
 before migrations run.
 """
 
+from dataclasses import dataclass
+
+import pytest
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, SchemaPathType
@@ -21,8 +25,15 @@ from infrahub.core.migrations.schema.node_relationship_remove import NodeRelatio
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    get_node_vertex_metadata,
+)
 from tests.helpers.db_validation import verify_graph
 
 
@@ -56,6 +67,30 @@ async def _count_active_is_related(db: InfrahubDatabase, identifier: str, branch
     """
     results = await db.execute_query(query=query, params={"identifier": identifier, "branch": branch.name})
     return results[0]["nbr"]
+
+
+async def _get_relationship_vertices_metadata(
+    db: InfrahubDatabase, identifier: str, branch_name: str
+) -> list[VertexMetadata]:
+    """Return the vertex metadata of every Relationship vertex of ``identifier`` reachable on ``branch_name``."""
+    results = await db.execute_query(
+        query=(
+            "MATCH (rel:Relationship {name: $identifier}) "
+            "WHERE exists((rel)-[:IS_RELATED {branch: $branch}]-()) "
+            "RETURN rel.updated_at AS updated_at, rel.updated_by AS updated_by, "
+            "rel.previous_updated_at AS previous_updated_at, rel.previous_updated_by AS previous_updated_by"
+        ),
+        params={"identifier": identifier, "branch": branch_name},
+    )
+    return [
+        VertexMetadata(
+            updated_at=row["updated_at"],
+            updated_by=row["updated_by"],
+            previous_updated_at=row["previous_updated_at"],
+            previous_updated_by=row["previous_updated_by"],
+        )
+        for row in results
+    ]
 
 
 async def test_default_branch_closes_in_place(
@@ -140,3 +175,164 @@ async def test_diff_shows_removed_for_preexisting_data(
     assert element.action is DiffAction.REMOVED
 
     await verify_graph(db=db)
+
+
+@dataclass
+class _RelationshipRemoval:
+    """State captured around a single ``owner`` relationship-removal migration on one branch."""
+
+    branch: Branch
+    node_id: str
+    identifier: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_relationship_removal(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _RelationshipRemoval:
+    """Run the ``owner``-relationship removal migration on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration node vertex metadata and branch edge fingerprint so callers can assert
+    the snapshot (default/global branch) and a rollback's restore.
+    """
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    identifier = schema.get(name="TestCar").get_relationship(name="owner").get_identifier()
+
+    node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "migration_user"
+    migration_time = Timestamp()
+
+    migration = await _prepare_removal(branch=branch, node_kind="TestCar", relationship_name="owner")
+    execution_result = await migration.execute(
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
+    )
+    assert not execution_result.errors
+
+    return _RelationshipRemoval(
+        branch=branch,
+        node_id=node_uuid,
+        identifier=identifier,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
+    )
+
+
+async def _assert_migration_metadata(db: InfrahubDatabase, removal: _RelationshipRemoval) -> None:
+    """Assert the removal's metadata effect, which differs by branch.
+
+    On every branch the relationship is closed on the operating branch (in place on default/global, via
+    deleted shadow edges on a user branch). Vertex-level metadata is maintained only on the
+    default/global branch, so only there does the removal bump ``updated_at``/``by`` on the Node and the
+    Relationship vertices and snapshot the prior values into ``previous_*``; on a user branch the shared
+    vertices are left untouched.
+    """
+    assert await _count_active_is_related(db=db, identifier=removal.identifier, branch=removal.branch) == 0
+
+    node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+    rel_metadatas = await _get_relationship_vertices_metadata(
+        db=db, identifier=removal.identifier, branch_name=removal.branch.name
+    )
+    assert rel_metadatas, "Expected the Relationship vertices to be reachable on the operating branch"
+    if removal.branch.is_default or removal.branch.is_global:
+        # The bump snapshots the pre-migration values so a merge-failure rollback can restore them.
+        assert node_after.updated_at == removal.migration_time.to_string()
+        assert node_after.updated_by == removal.user_id
+        assert node_after.previous_updated_at == removal.node_before.updated_at
+        assert node_after.previous_updated_by == removal.node_before.updated_by
+
+        # Every Relationship vertex is bumped to the migration timestamp and snapshots its prior values.
+        for rel_metadata in rel_metadatas:
+            assert rel_metadata.updated_at == removal.migration_time.to_string()
+            assert rel_metadata.updated_by == removal.user_id
+            assert rel_metadata.previous_updated_at is not None
+            assert rel_metadata.previous_updated_at != removal.migration_time.to_string()
+            assert rel_metadata.previous_updated_by is not None
+    else:
+        # A user-branch migration leaves the shared Node and Relationship vertices untouched, recording no snapshot.
+        assert node_after == removal.node_before
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+        for rel_metadata in rel_metadatas:
+            assert rel_metadata.updated_at != removal.migration_time.to_string()
+            assert rel_metadata.previous_updated_at is None
+            assert rel_metadata.previous_updated_by is None
+
+
+class TestNodeRelationshipRemoveMetadata:
+    """On the default branch, removing a relationship snapshots vertex metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def removal(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _RelationshipRemoval:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", color="#123456", owner=person.id)
+        await car.save(db=db)
+
+        return await _run_relationship_removal(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, removal: _RelationshipRemoval) -> None:
+        """The removal bumps updated_at/by on the Node and Relationship vertices and snapshots prior values."""
+        await _assert_migration_metadata(db=db, removal=removal)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, removal: _RelationshipRemoval) -> None:
+        """RollbackQuery undoes the migration: the branch edges and node metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=removal.branch,
+                at=removal.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+
+        # The node vertex metadata is restored to its pre-migration values and the snapshot is cleared.
+        node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+        assert node_after.updated_at == removal.node_before.updated_at
+        assert node_after.updated_by == removal.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        node_again = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+        assert node_again == node_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node
+) -> None:
+    """On a user branch the removal shadows the default edges but records no vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-rel-remove-meta", db=db)
+    removal = await _run_relationship_removal(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, removal=removal)

--- a/backend/tests/component/core/migrations/schema/test_node_relationship_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_relationship_remove.py
@@ -32,6 +32,7 @@ from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
+    branch_metadata_fingerprint,
     get_node_vertex_metadata,
 )
 from tests.helpers.db_validation import verify_graph
@@ -188,6 +189,7 @@ class _RelationshipRemoval:
     user_id: str
     node_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_relationship_removal(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _RelationshipRemoval:
@@ -201,6 +203,7 @@ async def _run_relationship_removal(db: InfrahubDatabase, branch: Branch, node_u
 
     node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "migration_user"
     migration_time = Timestamp()
@@ -219,6 +222,7 @@ async def _run_relationship_removal(db: InfrahubDatabase, branch: Branch, node_u
         user_id=user_id,
         node_before=node_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -311,6 +315,9 @@ class TestNodeRelationshipRemoveMetadata:
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
         )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
+        )
 
         # The node vertex metadata is restored to its pre-migration values and the snapshot is cleared.
         node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
@@ -324,6 +331,9 @@ class TestNodeRelationshipRemoveMetadata:
         await verify_graph(db=db)
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
         )
         node_again = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
         assert node_again == node_after

--- a/backend/tests/component/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_remove.py
@@ -1,8 +1,12 @@
+from dataclasses import dataclass
 from typing import Any
+
+import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_remove import (
     NodeRemoveMigration,
@@ -12,15 +16,61 @@ from infrahub.core.migrations.schema.node_remove import (
 from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.rollback import RollbackQuery, RollbackScope
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.component.core.migrations.schema.metadata_helpers import (
+    VertexMetadata,
+    branch_edge_fingerprint,
+    get_node_vertex_metadata,
+)
 from tests.component.core.migrations.schema.test_node_kind_update import validate_node_relationships
 from tests.db_snapshot import DbSnapshotter
 from tests.helpers.db_validation import verify_graph
 from tests.helpers.edge_timestamps import assert_edge_timestamps
 from tests.helpers.schema import load_schema
+
+
+@dataclass
+class _FieldRow:
+    """One torn-down Attribute/Relationship of a removed node: its closed edge plus its vertex metadata."""
+
+    name: str
+    uuid: str
+    from_user_id: str | None
+    from_time: str | None
+    metadata: VertexMetadata
+
+
+async def _get_car_field_metadata(db: InfrahubDatabase, node_uuid: str, branch_name: str) -> list[_FieldRow]:
+    """Return the deleted Attribute/Relationship fields of a removed TestCar and their vertex metadata."""
+    query = """
+        MATCH (n:TestCar {uuid: $node_uuid})
+        MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED {branch: $branch, status: "deleted"}]-(field)
+        RETURN r.from_user_id AS from_user_id, r.from AS from_time,
+            field.updated_at AS updated_at, field.updated_by AS updated_by,
+            field.previous_updated_at AS previous_updated_at, field.previous_updated_by AS previous_updated_by,
+            field.name AS name, field.uuid AS uuid
+    """
+    results = await db.execute_query(query=query, params={"node_uuid": node_uuid, "branch": branch_name})
+    return [
+        _FieldRow(
+            name=row["name"],
+            uuid=row["uuid"],
+            from_user_id=row["from_user_id"],
+            from_time=row["from_time"],
+            metadata=VertexMetadata(
+                updated_at=row["updated_at"],
+                updated_by=row["updated_by"],
+                previous_updated_at=row["previous_updated_at"],
+                previous_updated_by=row["previous_updated_by"],
+            ),
+        )
+        for row in results
+    ]
 
 
 async def test_query_out_default_branch(
@@ -208,60 +258,182 @@ async def test_migration_agnostic_relationship(
     await verify_graph(db=db)
 
 
-async def test_migration_metadata(db: InfrahubDatabase, car_accord_main: Node, branch: Branch) -> None:
-    """Test that metadata is set correctly when removing a node."""
-    schema = registry.schema.get_schema_branch(name=branch.name)
-    candidate_schema = schema.duplicate()
-    candidate_schema.delete(name="TestCar")
+@dataclass
+class _NodeRemoval:
+    """State captured around a single TestCar node-removal migration on one branch."""
 
-    test_user_id = "test-metadata-user"
+    branch: Branch
+    node_id: str
+    migration_time: Timestamp
+    user_id: str
+    node_before: VertexMetadata
+    pre_migration_fingerprint: list[tuple]
+
+
+async def _run_node_remove_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _NodeRemoval:
+    """Run the TestCar node-removal migration on ``branch`` and capture the surrounding state.
+
+    Captures the pre-migration node vertex metadata and branch edge fingerprint so callers can assert
+    the snapshot (default/global branch) and a rollback's restore.
+    """
+    node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
+    pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+
+    user_id = "migration_user"
     migration_time = Timestamp()
 
+    schema = registry.schema.get_schema_branch(name=branch.name)
     migration = NodeRemoveMigration(
         previous_node_schema=schema.get(name="TestCar"),
         new_node_schema=None,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
     )
     execution_result = await migration.execute(
-        migration_input=MigrationInput(db=db, at=migration_time, user_id=test_user_id), branch=branch
+        migration_input=MigrationInput(db=db, at=migration_time, user_id=user_id), branch=branch
     )
     assert not execution_result.errors
 
-    await verify_graph(db=db)
-
-    # Query for the deleted Node and its edge metadata
-    query = """
-    MATCH (n:TestCar {uuid: $node_uuid})-[r:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root)
-    RETURN r.from_user_id as from_user_id, r.from as from_time, n.updated_at as updated_at, n.updated_by as updated_by
-    """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": car_accord_main.id, "branch": branch.name},
+    return _NodeRemoval(
+        branch=branch,
+        node_id=node_uuid,
+        migration_time=migration_time,
+        user_id=user_id,
+        node_before=node_before,
+        pre_migration_fingerprint=pre_migration_fingerprint,
     )
-    assert len(results) == 1, "Expected exactly one deleted IS_PART_OF edge"
-    assert results[0]["from_user_id"] == test_user_id
-    assert results[0]["from_time"] == migration_time.to_string()
-    if branch.is_default:
-        assert results[0]["updated_at"] == migration_time.to_string()
-        assert results[0]["updated_by"] == test_user_id
 
-    # Query for the deleted Attributes/Relationships
-    query = """
-    MATCH (n:TestCar {uuid: $node_uuid})
-    MATCH (n)-[r:HAS_ATTRIBUTE|IS_RELATED {branch: $branch, status: "deleted"}]->(field)
-    RETURN r.from_user_id as from_user_id, r.from as from_time,
-        field.updated_at as updated_at, field.updated_by as updated_by,
-        field.name AS name, field.uuid AS uuid
+
+async def _assert_migration_metadata(db: InfrahubDatabase, removal: _NodeRemoval) -> None:
+    """Assert the removal's metadata effect, which differs by branch.
+
+    On every branch the change is reflected through the closed edges (the deleted IS_PART_OF edge to
+    Root and the closed HAS_ATTRIBUTE/IS_RELATED edges), which carry the migration user/timestamp.
+    Vertex-level metadata is maintained only on the default/global branch, so only there does the
+    removal bump ``updated_at``/``by`` on the node and its fields and snapshot the prior values into
+    ``previous_*``; on a user branch the shared vertices are left untouched.
     """
-    results = await db.execute_query(
-        query=query,
-        params={"node_uuid": car_accord_main.id, "branch": branch.name},
+    node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+    if removal.branch.is_default or removal.branch.is_global:
+        # The bump snapshots the pre-migration values so a merge-failure rollback can restore them. The
+        # node vertex is pre-existing and survives a rollback, so it too needs a snapshot.
+        assert node_after.updated_at == removal.migration_time.to_string()
+        assert node_after.updated_by == removal.user_id
+        assert node_after.previous_updated_at == removal.node_before.updated_at
+        assert node_after.previous_updated_by == removal.node_before.updated_by
+    else:
+        # A user-branch migration leaves the shared node vertex untouched and records no snapshot.
+        assert node_after == removal.node_before
+        assert node_after.previous_updated_at is None
+
+    # The removal closes the IS_PART_OF edge to Root with the migration's user/timestamp.
+    edge_results = await db.execute_query(
+        query="""
+        MATCH (n:TestCar {uuid: $node_uuid})-[r:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root)
+        RETURN r.from_user_id AS from_user_id, r.from AS from_time
+        """,
+        params={"node_uuid": removal.node_id, "branch": removal.branch.name},
     )
-    for result in results:
-        name = result["name"]
-        uuid = result["uuid"]
-        assert result["from_user_id"] == test_user_id, f"Wrong from_user_id on edge to {name} ({uuid})"
-        assert result["from_time"] == migration_time.to_string(), f"Wrong from_time on edge to {name} ({uuid})"
-        if branch.is_default:
-            assert result["updated_at"] == migration_time.to_string(), f"Wrong updated_at on {name} ({uuid})"
-            assert result["updated_by"] == test_user_id, f"Wrong updated_by on {name} ({uuid})"
+    assert len(edge_results) == 1, "Expected exactly one deleted IS_PART_OF edge"
+    assert edge_results[0]["from_user_id"] == removal.user_id
+    assert edge_results[0]["from_time"] == removal.migration_time.to_string()
+
+    # The node's Attributes/Relationships are torn down; each closed edge carries the migration user/time.
+    fields = await _get_car_field_metadata(db=db, node_uuid=removal.node_id, branch_name=removal.branch.name)
+    assert fields, "Expected at least one deleted HAS_ATTRIBUTE/IS_RELATED edge"
+    for field in fields:
+        assert field.from_user_id == removal.user_id, f"Wrong from_user_id on edge to {field.name} ({field.uuid})"
+        assert field.from_time == removal.migration_time.to_string(), (
+            f"Wrong from_time on edge to {field.name} ({field.uuid})"
+        )
+        if removal.branch.is_default or removal.branch.is_global:
+            assert field.metadata.updated_at == removal.migration_time.to_string(), (
+                f"Wrong updated_at on {field.name} ({field.uuid})"
+            )
+            assert field.metadata.updated_by == removal.user_id, f"Wrong updated_by on {field.name} ({field.uuid})"
+            assert field.metadata.previous_updated_at is not None, (
+                f"Missing previous_updated_at on {field.name} ({field.uuid})"
+            )
+            assert field.metadata.previous_updated_at != removal.migration_time.to_string(), (
+                f"previous_updated_at was not snapshotted before the bump on {field.name} ({field.uuid})"
+            )
+            assert field.metadata.previous_updated_by is not None, (
+                f"Missing previous_updated_by on {field.name} ({field.uuid})"
+            )
+        else:
+            # A user-branch migration records no snapshot on the shared field vertices.
+            assert field.metadata.previous_updated_at is None, f"Unexpected snapshot on {field.name} ({field.uuid})"
+
+
+class TestNodeRemoveMetadata:
+    """On the default branch, removing a node snapshots vertex metadata and a rollback restores it.
+
+    A class-scoped fixture runs the migration once; the metadata and rollback tests share it and run in
+    order (the rollback test reverts the state the metadata test observed).
+    """
+
+    @pytest.fixture(scope="class")
+    async def removal(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+        car_person_schema_scope_class: SchemaBranch,
+    ) -> _NodeRemoval:
+        person = await Node.init(db=db, schema="TestPerson", branch=default_branch_scope_class)
+        await person.new(db=db, name="John", height=180)
+        await person.save(db=db)
+        car = await Node.init(db=db, schema="TestCar", branch=default_branch_scope_class)
+        await car.new(db=db, name="accord", color="#123456", owner=person.id)
+        await car.save(db=db)
+
+        return await _run_node_remove_migration(db=db, branch=default_branch_scope_class, node_uuid=car.id)
+
+    async def test_migration_metadata(self, db: InfrahubDatabase, removal: _NodeRemoval) -> None:
+        """The removal bumps updated_at/by on the node and its fields and snapshots the prior values."""
+        await _assert_migration_metadata(db=db, removal=removal)
+
+    async def test_migration_rollback(self, db: InfrahubDatabase, removal: _NodeRemoval) -> None:
+        """The rollback undoes the migration: the branch edges and vertex metadata are restored, idempotently."""
+
+        async def _run_rollback() -> None:
+            query = await RollbackQuery.init(
+                db=db,
+                target_branch=removal.branch,
+                at=removal.migration_time,
+                scope=RollbackScope.SINCE_TIMESTAMP,
+                restore_metadata=True,
+            )
+            await query.execute(db=db)
+
+        await _run_rollback()
+        await verify_graph(db=db)
+
+        # The branch edges are restored exactly to their pre-migration state.
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+
+        # The node vertex metadata is restored to its pre-migration values and the snapshot is cleared.
+        node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+        assert node_after.updated_at == removal.node_before.updated_at
+        assert node_after.updated_by == removal.node_before.updated_by
+        assert node_after.previous_updated_at is None
+        assert node_after.previous_updated_by is None
+
+        # Running the rollback again is a no-op: nothing remains in the window to revert.
+        await _run_rollback()
+        await verify_graph(db=db)
+        assert (
+            await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        node_again = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
+        assert node_again == node_after
+
+
+async def test_migration_metadata_non_default_branch(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node
+) -> None:
+    """On a user branch the removal is reflected through edges but records no vertex-metadata snapshot."""
+    branch = await create_branch(branch_name="branch-node-remove-meta", db=db)
+    removal = await _run_node_remove_migration(db=db, branch=branch, node_uuid=car_accord_main.id)
+    await _assert_migration_metadata(db=db, removal=removal)

--- a/backend/tests/component/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/component/core/migrations/schema/test_node_remove.py
@@ -25,6 +25,7 @@ from infrahub.database import InfrahubDatabase
 from tests.component.core.migrations.schema.metadata_helpers import (
     VertexMetadata,
     branch_edge_fingerprint,
+    branch_metadata_fingerprint,
     get_node_vertex_metadata,
 )
 from tests.component.core.migrations.schema.test_node_kind_update import validate_node_relationships
@@ -268,6 +269,7 @@ class _NodeRemoval:
     user_id: str
     node_before: VertexMetadata
     pre_migration_fingerprint: list[tuple]
+    pre_migration_metadata: list[tuple]
 
 
 async def _run_node_remove_migration(db: InfrahubDatabase, branch: Branch, node_uuid: str) -> _NodeRemoval:
@@ -278,6 +280,7 @@ async def _run_node_remove_migration(db: InfrahubDatabase, branch: Branch, node_
     """
     node_before = await get_node_vertex_metadata(db=db, node_uuid=node_uuid)
     pre_migration_fingerprint = await branch_edge_fingerprint(db=db, branch_name=branch.name)
+    pre_migration_metadata = await branch_metadata_fingerprint(db=db, branch_name=branch.name)
 
     user_id = "migration_user"
     migration_time = Timestamp()
@@ -300,6 +303,7 @@ async def _run_node_remove_migration(db: InfrahubDatabase, branch: Branch, node_
         user_id=user_id,
         node_before=node_before,
         pre_migration_fingerprint=pre_migration_fingerprint,
+        pre_migration_metadata=pre_migration_metadata,
     )
 
 
@@ -412,6 +416,9 @@ class TestNodeRemoveMetadata:
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
         )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
+        )
 
         # The node vertex metadata is restored to its pre-migration values and the snapshot is cleared.
         node_after = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
@@ -425,6 +432,9 @@ class TestNodeRemoveMetadata:
         await verify_graph(db=db)
         assert (
             await branch_edge_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_fingerprint
+        )
+        assert (
+            await branch_metadata_fingerprint(db=db, branch_name=removal.branch.name) == removal.pre_migration_metadata
         )
         node_again = await get_node_vertex_metadata(db=db, node_uuid=removal.node_id)
         assert node_again == node_after

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -388,18 +388,3 @@ async def count_branch_edges_at(db: InfrahubDatabase, branch_name: str, at: str)
         params={"at": at, "branch": branch_name},
     )
     return result[0].get("c")
-
-
-async def get_node_metadata(db: InfrahubDatabase, node_uuid: str) -> dict[str, str | None]:
-    """Return a node vertex's ``updated_at``/``previous_updated_at`` metadata."""
-    result = await db.execute_query(
-        query=(
-            "MATCH (n:Node {uuid: $uuid}) "
-            "RETURN n.updated_at AS updated_at, n.previous_updated_at AS previous_updated_at"
-        ),
-        params={"uuid": node_uuid},
-    )
-    return {
-        "updated_at": result[0].get("updated_at"),
-        "previous_updated_at": result[0].get("previous_updated_at"),
-    }

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 from infrahub.core.branch import Branch
@@ -379,3 +380,68 @@ async def assert_attribute_absent(
     query = LATEST_ATTRIBUTE_PATH_STATUS_QUERY % {"label": node_label}
     results = await db.execute_query(query=query, params={"attr_name": attr_name, "branch_name": branch_name})
     assert len(results) == 0, f"Expected no active/deleted {node_label}.{attr_name} edges, found {len(results)}"
+
+
+async def count_branch_edges_at(db: InfrahubDatabase, branch_name: str, at: str) -> int:
+    """Count edges on a branch whose ``from`` timestamp equals ``at`` (edges written exactly then)."""
+    result = await db.execute_query(
+        query="MATCH ()-[r {from: $at, branch: $branch}]->() RETURN count(r) AS c",
+        params={"at": at, "branch": branch_name},
+    )
+    return result[0].get("c")
+
+
+@dataclass
+class VertexMetadata:
+    """The user-timestamp metadata stored directly on a Node/Attribute/Relationship vertex.
+
+    ``previous_updated_at``/``previous_updated_by`` hold the snapshot a schema migration or merge
+    records before bumping ``updated_at``/``updated_by``, so a merge-failure rollback can restore them.
+    """
+
+    updated_at: str | None = None
+    updated_by: str | None = None
+    previous_updated_at: str | None = None
+    previous_updated_by: str | None = None
+
+
+async def branch_edge_fingerprint(db: InfrahubDatabase, branch_name: str) -> list[tuple]:
+    """Snapshot every edge on a branch, keyed on endpoints, timestamps and status.
+
+    Two snapshots compare equal only when the branch's edges are identical, so an empty diff between a
+    pre-change and a post-rollback snapshot proves the rollback restored the branch exactly.
+    """
+    results = await db.execute_query(
+        query=(
+            "MATCH (src)-[r {branch: $branch}]->(dst) "
+            "RETURN type(r) AS edge_type, elementId(src) AS src, elementId(dst) AS dst, "
+            "r.from AS edge_from, r.to AS edge_to, r.status AS status"
+        ),
+        params={"branch": branch_name},
+    )
+    return sorted(
+        (
+            row["edge_type"],
+            row["src"],
+            row["dst"],
+            row["edge_from"] or "",
+            row["edge_to"] or "",
+            row["status"] or "",
+        )
+        for row in results
+    )
+
+
+async def get_node_metadata(db: InfrahubDatabase, node_uuid: str) -> dict[str, str | None]:
+    """Return a node vertex's ``updated_at``/``previous_updated_at`` metadata."""
+    result = await db.execute_query(
+        query=(
+            "MATCH (n:Node {uuid: $uuid}) "
+            "RETURN n.updated_at AS updated_at, n.previous_updated_at AS previous_updated_at"
+        ),
+        params={"uuid": node_uuid},
+    )
+    return {
+        "updated_at": result[0].get("updated_at"),
+        "previous_updated_at": result[0].get("previous_updated_at"),
+    }

--- a/backend/tests/helpers/db_validation.py
+++ b/backend/tests/helpers/db_validation.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any
 
 from infrahub.core.branch import Branch
@@ -389,47 +388,6 @@ async def count_branch_edges_at(db: InfrahubDatabase, branch_name: str, at: str)
         params={"at": at, "branch": branch_name},
     )
     return result[0].get("c")
-
-
-@dataclass
-class VertexMetadata:
-    """The user-timestamp metadata stored directly on a Node/Attribute/Relationship vertex.
-
-    ``previous_updated_at``/``previous_updated_by`` hold the snapshot a schema migration or merge
-    records before bumping ``updated_at``/``updated_by``, so a merge-failure rollback can restore them.
-    """
-
-    updated_at: str | None = None
-    updated_by: str | None = None
-    previous_updated_at: str | None = None
-    previous_updated_by: str | None = None
-
-
-async def branch_edge_fingerprint(db: InfrahubDatabase, branch_name: str) -> list[tuple]:
-    """Snapshot every edge on a branch, keyed on endpoints, timestamps and status.
-
-    Two snapshots compare equal only when the branch's edges are identical, so an empty diff between a
-    pre-change and a post-rollback snapshot proves the rollback restored the branch exactly.
-    """
-    results = await db.execute_query(
-        query=(
-            "MATCH (src)-[r {branch: $branch}]->(dst) "
-            "RETURN type(r) AS edge_type, elementId(src) AS src, elementId(dst) AS dst, "
-            "r.from AS edge_from, r.to AS edge_to, r.status AS status"
-        ),
-        params={"branch": branch_name},
-    )
-    return sorted(
-        (
-            row["edge_type"],
-            row["src"],
-            row["dst"],
-            row["edge_from"] or "",
-            row["edge_to"] or "",
-            row["status"] or "",
-        )
-        for row in results
-    )
 
 
 async def get_node_metadata(db: InfrahubDatabase, node_uuid: str) -> dict[str, str | None]:

--- a/changelog/+migration-previous-metadata.fixed.md
+++ b/changelog/+migration-previous-metadata.fixed.md
@@ -1,0 +1,1 @@
+Recovering from a failed branch merge now restores `updated_at`/`updated_by` metadata for objects, attributes, and relationships affected by a schema migration, such as changing the inheritance of a schema or adding a new attribute.


### PR DESCRIPTION
# Why

When a branch merge fails partway through, the recovery path rolls each affected
vertex back by restoring `updated_at`/`updated_by` from the
`previous_updated_at`/`previous_updated_by` snapshot the merge recorded before it
bumped the metadata. Schema migrations (inheritance changes, attribute add/remove,
kind changes, etc.) also bump `updated_at`/`updated_by` on the Node/Attribute/
Relationship vertices they touch — but they never wrote the `previous_updated_*`
snapshot. So if a merge that included a schema migration failed, rollback had
nothing to restore from and the affected objects were left with the migration's
timestamp/author instead of their original values.

**Goal:** make every schema-migration query snapshot the prior user-timestamp
metadata into `previous_updated_at`/`previous_updated_by` before it overwrites
`updated_at`/`updated_by`, so merge-failure rollback can restore it — matching what
the merge path already does.

**Non-goals:** no change to the rollback query itself, to the merge flow, or to
which vertices a migration touches. This only adds the snapshot write. The rollback
query already handles resetting the updated_at/by metadata using previous_updated_at/by.
This change is just to correctly set the previous_ properties during schema migrations.

Closes IFC-2716

## What changed

<!-- Behavioral changes: what users/systems will observe differently -->

- Recovering from a failed branch merge now restores `updated_at`/`updated_by` for
  objects, attributes, and relationships that a schema migration touched (e.g.
  changing schema inheritance or adding an attribute), instead of leaving them
  stamped with the migration's time/author.

<!-- Implementation notes -->

Each migration Cypher query that bumps `updated_at`/`updated_by` on a vertex now
first snapshots the prior values into `previous_updated_at`/`previous_updated_by`,
guarded so a migration that touches the same vertex twice in one run does not
clobber the original snapshot:

```cypher
SET v.previous_updated_at = CASE
        WHEN v.updated_at IS NULL OR v.updated_at <> $current_time THEN v.updated_at
        ELSE v.previous_updated_at
    END,
    v.previous_updated_by = CASE
        WHEN v.updated_at IS NULL OR v.updated_at <> $current_time THEN v.updated_by
        ELSE v.previous_updated_by
    END
SET v.updated_at = $current_time, v.updated_by = $user_id
```

The `CASE` condition means: only overwrite the snapshot when this is the first
write of the current migration timestamp. If the vertex's `updated_at` already
equals `$current_time`, the snapshot has already been taken this run and is left
untouched — the migration is idempotent with respect to the snapshot.

Vertices *created* by the migration (a newly added attribute, the renamed
attribute vertex, the duplicated node) have no prior metadata, so they are not
snapshotted — noted inline where it applies.

Queries updated:

- `query/attribute_add.py` — snapshot the parent Node
- `query/attribute_remove.py` — snapshot the Attribute and its Node
- `query/attribute_rename.py` — snapshot the Node
- `query/node_duplicate.py` — snapshot the original Node
- `schema/attribute_kind_update.py` — snapshot the Attribute and its Node
- `schema/node_relationship_remove.py` — snapshot the Relationship, Node, and peer
- `schema/node_remove.py` — snapshot the active Node and its peers (in/out)

<!-- What stayed the same -->

No schema changes, no new dependencies, no API changes. The rollback query and
merge flow are untouched.

## How to review

Start with one query (e.g. `query/attribute_remove.py`) to see the snapshot
pattern, then confirm the same `CASE`-guarded block was added everywhere a
migration does `SET v.updated_at = ...`. The tests are the bulk of the diff.

Key thing to scrutinize: the idempotency guard. A single migration run can pass
over the same vertex more than once (e.g. a node reachable as both active node and
peer); the `updated_at <> $current_time` check must prevent the second pass from
overwriting the real snapshot with the migration's own timestamp.

## Tests

New coverage:

- `test_all_migrations_rollback.py` — end-to-end: run each migration, capture a
  metadata + edge fingerprint before, roll back, assert the branch is restored
  exactly (empty diff).
- Per-migration tests (`test_attribute_kind_update.py`, `test_attribute_name_update.py`,
  `test_node_attribute_add.py`, `test_node_attribute_remove.py`,
  `test_node_kind_update.py`, `test_node_relationship_remove.py`, `test_node_remove.py`)
  extended to assert the `previous_updated_*` snapshot is written on migration and
  cleared on rollback.
- `metadata_helpers.py` / `helpers/db_validation.py` — shared fingerprint helpers.

## Impact & rollout

- **Backward compatibility:** no breaking changes. Existing vertices without a
  snapshot are handled by the `updated_at IS NULL` branch. No data migration needed.
- **Performance:** negligible — a couple of extra property writes on vertices the
  migration already writes.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`+migration-previous-metadata.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change) — n/a, internal recovery behavior
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds snapshotting of previous metadata in schema migrations so rollback after a failed merge can restore `updated_at`/`updated_by`. Adds end-to-end tests that confirm full graph and metadata restoration (IFC-2716).

- **Bug Fixes**
  - Save `previous_updated_at`/`previous_updated_by` before updates in: attribute add/remove/rename, attribute kind update, node relationship remove, node remove, and node duplicate (original node).
  - Guard against overwriting snapshots when the same timestamp is reused during a run.
  - Rollback restores vertex metadata from snapshots; added per-migration tests and an all-migrations merge/rollback test with shared helpers (`branch_metadata_fingerprint`, `branch_edge_fingerprint`, vertex metadata getters, `count_branch_edges_at`); removed dead test code; fixed a race in graph test 040 data prep.
  - No schema or API changes; changelog entry added.

<sup>Written for commit b75afc07769124a0bc3cb2e527b9029feb83781b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



