### PR TITLE
fix(backend): delete an account's Preference row on account deletion (IFC-2867)

### DIFF
--- a/backend/infrahub/core/preferences/models.py
+++ b/backend/infrahub/core/preferences/models.py
@@ -17,10 +17,10 @@ class Preference(StandardNode):
     client's built-in default).
 
     `owner_id` is a plain string, not a graph relationship: a StandardNode cannot declare a schema
-    relationship with `on_delete: cascade` (that is a schema-Node feature), so the schema cannot
-    cascade a Preference row when its account is deleted. Instead the account-delete mutation drops
-    the row explicitly (IFC-2867). A row orphaned by a deletion that bypasses the mutation stays
-    benign: account ids are UUIDs and never reused, so it is permanently unreachable.
+    relationship with `on_delete: cascade` (that is a schema-Node feature), so account deletion
+    cannot cascade to the Preference row through the schema and deletes it explicitly instead. A row
+    orphaned by a deletion path that skips that cleanup stays benign: account ids are UUIDs and
+    never reused, so it is permanently unreachable.
     """
 
     owner_id: str

--- a/backend/infrahub/core/preferences/models.py
+++ b/backend/infrahub/core/preferences/models.py
@@ -17,10 +17,10 @@ class Preference(StandardNode):
     client's built-in default).
 
     `owner_id` is a plain string, not a graph relationship: a StandardNode cannot declare a schema
-    relationship with `on_delete: cascade` (that is a schema-Node feature), so deleting an account
-    leaves its Preference row behind as unreachable dead data. Account ids are UUIDs and never reused,
-    so such a row is permanently unreachable and benign. Cleanup is out of scope for V1 and tracked in
-    Jira (IFC-2867).
+    relationship with `on_delete: cascade` (that is a schema-Node feature), so the schema cannot
+    cascade a Preference row when its account is deleted. Instead the account-delete mutation drops
+    the row explicitly (IFC-2867). A row orphaned by a deletion that bypasses the mutation stays
+    benign: account ids are UUIDs and never reused, so it is permanently unreachable.
     """
 
     owner_id: str

--- a/backend/infrahub/core/preferences/repository.py
+++ b/backend/infrahub/core/preferences/repository.py
@@ -52,3 +52,11 @@ class PreferenceRepository:
     async def save(self, preference: Preference, actor_id: str = SYSTEM_USER_ID) -> None:
         """Persist the preference, creating the row on first write or updating it in place."""
         await preference.save(db=self.db, user_id=actor_id)
+
+    async def delete_for_owner(self, owner_id: str) -> None:
+        """Delete every Preference row owned by `owner_id`; a no-op when there is none."""
+        query = await PreferenceGetByOwnerQuery.init(db=self.db, owner_ids={owner_id})
+        await query.execute(db=self.db)
+
+        for preference in query.get_preferences():
+            await preference.delete(db=self.db)

--- a/backend/infrahub/core/preferences/repository.py
+++ b/backend/infrahub/core/preferences/repository.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.constants import SYSTEM_USER_ID
-from infrahub.core.query.preference import PreferenceGetAllQuery, PreferenceGetByOwnerQuery
+from infrahub.core.query.preference import (
+    PreferenceDeleteByOwnerQuery,
+    PreferenceGetAllQuery,
+    PreferenceGetByOwnerQuery,
+)
 
 if TYPE_CHECKING:
     from infrahub.core.preferences.models import Preference
@@ -55,8 +59,5 @@ class PreferenceRepository:
 
     async def delete_for_owner(self, owner_id: str) -> None:
         """Delete every Preference row owned by `owner_id`; a no-op when there is none."""
-        query = await PreferenceGetByOwnerQuery.init(db=self.db, owner_ids={owner_id})
+        query = await PreferenceDeleteByOwnerQuery.init(db=self.db, owner_id=owner_id)
         await query.execute(db=self.db)
-
-        for preference in query.get_preferences():
-            await preference.delete(db=self.db)

