### PR TITLE
docs(webhooks): delivery-operability docs pass + QA checklist

### DIFF
--- a/dev/specs/ifc-2755-webhook-delivery-operability/qa-checklist.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/qa-checklist.md
@@ -6,7 +6,7 @@
 
 ## Scope
 
-Verify that a webhook delivery is a first-class, inspectable, and recoverable object in the Tasks tab: the delivered payload, request, and response are captured (with secrets masked), failures show a short classified reason with a remediation hint instead of a stacktrace, and an operator can retry or cancel a delivery through the generic task actions. Out of scope: the automated test suite and internal orchestration wiring.
+Verify that a webhook delivery is a recoverable object surfaced in the Tasks tab: the delivered payload and request are recorded in the delivery logs (with secrets masked) and exposed as structured request/response on the GraphQL API, failures show a short classified reason with a remediation hint instead of a stacktrace, and an operator can retry or cancel a delivery through the generic task actions. Out of scope: the automated test suite and internal orchestration wiring.
 
 ## Prerequisites
 
@@ -31,15 +31,27 @@ export WEBHOOK_TOKEN="Bearer test-secret"
 
 ### 1. Inspect what a delivery sent and received (US1)
 
-**What this verifies**: The payload, request, and response are captured and shown, with secrets masked.
+**What this verifies**: The delivered payload and request are recorded with secrets masked; the structured request/response are exposed on the GraphQL API.
 
 **Steps**:
 
-- [ ] Open a delivery and confirm **payload**, **request** (URL + headers), and **response** (status, body, latency) are shown.
-- [ ] Confirm masking: the ENV-sourced header, `webhook-signature`, and `Authorization`/`Cookie`/`X-API-Key` show `***`; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and non-credential static headers show verbatim.
-- [ ] Point the webhook at an error endpoint, trigger again, reopen: request/response are still present and reflect the **last attempt**.
+- [ ] Open a delivery → its **logs** show the target URL, the request headers, the payload, and the delivery outcome (HTTP status and latency). The structured request/response are not rendered on the page; they are on the API (next step).
+- [ ] Confirm masking in the logged headers: the ENV-sourced header, `webhook-signature`, and `Authorization`/`Cookie`/`X-API-Key` show `***`; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and non-credential static headers show verbatim.
+- [ ] Query the delivery and confirm the structured request/response reflect the **last attempt** (the response body is API-only):
 
-**Expected result**: No raw secret appears anywhere in the view; captured fields reflect the settling attempt.
+  ```graphql
+  query { InfrahubTask(ids: ["<run-id>"]) { edges { node {
+    ... on WebhookDeliveryTask {
+      http_request { url headers }
+      http_response { status_code body latency_ms }
+      error { status_class message remediation }
+    }
+  } } } }
+  ```
+
+- [ ] Point the webhook at an error endpoint, trigger again: the logs and the API fields are still present and reflect the last attempt.
+
+**Expected result**: No raw secret appears in the logs or the API response; captured fields reflect the settling attempt.
 
 ### 2. Understand why a delivery failed (US2)
 
@@ -64,7 +76,7 @@ export WEBHOOK_TOKEN="Bearer test-secret"
 **Steps**:
 
 - [ ] Fail a delivery against a **down** endpoint, bring it up, click **Retry** and confirm → a **new** row appears, carries the same payload, re-signs, and succeeds; the original row is unchanged.
-- [ ] Retry a **succeeded** delivery → the confirmation calls out re-delivering an already-processed event; on confirm a new delivery is produced.
+- [ ] Retry a **succeeded** delivery → the retry confirmation appears ("This creates a new task with the same settings…"); on confirm, a new delivery is produced. (The dialog does not currently single out re-delivering an already-processed event.)
 - [ ] On an in-progress / awaiting-retry delivery, confirm Retry is disabled with a reason.
 - [ ] Optional GraphQL: `mutation { InfrahubTaskRetry(data: {id: "<run-id>"}) { ok task { id } } }`.
 

