### PR TITLE
docs: harvest review lessons from last week's PRs into internal docs

### DIFF
--- a/.agents/rules/backend-component-design.md
+++ b/.agents/rules/backend-component-design.md
@@ -22,6 +22,8 @@ The single exception is editing existing code where adding a required parameter 
 
 Construct components as close to the application entry point as possible. Use a builder class or factory function when wiring is non-trivial, and inject each sub-component rather than constructing it inside a parent component's `__init__`.
 
+Prefect `@flow` functions are application entry points: resolve singleton getters (`get_database()`, `get_workflow()`, …) at the top of the flow only — never inside helpers or component internals — then build the component and delegate to it. The flow body stays a thin composition root; the business logic lives in the component.
+
 ## Single entry point, operating on arguments
 
 A component should generally expose a single entry point method (occasionally more, when justified by cohesive responsibility). That method only accepts the entities being operated on as arguments — it should not require additional dependencies to be passed in alongside the work payload.

--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -2,11 +2,15 @@
 paths:
   - "backend/**/*.py"
   - "python_testcontainers/**/*.py"
+  - "frontend/app/src/**/*.ts"
+  - "frontend/app/src/**/*.tsx"
 ---
 
 # Code documentation style
 
-Applies to docstrings, comments, and any inline documentation in Python source files.
+Applies to docstrings, comments, and any inline documentation in source files — Python and TypeScript alike.
+
+Never leave comments that narrate what the change is doing or restate the code below them ("// fetch the user", "# loop over the results"). Reviewers repeatedly have to ask for these to be removed.
 
 ## No references to other code
 

--- a/dev/guides/backend/creating-async-tasks.md
+++ b/dev/guides/backend/creating-async-tasks.md
@@ -68,8 +68,8 @@ Key requirements:
 - Names must be **lowercase with dashes** (e.g., `my-workflow`, not `my_workflow`)
 - Use `flow_run_name` for human-readable run names (see naming guidelines below)
 - Accept `context: InfrahubContext` parameter (injected automatically)
-- Use `get_run_logger()` for logging
-- Use dependency injection for services (`get_database()`, etc.)
+- Use `get_run_logger()` for logging — the stdlib default logger never surfaces in Prefect's UI/logs
+- Keep the flow body a thin composition root: resolve singletons (`get_database()`, `get_workflow()`, …) at the top of the flow only, build a component with those dependencies injected, and delegate to it. Business logic lives in the component, not the flow function — see `.agents/rules/backend-component-design.md`
 
 **`flow_run_name` guidelines:**
 
@@ -265,7 +265,8 @@ Before submitting your workflow:
 - [ ] Correct `WorkflowType` selected (CORE/USER/INTERNAL)
 - [ ] `DATABASE_CHANGE` tag added if workflow modifies database
 - [ ] Uses `get_run_logger()` for logging
