### PR TITLE
merge failure recovery small updates

### DIFF
--- a/backend/infrahub/core/merge/failure_identifier.py
+++ b/backend/infrahub/core/merge/failure_identifier.py
@@ -100,10 +100,13 @@ class MergeFailureIdentifier:
             await branch.save(db=self.db)
             registry.branch[branch.name] = branch
             await self.merge_write_blocker.set(branch=branch.name, state=MergeProtectionState.MERGE_FAILED)
+
+            worker_id = await self.merge_lock_holder()
             log.warning(
-                "Detected a failed merge; holding write protection until recovery",
+                "merge.failure.detected",
                 branch=branch.name,
                 merge_started_at=branch.merge_started_at,
+                worker_id=worker_id,
             )
             return branch.name
 

--- a/backend/tests/component/core/merge/conftest.py
+++ b/backend/tests/component/core/merge/conftest.py
@@ -9,6 +9,8 @@ from infrahub.core.merge.failure_recoverer import MergeFailureRecoverer
 from infrahub.core.merge.write_blocker import MergeWriteBlocker
 
 if TYPE_CHECKING:
+    import pytest
+
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
     from infrahub.services.component import InfrahubComponent
@@ -17,6 +19,20 @@ if TYPE_CHECKING:
 # Recovery finds the durably flagged branch directly, so the liveness grace period is irrelevant to
 # most tests; those that exercise the MERGING liveness gate override it per-call.
 GRACE_PERIOD_SECONDS = 180
+
+
+def find_logged_event(caplog: pytest.LogCaptureFixture, *, event: str, branch: str) -> dict | None:
+    """Return the structured payload of a captured log entry with the given event name and branch.
+
+    Structured logs are captured as the event dict on the record, so the returned mapping carries the
+    event's bound fields (worker id, timestamps, ...) for the caller to assert on. Returns ``None`` when
+    no matching entry was captured.
+    """
+    for record in caplog.records:
+        message = record.msg
+        if isinstance(message, dict) and message.get("event") == event and message.get("branch") == branch:
+            return message
+    return None
 
 
 class FailAtBranchResetRecoverer(MergeFailureRecoverer):

--- a/backend/tests/component/core/merge/test_failure_detection.py
+++ b/backend/tests/component/core/merge/test_failure_detection.py
@@ -16,6 +16,8 @@ from infrahub.worker import WORKER_IDENTITY
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
 
+from .conftest import find_logged_event
+
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
@@ -75,11 +77,13 @@ class TestFailureDetection:
         component: InfrahubComponent,
         merging_branch_for_10m: Branch,
         default_branch: Branch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         await cache.set(MERGE_LOCK_KEY, _lock_token(DEAD_WORKER))
         recovery = self._identifier(db, cache, component, default_branch)
 
-        flagged = await recovery.scan()
+        with caplog.at_level("WARNING", logger="infrahub"):
+            flagged = await recovery.scan()
 
         assert flagged == merging_branch_for_10m.name
         reloaded = await Branch.get_by_name(db=db, name=merging_branch_for_10m.name)
@@ -87,6 +91,11 @@ class TestFailureDetection:
         assert await MergeWriteBlocker(cache=cache).get() == MergeProtection(
             branch=merging_branch_for_10m.name, state=MergeProtectionState.MERGE_FAILED
         )
