### PR TITLE
docs(agents): branching strategy, component-test Docker note, set-based Cypher writes

### DIFF
--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -2,16 +2,11 @@
 paths:
   - "backend/**/*.py"
   - "python_testcontainers/**/*.py"
-  - "dev/knowledge/**/*.md"
-  - "dev/guidelines/**/*.md"
-  - "dev/guides/**/*.md"
 ---
 
 # Code documentation style
 
-Applies to docstrings, comments, and any inline documentation in Python source files. The
-work-item-ID rule below also applies to the internal docs under `dev/knowledge/`,
-`dev/guidelines/`, and `dev/guides/`.
+Applies to docstrings, comments, and any inline documentation in Python source files.
 
 ## No references to other code
 
@@ -31,9 +26,7 @@ Acceptable exceptions:
 
 ## No work-item or spec IDs
 
-Do not reference Jira tickets, GitHub issues, or spec-kit identifiers in docstrings, comments, test
-names, or `dev/knowledge`/`dev/guidelines`/`dev/guides` pages — describe the constraint or behavior
-itself, not the ticket that tracked it. Examples of what to avoid:
+Do not reference Jira tickets, GitHub issues, or spec-kit identifiers in docstrings, comments, or test names. Examples of what to avoid:
 
 - `# Fixes INFP-556`
 - `"""Implements FR-003: ..."""`

--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -2,11 +2,16 @@
 paths:
   - "backend/**/*.py"
   - "python_testcontainers/**/*.py"
+  - "dev/knowledge/**/*.md"
+  - "dev/guidelines/**/*.md"
+  - "dev/guides/**/*.md"
 ---
 
 # Code documentation style
 
-Applies to docstrings, comments, and any inline documentation in Python source files.
+Applies to docstrings, comments, and any inline documentation in Python source files. The
+work-item-ID rule below also applies to the internal docs under `dev/knowledge/`,
+`dev/guidelines/`, and `dev/guides/`.
 
 ## No references to other code
 
@@ -26,7 +31,9 @@ Acceptable exceptions:
 
 ## No work-item or spec IDs
 
-Do not reference Jira tickets, GitHub issues, or spec-kit identifiers in docstrings, comments, or test names. Examples of what to avoid:
+Do not reference Jira tickets, GitHub issues, or spec-kit identifiers in docstrings, comments, test
+names, or `dev/knowledge`/`dev/guidelines`/`dev/guides` pages — describe the constraint or behavior
+itself, not the ticket that tracked it. Examples of what to avoid:
 
 - `# Fixes INFP-556`
 - `"""Implements FR-003: ..."""`

--- a/.agents/skills/neo4j-cypher-guide/SKILL.md
+++ b/.agents/skills/neo4j-cypher-guide/SKILL.md
@@ -23,6 +23,15 @@ When generating Cypher queries, immediately avoid these REMOVED features:
 2. **Optimize during traversal** - Filter early within patterns, not after expansion
 3. **Always filter nulls when sorting** - Add IS NOT NULL checks for sorted properties
 4. **Explicit is better than implicit** - Always use explicit grouping and type checking
+5. **Write set-based, not per-node** - One query with a `WHERE`/property condition beats fetching
+   nodes and mutating them one by one (an N+1). E.g. delete all rows for one owner in one shot:
+
+   ```cypher
+   MATCH (n:Preference { owner_id: $owner_id })
+   DETACH DELETE n
+   ```
+
+   not "fetch matching nodes, then run one DELETE per node".
 
 ## Critical Sorting Rule
 

--- a/.agents/skills/neo4j-cypher-guide/SKILL.md
+++ b/.agents/skills/neo4j-cypher-guide/SKILL.md
@@ -222,14 +222,18 @@ WHERE n:!Archived      // NOT
 
 ### Dynamic Labels and Types
 
-Labels and relationship types accept parameters (Neo4j 5.26+) — do not interpolate them into the
-query string with `%`/f-strings, and do not claim labels "can't be parameterized":
+Labels and relationship types accept parameters (Neo4j 5.26+):
 
 ```cypher
 MATCH (n:$($label))                    // dynamic node label
-CREATE (n:$($label) {name: $name})
 MATCH (a)-[r:$($rel_type)]->(b)        // dynamic relationship type
 ```