--- a/dev/specs/ifc-2755-webhook-delivery-operability/qa-checklist.md
+++ b/dev/specs/ifc-2755-webhook-delivery-operability/qa-checklist.md
@@ -1,0 +1,115 @@
+# QA Checklist — Webhook Delivery Operability
+
+**Generated**: 2026-07-20 16:26 local
+**Feature**: specs/ifc-2755-webhook-delivery-operability
+**Source**: speckit.opsmill.qa
+
+## Scope
+
+Verify that a webhook delivery is a first-class, inspectable, and recoverable object in the Tasks tab: the delivered payload, request, and response are captured (with secrets masked), failures show a short classified reason with a remediation hint instead of a stacktrace, and an operator can retry or cancel a delivery through the generic task actions. Out of scope: the automated test suite and internal orchestration wiring.
+
+## Prerequisites
+
+- [ ] Working copy is on `develop` (or a branch with the implementation merged), e.g. `pmi-webhook-qa-docs`.
+- [ ] `uv sync --all-groups` and `cd frontend/app && pnpm install` completed cleanly.
+- [ ] Local stack running with the task-manager (Prefect) worker active.
+- [ ] A test HTTP target you control (request bin / local echo server) that you can take **up and down** to drive failures.
+
+## Setup
+
+```bash
+uv run invoke demo.start
+# note the ENV var you will reference from a webhook header, e.g.:
+export WEBHOOK_TOKEN="Bearer test-secret"
+```
+
+1. In the UI, `Integrations` → `Webhooks` → **+ Add Webhook**; create a Standard webhook at your test URL, event `infrahub.node.updated`, node kind of a node you can edit.
+2. Add a shared key (exercises signature redaction) and an ENVIRONMENT-sourced custom header referencing `WEBHOOK_TOKEN` (exercises secret redaction).
+3. Update a matching node to fire a delivery, then open the webhook → **Tasks** tab; each `webhook_send` run is a delivery.
+
+## Test Scenarios
+
+### 1. Inspect what a delivery sent and received (US1)
+
+**What this verifies**: The payload, request, and response are captured and shown, with secrets masked.
+
+**Steps**:
+
+- [ ] Open a delivery and confirm **payload**, **request** (URL + headers), and **response** (status, body, latency) are shown.
+- [ ] Confirm masking: the ENV-sourced header, `webhook-signature`, and `Authorization`/`Cookie`/`X-API-Key` show `***`; `Accept`, `Content-Type`, `webhook-id`, `webhook-timestamp`, and non-credential static headers show verbatim.
+- [ ] Point the webhook at an error endpoint, trigger again, reopen: request/response are still present and reflect the **last attempt**.
+
+**Expected result**: No raw secret appears anywhere in the view; captured fields reflect the settling attempt.
+
+### 2. Understand why a delivery failed (US2)
+
+**What this verifies**: Failures are classified with a remediation hint, retried per class, and logged without a stacktrace.
+
+**Steps**:
+
+- [ ] Drive each target and confirm the class + retry behavior:
+  - Unreachable host → `CONNECTION`, retried (3 attempts ~2m apart)
+  - 404 → `HTTP_CLIENT_ERROR`, no retry
+  - 500 → `HTTP_SERVER_ERROR`, retried
+  - Invalid TLS cert (validate certificates on) → `TLS`, no retry
+  - Slow past timeout → `TIMEOUT`, retried
+- [ ] Confirm per-attempt progress is visible in the delivery **logs** and the final reason reflects the settling attempt; no traceback for a classified failure.
+
+**Expected result**: Each failure shows the correct class and a matching hint; only an unexpected crash keeps a full traceback.
+
+### 3. Retry a delivery (US3)
+
+**What this verifies**: Retry replays the frozen payload as a new delivery against current config; the original is immutable.
+
+**Steps**:
+
+- [ ] Fail a delivery against a **down** endpoint, bring it up, click **Retry** and confirm → a **new** row appears, carries the same payload, re-signs, and succeeds; the original row is unchanged.
+- [ ] Retry a **succeeded** delivery → the confirmation calls out re-delivering an already-processed event; on confirm a new delivery is produced.
+- [ ] On an in-progress / awaiting-retry delivery, confirm Retry is disabled with a reason.
+- [ ] Optional GraphQL: `mutation { InfrahubTaskRetry(data: {id: "<run-id>"}) { ok task { id } } }`.
+
+**Expected result**: Retry is available only from a terminal state and always creates a new, independent delivery.
+
+### 4. Cancel an in-progress delivery (US4)
+
+**What this verifies**: Cancel stops the remaining auto-retry cycle; settled deliveries cannot be cancelled.
+
+**Steps**:
+
+- [ ] Trigger a delivery against a slow/failing endpoint so it enters awaiting-retry, click **Cancel** → it transitions to cancelled and no further attempts run.
+- [ ] Confirm Cancel is disabled (with a reason) on already-settled deliveries.
+- [ ] Confirm a cancelled delivery can then be **retried** (cancel→retry is the two-step restart).
+- [ ] Optional GraphQL: `mutation { InfrahubTaskCancel(data: {id: "<run-id>"}) { ok task { id } } }`.
+
+**Expected result**: Cancel halts scheduled attempts (in-flight request not recalled) and only applies to non-terminal deliveries.
+
+### 5. Authorization
+
+**What this verifies**: Recovery actions require webhook-management permission.
+
+**Steps**:
+
+- [ ] As an account **without** update permission on the webhook, attempt Retry and Cancel → both are rejected at the API with a clear permission error.
+
+**Expected result**: No new permission concept; existing webhook-management permission gates both actions.
+
+## Edge Cases
+
+- [ ] ENV header referencing an unset variable → delivery fails with a `CONFIG` reason naming the webhook and header, not a crash.
+- [ ] View a non-webhook task → generic `available_actions` (empty) and no request/response fields.
+- [ ] Retry a delivery whose run aged out of retention → "delivery no longer available", no broken retry.
+- [ ] Retry/Cancel an action that became unavailable since page load → rejected server-side, no silent double-send.
+
+## Teardown
+
+```bash
+uv run invoke demo.destroy
+```
+
+Delete the test webhook and its key-value headers if the stack is kept; take down the test endpoint.
+
+## Sign-off
+
+- [ ] All scenarios above pass.
+- [ ] No unexpected output, warnings, or errors observed.
+- [ ] Tester: ______________________  Date: __________

