### PR TITLE
docs: fix release-notes frontmatter from cubic review

### DIFF
--- a/docs/docs/release-notes/infrahub/release-1_1_2.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_1_2.mdx
@@ -2,7 +2,7 @@
 title: Release 1.1.2
 release_date: 2025-01-09
 release_type: patch
-description: "Added a configuration option for INFRAHUBPUBLICURL, which could be required for SSO depending on how Infrahub is published and accessed within your organization."
+description: "Added a configuration option for INFRAHUB_PUBLIC_URL, which could be required for SSO depending on how Infrahub is published and accessed within your organization."
 ---
 <table>
   <tbody>

--- a/docs/docs/release-notes/infrahub/release-1_1_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_1_6.mdx
@@ -2,7 +2,7 @@
 title: Release 1.1.6
 release_date: 2025-01-30
 release_type: patch
-description: "Allow Default Address Type quick selection in the Resource Manager form (3489) Added code viewer for new content-types, preview of raw markdown content, one-click file download or cop, and redesign of artifact details view (5452)"
+description: "Allow Default Address Type quick selection in the Resource Manager form (3489) Added code viewer for new content-types, preview of raw markdown content, one-click file download or copy, and redesign of artifact details view (5452)"
 ---
 <table>
   <tbody>

--- a/docs/docs/release-notes/infrahub/release-1_2_1.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_2_1.mdx
@@ -2,7 +2,7 @@
 title: Release 1.2.1
 release_date: 2025-03-26
 release_type: patch
-description: "Added relationships changes details in the activities. Added an INFRAHUBSCHEMASTRICTMODE environment variable."
+description: "Added relationships changes details in the activities. Added an INFRAHUB_SCHEMA_STRICT_MODE environment variable."
 ---
 <table>
   <tbody>

--- a/docs/docs/release-notes/infrahub/release-1_2_9.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_2_9.mdx
@@ -2,7 +2,7 @@
 title: Release 1.2.9
 release_date: 2025-05-07
 release_type: patch
-description: "Added the INFRAHUBTESTINGSCHEMASTRICTMODE environment variable to allow users to control INFRAHUBSCHEMASTRICTMODE when using infrahub-testcontainers."
+description: "Added the INFRAHUB_TESTING_SCHEMA_STRICT_MODE environment variable to allow users to control INFRAHUB_SCHEMA_STRICT_MODE when using infrahub-testcontainers."
 ---
 <table>
   <tbody>

--- a/docs/docs/release-notes/infrahub/release-1_3_1.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_3_1.mdx
@@ -2,7 +2,7 @@
 title: Release 1.3.1
 release_date: 2025-06-12
 release_type: patch
-description: "Fix bug that could prevent renaming a unique attribute on a schema (6147) Fix a bug where Number attribute minvalue/maxvalue/excludedvalues constraints were not enforced during node creation (6714)"
+description: "Fix bug that could prevent renaming a unique attribute on a schema (6147) Fix a bug where Number attribute min_value/max_value/excluded_values constraints were not enforced during node creation (6714)"
 ---
 <!-- markdownlint-disable-file MD001 -->
 <table>

--- a/docs/docs/release-notes/infrahub/release-1_3_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_3_3.mdx
@@ -2,7 +2,7 @@
 title: Release 1.3.3
 release_date: 2025-07-15
 release_type: patch
-description: "<!-- vale off --> Add a command to run a single migration"
+description: "Add a command to run a single migration"
 ---
 <!-- markdownlint-disable-file MD001 -->
 <table>

--- a/docs/docs/release-notes/infrahub/release-1_4_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_3.mdx
@@ -2,7 +2,7 @@
 title: Release 1.4.3
 release_date: 2025-08-29
 release_type: patch
-description: "Force branches data to be reloaded when the hash doesn't look healthy In the UI, clicking the artifact generation button now refreshes the token and retries if the access token has expired."
+description: "Force branches data to be reloaded when the hash doesn't look healthy. In the UI, clicking the artifact generation button now refreshes the token and retries if the access token has expired."
 ---
 <!-- markdownlint-disable-file MD001 -->
 <table>

--- a/docs/docs/release-notes/infrahub/release-1_5_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_5_0.mdx
@@ -2,7 +2,7 @@
 title: Release 1.5.0
 release_date: 2025-11-10
 release_type: minor
-description: "New features, performance improvements, and fixes across the platform."
+description: "HFID and display_label refactored at write time, Profiles reworked, backup/restore tool added, webhook formats aligned."
 ---
 <table>
   <tbody>

--- a/docs/docs/release-notes/infrahub/release-1_8_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_8_0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.8.0
-release_date: 2026-03-22
+release_date: 2026-03-16
 release_type: minor
 description: "File objects, automatic branch freeze-on-merge, resource pools in object templates, Kubernetes backup support."
 ---
