### PR TITLE
queries for node-scoped uniqueness constraints

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -105,6 +105,7 @@ class NodeDiffFieldSummary:
     kind: str
     attribute_names: set[str] = field(default_factory=set)
     relationship_names: set[str] = field(default_factory=set)
+    node_uuids: set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/backend/infrahub/core/validators/node_diff_index.py
+++ b/backend/infrahub/core/validators/node_diff_index.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrahub.core.diff.model.path import NodeDiffFieldSummary
+
+
+class NodeDiffIndex:
+    """Which fields and nodes changed, per kind, in a data diff.
+
+    `initialize` must be called for a given diff before any query method is used.
+    """
+
+    def __init__(self) -> None:
+        self._initialized: bool = False
+        self._kinds: set[str] = set()
+        self._attribute_names_by_kind: dict[str, set[str]] = {}
+        self._relationship_names_by_kind: dict[str, set[str]] = {}
+        self._node_uuids_by_kind: dict[str, set[str]] = {}
+
+    def initialize(self, node_diffs: list[NodeDiffFieldSummary]) -> None:
+        self._kinds = set()
+        self._attribute_names_by_kind = {}
+        self._relationship_names_by_kind = {}
+        self._node_uuids_by_kind = {}
+        for node_diff in node_diffs:
+            self._kinds.add(node_diff.kind)
+            self._attribute_names_by_kind.setdefault(node_diff.kind, set()).update(node_diff.attribute_names)
+            self._relationship_names_by_kind.setdefault(node_diff.kind, set()).update(node_diff.relationship_names)
+            self._node_uuids_by_kind.setdefault(node_diff.kind, set()).update(node_diff.node_uuids)
+        self._initialized = True
+
+    def _ensure_initialized(self) -> None:
+        if not self._initialized:
+            raise RuntimeError("NodeDiffIndex must be initialized with initialize() before its query methods are used")
+
+    @property
+    def kinds(self) -> set[str]:
+        self._ensure_initialized()
+        return self._kinds
+
+    def has_attribute_diff(self, kind: str, name: str) -> bool:
+        self._ensure_initialized()
+        return name in self._attribute_names_by_kind.get(kind, set())
+
+    def has_relationship_diff(self, kind: str, name: str) -> bool:
+        self._ensure_initialized()
+        return name in self._relationship_names_by_kind.get(kind, set())
+
+    def uuids_for_kinds(self, kinds: set[str]) -> set[str]:
+        self._ensure_initialized()
+        uuids: set[str] = set()
+        for kind in kinds:
+            uuids |= self._node_uuids_by_kind.get(kind, set())
+        return uuids