--- a/docs/docs/webhooks/custom-transformation.mdx
+++ b/docs/docs/webhooks/custom-transformation.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 # Webhook with custom Transformation
 
-Custom webhooks allow you to transform event data before sending it to an external endpoint. This is useful when the receiving system expects a specific payload format, such as Slack, Microsoft Teams, GitHub Actions, or other third-party APIs.
+Use a custom webhook to transform event data before Infrahub sends it to an external endpoint. This is useful when the receiving system expects a specific payload format, such as Slack, Microsoft Teams, GitHub Actions, or other third-party APIs.
 
 For general information about Python Transformations, see the [Python Transformation guide](../academy/tutorials/transformations/build-a-python-transformation). For details about webhook events and payloads, see [Webhooks](./overview).
 
@@ -163,4 +163,4 @@ mutation CreateCustomWebhook {
 1. Make a change that triggers the configured event. For example, update a node if using `infrahub.node.updated`.
 2. Check that your external endpoint received the transformed payload.
 
-For troubleshooting, check the Infrahub logs for webhook delivery status and any Transformation errors.
+If a delivery does not arrive, open the webhook and select the delivery from its related tasks. Its logs show the request that was sent and the delivery outcome, and on failure the [classified reason](./overview#when-a-delivery-fails). See [Header and payload logging](./overview#header-and-payload-logging) for what each delivery records.

--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -8,7 +8,7 @@ import FastapiWebhookReciever from '!!raw-loader!../media/fastapi_webhook_receiv
 
 # What are webhooks?
 
-Webhooks are HTTP callbacks that deliver data to external systems in real-time when an [event](../events/event-system) occurs within Infrahub. They allow you to:
+Webhooks push data to external systems each time a matching [event](../events/event-system) occurs in Infrahub. Use them to:
 
 - Notify external systems about changes in your infrastructure (for example new configuration generated)
 - Trigger automated workflows in CI/CD pipelines
@@ -16,15 +16,15 @@ Webhooks are HTTP callbacks that deliver data to external systems in real-time w
 - Build custom integrations with your existing toolchain
 
 :::info
-The **Webhook System** also powers the [Activity Log](../deploy-manage/run-observe/activity-log).
+The [Activity Log](../deploy-manage/run-observe/activity-log) is built on the same webhook system.
 :::
 
 ## Configuring webhooks
 
-Infrahub supports two different types of webhooks:
+Infrahub supports two types of webhooks:
 
 - `Standard Webhook` sends event information to an external endpoint. See [Create a webhook](./create.mdx) for setup.
-- `Custom Webhook` allows the ability to tie events to a [Transformation](../transformations/overview) to configure the payload being sent to an external endpoint. See [Webhook with custom Transformation](./custom-transformation.mdx) for the full walkthrough.
+- `Custom Webhook` connects events to a [Transformation](../transformations/overview) so you can shape the payload sent to an external endpoint. See [Webhook with custom Transformation](./custom-transformation.mdx) for the full walkthrough.
 
 :::note
 
@@ -41,7 +41,7 @@ Webhooks can be configured to trigger on specific event types, such as:
 - `infrahub.branch.merged`
 - `infrahub.node.updated`
 
-This allows you to tailor webhooks for specific use cases.
+Tailor a webhook to a specific use case by choosing the events it triggers on.
 
 ### Configuring branch types
 
@@ -268,7 +268,7 @@ Custom headers are defined as reusable **key-value pair** entities that can be s
 1. Create a key-value pair via the UI or GraphQL API, specifying a **name** (human-friendly identifier), a **key** (the HTTP header field name), and a **value**.
 2. Associate the key-value pair with one or more webhooks using the **headers** relationship on the webhook.
 
-A single key-value pair can be linked to multiple webhooks (many-to-many relationship). When the key-value pair is updated, all linked webhooks automatically pick up the new value on their next trigger.
+A single key-value pair can be linked to multiple webhooks (many-to-many relationship). When the key-value pair is updated, all linked webhooks use the new value on their next trigger.
 
 ### Header merge behavior
 
@@ -314,4 +314,10 @@ Each webhook delivery runs as a task. Open a webhook and select a delivery from 
 | Retry | The delivery has finished, or is being cancelled | Re-sends the original payload as a new delivery and leaves the original record unchanged. Useful when a delivery failed because the target was temporarily unavailable or misconfigured. |
 | Cancel | The delivery is still running or waiting to retry | Stops the delivery, including one waiting to be retried, so no further attempts are made. A request already in flight to the target cannot be recalled. |
 
-The Retry and Cancel actions appear only when they apply to the delivery's current state.
+The Retry and Cancel actions appear only when they apply to the delivery's current state. Retrying creates a new delivery with the same settings and leaves the original unchanged; the new delivery re-computes its signature and runs against the current webhook configuration. Retry is available on any finished delivery, including one that already succeeded, so you can re-deliver an event on demand.
+
+## Writing a reliable receiver
+
+- **Return a `2xx` status quickly.** The response acknowledges receipt; an endpoint slower than the delivery timeout is treated as a failed attempt.
+- **Make the receiver idempotent.** Transient failures — connection errors, timeouts, and `5xx` responses — are retried automatically, and a delivery can also be retried manually, so the same event can arrive more than once. Use the `webhook-id` header to detect duplicates.
+- **Verify the signature before trusting a payload.** When a shared key is configured, check the `webhook-signature` header against it — see [Shared key for security](#shared-key-for-security).


### PR DESCRIPTION
Audit-first improvement pass (writing-infrahub-docs skill, UC1) on the three `docs/docs/webhooks/` pages, aligning them with the delivery-operability feature (ifc-2755, #9810/#9941) and the docs voice rules. Also adds a manual QA checklist for the feature.

## overview.mdx
- Recovery prose: a retry creates a new delivery with the same settings, re-signs, runs against current config, and leaves the original unchanged; retry is available on any finished delivery.
- New **Writing a reliable receiver** section: return `2xx` quickly, idempotency + `webhook-id` dedup, verify the signature.
- Voice: capability-lead opener (dropped "in real-time" / "allow you to"); `powers`→built on; `tie`→connects; removed "allows you to" / "pick up" / "two different".

## custom-transformation.mdx
- Intro voice fix; troubleshooting now points at the delivery logs + classified failure reason.

## QA checklist
- `dev/specs/ifc-2755-webhook-delivery-operability/qa-checklist.md` — manual, customer-facing QA checklist (speckit.opsmill.qa).

## Verification
- `cd docs && npm run build` — success, no broken links/anchors.
- `uv run invoke docs.lint` — markdownlint 0 errors, Vale 0/0.
- No changelog fragment (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the webhooks docs to document delivery recovery and reliable receiver practices, and adds a customer-facing QA checklist. Aligns with the delivery-operability feature (Linear ifc-2755).

- **Docs**
  - Document retry behavior: creates a new delivery, re-signs, runs with current config; available on any finished delivery.
  - Add “Writing a reliable receiver”: return `2xx` quickly, ensure idempotency using `webhook-id`, verify `webhook-signature`.
  - Update troubleshooting for custom transformations to use delivery logs and the classified failure reason; QA checklist updated to match shipped UI (structured request/response are GraphQL-only; task page shows logs plus retry/cancel).

<sup>Written for commit d7b182810163e671827737fae4ebe961cdb9a13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

