### PR TITLE
docs(skills): shipping-features fixes from IFC-2867 retrospective

### DIFF
--- a/.agents/skills/shipping-features/SKILL.md
+++ b/.agents/skills/shipping-features/SKILL.md
@@ -106,9 +106,12 @@ never auto-transition. If Jira is absent, record status in the `ship.md` index o
 ### Stage 1 — Intake
 Restate the ask in one sentence; classify (checkpoint). If no ticket and the project tracks work,
 offer `creating-issues` / `/create-issue`; harden a fuzzy idea with `grilling-ideas` / `creating-prd`.
-Cut the branch via `/speckit-git-feature` (validates Jira/JPD ref) or `git checkout -b`. Open the
-`ship.md` index (feature id, issue, branch). **Gate:** issue with clear scope, on a named branch.
-**Checkpoint:** scope accepted → propose Jira *In design*.
+**Pick the base branch deliberately:** before cutting, verify the code the ticket references
+actually exists on the intended base (`git ls-tree <base> -- <path>`) — follow-up tickets often
+reference modules that only exist on the integration branch (e.g. `develop`), not the default
+branch. Then cut via `/speckit-git-feature` (validates Jira/JPD ref) or `git checkout -b`. Open the
+`ship.md` index (feature id, issue, branch). **Gate:** issue with clear scope, on a named branch
+whose base contains the referenced code. **Checkpoint:** scope accepted → propose Jira *In design*.
 
 ### Stage 2 — Prep
 - **S (or opt-in):** `/speckit-opsmill-prep` hands-off → one checkpoint on the resulting `tasks.md`.
@@ -133,6 +136,10 @@ has no unaddressed high-severity findings. **Checkpoint:** findings & fixes acce
    **Checkpoint:** user picks single / accepts split. Never force a split.
 3. **Open** the PR with `pr` → `/git-pr` → `gh pr create`. Record PR URL in `ship.md`; propose Jira
    *In review*. Then `/pr-monitor` (or `gh run watch`) follows CI; red loops back to the Stage 3 fix pass.
+4. **Review feedback:** when processing review comments, fetch **all** unresolved threads — every
+   author, review bots included — never only the reviewer the user named; assess each (fix, or
+   answer on the thread with evidence). **Re-fetch the threads after every push**: bots re-review
+   the new diff and their newest findings are otherwise invisible.
 Optional `/qa` and spec-&-code review where the project defines them.
 
 ### Stage 5 — Extract *(manual)*

--- a/.agents/skills/shipping-features/phases/manifest.md
+++ b/.agents/skills/shipping-features/phases/manifest.md
@@ -18,7 +18,10 @@ specs/<feature>/
 
 Locate the dir via `.specify/feature.json` (`{"feature_directory": "specs/<feature>"}`). For a
 bug/chore that skips speckit, create `specs/<feature>/ship.md` from the branch slug and still write
-`feature.json` so downstream speckit calls agree on the dir.
+`feature.json` so downstream speckit calls agree on the dir — **unless `feature.json` already points
+at a different feature's directory**: it is untracked local state that may belong to other
+in-progress work, so never overwrite it for a lane that runs no speckit steps. Leave it alone, note
+the decision in `ship.md`, and rely on the branch-matching resume scan instead.
 
 ## Schema
 

--- a/.agents/skills/shipping-features/phases/reliability.md
+++ b/.agents/skills/shipping-features/phases/reliability.md
@@ -56,5 +56,11 @@ skeptic breaks that correlated error).
 - **One synthesizer per divergence.** Never feed N parallel framings into N downstream agents.
 - **A skeptic must try to fail the claim.** Prompt it to refute, defaulting to "not proven" when
   uncertain — a verifier that rubber-stamps is worse than none (false confidence).
+- **Give the skeptic explicit lenses, even at `S`.** A single refute-the-claim prompt anchors on
+  spec conformance and misses orthogonal defects. Always name at least: (1) spec/bug correctness,
+  (2) interaction with existing concurrent paths (locks, transactions, in-flight writers touching
+  the same data), (3) compliance with the repo's own guidelines (`dev/guidelines/` or equivalent),
+  (4) query/IO efficiency (N+1s, per-item loops that should be set-based). One agent, four lenses —
+  this is not parallelism.
 - **Don't stack to look thorough.** Three layers on a no-risk phase is wasted tokens and slower
   checkpoints. Match the layers to the flags in `ship.md`.


### PR DESCRIPTION
## Summary

First real-world run of the `shipping-features` skill (IFC-2867 → PR #10000, chore·S lane) surfaced four orchestration gaps; this patches them into the skill:

1. **Intake — base-branch verification.** The run cut its branch off `stable`; the module the ticket references only exists on `develop`, forcing a re-cut. Intake now says to verify the referenced code exists on the base (`git ls-tree`) before cutting, and the gate includes it.
2. **Manifest — `feature.json` conflict.** The manifest phase said to always write `.specify/feature.json`, but it was already occupied by another feature's untracked local state. Now: never overwrite it for a lane that runs no speckit steps; note the decision in `ship.md` and rely on the branch-matching resume scan.
3. **Reliability — skeptic lenses.** The single S-size skeptic pass validated spec conformance but missed a lock race with a concurrent writer, an N+1 delete, and a repo-guideline violation — all three were later found by reviewers. The skeptic now gets four named lenses (correctness, concurrency, guidelines compliance, IO efficiency), still as one agent.
4. **Delivery — review-thread hygiene.** Processing only the comments from the reviewer the user named hid two bot P1s (one valid), and threads were never re-fetched after pushes. Delivery now mandates fetching all unresolved threads (bots included) and re-fetching after every push.

Full retrospective: `specs/ifc2867-preference-cleanup/retrospective.md` (local, on the IFC-2867 session machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the `shipping-features` skill after the IFC-2867 run by fixing branch selection, manifest safety, verification rigor, and review hygiene. Prevents bad base branches, protects local `.specify/feature.json`, adds explicit skeptic lenses (correctness, concurrency, guidelines, IO efficiency), and always fetches all unresolved review threads (bots included) and re-fetches after each push.

<sup>Written for commit 8daa7de4e6dc372f9ed39435109be3f6c35c14ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