--- a/backend/infrahub/core/query/preference.py
+++ b/backend/infrahub/core/query/preference.py
@@ -83,7 +83,6 @@ class PreferenceGetByOwnerQuery(PreferenceReadQuery):
         # Cypher parameters cannot bind a set, so pass the ids as a list.
         self.params["owner_ids"] = list(self.owner_ids)
 
-        # The label is the Preference StandardNode type name (Cypher labels can't be parameterised).
         query = """
         MATCH (n:Preference)
         WHERE n.owner_id IN $owner_ids
@@ -106,7 +105,6 @@ class PreferenceDeleteByOwnerQuery(StandardNodeQuery):
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["owner_id"] = self.owner_id
 
-        # The label is the Preference StandardNode type name (Cypher labels can't be parameterised).
         query = """
         MATCH (n:Preference { owner_id: $owner_id })
         DETACH DELETE n
@@ -120,7 +118,6 @@ class PreferenceGetAllQuery(PreferenceReadQuery):
     name = "preference_get_all"
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
-        # The label is the Preference StandardNode type name (Cypher labels can't be parameterised).
         query = """
         MATCH (n:Preference)
         """

--- a/backend/infrahub/core/query/preference.py
+++ b/backend/infrahub/core/query/preference.py
@@ -92,6 +92,28 @@ class PreferenceGetByOwnerQuery(PreferenceReadQuery):
         self._set_return_shape()
 
 
+class PreferenceDeleteByOwnerQuery(StandardNodeQuery):
+    """Delete every Preference row owned by one owner, in ONE query (no fetch-then-delete-each)."""
+
+    name = "preference_delete_by_owner"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(self, owner_id: str, **kwargs: Any) -> None:
+        self.owner_id = owner_id
+        super().__init__(**kwargs)
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params["owner_id"] = self.owner_id
+
+        # The label is the Preference StandardNode type name (Cypher labels can't be parameterised).
+        query = """
+        MATCH (n:Preference { owner_id: $owner_id })
+        DETACH DELETE n
+        """
+        self.add_to_query(query=query)
+
+
 class PreferenceGetAllQuery(PreferenceReadQuery):
     """Fetch every Preference row, across all owners."""
 

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -11,6 +11,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.order import OrderModel
+from infrahub.core.preferences.repository import PreferenceRepository
 from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
 from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
@@ -18,11 +19,14 @@ from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.mutations.main import DeleteResult, InfrahubMutationMixin, InfrahubMutationOptions
+from infrahub.log import get_logger
 
 from ..types import InfrahubObjectType
 
 if TYPE_CHECKING:
     from ..initialization import GraphqlContext
+
+log = get_logger()
 
 
 class InfrahubAccountTokenCreateInput(InputObjectType):
@@ -220,4 +224,16 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
         if graphql_context.account_session and obj.id == graphql_context.account_session.authenticating_account_id:
             raise ValidationError(input_value="Cannot delete your own account")
 
-        return await super().mutate_delete(info=info, data=data, branch=branch)
+        result = await super().mutate_delete(info=info, data=data, branch=branch)
+
+        # Accounts are branch-agnostic, so the deletion is effective everywhere at once; drop the
+        # account's Preference row (a StandardNode keyed by owner_id, which cannot cascade via the
+        # schema) instead of leaving it behind as unreachable dead data (IFC-2867). Best-effort: the
+        # account is already deleted, so a cleanup failure must not fail the mutation — the orphaned
+        # row is benign (account ids are UUIDs and never reused, so it stays unreachable).
+        try:
+            await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)
+        except Exception as exc:
+            log.warning(f"Failed to delete the Preference row of deleted account {obj.id}: {exc}")
+
+        return result

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -5,12 +5,14 @@ from graphql import GraphQLResolveInfo
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
+from infrahub import lock
 from infrahub.auth.types import AuthType
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.order import OrderModel
+from infrahub.core.preferences.constants import PREFERENCE_LOCK_NAMESPACE
 from infrahub.core.preferences.repository import PreferenceRepository
 from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
 from infrahub.core.schema import NodeSchema