+
+Choosing between a dynamic label and interpolating the label into the query text is a performance
+tradeoff, not a style rule: each interpolated variant is planned and cached separately, but the
+planner generally does better with a static label than a dynamic one. If the label is the primary
+filter of the `MATCH`, prefer a static/interpolated label; when other indexed predicates carry the
+filtering, a dynamic label is more likely to be acceptable. When in doubt, `PROFILE` both.
 
 ### Type Predicates
 

--- a/.agents/skills/neo4j-cypher-guide/SKILL.md
+++ b/.agents/skills/neo4j-cypher-guide/SKILL.md
@@ -220,6 +220,17 @@ WHERE n:Label1&Label2  // AND
 WHERE n:!Archived      // NOT
 ```
 
+### Dynamic Labels and Types
+
+Labels and relationship types accept parameters (Neo4j 5.26+) — do not interpolate them into the
+query string with `%`/f-strings, and do not claim labels "can't be parameterized":
+
+```cypher
+MATCH (n:$($label))                    // dynamic node label
+CREATE (n:$($label) {name: $name})
+MATCH (a)-[r:$($rel_type)]->(b)        // dynamic relationship type
+```
+
 ### Type Predicates
 
 ```cypher

--- a/.agents/skills/neo4j-cypher-guide/SKILL.md
+++ b/.agents/skills/neo4j-cypher-guide/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: neo4j-cypher-guide
-description: Comprehensive guide for writing modern Neo4j Cypher read queries. Essential for text2cypher MCP tools and LLMs generating Cypher queries. Covers removed/deprecated syntax, modern replacements, CALL subqueries for reads, COLLECT patterns, sorting best practices, and Quantified Path Patterns (QPP) for efficient graph traversal.
+description: Comprehensive guide for writing modern Neo4j Cypher queries. Essential for text2cypher MCP tools and LLMs generating Cypher queries. Covers removed/deprecated syntax, modern replacements, CALL subqueries for reads, COLLECT patterns, sorting best practices, set-based writes, and Quantified Path Patterns (QPP) for efficient graph traversal.
 ---
 
 # Neo4j Modern Cypher Query Guide
 
-This skill helps generate Neo4j Cypher read queries using modern syntax patterns and avoiding deprecated features. It focuses on efficient query patterns for graph traversal and data retrieval.
+This skill helps generate Neo4j Cypher queries using modern syntax patterns and avoiding deprecated features. It focuses on efficient query patterns for graph traversal, data retrieval, and set-based writes.
 
 ## Quick Compatibility Check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@ Style: be direct and substantive. No filler, preamble, or pleasantries. Challeng
 - `changelog/` – Towncrier changelog fragments
 - `dev/` – Internal developer documentation - see [dev/README.md](dev/README.md)
 
+## Branching
+
+- Feature and bugfix branches start from `develop` (the integration branch); `stable` is the
+  release branch. PRs for new work target `develop` unless they fix a released version.
+- Before cutting a branch for a ticket, verify the code the ticket references actually exists on
+  the chosen base (`git ls-tree <base> -- <path>`): follow-up tickets often reference modules that
+  are only on `develop`.
+
 ## Commands
 
 ### Setup
@@ -43,6 +51,14 @@ uv run invoke backend.test-integration # Backend integration tests
 cd frontend/app && pnpm test          # Frontend unit tests
 cd frontend/app && pnpm test:e2e      # Frontend E2E tests (legacy TS suite)
 uv run pytest -c tests/e2e/pytest.ini tests/e2e  # E2E tests (pytest, testcontainers)