-- [ ] Uses dependency injection for services
+- [ ] Flow body is a thin composition root — singletons resolved at the flow entry, logic in a dependency-injected component
+- [ ] Any other code that needs the workflow's name imports its `WorkflowDefinition` from `catalogue.py` instead of re-typing the string
 - [ ] Tests cover workflow execution (using local execution mode)
 - [ ] Code passes `uv run invoke lint`
 

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -72,14 +72,18 @@ WorkflowDefinition(
 
 ### Flow Functions
 
-Async functions decorated with `@flow` containing business logic:
+Async functions decorated with `@flow`. A flow function is a **composition root, not the home of business logic**: it resolves the singleton services (`get_database()`, `get_workflow()`, …), builds a component with those dependencies injected, and delegates to it. Keep the flow body thin — the logic lives in the component, where it is testable without a running worker (see `.agents/rules/backend-component-design.md`).
 
 ```python
 @flow(name="branch-merge", flow_run_name="Merge branch {branch}")
 async def merge_branch(branch: str, context: InfrahubContext) -> None:
     database = await get_database()
-    # ... implementation
+    async with database.start_session() as db:
+        merger = BranchMerger(db=db, diff_coordinator=..., ...)  # collaborators injected here
+        await merger.merge()
 ```
+
+Singleton getters belong at this entry point only — do not call `get_database()`/`get_workflow()` inside helper functions or component internals; pass the resolved services down as constructor arguments.
 
 ### Task Functions
 
@@ -101,6 +105,8 @@ Names must use **lowercase with dashes** (not underscores):
 - Bad: `branch_merge`, `BranchMerge`, `branchMerge`
 
 All flows and tasks must have an explicit `name` parameter in their decorator.
+
+**Reference workflow names via the catalogue, never as re-typed string literals.** When code outside the flow needs a workflow's name — dispatching it, filtering its flow runs, labelling metrics — import the `WorkflowDefinition` from `backend/infrahub/workflows/catalogue.py` and use it (e.g. pass `workflow=WEBHOOK_PROCESS`, or read `WEBHOOK_PROCESS.name`). A duplicated literal drifts silently when the flow is renamed.
 
 ### Flow Run Names
 
@@ -260,6 +266,10 @@ Existing examples: `DisplayLabelNodeIDQuery`, `HFIDNodeIDQuery`, `ComputedAttrib
 ### A subflow succeeds only when it is completed
 
 When inspecting a subflow's terminal state, gate on `state.is_completed()`, not on the negation of `state.is_failed()`. `is_failed()` is only one terminal failure mode — a `CANCELLED` or `CRASHED` subflow is not failed but is also not a success, so `if not state.is_failed(): return` reports those as success. Treat "completed" as the only success and every other terminal state as a failure.
+
+### Observability side-writes must never change the primary outcome
+
+A write whose only purpose is observability — persisting a Prefect artifact that captures a request/response, emitting a metric, invoking a metrics-observer callback — is best-effort by definition. It must be exception-isolated (catch, log a warning, continue) so that its failure can never fail, retry, or alter the outcome of the operation it observes: a webhook delivery that succeeded must not be reported as failed because the capture artifact could not be written, and a metrics callback raising must not corrupt lock/pool state. The primary operation's result is decided before and independently of the telemetry write.
 
 ### Post-commit follow-up work is best-effort
 

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -35,7 +35,7 @@ Gate workflow actions and operational scope. Defined in `GlobalPermissions` enum
 
 Global permission resolution: deny preempts allow. If any loaded permission for an action has decision=DENY, the permission is denied regardless of other ALLOW entries.
 
-Any re-implementation of this check outside the backend — a frontend gate hiding UI behind a permission, for example — must mirror these exact semantics (DENY preemption, superadmin bypass), not a naive "some grant allows it" test. A user holding both an ALLOW and a DENY grant would otherwise see UI the backend rejects.
+Any re-implementation of this check outside the backend — a frontend gate hiding UI behind a permission, for example — must mirror these exact semantics (DENY preemption, super admin bypass), not a naive "some grant allows it" test. A user holding both an ALLOW and a DENY grant would otherwise see UI the backend rejects.
 
 ### Object Permissions
 

--- a/dev/knowledge/backend/permissions.md
+++ b/dev/knowledge/backend/permissions.md
@@ -35,6 +35,8 @@ Gate workflow actions and operational scope. Defined in `GlobalPermissions` enum
 
 Global permission resolution: deny preempts allow. If any loaded permission for an action has decision=DENY, the permission is denied regardless of other ALLOW entries.
 
+Any re-implementation of this check outside the backend — a frontend gate hiding UI behind a permission, for example — must mirror these exact semantics (DENY preemption, superadmin bypass), not a naive "some grant allows it" test. A user holding both an ALLOW and a DENY grant would otherwise see UI the backend rejects.
+
 ### Object Permissions
 
 Gate CRUD operations on specific kinds. Defined by four fields:

--- a/dev/knowledge/backend/query-pattern.md
+++ b/dev/knowledge/backend/query-pattern.md
@@ -86,6 +86,10 @@ self.add_to_query("MATCH (n { uuid: $uuid })")
 self.add_to_query(f"MATCH (n {{ uuid: '{user_provided_id}' }})")
 ```
 
+### Keep Cypher readable inline
+
+Readability of the raw query outranks deduplication. Do not extract repeated Cypher blocks into shared Python string-building helpers or fragment formatters just to avoid duplication — a query assembled from indirected fragments is much harder to read, review, and paste into a Neo4j console. Duplicating a few similar Cypher blocks inline is the accepted trade-off.
+
 ### Return Labels
 
 The RETURN clause is automatically generated from `return_labels`. Call `update_return_labels()` to specify what to return.
@@ -124,6 +128,11 @@ class MyQuery(Query):
 Pagination (`LIMIT`/`OFFSET`) is automatically appended based on constructor parameters. To write pagination directly in your query, set `insert_limit = False`:
 
 > **List reads default to a page limit (e.g. `Branch.get_list` defaults to `limit=1000`).** Any check that must reason over *all* matching rows — "is any branch merging?", "are there duplicates?" — must not rely on an unbounded read of a default page. Narrow the query with a filter (a status/kind predicate) or paginate explicitly; otherwise the check silently ignores everything past the first page once the table grows.
+>
+> Two corollaries:
+>
+> - **Never derive a count with `len()` on a list read.** `len(Branch.get_list(...))` caps at the page limit and silently under-reports. Use the dedicated count method (`Branch.get_list_count`) or add one — a count query is also far cheaper than materializing the rows.
+> - **A "pick the newest/best from a filtered list" reduction must page through *all* results first.** This applies to any paginated API, not just our Query classes (e.g. Prefect artifact listings): reducing over only the first page silently returns a stale or missing winner once results exceed the page size.
 
 ```python
 class MyQuery(Query):


### PR DESCRIPTION
# Why

Reviewers repeated the same guidance across last week's PRs — thin Prefect flows, page-limit traps, narration comments — because each lesson lived in a review thread and died there. This is a `harvesting-review` run over the PRs reviewed 2026-07-14 → 2026-07-21, turning the feedback that generalizes into durable internal-doc conventions so a future author (human or agent) follows the convention the first time.

Non-goals: no lessons from still-open PRs whose pattern isn't in-tree yet (#9965 custom-scalar conventions, #9970 attribute-kind enumerations, #9948 react-aria popover gotcha), and nothing already codified on `develop` (#9977's wrong-type/checker-re-enable rule, the exception-handling section) or in-flight inside an open PR (#9805's registry hot/cold-path edit to `query-pattern.md`).

## Source PRs

Lessons were learned from the review threads of:

- #9932, #9849, #9805 — ajtmccarty, repeatedly: Prefect flows should be thin wrappers around dependency-injected components; singleton getters belong at entry points
- #9805 — dgarros: pull workflow names from the catalogue, not hardcoded strings; cubic: `len(Branch.get_list(...))` under-counts past the page limit
- #9941 — cubic: a Prefect-artifact capture write must never flip a successful webhook delivery to failed; artifact listings must paginate before pick-latest
- #9879 — cubic: metrics-observer callbacks must be exception-isolated from lock/pool state
- #9980 — ajtmccarty: rejected extracting duplicated Cypher into Python fragment builders — inline readability wins
- #9871 — cubic: frontend permission gate didn't mirror backend DENY-preemption; bilalabbad: narration comments
- #9880, #9814, #9942, #9952, #9977 — bilalabbad, ajtmccarty, polmichel: recurring "remove comments that narrate what the code does" feedback on both frontend and backend

Also scanned with no new lessons to harvest (already covered, PR-local, or no substantive review): #9815, #9893, #9923, #9924, #9928, #9930, #9937, #9938, #9939, #9943, #9944, #9947, #9956, #9963, #9631.

## What changed

Strengthened existing coverage (rule existed but wasn't landing):

- `dev/knowledge/backend/async-tasks.md` + `dev/guides/backend/creating-async-tasks.md`: the knowledge doc literally said flow functions "contain business logic", contradicting the DI guidance reviewers gave on three separate PRs. Rewritten: flows are thin composition roots — resolve singletons at the flow entry, build the component, delegate. Guide + checklist updated to match.
- `.agents/rules/backend-component-design.md`: one paragraph naming `@flow` functions as the application entry points where singleton getters are resolved.
- `dev/knowledge/backend/query-pattern.md`: the page-limit warning now spells out its two recurring corollaries — never derive a count with `len()` on a list read (use `get_list_count`), and pick-latest reductions over paginated APIs must page through all results first.
- `.agents/rules/code-doc-style.md`: extended from backend-only paths to frontend `*.ts`/`*.tsx` — the no-narration-comments rule existed but reviewers kept having to raise it on frontend PRs it didn't apply to.

New rules:

- `dev/knowledge/backend/async-tasks.md`: reference workflow names via the catalogue `WorkflowDefinition`, never re-typed string literals; observability side-writes (capture artifacts, metrics callbacks) are best-effort and never change the primary operation's outcome.
- `dev/knowledge/backend/query-pattern.md`: keep Cypher readable inline — don't extract shared fragments into Python string-building helpers just to dedupe.
- `dev/knowledge/backend/permissions.md`: any client-side re-implementation of the permission check must mirror backend DENY-preemption semantics.

What stayed the same: docs-only — no code, no generated files, no schema.

## How to review

The two `.agents/rules/*` edits deserve the most scrutiny — they auto-inject into every agent turn, so their token cost is paid repo-wide. Everything else loads only via the router. The `async-tasks.md` flow-function rewrite is the highest-value fix (it corrected an active contradiction); the rest are one-paragraph additions to existing sections.

## How to test

```bash
docs/node_modules/.bin/markdownlint-cli2 dev/knowledge/backend/async-tasks.md dev/knowledge/backend/query-pattern.md dev/knowledge/backend/permissions.md dev/guides/backend/creating-async-tasks.md .agents/rules/code-doc-style.md .agents/rules/backend-component-design.md
```

The only reported errors are pre-existing in untouched sections of `permissions.md`.

## Impact & rollout

- **Backward compatibility:** docs-only, no runtime impact
- **Deployment notes:** safe to merge; flows down to `develop` with the next stable→develop merge

## Checklist

- [ ] Tests added/updated (n/a — docs-only)
- [ ] Changelog entry added (n/a — internal docs)
- [ ] External docs updated (n/a)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8k1FwDp5KZ5sAWbhrVmd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8k1FwDp5KZ5sAWbhrVmd5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only update harvesting recurring review feedback into internal guides and `/.agents` rules to prevent repeat comments. Clarifies thin Prefect flows, safe pagination, readable Cypher, comment style (now applies to TS/TSX), permission semantics, and telemetry isolation.

- **New Rules and Clarifications**
  - Flows are thin composition roots: resolve singletons at the flow entry, inject into a component, and delegate (logic lives in the component).
  - Reference workflow names via the catalogue `WorkflowDefinition`, not string literals.
  - Observability writes (artifacts, metrics callbacks) are best-effort and exception-isolated; they must never change the primary outcome.
  - Pagination: do not use `len()` on page-limited reads; use count methods and paginate fully before any “pick latest/best” reduction.
  - Keep Cypher readable inline; avoid Python fragment builders used only to dedupe.
  - Frontend permission gates must mirror backend DENY-preemption semantics.
  - Extend “no narration comments” rule to `frontend/app/src/**/*.ts` and `frontend/app/src/**/*.tsx`.

<sup>Written for commit 7f0fa5028413d15dd08d8ec7c09638a057424ca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