@@ -228,11 +230,14 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
 
         # Accounts are branch-agnostic, so the deletion is effective everywhere at once; drop the
         # account's Preference row (a StandardNode keyed by owner_id, which cannot cascade via the
-        # schema) instead of leaving it behind as unreachable dead data (IFC-2867). Best-effort: the
-        # account is already deleted, so a cleanup failure must not fail the mutation — the orphaned
-        # row is benign (account ids are UUIDs and never reused, so it stays unreachable).
+        # schema) instead of leaving it behind as unreachable dead data (IFC-2867). The per-owner
+        # preference lock serialises this with InfrahubSetPreferences' read-modify-write, so an
+        # in-flight upsert cannot resurrect the row mid-delete. Best-effort: the account is already
+        # deleted, so a cleanup failure must not fail the mutation — the orphaned row is benign
+        # (account ids are UUIDs and never reused, so it stays unreachable).
         try:
-            await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)
+            async with lock.registry.get(name=obj.id, namespace=PREFERENCE_LOCK_NAMESPACE, local=False):
+                await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)
         except Exception as exc:
             log.warning(f"Failed to delete the Preference row of deleted account {obj.id}: {exc}")
 

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -236,10 +236,8 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
 
         result = await super().mutate_delete(info=info, data=data, branch=branch)
 
-        # Drop the account's Preference row (no schema cascade for StandardNodes — see the
-        # Preference docstring, IFC-2867). The lock serialises with InfrahubSetPreferences'
-        # read-then-save so an in-flight upsert cannot re-create the row. Best-effort: the account
-        # is already deleted, so a cleanup failure only logs (the orphaned row is benign).
+        # Best-effort Preference cleanup: the shared per-owner lock keeps an in-flight preference
+        # upsert from re-creating the row, and a failure only logs (the orphaned row is benign).
         try:
             async with lock.registry.get(name=obj.id, namespace=PREFERENCE_LOCK_NAMESPACE, local=False):
                 await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -236,14 +236,10 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
 
         result = await super().mutate_delete(info=info, data=data, branch=branch)
 
-        # Accounts are branch-agnostic, so the deletion is effective everywhere at once; drop the
-        # account's Preference row (a StandardNode keyed by owner_id, which cannot cascade via the
-        # schema) instead of leaving it behind as unreachable dead data (IFC-2867). The per-owner
-        # preference lock is required because InfrahubSetPreferences upserts under it as a
-        # read-then-save: without the lock this delete can run between that read and save, and the
-        # save re-creates the row for the just-deleted account — a permanent orphan. Best-effort:
-        # the account is already deleted, so a cleanup failure must not fail the mutation — the
-        # orphaned row is benign (account ids are UUIDs and never reused, so it stays unreachable).
+        # Drop the account's Preference row (no schema cascade for StandardNodes — see the
+        # Preference docstring, IFC-2867). The lock serialises with InfrahubSetPreferences'
+        # read-then-save so an in-flight upsert cannot re-create the row. Best-effort: the account
+        # is already deleted, so a cleanup failure only logs (the orphaned row is benign).
         try:
             async with lock.registry.get(name=obj.id, namespace=PREFERENCE_LOCK_NAMESPACE, local=False):
                 await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any
 from graphene import Boolean, Field, InputField, InputObjectType, Mutation, ObjectType, String
 from graphql import GraphQLResolveInfo
 from infrahub_sdk.uuidt import UUIDT
+from neo4j.exceptions import DriverError, Neo4jError
+from redis.exceptions import RedisError
 from typing_extensions import Self
 
 from infrahub import lock
@@ -18,7 +20,7 @@ from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
 from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, retry_db_transaction