--- a/backend/infrahub/core/validators/uniqueness/dependent_resolver.py
+++ b/backend/infrahub/core/validators/uniqueness/dependent_resolver.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+from infrahub.core import registry
+
+from .query import AffectedUniquenessDependentsQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
+
+
+class UniquenessDependentResolverInterface(Protocol):
+    """Resolve which nodes of a kind reference a set of changed peer nodes.
+
+    A uniqueness path such as "owner__name" makes a kind's constraint depend on a peer kind's
+    attribute; when the peer changes, the constrained nodes themselves are absent from the diff and
+    must be resolved by traversal before they can be node-scoped.
+    """
+
+    async def resolve(self, node_kind: str, relationship_identifier: str, peer_uuids: list[str]) -> set[str]: ...
+
+
+class UniquenessDependentResolver:
+    """Resolve which nodes of a kind reference changed peer nodes, for cross-kind uniqueness scoping."""
+
+    def __init__(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> None:
+        self.db = db
+        self.branch = branch
+        self.at = at
+
+    async def resolve(self, node_kind: str, relationship_identifier: str, peer_uuids: list[str]) -> set[str]:
+        """Return the uuids of `node_kind` nodes related via `relationship_identifier` to any peer in `peer_uuids`.
+
+        Only relationships visible from this branch (its own, its base, and the global branch) are
+        considered. The result is a superset of the truly-related nodes and is empty when no peer
+        uuids are given or none are referenced.
+        """
+        if not peer_uuids:
+            return set()
+        query = await AffectedUniquenessDependentsQuery.init(
+            db=self.db,
+            branch=self.branch,
+            at=self.at,
+            node_kind=node_kind,
+            relationship_identifier=relationship_identifier,
+            peer_uuids=peer_uuids,
+            default_branch_name=registry.default_branch,
+        )
+        await query.execute(db=self.db)
+        return query.get_dependent_uuids()

--- a/backend/infrahub/core/validators/uniqueness/query/__init__.py
+++ b/backend/infrahub/core/validators/uniqueness/query/__init__.py
@@ -1,0 +1,14 @@
+from ..model import QueryAttributePathValued, QueryRelationshipPathValued
+from .affected_dependents import AffectedUniquenessDependentsQuery
+from .targeted_validation import TargetedUniquenessValidationQuery, TargetedUniquenessViolation
+from .validation import NodeUniqueAttributeConstraintQuery, UniquenessValidationQuery
+
+__all__ = [
+    "AffectedUniquenessDependentsQuery",
+    "NodeUniqueAttributeConstraintQuery",
+    "QueryAttributePathValued",
+    "QueryRelationshipPathValued",
+    "TargetedUniquenessValidationQuery",
+    "TargetedUniquenessViolation",
+    "UniquenessValidationQuery",
+]

--- a/backend/infrahub/core/validators/uniqueness/query/affected_dependents.py
+++ b/backend/infrahub/core/validators/uniqueness/query/affected_dependents.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.core.query import Query, QueryType
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+
+class AffectedUniquenessDependentsQuery(Query):
+    """Return the nodes of a kind related, through a named relationship, to any of a set of peer nodes.
+
+    Considers edges at the timestamp on the input branch, default branch, and global branch, regardless
+    of when the input branch forked from the default branch. That is, changes made on the default branch
+    after the input branch was created WILL be included in the results.
+
+    Each hop of the path (peer→relationship and relationship→node) is resolved to a single winner
+    across the visible branches: the latest edge on the deepest branch decides, so a change on the
+    input branch overrides the default branch. The user branch will always override the default
+    branch if changes conflict.
+    """
+
+    name = "affected_uniqueness_dependents"
+    type = QueryType.READ
+
+    def __init__(
+        self,
+        node_kind: str,
+        relationship_identifier: str,
+        peer_uuids: list[str],
+        default_branch_name: str,
+        **kwargs: Any,
+    ) -> None:
+        self.node_kind = node_kind
+        self.relationship_identifier = relationship_identifier
+        self.peer_uuids = peer_uuids
+        self.default_branch_name = default_branch_name
+        super().__init__(**kwargs)
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params = {
+            "rel_identifier": self.relationship_identifier,
+            "peer_uuids": self.peer_uuids,
+            "at": self.at.to_string(),
+            "branch": self.branch.name,
+            "default_branch": self.default_branch_name,
+            "global_branch": GLOBAL_BRANCH_NAME,
+        }
+        query = """
+// --------------------
+// start with all possible active Relationship paths on a branch we care about
+// --------------------
+MATCH (peer)-[r1:IS_RELATED]-(rel:Relationship {name: $rel_identifier})-[r2:IS_RELATED]-(node:%(node_kind)s)
+WHERE peer.uuid IN $peer_uuids
+AND peer <> node
+AND r1.branch IN [$branch, $default_branch, $global_branch]
+AND r1.status = "active"
+AND r1.from <= $at
+AND (r1.to IS NULL OR r1.to >= $at)
+AND r2.branch IN [$branch, $default_branch, $global_branch]
+AND r2.status = "active"
+AND r2.from <= $at
+AND (r2.to IS NULL OR r2.to >= $at)
+WITH DISTINCT peer, rel, node
+// --------------------
+// keep only active edges. the latest edge on the deepest branch wins.
+// --------------------
+CALL (peer, rel) {
+    MATCH (peer)-[r:IS_RELATED]-(rel)
+    WHERE r.branch IN [$branch, $default_branch, $global_branch]
+    AND r.from <= $at
+    AND (r.to IS NULL OR r.to >= $at)
+    WITH r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    WITH is_active
+    WHERE is_active = TRUE
+    RETURN TRUE AS peer_rel_is_live
+}
+CALL (rel, node) {
+    MATCH (rel)-[r:IS_RELATED]-(node)
+    WHERE r.branch IN [$branch, $default_branch, $global_branch]
+    AND r.from <= $at
+    AND (r.to IS NULL OR r.to >= $at)
+    WITH r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    WITH is_active
+    WHERE is_active = TRUE
+    RETURN TRUE AS rel_node_is_live
+}
+        """ % {
+            "node_kind": self.node_kind,
+        }
+        self.add_to_query(query=query)
+        self.return_labels = ["DISTINCT node.uuid AS node_uuid"]
+
+    def get_dependent_uuids(self) -> set[str]:
+        return {result.get_as_type("node_uuid", return_type=str) for result in self.results}

--- a/backend/infrahub/core/validators/uniqueness/query/targeted_validation.py
+++ b/backend/infrahub/core/validators/uniqueness/query/targeted_validation.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.graph.schema import GraphAttributeValueIndexedNode, GraphAttributeValueNode
+from infrahub.core.query import Query, QueryType
+from infrahub.types import is_large_attribute_type
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from infrahub.core.schema.basenode_schema import SchemaAttributePath
+    from infrahub.database import InfrahubDatabase
+
+
+@dataclass(frozen=True)
+class TargetedUniquenessViolation:
+    """One changed node sharing its full constraint-value tuple with at least one other node."""
+
+    changed_uuid: str
+    element_values: tuple[Any, ...]
+    partner_uuids: tuple[str, ...]
+
+
+class TargetedUniquenessValidationQuery(Query):
+    """Find uniqueness violations for a set of changed nodes.
+
+    For one uniqueness constraint group, resolve the changed nodes' current value for a first
+    element only, probe the whole population for other nodes sharing that value, and drop every
+    changed node with no match. Each subsequent element is resolved only for the changed nodes
+    that still have live matches, and each candidate set shrinks by comparing the candidates'
+    current value for that element. A changed node is reported only if at least one other node
+    still shares its full value tuple after the last element.
+
+    Values are compared as stored in the graph: enum values in their raw form and null attribute
+    values as the null sentinel, so two nulls collide. A node without a live value for an element
+    (e.g. a relationship with no peer) contributes no tuple and cannot collide on that group.
+
+    Changed nodes and candidate partners must themselves be live: their latest IS_PART_OF edge on
+    a visible branch must be active. This excludes nodes deleted on the branch and stale same-uuid
+    duplicates left behind by kind or inheritance migrations.
+
+    Supported constraint elements are node attributes (compared by value) and cardinality-one
+    relationships (compared by peer uuid). Attributes of related peers are not supported.
+    """
+
+    name = "uniqueness_constraint_validation_targeted"
+    type = QueryType.READ
+    insert_return = False
+
+    def __init__(
+        self,
+        kind: str,
+        constraint_elements: list[SchemaAttributePath],
+        node_uuids: list[str],
+        **kwargs: Any,
+    ) -> None:
+        if not constraint_elements:
+            raise ValueError("At least one constraint element is required")
+        for element in constraint_elements:
+            if element.relationship_schema is not None and element.attribute_schema is not None:
+                raise ValueError(
+                    f"{element.to_string()} is not supported for a targeted uniqueness check: "
+                    "attributes of related peers cannot be part of a uniqueness constraint"
+                )
+            if element.relationship_schema is None and element.attribute_schema is None:
+                raise ValueError("A constraint element requires an attribute or a relationship")
+            if element.attribute_schema is not None and (element.attribute_property_name or "value") != "value":
+                raise ValueError(
+                    f"{element.attribute_property_name} is not a valid property for a uniqueness constraint"
+                )
+        self.kind = kind
+        self.constraint_elements = constraint_elements
+        self.node_uuids = node_uuids
+        super().__init__(**kwargs)
+
+    def get_context(self) -> dict[str, str]:
+        return {"kind": self.kind}
+
+    def _render_liveness_check(self, source_var: str, alias: str, branch_filter: str) -> str:
+        """Render a subquery keeping only rows whose node is live.
+
+        The latest IS_PART_OF edge on a visible branch decides: a node deleted on the branch, or a
+        stale same-uuid duplicate left by a kind or inheritance migration, resolves to a non-active
+        winner and the row is eliminated.
+        """
+        return """
+CALL (%(source_var)s) {
+    MATCH (%(source_var)s)-[r:IS_PART_OF]->(:Root)
+    WHERE %(branch_filter)s
+    WITH r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH is_active
+    LIMIT 1
+    WITH is_active
+    WHERE is_active = TRUE
+    RETURN TRUE AS %(alias)s
+}
+        """ % {
+            "source_var": source_var,
+            "alias": alias,
+            "branch_filter": branch_filter,
+        }
+
+    def _is_large_type(self, element: SchemaAttributePath) -> bool:
+        return element.attribute_schema is not None and is_large_attribute_type(element.attribute_schema.kind)
+
+    def _anchor_element_index(self) -> int:
+        """Pick the element whose population probe anchors the query.
+
+        The anchor is the only population-wide MATCH, so prefer an element whose value can be
+        found through an index: any relationship element (peer uuid) or any attribute whose kind
+        has an indexed value label. Fall back to the first element when none qualifies.
+        """
+        for index, element in enumerate(self.constraint_elements):
+            if not self._is_large_type(element):
+                return index
+        return 0
+
+    def _render_value_resolution(
+        self, source_var: str, element: SchemaAttributePath, index: int, value_var: str, branch_filter: str
+    ) -> tuple[str, dict[str, Any]]:
+        """Render a subquery resolving the current value of one constraint element for one node.
+
+        The winning edge per step is the latest one on the deepest branch; the row is eliminated
+        when the winner is not active, so a node without a live value yields no row.
+        """
+        if element.attribute_schema is not None:
+            attr_name_var = f"attr_name_{index}"
+            query = """
+CALL (%(source_var)s) {
+    MATCH (%(source_var)s)-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})
+    WHERE %(branch_filter)s
+    WITH attr, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH attr, is_active
+    LIMIT 1
+    WITH attr, is_active
+    WHERE is_active = TRUE
+    MATCH (attr)-[r:HAS_VALUE]->(av:AttributeValue)
+    WHERE %(branch_filter)s
+    WITH av, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH av, is_active
+    LIMIT 1
+    WITH av, is_active
+    WHERE is_active = TRUE
+    RETURN av.value AS %(value_var)s
+}
+            """ % {
+                "source_var": source_var,
+                "attr_name_var": attr_name_var,
+                "branch_filter": branch_filter,
+                "value_var": value_var,
+            }
+            return query, {attr_name_var: element.attribute_schema.name}
+
+        relationship_schema = element.active_relationship_schema
+        rel_identifier_var = f"rel_identifier_{index}"
+        query_arrows = relationship_schema.get_query_arrows()
+        query = """
+CALL (%(source_var)s) {
+    MATCH (%(source_var)s)%(lstart)s[r:IS_RELATED]%(lend)s(rel:Relationship {name: $%(rel_identifier_var)s})
+    WHERE %(branch_filter)s
+    WITH rel, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH rel, is_active
+    LIMIT 1
+    WITH rel, is_active
+    WHERE is_active = TRUE
+    MATCH (rel)%(rstart)s[r:IS_RELATED]%(rend)s(peer:Node)
+    WHERE %(branch_filter)s AND peer.uuid <> %(source_var)s.uuid
+    WITH peer, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH peer, is_active
+    LIMIT 1
+    WITH peer, is_active
+    WHERE is_active = TRUE
+    RETURN peer.uuid AS %(value_var)s
+}
+        """ % {
+            "source_var": source_var,
+            "rel_identifier_var": rel_identifier_var,
+            "lstart": query_arrows.left.start,
+            "lend": query_arrows.left.end,
+            "rstart": query_arrows.right.start,
+            "rend": query_arrows.right.end,
+            "branch_filter": branch_filter,
+            "value_var": value_var,
+        }
+        return query, {rel_identifier_var: relationship_schema.get_identifier()}
+
+    def _render_anchor_probe(
+        self, element: SchemaAttributePath, index: int, value_var: str, matches_var: str, branch_filter: str
+    ) -> str:
+        """Render the population-wide probe for the anchor element.
+
+        The MATCH is historical (any edge ever created), so each candidate's current value is
+        re-resolved and compared before it counts as a match.
+        """
+        if element.attribute_schema is not None:
+            attr_value_label = (
+                GraphAttributeValueNode.get_default_label()
+                if self._is_large_type(element)
+                else GraphAttributeValueIndexedNode.get_default_label()
+            )
+            anchor_match = (
+                "MATCH (candidate:%(kind)s)-[:HAS_ATTRIBUTE]->(:Attribute {name: $attr_name_%(index)s})"
+                "-[:HAS_VALUE]->(av:%(attr_value_label)s)\n"
+                "    WHERE av.value = %(value_var)s AND candidate.uuid <> changed.uuid"
+            ) % {
+                "kind": self.kind,
+                "index": index,
+                "attr_value_label": attr_value_label,
+                "value_var": value_var,
+            }
+        else:
+            query_arrows = element.active_relationship_schema.get_query_arrows()
+            anchor_match = (
+                "MATCH (candidate:%(kind)s)%(lstart)s[:IS_RELATED]%(lend)s"
+                "(:Relationship {name: $rel_identifier_%(index)s})%(rstart)s[:IS_RELATED]%(rend)s(anchor_peer:Node)\n"
+                "    WHERE anchor_peer.uuid = %(value_var)s AND candidate.uuid <> changed.uuid"
+            ) % {
+                "kind": self.kind,
+                "index": index,
+                "lstart": query_arrows.left.start,
+                "lend": query_arrows.left.end,
+                "rstart": query_arrows.right.start,
+                "rend": query_arrows.right.end,
+                "value_var": value_var,
+            }
+
+        candidate_liveness = self._render_liveness_check(
+            source_var="candidate", alias="candidate_is_live", branch_filter=branch_filter
+        )
+        candidate_resolution, _ = self._render_value_resolution(
+            source_var="candidate",
+            element=element,
+            index=index,
+            value_var=f"cand_value_{index}",
+            branch_filter=branch_filter,
+        )
+        return """
+CALL (changed, %(value_var)s) {
+    %(anchor_match)s
+    WITH DISTINCT candidate, %(value_var)s
+    %(candidate_liveness)s
+    %(candidate_resolution)s
+    WITH candidate, cand_value_%(index)s, %(value_var)s
+    WHERE cand_value_%(index)s = %(value_var)s
+    RETURN collect(DISTINCT candidate) AS %(matches_var)s
+}
+        """ % {
+            "value_var": value_var,
+            "anchor_match": anchor_match,
+            "candidate_liveness": candidate_liveness,
+            "candidate_resolution": candidate_resolution,
+            "index": index,
+            "matches_var": matches_var,
+        }
+
+    def _render_reduction_probe(
+        self,
+        element: SchemaAttributePath,
+        index: int,
+        value_var: str,
+        previous_matches_var: str,
+        matches_var: str,
+        branch_filter: str,
+        carried_vars: list[str],
+    ) -> str:
+        """Render the filter keeping only surviving candidates whose current value still matches.
+
+        The candidate list is unwound in the outer scope, so only the per-candidate value
+        resolution needs a subquery. A changed node whose candidates are all eliminated produces
+        no row for the final aggregation, which is what removes it.
+        """
+        candidate_resolution, _ = self._render_value_resolution(
+            source_var="candidate",
+            element=element,
+            index=index,
+            value_var=f"cand_value_{index}",
+            branch_filter=branch_filter,
+        )
+        carried = ", ".join(carried_vars)
+        return """
+UNWIND %(previous_matches_var)s AS candidate
+%(candidate_resolution)s
+WITH %(carried)s, candidate, cand_value_%(index)s
+WHERE cand_value_%(index)s = %(value_var)s
+WITH %(carried)s, collect(DISTINCT candidate) AS %(matches_var)s
+        """ % {
+            "previous_matches_var": previous_matches_var,
+            "value_var": value_var,
+            "candidate_resolution": candidate_resolution,
+            "index": index,
+            "matches_var": matches_var,
+            "carried": carried,
+        }
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string(), is_isolated=False)
+        self.params.update(branch_params)
+        self.params["node_uuids"] = self.node_uuids
+
+        anchor_index = self._anchor_element_index()
+        probe_order = [anchor_index] + [
+            index for index in range(len(self.constraint_elements)) if index != anchor_index
+        ]
+
+        query_parts = [
+            "MATCH (changed:Node)\nWHERE changed.uuid IN $node_uuids",
+            self._render_liveness_check(source_var="changed", alias="changed_is_live", branch_filter=branch_filter),
+        ]
+        resolved_value_vars: list[str] = []
+        matches_var = ""
+        for step, element_index in enumerate(probe_order):
+            element = self.constraint_elements[element_index]
+            value_var = f"value_{element_index}"
+            resolution, element_params = self._render_value_resolution(
+                source_var="changed",
+                element=element,
+                index=element_index,
+                value_var=value_var,
+                branch_filter=branch_filter,
+            )
+            self.params.update(element_params)
+            query_parts.append(resolution)
+            resolved_value_vars.append(value_var)
+
+            previous_matches_var = matches_var
+            matches_var = f"matches_{step}"
+            if step == 0:
+                query_parts.append(
+                    self._render_anchor_probe(
+                        element=element,
+                        index=element_index,
+                        value_var=value_var,
+                        matches_var=matches_var,
+                        branch_filter=branch_filter,
+                    )
+                )
+            else:
+                query_parts.append(
+                    self._render_reduction_probe(
+                        element=element,
+                        index=element_index,
+                        value_var=value_var,
+                        previous_matches_var=previous_matches_var,
+                        matches_var=matches_var,
+                        branch_filter=branch_filter,
+                        carried_vars=["changed", *resolved_value_vars],
+                    )
+                )
+            carried_vars = ["changed", *resolved_value_vars, matches_var]
+            query_parts.append(
+                "WITH %(carried_vars)s\nWHERE size(%(matches_var)s) > 0"
+                % {"carried_vars": ", ".join(carried_vars), "matches_var": matches_var}
+            )
+
+        element_values = ", ".join(f"value_{index}" for index in range(len(self.constraint_elements)))
+        query_parts.append(
+            "RETURN changed.uuid AS changed_uuid,\n"
+            "    [%(element_values)s] AS element_values,\n"
+            "    [candidate IN %(matches_var)s | candidate.uuid] AS partner_uuids"
+            % {"element_values": element_values, "matches_var": matches_var}
+        )
+
+        self.add_to_query("\n".join(query_parts))
+        self.return_labels = ["changed_uuid", "element_values", "partner_uuids"]
+
+    def get_data(self) -> Generator[TargetedUniquenessViolation, None, None]:
+        for result in self.results:
+            yield TargetedUniquenessViolation(
+                changed_uuid=result.get_as_type("changed_uuid", return_type=str),
+                element_values=result.get_as_type("element_values", return_type=tuple),
+                partner_uuids=tuple(result.get_as_list_of_type("partner_uuids", return_type=str)),
+            )