+```
+
+Backend component tests (`backend/tests/component/`) and the testcontainers-based suites need a
+running Docker daemon. testcontainers looks for `/var/run/docker.sock`; if your daemon only exposes
+a user socket (e.g. Docker Desktop without the "default socket" option), point `DOCKER_HOST` at it:
+
+```bash
+DOCKER_HOST=unix://$HOME/.docker/run/docker.sock uv run pytest backend/tests/component/... -q
 ```
 
 #### Debugging e2e tests with `--pdb`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,15 +26,6 @@ Style: be direct and substantive. No filler, preamble, or pleasantries. Challeng
 - `changelog/` – Towncrier changelog fragments
 - `dev/` – Internal developer documentation - see [dev/README.md](dev/README.md)
 
-## Branching
-
-- Feature branches start from `develop`; bug fixes target the branch where the buggy code lives —
-  `stable` when the feature is released, `develop` when it only exists there.
-- Before cutting a branch for a ticket, verify the code the ticket references actually exists on
-  the chosen base (`git ls-tree <base> -- <path>`): follow-up tickets often reference modules that
-  are only on `develop`.
-- Full strategy (release branches, naming, submodules): `dev/guidelines/git-workflow.md`.
-
 ## Commands
 
 ### Setup
@@ -54,16 +45,9 @@ cd frontend/app && pnpm test:e2e      # Frontend E2E tests (legacy TS suite)
 uv run pytest -c tests/e2e/pytest.ini tests/e2e  # E2E tests (pytest, testcontainers)
 ```
 
-Backend component tests (`backend/tests/component/`) start their backing services (Neo4j, ...)
-through testcontainers by default (`INFRAHUB_USE_TEST_CONTAINERS`, default `true`), which needs a
-running Docker daemon. testcontainers looks for `/var/run/docker.sock`; if your daemon only exposes
-a user socket (e.g. Docker Desktop without the "default socket" option), point `DOCKER_HOST` at it.
-Alternatively, set `INFRAHUB_USE_TEST_CONTAINERS=false` to run against an already-running database
-configured through the normal settings.
-
-```bash
-DOCKER_HOST=unix://$HOME/.docker/run/docker.sock uv run pytest backend/tests/component/... -q
-```
+Component tests (`backend/tests/component/`) start their backing services via testcontainers, so
+they need a running Docker daemon (set `INFRAHUB_USE_TEST_CONTAINERS=false` to reuse an
+already-running database instead).
 
 #### Debugging e2e tests with `--pdb`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ checkout.
 
 ## Coding Standards
 
-- Backend: `dev/guidelines/backend/python.md`
+- Backend: `dev/guidelines/backend/python.md` (load before writing backend Python — typing, exception handling) and `dev/guidelines/backend/checklist.md` (feature-planning checklist)
 - Frontend: `frontend/app/AGENTS.md`
 - Git workflow: `dev/guidelines/git-workflow.md`
 - Markdown: `dev/guidelines/markdown.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,12 @@ Style: be direct and substantive. No filler, preamble, or pleasantries. Challeng
 
 ## Branching
 
-- Feature and bugfix branches start from `develop` (the integration branch); `stable` is the
-  release branch. PRs for new work target `develop` unless they fix a released version.
+- Feature branches start from `develop`; bug fixes target the branch where the buggy code lives —
+  `stable` when the feature is released, `develop` when it only exists there.
 - Before cutting a branch for a ticket, verify the code the ticket references actually exists on
   the chosen base (`git ls-tree <base> -- <path>`): follow-up tickets often reference modules that
   are only on `develop`.
+- Full strategy (release branches, naming, submodules): `dev/guidelines/git-workflow.md`.
 
 ## Commands
 
@@ -53,9 +54,12 @@ cd frontend/app && pnpm test:e2e      # Frontend E2E tests (legacy TS suite)
 uv run pytest -c tests/e2e/pytest.ini tests/e2e  # E2E tests (pytest, testcontainers)
 ```
 
-Backend component tests (`backend/tests/component/`) and the testcontainers-based suites need a
+Backend component tests (`backend/tests/component/`) start their backing services (Neo4j, ...)
+through testcontainers by default (`INFRAHUB_USE_TEST_CONTAINERS`, default `true`), which needs a
 running Docker daemon. testcontainers looks for `/var/run/docker.sock`; if your daemon only exposes