-from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError, ValidationError
+from infrahub.exceptions import DatabaseError, NodeNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.mutations.main import DeleteResult, InfrahubMutationMixin, InfrahubMutationOptions
 from infrahub.log import get_logger
@@ -231,14 +233,15 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
         # Accounts are branch-agnostic, so the deletion is effective everywhere at once; drop the
         # account's Preference row (a StandardNode keyed by owner_id, which cannot cascade via the
         # schema) instead of leaving it behind as unreachable dead data (IFC-2867). The per-owner
-        # preference lock serialises this with InfrahubSetPreferences' read-modify-write, so an
-        # in-flight upsert cannot resurrect the row mid-delete. Best-effort: the account is already
-        # deleted, so a cleanup failure must not fail the mutation — the orphaned row is benign
-        # (account ids are UUIDs and never reused, so it stays unreachable).
+        # preference lock is required because InfrahubSetPreferences upserts under it as a
+        # read-then-save: without the lock this delete can run between that read and save, and the
+        # save re-creates the row for the just-deleted account — a permanent orphan. Best-effort:
+        # the account is already deleted, so a cleanup failure must not fail the mutation — the
+        # orphaned row is benign (account ids are UUIDs and never reused, so it stays unreachable).
         try:
             async with lock.registry.get(name=obj.id, namespace=PREFERENCE_LOCK_NAMESPACE, local=False):
                 await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)
-        except Exception as exc:
+        except (DatabaseError, DriverError, Neo4jError, RedisError) as exc:
             log.warning(f"Failed to delete the Preference row of deleted account {obj.id}: {exc}")
 
         return result

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -20,7 +20,13 @@ from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
 from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, retry_db_transaction
-from infrahub.exceptions import DatabaseError, NodeNotFoundError, PermissionDeniedError, ValidationError
+from infrahub.exceptions import (
+    DatabaseError,
+    NodeNotFoundError,
+    PermissionDeniedError,
+    QueryTimeoutError,
+    ValidationError,
+)
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.mutations.main import DeleteResult, InfrahubMutationMixin, InfrahubMutationOptions
 from infrahub.log import get_logger
@@ -241,7 +247,7 @@ class InfrahubAccountMutation(InfrahubMutationMixin, Mutation):
         try:
             async with lock.registry.get(name=obj.id, namespace=PREFERENCE_LOCK_NAMESPACE, local=False):
                 await PreferenceRepository(db=graphql_context.db).delete_for_owner(owner_id=obj.id)
-        except (DatabaseError, DriverError, Neo4jError, RedisError) as exc:
+        except (DatabaseError, QueryTimeoutError, DriverError, Neo4jError, RedisError) as exc:
             log.warning(f"Failed to delete the Preference row of deleted account {obj.id}: {exc}")
 
         return result