--- a/backend/infrahub/core/validators/uniqueness/query/validation.py
+++ b/backend/infrahub/core/validators/uniqueness/query/validation.py
@@ -7,12 +7,12 @@ from infrahub.core.graph.schema import GraphAttributeValueIndexedNode, GraphAttr
 from infrahub.core.query import Query, QueryType
 from infrahub.types import is_large_attribute_type
 
-from .model import QueryAttributePathValued, QueryRelationshipPathValued
+from ..model import QueryAttributePathValued, QueryRelationshipPathValued
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
-    from .model import NodeUniquenessQueryRequest, NodeUniquenessQueryRequestValued
+    from ..model import NodeUniquenessQueryRequest, NodeUniquenessQueryRequestValued
 
 
 class NodeUniqueAttributeConstraintQuery(Query):
@@ -350,7 +350,7 @@ CALL (node) {
         params: dict[str, str | int | float | bool] = {}
         rel_attr_query = ""
         rel_attr_match = ""
-        if rel_path.attribute_name and rel_path.attribute_value:
+        if rel_path.attribute_name is not None and rel_path.attribute_value is not None:
             attr_name_var = f"attr_name_{index}"
             attr_value_var = f"attr_value_{index}"
 

--- a/backend/tests/component/core/constraint_validators/test_targeted_uniqueness_query.py
+++ b/backend/tests/component/core/constraint_validators/test_targeted_uniqueness_query.py
@@ -2,8 +2,13 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.shared import MigrationInput
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, NodeSchema, SchemaRoot
 from infrahub.core.schema.basenode_schema import SchemaAttributePath
 from infrahub.core.validators.uniqueness.query import (
@@ -40,6 +45,27 @@ async def _update_car(db: InfrahubDatabase, branch: Branch, car_id: str, **attri
     for name, value in attribute_values.items():
         car.get_attribute(name).value = value
     await car.save(db=db)
+
+
+async def _migrate_car_kind_on_branch(db: InfrahubDatabase, default_branch: Branch, branch: Branch) -> MainSchemaTypes:
+    """Migrate the whole TestCar kind to Test2NewCar on the branch and return the new schema.
+
+    The migration results in multiple Node vertices with the same UUID, a case that can be difficult
+    to handle correctly.
+    """
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    new_car_schema = schema_branch.get_node(name="TestCar")
+    new_car_schema.name = "NewCar"
+    new_car_schema.namespace = "Test2"
+    registry.schema.set(name="Test2NewCar", schema=new_car_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema_branch.get(name="TestCar"),
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+    execution_result = await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
+    assert not execution_result.errors
+    return new_car_schema
 
 
 class TestTargetedUniquenessQuery:
@@ -387,6 +413,58 @@ class TestTargetedUniquenessQuery:
         assert set(by_changed) == {car_accord_main.id, car_prius_main.id}
         assert by_changed[car_accord_main.id].partner_uuids == (car_prius_main.id,)
         assert by_changed[car_prius_main.id].partner_uuids == (car_accord_main.id,)
+
+    async def test_same_uuid_duplicate_from_kind_migration(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        default_branch: Branch,
+    ) -> None:
+        # accord, prius, and camry all share nbr_seats=5
+        migration_branch = await create_branch(db=db, branch_name="kind-migration-branch")
+        new_car_schema = await _migrate_car_kind_on_branch(
+            db=db, default_branch=default_branch, branch=migration_branch
+        )
+
+        # the branch accord moves to 9 after the migration; still 5 on default branch
+        migrated_accord = await NodeManager.get_one(db=db, branch=migration_branch, id=car_accord_main.id)
+        migrated_accord.get_attribute("nbr_seats").value = 9
+        await migrated_accord.save(db=db)
+
+        elements = [_attr_element(new_car_schema, "nbr_seats")]
+
+        # updated value on branch is accepted as unique following the migration
+        violations = await _run_query(db, migration_branch, "Test2NewCar", elements, [car_accord_main.id])
+
+        assert violations == []
+
+        # camry and prius (both nbr_seats=5) collide. accord does not.
+        violations = await _run_query(db, migration_branch, "Test2NewCar", elements, [car_camry_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_camry_main.id
+        assert violations[0].partner_uuids == (car_prius_main.id,)
+        assert violations[0].element_values == (5,)
+
+        # the stale prius object is then updated on the DEFAULT branch after the migration; the
+        # attribute vertices are shared, so the new value must be visible through prius's live
+        # vertex on the migration branch and now collide with the branch-updated accord (9)
+        await _update_car(db, default_branch, car_prius_main.id, nbr_seats=9)
+
+        violations = await _run_query(db, migration_branch, "Test2NewCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_accord_main.id
+        assert violations[0].partner_uuids == (car_prius_main.id,)
+        assert violations[0].element_values == (9,)
+
+        # and camry (still 5) has lost its only partner: prius's superseded value-5 edge on the
+        # default branch must not still count for it
+        violations = await _run_query(db, migration_branch, "Test2NewCar", elements, [car_camry_main.id])
+
+        assert violations == []
 
     async def test_peer_attribute_element_rejected(
         self,

--- a/backend/tests/component/core/constraint_validators/test_targeted_uniqueness_query.py
+++ b/backend/tests/component/core/constraint_validators/test_targeted_uniqueness_query.py
@@ -1,0 +1,438 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema import AttributeSchema, MainSchemaTypes, NodeSchema, SchemaRoot
+from infrahub.core.schema.basenode_schema import SchemaAttributePath
+from infrahub.core.validators.uniqueness.query import (
+    TargetedUniquenessValidationQuery,
+    TargetedUniquenessViolation,
+)
+from infrahub.database import InfrahubDatabase
+
+
+def _attr_element(schema: MainSchemaTypes, name: str) -> SchemaAttributePath:
+    return SchemaAttributePath(attribute_schema=schema.get_attribute(name))
+
+
+def _rel_element(schema: MainSchemaTypes, name: str) -> SchemaAttributePath:
+    return SchemaAttributePath(relationship_schema=schema.get_relationship(name))
+
+
+async def _run_query(
+    db: InfrahubDatabase,
+    branch: Branch,
+    kind: str,
+    constraint_elements: list[SchemaAttributePath],
+    node_uuids: list[str],
+) -> list[TargetedUniquenessViolation]:
+    query = await TargetedUniquenessValidationQuery.init(
+        db=db, branch=branch, kind=kind, constraint_elements=constraint_elements, node_uuids=node_uuids
+    )
+    await query.execute(db=db)
+    return list(query.get_data())
+
+
+async def _update_car(db: InfrahubDatabase, branch: Branch, car_id: str, **attribute_values: object) -> None:
+    car = await NodeManager.get_one(id=car_id, db=db, branch=branch)
+    for name, value in attribute_values.items():
+        car.get_attribute(name).value = value
+    await car.save(db=db)
+
+
+class TestTargetedUniquenessQuery:
+    async def test_batched_mixed_colliding_and_unique(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+        car_yaris_main: Node,
+        branch: Branch,
+    ) -> None:
+        # accord shares nbr_seats=5 with the untouched prius and camry; volt is made unique
+        await _update_car(db, branch, car_volt_main.id, nbr_seats=2)
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(
+            db, branch, "TestCar", [_attr_element(schema, "nbr_seats")], [car_accord_main.id, car_volt_main.id]
+        )
+
+        assert len(violations) == 1
+        violation = violations[0]
+        assert violation.changed_uuid == car_accord_main.id
+        assert violation.element_values == (5,)
+        assert set(violation.partner_uuids) == {car_prius_main.id, car_camry_main.id}
+
+    async def test_multi_field_matches_full_tuple_only(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+        car_yaris_main: Node,
+        branch: Branch,
+    ) -> None:
+        # pairwise overlap on single elements but no shared full tuple: accord(5, red),
+        # prius(5, blue), volt(4, blue); camry and yaris are moved out of the way
+        await _update_car(db, branch, car_accord_main.id, nbr_seats=5, color="#ff0000")
+        await _update_car(db, branch, car_prius_main.id, nbr_seats=5, color="#0000ff")
+        await _update_car(db, branch, car_volt_main.id, nbr_seats=4, color="#0000ff")
+        await _update_car(db, branch, car_camry_main.id, nbr_seats=9)
+        await _update_car(db, branch, car_yaris_main.id, nbr_seats=8)
+        schema = registry.schema.get("TestCar", branch=branch)
+        elements = [_attr_element(schema, "nbr_seats"), _attr_element(schema, "color")]
+        changed = [car_accord_main.id, car_prius_main.id, car_volt_main.id]
+
+        violations = await _run_query(db, branch, "TestCar", elements, changed)
+
+        assert violations == []
+
+        # completing the tuple match flags exactly the two matching cars
+        await _update_car(db, branch, car_prius_main.id, color="#ff0000")
+
+        violations = await _run_query(db, branch, "TestCar", elements, changed)
+
+        assert {v.changed_uuid for v in violations} == {car_accord_main.id, car_prius_main.id}
+        by_changed = {v.changed_uuid: v for v in violations}
+        assert by_changed[car_accord_main.id].partner_uuids == (car_prius_main.id,)
+        assert by_changed[car_prius_main.id].partner_uuids == (car_accord_main.id,)
+        assert by_changed[car_accord_main.id].element_values == (5, "#ff0000")
+
+    async def test_multi_field_group_with_relationship_element(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        person_john_main: Node,
+        person_jane_main: Node,
+        branch: Branch,
+    ) -> None:
+        # accord and prius share owner john AND nbr_seats=5; camry has the same seats but a
+        # different owner, so it must not match the tuple
+        schema = registry.schema.get("TestCar", branch=branch)
+        elements = [_rel_element(schema, "owner"), _attr_element(schema, "nbr_seats")]
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_accord_main.id
+        assert violations[0].partner_uuids == (car_prius_main.id,)
+        assert violations[0].element_values == (person_john_main.id, 5)
+
+        # same owner but different seats no longer matches
+        await _update_car(db, branch, car_prius_main.id, nbr_seats=7)
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert violations == []
+
+    async def test_relationship_only_collision_and_missing_peer(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+        person_john_main: Node,
+        branch: Branch,
+    ) -> None:
+        # driver is an optional cardinality-one relationship: accord and camry are given the same
+        # driver, volt has none
+        for car_id in (car_accord_main.id, car_camry_main.id):
+            car = await NodeManager.get_one(id=car_id, db=db, branch=branch)
+            await car.get_relationship("driver").update(data=person_john_main, db=db)
+            await car.save(db=db)
+        schema = registry.schema.get("TestCar", branch=branch)
+        elements = [_rel_element(schema, "driver")]
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_accord_main.id
+        assert violations[0].partner_uuids == (car_camry_main.id,)
+        assert violations[0].element_values == (person_john_main.id,)
+
+        # a changed node without a live peer contributes no value and cannot collide
+        violations = await _run_query(db, branch, "TestCar", elements, [car_volt_main.id])
+
+        assert violations == []
+
+    async def test_null_attribute_values_collide(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        person_john_main: Node,
+        branch: Branch,
+    ) -> None:
+        # two cars without nbr_seats store the null sentinel and must still collide
+        car_a = await Node.init(db=db, schema="TestCar", branch=branch)
+        await car_a.new(db=db, name="nullseats-a", owner=person_john_main.id)
+        await car_a.save(db=db)
+        car_b = await Node.init(db=db, schema="TestCar", branch=branch)
+        await car_b.new(db=db, name="nullseats-b", owner=person_john_main.id)
+        await car_b.save(db=db)
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(db, branch, "TestCar", [_attr_element(schema, "nbr_seats")], [car_a.id])
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_a.id
+        assert violations[0].partner_uuids == (car_b.id,)
+        assert violations[0].element_values == ("NULL",)
+
+    async def test_enum_attribute_collision_uses_stored_value(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_camry_main: Node,
+        car_prius_main: Node,
+        branch: Branch,
+    ) -> None:
+        await _update_car(db, branch, car_accord_main.id, transmission="manual")
+        await _update_car(db, branch, car_camry_main.id, transmission="manual")
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(
+            db, branch, "TestCar", [_attr_element(schema, "transmission")], [car_accord_main.id]
+        )
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == car_accord_main.id
+        assert violations[0].partner_uuids == (car_camry_main.id,)
+        assert violations[0].element_values == ("manual",)
+
+    async def test_large_attribute_type_validated(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_person_schema: object,
+    ) -> None:
+        schema_root = SchemaRoot(
+            nodes=[
+                NodeSchema(
+                    name="Document",
+                    namespace="Test",
+                    attributes=[
+                        AttributeSchema(name="name", kind="Text"),
+                        AttributeSchema(name="content", kind="TextArea", optional=True),
+                    ],
+                )
+            ]
+        )
+        registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+        shared_content = "lorem ipsum " * 50
+        doc_a = await Node.init(db=db, schema="TestDocument", branch=default_branch)
+        await doc_a.new(db=db, name="doc-a", content=shared_content)
+        await doc_a.save(db=db)
+        doc_b = await Node.init(db=db, schema="TestDocument", branch=default_branch)
+        await doc_b.new(db=db, name="doc-b", content=shared_content)
+        await doc_b.save(db=db)
+        schema = registry.schema.get("TestDocument", branch=default_branch)
+
+        # a large-type attribute has no value index but is still validated
+        violations = await _run_query(
+            db, default_branch, "TestDocument", [_attr_element(schema, "content")], [doc_a.id]
+        )
+
+        assert len(violations) == 1
+        assert violations[0].partner_uuids == (doc_b.id,)
+
+        # in a multi-element group the full tuple must match: shared content but distinct names
+        elements = [_attr_element(schema, "content"), _attr_element(schema, "name")]
+
+        violations = await _run_query(db, default_branch, "TestDocument", elements, [doc_a.id])
+
+        assert violations == []
+
+        # a third document sharing both content and name completes the tuple
+        doc_c = await Node.init(db=db, schema="TestDocument", branch=default_branch)
+        await doc_c.new(db=db, name="doc-a", content=shared_content)
+        await doc_c.save(db=db)
+
+        violations = await _run_query(db, default_branch, "TestDocument", elements, [doc_a.id])
+
+        assert len(violations) == 1
+        assert violations[0].partner_uuids == (doc_c.id,)
+        assert violations[0].element_values == (shared_content, "doc-a")
+
+    async def test_post_fork_updates_on_main_and_branch(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        default_branch: Branch,
+        branch: Branch,
+    ) -> None:
+        # accord, prius and camry all share nbr_seats=5 when the branch forks; both partners then
+        # get distinct values on main, which the branch must see: the collision is gone
+        await _update_car(db, default_branch, car_prius_main.id, nbr_seats=8)
+        await _update_car(db, default_branch, car_camry_main.id, nbr_seats=9)
+        schema = registry.schema.get("TestCar", branch=branch)
+        elements = [_attr_element(schema, "nbr_seats")]
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert violations == []
+
+        # camry then gets a new value on main and accord the same new value on the branch; the
+        # two non-conflicting updates must collide across branches
+        await _update_car(db, default_branch, car_camry_main.id, nbr_seats=7)
+        await _update_car(db, branch, car_accord_main.id, nbr_seats=7)
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].partner_uuids == (car_camry_main.id,)
+        assert violations[0].element_values == (7,)
+
+        # the same collision is found when the main-updated node is the changed one
+        violations = await _run_query(db, branch, "TestCar", elements, [car_camry_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].partner_uuids == (car_accord_main.id,)
+
+    async def test_branch_visibility(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        branch: Branch,
+    ) -> None:
+        schema = registry.schema.get("TestCar", branch=branch)
+        elements = [_attr_element(schema, "nbr_seats")]
+
+        # data created on main only is visible from the branch
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert set(violations[0].partner_uuids) == {car_prius_main.id, car_camry_main.id}
+
+        # the branch-local value overrides main and no longer collides
+        await _update_car(db, branch, car_accord_main.id, nbr_seats=6)
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert violations == []
+
+        # two branch-local values collide with each other
+        await _update_car(db, branch, car_camry_main.id, nbr_seats=6)
+
+        violations = await _run_query(db, branch, "TestCar", elements, [car_accord_main.id])
+
+        assert len(violations) == 1
+        assert violations[0].partner_uuids == (car_camry_main.id,)
+        assert violations[0].element_values == (6,)
+
+    async def test_partner_deleted_on_branch_is_ignored(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        branch: Branch,
+    ) -> None:
+        # accord, prius and camry share nbr_seats=5 on main, but both partners are deleted on the
+        # branch, so the branch-level deletion overrides the value they still hold on main
+        for car_id in (car_prius_main.id, car_camry_main.id):
+            car = await NodeManager.get_one(id=car_id, db=db, branch=branch)
+            await car.delete(db=db)
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(db, branch, "TestCar", [_attr_element(schema, "nbr_seats")], [car_accord_main.id])
+
+        assert violations == []
+
+    async def test_changed_node_deleted_on_branch_is_ignored(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        branch: Branch,
+    ) -> None:
+        # a node in the changed set was deleted on the branch: the value it still holds on main
+        # must not be used, even though prius and camry still share it
+        car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+        await car.delete(db=db)
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(db, branch, "TestCar", [_attr_element(schema, "nbr_seats")], [car_accord_main.id])
+
+        assert violations == []
+
+    async def test_changed_nodes_collide_with_each_other(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        branch: Branch,
+    ) -> None:
+        # only accord and prius keep nbr_seats=5; both are changed and must report each other
+        await _update_car(db, branch, car_camry_main.id, nbr_seats=9)
+        schema = registry.schema.get("TestCar", branch=branch)
+
+        violations = await _run_query(
+            db, branch, "TestCar", [_attr_element(schema, "nbr_seats")], [car_accord_main.id, car_prius_main.id]
+        )
+
+        by_changed = {v.changed_uuid: v for v in violations}
+        assert set(by_changed) == {car_accord_main.id, car_prius_main.id}
+        assert by_changed[car_accord_main.id].partner_uuids == (car_prius_main.id,)
+        assert by_changed[car_prius_main.id].partner_uuids == (car_accord_main.id,)
+
+    async def test_peer_attribute_element_rejected(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        branch: Branch,
+    ) -> None:
+        car_schema = registry.schema.get("TestCar", branch=branch)
+        person_schema = registry.schema.get_node_schema("TestPerson", branch=branch)
+        peer_attribute_element = SchemaAttributePath(
+            relationship_schema=car_schema.get_relationship("owner"),
+            related_schema=person_schema,
+            attribute_schema=person_schema.get_attribute("height"),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"^owner__height is not supported for a targeted uniqueness check: "
+                r"attributes of related peers cannot be part of a uniqueness constraint$"
+            ),
+        ):
+            await TargetedUniquenessValidationQuery.init(
+                db=db,
+                branch=branch,
+                kind="TestCar",
+                constraint_elements=[peer_attribute_element],
+                node_uuids=[car_accord_main.id],
+            )
+
+    async def test_generic_kind_finds_collisions_across_implementations(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_person_generics_data_simple: dict[str, Node],
+    ) -> None:
+        # all three cars (two TestElectricCar, one TestGazCar) share nbr_seats=4; the query is
+        # anchored on the generic kind and one changed implementing node
+        data = car_person_generics_data_simple
+        schema = registry.schema.get("TestCar", branch=default_branch)
+
+        violations = await _run_query(
+            db, default_branch, "TestCar", [_attr_element(schema, "nbr_seats")], [data["c1"].id]
+        )
+
+        assert len(violations) == 1
+        assert violations[0].changed_uuid == data["c1"].id
+        assert set(violations[0].partner_uuids) == {data["c2"].id, data["c3"].id}
+        assert violations[0].element_values == (4,)

--- a/backend/tests/component/core/constraint_validators/test_uniqueness_dependent_resolver.py
+++ b/backend/tests/component/core/constraint_validators/test_uniqueness_dependent_resolver.py
@@ -1,0 +1,127 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolver
+from infrahub.database import InfrahubDatabase
+
+
+async def _owner_identifier(default_branch: Branch) -> str:
+    car_schema = registry.schema.get("TestCar", branch=default_branch)
+    return car_schema.get_relationship("owner").get_identifier()
+
+
+class TestUniquenessDependentResolver:
+    async def test_resolves_nodes_referencing_changed_peers(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_volt_main: Node,
+        car_prius_main: Node,
+        car_camry_main: Node,
+        person_john_main: Node,
+        default_branch: Branch,
+    ) -> None:
+        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+
+        dependents = await resolver.resolve(
+            node_kind="TestCar",
+            relationship_identifier=await _owner_identifier(default_branch),
+            peer_uuids=[person_john_main.id],
+        )
+
+        # the cars owned by john, and not those owned by anyone else
+        assert dependents == {car_accord_main.id, car_volt_main.id, car_prius_main.id}
+        assert car_camry_main.id not in dependents
+
+    async def test_empty_peer_uuids_returns_empty(
+        self, db: InfrahubDatabase, car_accord_main: Node, default_branch: Branch
+    ) -> None:
+        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+
+        dependents = await resolver.resolve(
+            node_kind="TestCar",
+            relationship_identifier=await _owner_identifier(default_branch),
+            peer_uuids=[],
+        )
+
+        assert dependents == set()
+
+    async def test_covers_default_branch_changes_made_after_the_branch_forked(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        person_john_main: Node,
+        default_branch: Branch,
+    ) -> None:
+        # fork a branch, THEN add a car on the default branch after the fork
+        feature_branch = await create_branch(branch_name="feature-branch", db=db)
+        car_schema = registry.schema.get_node_schema("TestCar", branch=default_branch, duplicate=False)
+        latecomer_car = await Node.init(db=db, schema=car_schema, branch=default_branch)
+        await latecomer_car.new(db=db, name="latecomer", nbr_seats=2, is_electric=False, owner=person_john_main.id)
+        await latecomer_car.save(db=db)
+
+        resolver = UniquenessDependentResolver(db=db, branch=feature_branch)
+
+        dependents = await resolver.resolve(
+            node_kind="TestCar",
+            relationship_identifier=await _owner_identifier(default_branch),
+            peer_uuids=[person_john_main.id],
+        )
+
+        # validation runs against the current default branch, so a relationship added to default after
+        # the fork is included even though the branch's own view predates it
+        assert latecomer_car.id in dependents
+        assert car_accord_main.id in dependents
+
+    async def test_post_fork_default_branch_deletion_excludes_when_branch_is_silent(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        person_john_main: Node,
+        default_branch: Branch,
+    ) -> None:
+        # after the fork, accord is deleted on the DEFAULT branch; the input branch never touches
+        # it, so the default branch's latest state decides and accord is excluded
+        input_branch = await create_branch(branch_name="silent-branch", db=db)
+        accord_on_main = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
+        await accord_on_main.delete(db=db)
+
+        resolver = UniquenessDependentResolver(db=db, branch=input_branch)
+
+        dependents = await resolver.resolve(
+            node_kind="TestCar",
+            relationship_identifier=await _owner_identifier(default_branch),
+            peer_uuids=[person_john_main.id],
+        )
+
+        assert car_accord_main.id not in dependents
+        assert car_prius_main.id in dependents
+
+    async def test_excludes_node_whose_relationship_is_deleted_on_input_branch(
+        self,
+        db: InfrahubDatabase,
+        car_accord_main: Node,
+        car_prius_main: Node,
+        person_john_main: Node,
+        default_branch: Branch,
+    ) -> None:
+        # accord's owner relationship is active on the default branch; delete it only on the input branch
+        input_branch = await create_branch(branch_name="delete-branch", db=db)
+        accord_on_branch = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=input_branch)
+        await accord_on_branch.delete(db=db)
+
+        resolver = UniquenessDependentResolver(db=db, branch=input_branch)
+
+        dependents = await resolver.resolve(
+            node_kind="TestCar",
+            relationship_identifier=await _owner_identifier(default_branch),
+            peer_uuids=[person_john_main.id],
+        )
+
+        # the input-branch deletion overrides the default branch (it is what the merge will
+        # produce), so accord is excluded; prius keeps its untouched relationship and stays
+        assert car_accord_main.id not in dependents
+        assert car_prius_main.id in dependents

--- a/backend/tests/unit/core/validators/test_node_diff_index.py
+++ b/backend/tests/unit/core/validators/test_node_diff_index.py
@@ -1,0 +1,75 @@
+import pytest
+
+from infrahub.core.diff.model.path import NodeDiffFieldSummary
+from infrahub.core.validators.node_diff_index import NodeDiffIndex
+
+
+def test_query_before_initialize_raises() -> None:
+    index = NodeDiffIndex()
+
+    match = r"^NodeDiffIndex must be initialized with initialize\(\) before its query methods are used$"
+    with pytest.raises(RuntimeError, match=match):
+        _ = index.kinds
+    with pytest.raises(RuntimeError, match=match):
+        index.has_attribute_diff(kind="TestCar", name="name")
+    with pytest.raises(RuntimeError, match=match):
+        index.has_relationship_diff(kind="TestCar", name="owner")
+    with pytest.raises(RuntimeError, match=match):
+        index.uuids_for_kinds({"TestCar"})
+
+
+def test_indexes_fields_and_uuids_per_kind() -> None:
+    index = NodeDiffIndex()
+    index.initialize(
+        [
+            NodeDiffFieldSummary(
+                kind="TestCar",
+                attribute_names={"name", "color"},
+                relationship_names={"owner"},
+                node_uuids={"c1", "c2"},
+            ),
+            NodeDiffFieldSummary(kind="TestPerson", attribute_names={"height"}, node_uuids={"p1"}),
+        ]
+    )
+
+    assert index.kinds == {"TestCar", "TestPerson"}
+    assert index.has_attribute_diff(kind="TestCar", name="name")
+    assert not index.has_attribute_diff(kind="TestCar", name="missing")
+    assert not index.has_attribute_diff(kind="Unknown", name="name")
+    assert index.has_relationship_diff(kind="TestCar", name="owner")
+    assert not index.has_relationship_diff(kind="TestPerson", name="owner")
+    assert index.uuids_for_kinds({"TestCar", "TestPerson"}) == {"c1", "c2", "p1"}
+    assert index.uuids_for_kinds({"Unknown"}) == set()
+
+
+def test_summaries_for_same_kind_are_merged() -> None:
+    index = NodeDiffIndex()
+    index.initialize(
+        [
+            NodeDiffFieldSummary(kind="TestCar", attribute_names={"name"}, node_uuids={"c1"}),
+            NodeDiffFieldSummary(kind="TestCar", attribute_names={"color"}, node_uuids={"c2"}),
+        ]
+    )
+
+    assert index.has_attribute_diff(kind="TestCar", name="name")
+    assert index.has_attribute_diff(kind="TestCar", name="color")
+    assert index.uuids_for_kinds({"TestCar"}) == {"c1", "c2"}
+
+
+def test_initialize_resets_prior_state() -> None:
+    index = NodeDiffIndex()
+    index.initialize([NodeDiffFieldSummary(kind="A", attribute_names={"x"}, node_uuids={"a1"})])
+    index.initialize([NodeDiffFieldSummary(kind="B", attribute_names={"y"}, node_uuids={"b1"})])
+
+    assert index.kinds == {"B"}
+    assert not index.has_attribute_diff(kind="A", name="x")
+    assert index.uuids_for_kinds({"A"}) == set()
+
+
+def test_empty_diff() -> None:
+    index = NodeDiffIndex()
+    index.initialize([])
+
+    assert index.kinds == set()
+    assert not index.has_attribute_diff(kind="A", name="x")
+    assert index.uuids_for_kinds({"A"}) == set()


### PR DESCRIPTION
# Why

When uniqueness validation fires from a data change (proposed-change checks, merges, rebases), the
`UniquenessChecker` scans the **entire population** of each implicated kind via
`NodeUniqueAttributeConstraintQuery` — cost tracks how many objects exist, not how many changed.
The scan also returns every population-wide duplicate (>100k rows on that dataset) for Python-side
post-processing, including violations that pre-date the change.

**Goal:** provide the query and component foundation to validate only the *changed* nodes: a
batched, index-anchored query whose cost tracks the size of the change, plus the pieces that
identify which nodes a data diff implicates.

**Non-goals:** this PR does not yet *wire* any of it. `UniquenessChecker` still runs the full scan;
the determiner does not yet emit changed-node uuids. The checker integration, the diff-side scoping,
and generic/implementation dedup are stacked follow-ups. Nothing in this PR changes runtime
behavior.

Part of IFC-2796. Later PR(s) will actually wire the changes into the tasks and test them.

## What changed

**Behavioral changes:** none — every addition is unused by production code paths in this PR.

**New pieces (grouped by role in the upcoming targeted path):**

- **`TargetedUniquenessValidationQuery`** (`validators/uniqueness/query/targeted_validation.py`) —
  one Cypher query per (kind, constraint group) validating ALL changed nodes against the full
  population in a single round trip. It resolves the first constraint element's value for the
  changed nodes only, probes the population for other nodes sharing it through the
  `AttributeValueIndexed`/`Node(uuid)` indexes, drops changed nodes with no match, and resolves each
  subsequent element only for the survivors — a changed node whose first element collides with
  nothing never has its remaining values read.
- **`AffectedUniquenessDependentsQuery` + `UniquenessDependentResolver`**
  (`query/affected_dependents.py`, `dependent_resolver.py`) — cross-kind resolution: when a
  constraint reads a peer's attribute (e.g. `owner__name`), a change to the *peer* kind implicates
  nodes of the constrained kind; this resolves the changed peers into those nodes. Each hop resolves
  to a single winner across the input/default/global branches (latest edge on the deepest branch),
  so a relationship deleted on the input branch excludes the node — matching what the merge will
  produce — while the default branch's post-fork state decides wherever the input branch is silent.
- **`NodeDiffIndex`** (`validators/node_diff_index.py`) — per-kind index over a data diff's changed
  attributes, relationships, and node uuids; `NodeDiffFieldSummary` gains the `node_uuids` field it
  reads.
- **Query package restructure:** `validators/uniqueness/query.py` moves to
  `validators/uniqueness/query/validation.py` inside a new package whose `__init__` re-exports
  everything — existing import paths are unchanged.

**Design decisions worth knowing:**

- Peer-attribute constraint elements (`owner__name`) are **rejected** by the targeted query
  (`ValueError`): schema updates disallow attributes-of-relationships in `uniqueness_constraints`
  today, so the targeted path never legitimately receives one.

**What stayed the same:** `NodeUniqueAttributeConstraintQuery` and `UniquenessValidationQuery` are
untouched (the latter still serves the node-save constraint in
`core/node/constraints/grouped_uniqueness.py`); `UniquenessChecker` behavior is unchanged; no DB
schema or migration changes.

# Performance

Regarding the new targeted uniqueness query, on a large local dataset (≈500k `DcimInterface` nodes),
a single uniqueness-constraints scan ran for 8+ minutes and then OOM-killed Neo4j. A sibling kind's
scan ran for 30 minutes before being killed.

Benchmarked against a large generated dataset (2%/5%-of-population change branches): the targeted
query validates 9,400 changed nodes of a 503k-node kind in ~12s and 23,500 in ~29s, where the
current full scan of the same kind ran 8.4 minutes before OOM-killing Neo4j (and >30 minutes on a
464k-node sibling kind before being killed). All 31 implicated kinds complete in ~32s / ~60s total.

## Impact & rollout

- **Backward compatibility:** no behavior change — additions only, plus an import-transparent file
  move. API contract unchanged.
- **Performance:** no actual changes in this PR.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry (deferred to the follow-up PR that wires the behavior change)
- [ ] External docs updated (n/a — no user-facing change yet)
- [ ] Internal .md docs updated (n/a)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds index-backed, node-scoped uniqueness validation that checks only changed nodes and their dependents instead of scanning all nodes. Supports IFC-2796 and reduces validation time on large kinds; honors branch visibility, post-fork default updates, and migrated-kind duplicates.

- **New Features**
  - `TargetedUniquenessValidationQuery` validates only given node UUIDs for one constraint, comparing attributes and 1:1 relationships while enforcing node liveness and branch visibility; supports large attribute types (no index), generic kinds across implementations, and ignores stale same-UUID duplicates from kind migrations.
  - Added `UniquenessDependentResolver` (uses `AffectedUniquenessDependentsQuery`) to resolve constrained nodes referencing changed peers; added `NodeDiffIndex` and extended `NodeDiffFieldSummary` with `node_uuids` to drive scoping.

- **Refactors**
  - Moved uniqueness queries under `core/validators/uniqueness/query` and re-exported to keep imports stable.
  - Fixed a value check so falsy attribute values compare correctly.

<sup>Written for commit 38e6b1c194ca92d1762903f4967690133f53a789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