@@ -12,7 +12,7 @@ description: "File objects, automatic branch freeze-on-merge, resource pools in 
     </tr>
     <tr>
       <th>Release Date</th>
-      <td>March 22nd, 2026</td>
+      <td>March 16th, 2026</td>
     </tr>
     <tr>
       <th>Tag</th>

--- a/docs/scripts/backfill-release-frontmatter.mjs
+++ b/docs/scripts/backfill-release-frontmatter.mjs
@@ -81,7 +81,11 @@ for (const file of fs.readdirSync(DIR).sort()) {
   const full = path.join(DIR, file);
   const src = fs.readFileSync(full, "utf8");
   const fm = src.match(/^---\n([\s\S]*?)\n---\n/);
-  if (!fm) { console.warn(`SKIP (no frontmatter): ${file}`); continue; }
+  if (!fm) {
+    if (CHECK) { console.error(`MISSING frontmatter: ${file} → no frontmatter block`); missing++; }
+    else console.warn(`SKIP (no frontmatter): ${file}`);
+    continue;
+  }
 
   const has = (k) => new RegExp(`^${k}:`, "m").test(fm[1]);
   const body = src.slice(fm[0].length);
@@ -97,8 +101,9 @@ for (const file of fs.readdirSync(DIR).sort()) {
   }
   if (!has("release_type")) additions.push(`release_type: ${type}`);
   if (!has("description")) {
-    const desc = draftDescription(body, type).replace(/"/g, "'");
-    additions.push(`description: "${desc}"`);
+    // Serialize via JSON.stringify so backslashes/quotes in the drafted text
+    // stay valid YAML (a plain quoted interpolation would only escape `"`).
+    additions.push(`description: ${JSON.stringify(draftDescription(body, type))}`);
   }
 
   if (additions.length === 0) continue;


### PR DESCRIPTION
Addresses the [cubic review on #9978](https://github.com/opsmill/infrahub/pull/9978) — the release-notes `description` frontmatter that the backfill drafted (added on `stable`) had several content errors, plus two robustness gaps in the backfill script. Fixing at the source (`stable`) so the corrections propagate to `develop` on the next sync.

## Frontmatter description fixes

| File | Fix |
|---|---|
| `release-1_1_2.mdx` | `INFRAHUBPUBLICURL` → `INFRAHUB_PUBLIC_URL` |
| `release-1_1_6.mdx` | typo `cop` → `copy` |
| `release-1_2_1.mdx` | `INFRAHUBSCHEMASTRICTMODE` → `INFRAHUB_SCHEMA_STRICT_MODE` |
| `release-1_2_9.mdx` | `INFRAHUBTESTINGSCHEMASTRICTMODE` / `INFRAHUBSCHEMASTRICTMODE` → underscored names |
| `release-1_3_1.mdx` | `minvalue/maxvalue/excludedvalues` → `min_value/max_value/excluded_values` |
| `release-1_3_3.mdx` | drop leaked `<!-- vale off -->` directive from the description |
| `release-1_4_3.mdx` | add missing sentence break (`healthy. In the UI`) |
| `release-1_5_0.mdx` | replace generic placeholder (identical to 1.4.0's) with a release-specific summary |

## Release-date correction (1.8.0)

- `release-1_8_0.mdx`: `release_date` corrected to **2026-03-16** (frontmatter + body table), matching the `infrahub-v1.8.0` git tag. It was recorded as 2026-03-22.
- **1.8.1 is left unchanged** (2026-03-19, matching `infrahub-v1.8.1`). cubic flagged 1.8.1 as chronologically impossible, but that was a consequence of the wrong 1.8.0 date — with 1.8.0 corrected to 03-16, the 1.8.0 → 1.8.1 → 1.8.2 (03-25) order is consistent.

## Backfill script (`backfill-release-frontmatter.mjs`)

- `--check` now **fails** on files with no frontmatter block (previously skipped with a warning, so CI could pass on the most incomplete files).
- Descriptions are serialized with `JSON.stringify` so backslashes/quotes stay valid YAML (the old quoted interpolation only escaped `"`).

## Validation

- `node scripts/backfill-release-frontmatter.mjs --check` — passes.
- Frontmatter of every edited file parses as valid YAML.
- `node --check` on the script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frontmatter errors in release notes and corrects the 1.8.0 release date. Hardens the backfill script to fail on missing frontmatter and output YAML-safe descriptions.

- **Bug Fixes**
  - Corrected env var/parameter names and typos in release descriptions (1.1.2, 1.1.6, 1.2.1, 1.2.9, 1.3.1, 1.3.3, 1.4.3, 1.5.0).
  - Set 1.8.0 release_date to 2026-03-16 in frontmatter and the table.
  - `docs/scripts/backfill-release-frontmatter.mjs`: `--check` now fails on files without frontmatter; descriptions use `JSON.stringify` for YAML-safe escaping.

<sup>Written for commit 6f02322e4737cf891aab94b97e30b5282d9d158f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