--- a/backend/tests/component/core/test_preference_repository.py
+++ b/backend/tests/component/core/test_preference_repository.py
@@ -81,3 +81,25 @@ async def test_get_all_returns_rows_for_all_owners(db: InfrahubDatabase, default
 
     all_rows = await repository.get_all()
     assert {preference.owner_id for preference in all_rows} == {"owner-a", "owner-b", GLOBAL_OWNER_ID}
+
+
+async def test_delete_for_owner_removes_only_that_owners_row(db: InfrahubDatabase, default_branch: Branch) -> None:
+    repository = PreferenceRepository(db=db)
+    await repository.save(Preference(owner_id="owner-a", timezone="Europe/Paris"))
+    await repository.save(Preference(owner_id="owner-b", date_format="ISO_DATETIME"))
+    await repository.save(Preference(owner_id=GLOBAL_OWNER_ID, timezone="UTC"))
+
+    await repository.delete_for_owner(owner_id="owner-a")
+
+    # Only owner-a's row is gone; the other owner's row and the global row are untouched.
+    assert await repository.get_for_owner(owner_id="owner-a") is None
+    assert {preference.owner_id for preference in await repository.get_all()} == {"owner-b", GLOBAL_OWNER_ID}
+
+
+async def test_delete_for_owner_is_a_noop_when_no_row_exists(db: InfrahubDatabase, default_branch: Branch) -> None:
+    repository = PreferenceRepository(db=db)
+    await repository.save(Preference(owner_id="owner-a", timezone="Europe/Paris"))
+
+    await repository.delete_for_owner(owner_id="owner-absent")
+
+    assert {preference.owner_id for preference in await repository.get_all()} == {"owner-a"}

--- a/backend/tests/component/graphql/test_core_account.py
+++ b/backend/tests/component/graphql/test_core_account.py
@@ -7,6 +7,9 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.preferences.constants import GLOBAL_OWNER_ID
+from infrahub.core.preferences.models import Preference
+from infrahub.core.preferences.repository import PreferenceRepository
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
@@ -265,3 +268,41 @@ async def test_admin_cannot_delete_own_account(
 
     assert result.errors
     assert str(result.errors[0].message) == "Cannot delete your own account"
+
+
+async def test_account_delete_also_deletes_its_preference_row(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_permission_backend: None,
+    authentication_base: None,
+    session_admin: AccountSession,
+    first_account: Node,
+) -> None:
+    repository = PreferenceRepository(db=db)
+    await repository.save(Preference(owner_id=first_account.id, timezone="Europe/Paris"))
+    await repository.save(Preference(owner_id=GLOBAL_OWNER_ID, timezone="UTC"))
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db,
+        branch=default_branch,
+        account_session=session_admin,
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CORE_ACCOUNT_DELETE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": first_account.id},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["CoreAccountDelete"]["ok"] is True
+
+    # The deleted account's row is gone; the global row is untouched.
+    assert await repository.get_for_owner(owner_id=first_account.id) is None
+    global_row = await repository.get_for_owner(owner_id=GLOBAL_OWNER_ID)
+    assert global_row is not None
+    assert global_row.timezone == "UTC"

--- a/backend/tests/component/graphql/test_core_account.py
+++ b/backend/tests/component/graphql/test_core_account.py
@@ -281,6 +281,9 @@ async def test_account_delete_also_deletes_its_preference_row(
     repository = PreferenceRepository(db=db)
     await repository.save(Preference(owner_id=first_account.id, timezone="Europe/Paris"))
     await repository.save(Preference(owner_id=GLOBAL_OWNER_ID, timezone="UTC"))
+    # Guard against a silently failing save: the delete assertion below is only meaningful if the
+    # row actually existed before the mutation.
+    assert await repository.get_for_owner(owner_id=first_account.id) is not None
 
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(

--- a/changelog/+ifc-2867.fixed.md
+++ b/changelog/+ifc-2867.fixed.md
@@ -1,0 +1,1 @@
+Deleting an account now also deletes its stored user preferences instead of leaving them behind as unreachable data.

--- a/changelog/+ifc-2867.fixed.md
+++ b/changelog/+ifc-2867.fixed.md
@@ -1,1 +1,0 @@
-Deleting an account now also deletes its stored user preferences instead of leaving them behind as unreachable data.

--- a/dev/knowledge/backend/preferences.md
+++ b/dev/knowledge/backend/preferences.md
@@ -114,7 +114,7 @@ source.
 
 - **Orphan rows.** A `StandardNode` cannot declare an `on_delete: cascade` schema relationship, so
   the schema cannot cascade a `Preference` row when its account is deleted. Instead the account-delete
-  mutation drops the row explicitly, best-effort and under the per-owner preference lock (IFC-2867).
+  mutation drops the row explicitly, best-effort and under the per-owner preference lock.
   A deletion path that bypasses the mutation still leaves the row behind; that orphan is benign:
   account ids are UUIDs and are never reused, so it is permanently unreachable.
 - **`Optional[X]` on the model.** Persisted nullable fields use `Optional[X]` rather than `X | None`

--- a/dev/knowledge/backend/preferences.md
+++ b/dev/knowledge/backend/preferences.md
@@ -78,6 +78,11 @@ The read-modify-write runs inside a per-owner distributed lock keyed on `owner_i
 observe "no row" and create a duplicate, and concurrent updates could lose writes. The read runs
 inside the lock so it observes any in-flight write for the same owner. Distinct owners never contend.
 
+This lock is an invariant, not an implementation detail of the upsert: **every path that mutates
+Preference rows — deletes included — must acquire the same per-owner lock**, because a mutation
+running outside it can interleave with the read-then-save above (e.g. a delete slipping between the
+read and the save gets silently undone by the save).
+
 ## Permissions
 
 | Path | Requirement |

--- a/dev/knowledge/backend/preferences.md
+++ b/dev/knowledge/backend/preferences.md
@@ -108,7 +108,9 @@ source.
 ## Caveats
 
 - **Orphan rows.** A `StandardNode` cannot declare an `on_delete: cascade` schema relationship, so
-  deleting an account leaves its `Preference` row behind. Account ids are UUIDs and are never reused,
-  so the row is permanently unreachable and benign. Cleanup is out of scope for V1 (tracked in Jira).
+  the schema cannot cascade a `Preference` row when its account is deleted. Instead the account-delete
+  mutation drops the row explicitly, best-effort and under the per-owner preference lock (IFC-2867).
+  A deletion path that bypasses the mutation still leaves the row behind; that orphan is benign:
+  account ids are UUIDs and are never reused, so it is permanently unreachable.
 - **`Optional[X]` on the model.** Persisted nullable fields use `Optional[X]` rather than `X | None`
   because of how `StandardNode.guess_field_type` works on Python before 3.14.


### PR DESCRIPTION
## Summary

Follow-up from the user/global preferences work (IFC-2718): a `Preference` is a `StandardNode` keyed by a plain-string `owner_id`, so the schema cannot cascade it with `on_delete: cascade` when its account is deleted — the row was left behind as unreachable dead data.

This hooks the account-delete mutation to drop the row explicitly (ticket option 1, the cleanup hook). Accounts are branch-agnostic, so the deletion is effective everywhere at once and the hook needs no branch condition.

## Changes

- `PreferenceRepository.delete_for_owner(owner_id)` — deletes every Preference row for an owner; no-op when there is none.
- `InfrahubAccountMutation.mutate_delete` — after the account delete succeeds, drops the account's Preference row. Best-effort: a cleanup failure logs a warning instead of failing the mutation (the account is already gone, and the orphan stays benign since account ids are UUIDs and never reused).
- Updated the `Preference` docstring, which pointed at IFC-2867 as the tracking ticket.
- Changelog fragment.

## Tests

- Component (repository): `delete_for_owner` removes only the target owner's row (other owners + global row untouched); no-op when no row exists.
- Component (GraphQL): `CoreAccountDelete` removes the deleted account's Preference row and leaves the global row untouched.
- Ran locally: ruff, mypy, preference unit tests, and both component test files (14 passed).

Jira: [IFC-2867](https://opsmill.atlassian.net/browse/IFC-2867)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-2867]: https://opsmill.atlassian.net/browse/IFC-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes an account’s `Preference` row when the account is deleted to prevent orphaned data. Global preferences stay untouched. (IFC-2867)

- **Bug Fixes**
  - Added `PreferenceRepository.delete_for_owner(owner_id)` using a single-query `PreferenceDeleteByOwnerQuery` (`DETACH DELETE` by `owner_id`).
  - Updated `CoreAccountDelete` to run cleanup under the per-owner preference lock; on failure catch `DatabaseError`, `QueryTimeoutError`, `DriverError`, `Neo4jError`, and `RedisError`, log, and do not fail. Trimmed comments, removed ticket IDs, and dropped the unreleased changelog fragment.

<sup>Written for commit 63cbee95976b742011753aaf23d2d9dc1952d59f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

