### PR TITLE
fix(docs): sync release-notes support files to infrahub-docs

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'docs/docs/**'
       - 'docs/sidebars.ts'
+      - 'docs/sidebar-releases.ts'
+      - 'docs/plugins/**'
+      - 'docs/src/components/ReleaseFeed/**'
   workflow_dispatch:
 
 jobs:
@@ -32,10 +35,19 @@ jobs:
           # Remove existing files in target repo
           rm -rf target-repo/docs/docs/*
           rm -f target-repo/docs/sidebars.ts
+          rm -f target-repo/docs/sidebar-releases.ts
+          rm -rf target-repo/docs/plugins
+          rm -rf target-repo/docs/src/components/ReleaseFeed
 
           # Copy files from source repo to target repo
           cp -r source-repo/docs/docs/* target-repo/docs/docs/
           cp source-repo/docs/sidebars.ts target-repo/docs/sidebars.ts
+          # sidebars.ts imports ./sidebar-releases; the ReleaseFeed component and
+          # release-notes-data plugin power the /release-notes/infrahub feed.
+          cp source-repo/docs/sidebar-releases.ts target-repo/docs/sidebar-releases.ts
+          cp -r source-repo/docs/plugins target-repo/docs/plugins
+          mkdir -p target-repo/docs/src/components
+          cp -r source-repo/docs/src/components/ReleaseFeed target-repo/docs/src/components/ReleaseFeed
 
           # Commit and push changes to target repository
           cd target-repo


### PR DESCRIPTION
## Problem

The [infrahub-docs](https://github.com/opsmill/infrahub-docs) Cloudflare build is failing:

```
[ERROR] Sidebars file at ".../docs/sidebars.ts" failed to be loaded.
[cause]: Error: Cannot find module './sidebar-releases'
```

The `Sync Folders` workflow copies only `docs/docs/**` and `docs/sidebars.ts` into infrahub-docs. The release-notes redesign added companion files that the synced `sidebars.ts` and `release-notes/infrahub/index.mdx` now import, but which live **outside** those synced paths, so they never reached infrahub-docs:

| File | Consumed by |
|------|-------------|
| `docs/sidebar-releases.ts` | `sidebars.ts` (`generateInfrahubReleaseSidebar()`) |
| `docs/plugins/release-notes-data.js` | `<ReleaseFeed/>` via `usePluginData` |
| `docs/src/components/ReleaseFeed/` | `release-notes/infrahub/index.mdx` |

Docusaurus aborts at sidebar loading (before webpack), so the build log only surfaced the first missing file — the others fail next once it's resolved.

## Change

Extend `.github/workflows/sync-docs.yml` to also sync these three paths (with matching `paths:` triggers). Only the `ReleaseFeed` component subdirectory is copied, not all of `src/components/`, since infrahub-docs maintains its own shared components.

## Companion change (separate repo)

Registering the `release-notes-data` plugin must be done in **infrahub-docs'** own `docusaurus.config.ts` — that config is not synced from here. That one-line change needs to land in infrahub-docs alongside the first sync that delivers these files.

## Testing

Reproduced the infrahub-docs build locally with these files present + the plugin registered: build succeeds (`Generated static files`, 629 docs) and `<ReleaseFeed/>` renders at `/release-notes/infrahub`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `infrahub-docs` Cloudflare build by syncing the release-notes support files required by the sidebar and feed. Adds missing paths and triggers to the docs sync workflow so release notes render correctly.

- **Bug Fixes**
  - Extend `.github/workflows/sync-docs.yml` to sync: `docs/sidebar-releases.ts`, `docs/plugins/**` (includes `release-notes-data.js`), and `docs/src/components/ReleaseFeed/**`.
  - Add matching `paths:` triggers and remove existing target files before copying to avoid stale artifacts.

- **Migration**
  - In `infrahub-docs`, register the `release-notes-data` plugin in `docusaurus.config.ts`.

<sup>Written for commit 967f1131b11f5bc5e133473d82e6bb9c4d784572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

