### PR TITLE
chore(testcontainers): update cAdvisor to v0.60.5 and switch to ghcr.io

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
@@ -336,7 +336,7 @@ services:
     tty: true
 
   cadvisor:
-    image: "${CADVISOR_DOCKER_IMAGE:-gcr.io/cadvisor/cadvisor:v0.51.0}"
+    image: "${CADVISOR_DOCKER_IMAGE:-ghcr.io/google/cadvisor:v0.60.5}"
     command:
       - -disable_root_cgroup_stats=true
       - -docker_only=true

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -250,7 +250,7 @@ services:
     tty: true
 
   cadvisor:
-    image: "${CADVISOR_DOCKER_IMAGE:-gcr.io/cadvisor/cadvisor:v0.51.0}"
+    image: "${CADVISOR_DOCKER_IMAGE:-ghcr.io/google/cadvisor:v0.60.5}"
     command:
       - -disable_root_cgroup_stats=true
       - -docker_only=true

--- a/python_testcontainers/infrahub_testcontainers/prometheus.yml
+++ b/python_testcontainers/infrahub_testcontainers/prometheus.yml
@@ -6,7 +6,7 @@ scrape_configs:
   - job_name: 'infrahub-server'
     dns_sd_configs:
       - names:
-          - server
+          - infrahub-server
         type: A
         port: 8000
 


### PR DESCRIPTION
## Summary

Updates the default cAdvisor image in the testcontainers docker compose files to match the recent observability change in `stable` (commit `0a8499724`).

- `gcr.io/cadvisor/cadvisor:v0.51.0` → `ghcr.io/google/cadvisor:v0.60.5`

Applied to both:
- `python_testcontainers/infrahub_testcontainers/docker-compose.test.yml`
- `python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml`

The `CADVISOR_DOCKER_IMAGE` env override is preserved as the default value.

## Context

`gcr.io/cadvisor/cadvisor` is no longer the maintained registry; the observability stack already switched to `ghcr.io/google/cadvisor:v0.60.5`. This brings the testcontainers e2e stack in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch cAdvisor in testcontainers to `ghcr.io/google/cadvisor:v0.60.5` and fix Prometheus to scrape `infrahub-server`. Updates both docker-compose files and `prometheus.yml`; the `CADVISOR_DOCKER_IMAGE` override remains supported.

<sup>Written for commit 49951753a5770b9a30855fc121ad61a744011c53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/9998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