+        # Detection emits a structured entry an operator can locate by branch, carrying the dead worker.
+        logged = find_logged_event(caplog, event="merge.failure.detected", branch=merging_branch_for_10m.name)
+        assert logged is not None
+        assert logged["worker_id"] == DEAD_WORKER
+        assert logged["merge_started_at"] == merging_branch_for_10m.merge_started_at
 
     async def test_active_holder_is_not_flagged(
         self,

--- a/backend/tests/component/core/merge/test_recovery.py
+++ b/backend/tests/component/core/merge/test_recovery.py
@@ -27,6 +27,7 @@ from .conftest import (
     FailAtLockReleaseRecoverer,
     build_identifier,
     build_recovery,
+    find_logged_event,
 )
 
 if TYPE_CHECKING:
@@ -256,6 +257,7 @@ class TestRecovery:
         register_core_models_schema: SchemaBranch,
         cache: MemoryCache,
         component: InfrahubComponent,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         branch = Branch(
             name="recovery-failed-step",
@@ -275,7 +277,8 @@ class TestRecovery:
             cache=cache,
         )
 
-        report = await recovery.recover()
+        with caplog.at_level("ERROR", logger="infrahub"):
+            report = await recovery.recover()
 
         assert report.outcome == RecoveryOutcome.FAILED
         assert report.branch == branch.name
@@ -283,6 +286,8 @@ class TestRecovery:
         reloaded = await Branch.get_by_name(db=db, name=branch.name)
         assert reloaded.status == BranchStatus.MERGE_FAILED
         assert await blocker.get() == MergeProtection(branch=branch.name, state=MergeProtectionState.MERGE_FAILED)
+        # The failure is observable: a locatable entry records which branch's recovery failed.
+        assert find_logged_event(caplog, event="merge.recovery.failed", branch=branch.name) is not None
 
     async def test_lock_release_failure_holds_protection_and_lock(
         self,
@@ -403,6 +408,7 @@ class TestRecovery:
         register_core_models_schema: SchemaBranch,
         cache: MemoryCache,
         component: InfrahubComponent,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         branch = Branch(
             name="recovery-named-target",
@@ -415,13 +421,17 @@ class TestRecovery:
         await blocker.set(branch=branch.name, state=MergeProtectionState.MERGE_FAILED)
 
         recovery = build_recovery(db=db, cache=cache, component=component, default_branch=default_branch)
-        report = await recovery.recover(branch_name=branch.name)
+        with caplog.at_level("INFO", logger="infrahub"):
+            report = await recovery.recover(branch_name=branch.name)
 
         assert report.outcome == RecoveryOutcome.RECOVERED
         assert report.branch == branch.name
         reloaded = await Branch.get_by_name(db=db, name=branch.name)
         assert reloaded.status == BranchStatus.OPEN
         assert await blocker.get() is None
+        # A completed recovery brackets its work with locatable start and completion entries.
+        assert find_logged_event(caplog, event="merge.recovery.started", branch=branch.name) is not None
+        assert find_logged_event(caplog, event="merge.recovery.completed", branch=branch.name) is not None
 
     async def test_named_branch_that_is_not_recoverable_leaves_other_markers(
         self,

--- a/backend/tests/component/graphql/queries/test_branch.py
+++ b/backend/tests/component/graphql/queries/test_branch.py
@@ -8,6 +8,7 @@ from infrahub.auth.session import AccountSession
 from infrahub.core.branch import Branch
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.graphql.types import BranchType, InfrahubBranch
@@ -883,6 +884,45 @@ class TestBranchQuery(TestInfrahubApp):
         assert result.data
         branch_names = [edge["node"]["name"]["value"] for edge in result.data["InfrahubBranch"]["edges"]]
         assert "status-test-branch" not in branch_names
+
+    async def test_merge_failed_status_is_visible(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        service: InfrahubServices,
+    ) -> None:
+        """A branch left in MERGE_FAILED reports that state through normal branch inspection."""
+        branch = Branch(
+            name="merge-failed-branch",
+            status=BranchStatus.MERGE_FAILED,
+            branched_from=Timestamp().to_string(),
+        )
+        await branch.save(db=db)
+
+        query = """
+        query {
+            InfrahubBranch {
+                edges {
+                    node { name { value } status { value } }
+                }
+            }
+        }
+        """
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            root_value=None,
+        )
+
+        assert result.errors is None
+        assert result.data
+        statuses = {
+            edge["node"]["name"]["value"]: edge["node"]["status"]["value"]
+            for edge in result.data["InfrahubBranch"]["edges"]
+        }
+        assert statuses["merge-failed-branch"] == "MERGE_FAILED"
 
     async def test_filter_by_created_at_range(
         self,

--- a/dev/specs/ifc-2437-merge-failure-recovery/tasks.md
+++ b/dev/specs/ifc-2437-merge-failure-recovery/tasks.md
@@ -96,7 +96,7 @@ Infrahub backend monolith: `backend/infrahub/...`; tests under `backend/tests/{u
 - [X] T034 [US3] Integration-docker test (recovery half) in `backend/tests/integration_docker/test_merge_kill_recovery.py`: after `MERGE_FAILED`, `infrahub recover --yes` → default-branch writes succeed, branch re-merges (SC-009).
 - [ ] T035 [US3] **[ASK-FIRST]** Add RANGE `IndexItem` entries for edge `from`/`to` + a node `updated_at` index in `backend/infrahub/core/graph/index.py` (research R8). **Jira IFC-2715**.
 - [ ] T036 [US3] **[ASK-FIRST]** Add the graph migration creating the new indexes (under `backend/infrahub/core/migrations/graph/`), bumping the graph version. **Jira IFC-2715**.
-- [ ] T037 [US3] **[ASK-FIRST]** Update schema-migration queries that bump vertex `updated_at/by` (e.g. `core/migrations/schema/attribute_kind_update.py`, `core/migrations/query/attribute_add.py`, `node_duplicate.py`, `node_remove.py`, …) to co-write `previous_updated_at/by`, mirroring `DiffMergeMetadataQuery` (research R8). **Jira IFC-2716**.
+- [X] T037 [US3] **[ASK-FIRST]** Update schema-migration queries that bump vertex `updated_at/by` (e.g. `core/migrations/schema/attribute_kind_update.py`, `core/migrations/query/attribute_add.py`, `node_duplicate.py`, `node_remove.py`, …) to co-write `previous_updated_at/by`, mirroring `DiffMergeMetadataQuery` (research R8). **Jira IFC-2716**.
 - [X] T038 [US3] Add a changelog fragment for **`infrahub recover`** under `changelog/`.
 
 **Checkpoint**: An operator can fully recover a failed merge and re-merge; metadata is restored; recovery is idempotent.
@@ -111,11 +111,11 @@ Infrahub backend monolith: `backend/infrahub/...`; tests under `backend/tests/{u
 
 **Independent Test**: Force a failed merge then recover it; the `MERGE_FAILED` state is visible via branch inspection, and the failure and the recovery each produce a locatable structured log entry.
 
-- [ ] T039 [US4] Emit the `merge.failure.detected` **structured log entry** (branch, `merge_started_at`, proposed_change, worker_id, source) from `detect_and_mark` in `backend/infrahub/core/merge/failure_recovery.py` (FR-026).
-- [ ] T040 [US4] Emit `merge.recovery.started`/`completed`/`failed` **structured log entries** (not message-bus events — the CLI has no bus) from `recover()`/the CLI in `failure_recovery.py` + `backend/infrahub/cli/recover.py` (FR-027, contracts §9).
-- [ ] T041 [P] [US4] Functional test in `backend/tests/functional/merge/test_merge_failed_visibility.py`: `MERGE_FAILED` observable via branch inspection (GraphQL enum auto-exposed; SDK mirror from T011) (FR-025, US4 #1).
-- [ ] T042 [P] [US4] Functional test in `backend/tests/functional/merge/test_merge_recovery_logging.py`: detection and recovery each produce a log entry locatable by branch name (SC-011, US4 #2/#3).
-- [ ] T043 [US4] Add a changelog fragment for **failed/recovered-merge visibility** under `changelog/`.
+- [X] T039 [US4] Emit the `merge.failure.detected` **structured log entry** (branch, `merge_started_at`, proposed_change, worker_id, source) from `detect_and_mark` in `backend/infrahub/core/merge/failure_recovery.py` (FR-026).
+- [X] T040 [US4] Emit `merge.recovery.started`/`completed`/`failed` **structured log entries** (not message-bus events — the CLI has no bus) from `recover()`/the CLI in `failure_recovery.py` + `backend/infrahub/cli/recover.py` (FR-027, contracts §9).
+- [X] T041 [P] [US4] Component test in `backend/tests/component/graphql/queries/test_branch.py` (`test_merge_failed_status_is_visible`): `MERGE_FAILED` observable via branch inspection through the auto-exposed GraphQL enum (FR-025, US4 #1). Folded into the existing GraphQL branch-query test rather than a standalone functional test — the visibility contract is end-to-end GraphQL serialization of the enum value, which a component test exercises directly.
+- [X] T042 [P] [US4] Logging assertions folded into the existing component tests that already drive the behavior (no standalone functional test): `merge.failure.detected` in `backend/tests/component/core/merge/test_failure_detection.py`, and `merge.recovery.started`/`completed`/`failed` in `backend/tests/component/core/merge/test_recovery.py`, each locatable by branch name via the shared `find_logged_event` helper in that dir's `conftest.py` (SC-011, US4 #2/#3).
+- [X] T043 [US4] Add a changelog fragment for **failed/recovered-merge visibility** under `changelog/`.
 
 **Checkpoint**: The failed state and its resolution are observable.
 


### PR DESCRIPTION
- adds some more logging to merge failure recovery with tests
- graphql test for getting a MERGE_FAILED branch
- some final task updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured logging for merge failure detection and recovery, and verifies MERGE_FAILED is visible via GraphQL to support reliable recovery for IFC-2437. Also adds targeted tests and marks related spec tasks complete.

- **New Features**
  - Emit structured event "merge.failure.detected" with branch, merge_started_at, and worker_id when a stuck MERGING branch is marked MERGE_FAILED.
  - Ensure recovery logs "merge.recovery.started", "merge.recovery.completed", and "merge.recovery.failed"; covered by component tests via a shared log-capture helper.
  - GraphQL: MERGE_FAILED status is surfaced in InfrahubBranch queries; component test added.
  - Specs: mark US4 observability tasks as done and document test locations.

<sup>Written for commit 6c4c0abd96dd14c5ff5193033cd78123ab2e4700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