-a user socket (e.g. Docker Desktop without the "default socket" option), point `DOCKER_HOST` at it:
+a user socket (e.g. Docker Desktop without the "default socket" option), point `DOCKER_HOST` at it.
+Alternatively, set `INFRAHUB_USE_TEST_CONTAINERS=false` to run against an already-running database
+configured through the normal settings.
 
 ```bash
 DOCKER_HOST=unix://$HOME/.docker/run/docker.sock uv run pytest backend/tests/component/... -q

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -39,12 +39,12 @@ backend Python, including:
 - Docstring conventions
 - Naming conventions
 - Query patterns
+- Type hints
 - Exception handling (catch the narrowest types the call path actually raises)
 
 When planning or implementing a backend feature, also walk
 `dev/guidelines/backend/checklist.md` — migrations, query efficiency (set-based, no N+1),
 permissions, error handling.
-- Type hints
 
 ### Neo4j/Cypher Queries
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -31,13 +31,19 @@ uv run invoke backend.generate         # Regenerate schemas/protocols
 
 ## Coding Standards
 
-See `dev/guidelines/backend/python.md` for detailed coding standards including:
+See `dev/guidelines/backend/python.md` for detailed coding standards — load it before writing
+backend Python, including:
 
 - Async-first patterns
 - Pydantic models
 - Docstring conventions
 - Naming conventions
 - Query patterns
+- Exception handling (catch the narrowest types the call path actually raises)
+
+When planning or implementing a backend feature, also walk
+`dev/guidelines/backend/checklist.md` — migrations, query efficiency (set-based, no N+1),
+permissions, error handling.
 - Type hints
 
 ### Neo4j/Cypher Queries
@@ -81,7 +87,8 @@ See `dev/knowledge/backend/testing.md` for detailed testing infrastructure docum
 
 ### Guidelines
 
-- `dev/guidelines/backend/python.md` - Python coding standards
+- `dev/guidelines/backend/python.md` - Python coding standards — load before writing backend Python (typing, imports, exception handling, docstrings)
+- `dev/guidelines/backend/checklist.md` - feature checklist — walk when planning or implementing a backend feature (migrations, query efficiency, permissions)
 - `dev/guidelines/changelog.md` - Changelog fragment creation
 
 ### Knowledge (How the system works)

--- a/dev/guidelines/backend/checklist.md
+++ b/dev/guidelines/backend/checklist.md
@@ -39,7 +39,7 @@ Design the feature to ensure:
 Plan for query efficiency and data volume by considering:
 
 - **Database round-trips** - design to use batch queries when operating on multiple nodes
-- **N+1 query patterns** - plan to load related data in bulk rather than iteratively
+- **N+1 query patterns** - operate set-based in both directions: load related data in bulk, and update/delete by condition in one query instead of mutating each fetched node individually
 - **Data volume per query** - avoid overquerying by fetching only necessary fields and relationships
 - **Memory footprint** - consider how much data will be held in memory during processing
 - **Pagination and streaming** - plan to process large result sets incrementally when appropriate

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -354,6 +354,7 @@ except NodeNotFoundError:
 Guidelines:
 
 - **Name the exceptions.** Catch the narrowest type(s) that the called code actually raises. If several are handled the same way, group them: `except (NodeNotFoundError, BranchNotFoundError):`.
+- **Check the hierarchy before narrowing.** Infrahub's exception types are mostly direct `Error` subclasses, not a tree — `QueryTimeoutError` is a *sibling* of `DatabaseError`, so catching `DatabaseError` does not cover query timeouts. Verify in `backend/infrahub/exceptions.py` which types the call path actually raises before writing the tuple.
 - **Keep the `try` body small.** Wrap only the statement that can raise, not a whole block, so an unexpected error elsewhere isn't caught by accident.
 - **Never silence.** A bare `except Exception: pass` hides real failures. If there is genuinely nothing to do, comment why, and at minimum `log.debug(...)`.
 - **Re-raise what you can't handle.** If you must catch broadly to add context or clean up, re-raise afterwards (`raise` to preserve the traceback, or `raise NewError(...) from exc` to chain).

--- a/dev/guidelines/changelog.md
+++ b/dev/guidelines/changelog.md
@@ -8,6 +8,10 @@ Guidelines for creating changelog entries using Towncrier.
 
 Every issue fix or new feature should include a changelog entry. The message should be short, user-facing, and describe what was fixed or implemented without technical implementation details.
 
+**Exception — unreleased features need no fragment.** A fix or follow-up to a feature that has not
+shipped in any release is not user-observable: the feature's own `added` fragment already covers
+everything a user will ever see, and a `fixed` entry for something never released is noise.
+
 ### Command
 
 Always create fragments with `towncrier create`. **Do not hand-write the file** — the command derives the location from the Towncrier config and places the fragment correctly no matter which directory you run it from.

--- a/dev/guidelines/documentation.md
+++ b/dev/guidelines/documentation.md
@@ -88,6 +88,8 @@ Infrahub documentation follows the [Diataxis framework](https://diataxis.fr/), s
 - Use marketing language or hype (in topics)
 - Skip definitions of technical terms
 - Focus on "how to" instead of "how it works" (in topics)
+- Reference Jira tickets, GitHub issues, or spec IDs — describe the behavior or constraint itself;
+  work-item IDs belong in commit messages, PR descriptions, and changelog fragments
 
 ## Documentation Workflow
 

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -8,8 +8,9 @@ Git workflow and commit conventions for the project.
 
 - **Main branches:** `stable` (production), `develop` (development), `release-*` (releases)
 - **Feature branches:** Create from `develop`, merge back via PR
-- **Bug fixes:** target the branch where the buggy code lives — `stable` when the feature is
-  released, `develop` when it only exists there
+- **Bug fixes:** target the oldest branch that needs the fix — `stable` when the bug is in released
+  code and the fix should ship in a patch release, `develop` when the code only exists there or the
+  fix can wait for the next minor
 - **Verify the base before cutting:** check that the code the ticket references actually exists on
   the chosen base (`git ls-tree <base> -- <path>`); follow-up tickets often reference modules that
   are only on `develop`

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -8,6 +8,11 @@ Git workflow and commit conventions for the project.
 
 - **Main branches:** `stable` (production), `develop` (development), `release-*` (releases)
 - **Feature branches:** Create from `develop`, merge back via PR
+- **Bug fixes:** target the branch where the buggy code lives — `stable` when the feature is
+  released, `develop` when it only exists there
+- **Verify the base before cutting:** check that the code the ticket references actually exists on
+  the chosen base (`git ls-tree <base> -- <path>`); follow-up tickets often reference modules that
+  are only on `develop`
 - **Branch naming:** `<initials>-<short-description>` (e.g., `jd-add-breadcrumbs`)
 
 ## Versioning


### PR DESCRIPTION
## Summary

Three small context improvements from the IFC-2867 session retrospective (PR #10000):

- **Branching** (new `AGENTS.md` section): feature/bugfix branches start from `develop`; verify the code a ticket references exists on the chosen base before cutting a branch — the session first cut its branch off `stable`, where the referenced module doesn't exist yet.
- **Component tests & Docker** (`AGENTS.md` testing section): `backend/tests/component/` needs a running Docker daemon, and testcontainers only looks at `/var/run/docker.sock` — documented the `DOCKER_HOST` override for daemons exposing a user socket only.
- **Set-based Cypher writes** (`neo4j-cypher-guide` skill): prefer one conditioned write query over fetch-then-mutate-each (N+1) — a reviewer had to point this out on #10000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies branching rules, documents Docker needs for component tests, and expands the Neo4j Cypher guide with set-based writes and dynamic label/type guidance. Also links the backend feature checklist, tightens exception handling guidance, and updates changelog/docs rules (IFC-2867 follow-up).

- **Guideline updates**
  - Branching in `dev/guidelines/git-workflow.md`: features from `develop`; bug fixes to the oldest affected branch; verify the base contains the code.
  - Component tests: default path needs a Docker daemon; set `INFRAHUB_USE_TEST_CONTAINERS=false` to reuse an existing DB.
  - Backend docs: link `dev/guidelines/backend/checklist.md`; add an exception-hierarchy note; fix the coding-standards list glitch.
  - Cypher guide: add set-based write guidance and dynamic labels/types (`$($param)`, Neo4j 5.26+) with planner/plan-cache tradeoffs.
  - Changelog/docs: skip fragments for fixes to unreleased features; avoid ticket/spec IDs in documentation.

<sup>Written for commit ded472a4bc6d5142537e2e21b1585f687f7c032f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

