### PR TITLE
docs(schema): add namespaces page

### DIFF
--- a/docs/docs/schema/namespaces.mdx
+++ b/docs/docs/schema/namespaces.mdx
@@ -1,0 +1,52 @@
+---
+title: Namespaces
+---
+
+# Namespaces
+
+Every model in your schema belongs to a namespace. A namespace groups related models together and makes each model's `kind` unique, so two teams can both define a `Device` model without a name collision.
+
+## How a namespace forms a kind
+
+Infrahub builds a model's `kind` by concatenating its `namespace` and its `name`. A node with namespace `Dcim` and name `Device` has the kind `DcimDevice` — the identifier you use in GraphQL, the SDK, and the UI. See [Nodes & attributes](./nodes-and-attributes) for how `namespace` and `name` are set on a node.
+
+Because the `kind` combines both parts, the same `name` can appear in different namespaces without conflict. `DcimDevice` and `IpopsDevice` are distinct kinds. The `kind` — the (`namespace`, `name`) pair — must be unique across the schema.
+
+## Naming rules
+
+A namespace must match the regular expression `^[A-Z][a-z0-9]+$` and be 3 to 64 characters long:
+
+- Start with a single uppercase letter.
+- Continue with lowercase letters and digits only.
+
+This rules out two patterns that are otherwise common:
+
+- **Underscores** — `Tx_core` is rejected. A namespace contains no separators.
+- **Interior uppercase** — `IPOps` is rejected, because only the first letter can be uppercase.
+
+Write the namespace as one capitalized word: `Ipops`, `Dcim`, `Netops`, `Transport`.
+
+## Reserved namespaces
+
+Infrahub reserves a set of namespaces for its own models. You cannot create schema models in them:
+
+`Account`, `Branch`, `Builtin`, `Core`, `Deprecated`, `Diff`, `Infrahub`, `Internal`, `Lineage`, `Profile`, `Schema`, `Template`.
+
+Loading a schema that places a node in one of these namespaces fails with a restricted-namespace error. Choose a namespace outside the list for your own models.
+
+## Organize namespaces across teams
+
+When several teams or repositories load schemas into one Infrahub instance, use the namespace as each team's prefix. Each team owns a namespace and defines its models under it:
+
+- The IP operations team owns `Ipops` and defines `IpopsDevice`, `IpopsInterface`.
+- The transport team owns `Transport` and defines `TransportCircuit`.
+
+A central team owns the shared models — the [`Generic`](./generics-and-inheritance) nodes and common objects every team builds on — under its own namespace. Teams develop their schemas in branches and validate against the shared models before merging.
+
+Because the namespace is part of the `kind`, one team's `IpopsDevice` never collides with another team's `TransportDevice`, and each repository evolves its own models independently.
+
+## Related
+
+- [Nodes & attributes](./nodes-and-attributes) — where `namespace` and `name` are defined on a node
+- [Generics & inheritance](./generics-and-inheritance) — sharing common models across namespaces
+- [Node reference](../reference/schema/node) — the full list of node options, including the `namespace` constraint

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -100,6 +100,7 @@ const sidebars: SidebarsConfig = {
           link: { type: 'doc', id: 'schema/overview' }, // hub
           items: [
             { type: 'doc', id: 'schema/nodes-and-attributes', label: 'Nodes & attributes' },
+            { type: 'doc', id: 'schema/namespaces', label: 'Namespaces' },
             { type: 'doc', id: 'schema/relationships', label: 'Relationships' },
             { type: 'doc', id: 'schema/generics-and-inheritance', label: 'Generics & inheritance' },
             { type: 'doc', id: 'schema/branch-awareness', label: 'Branch awareness' },


### PR DESCRIPTION
## What

Adds a concept page for schema **namespaces** under Schema & Data › About Schema (`docs/docs/schema/namespaces.mdx`), and wires it into the sidebar after "Nodes & attributes".

## Why

Recurring customer questions about how to organize a schema across multiple teams — specifically why underscores/interior-caps are rejected in a namespace, and how to avoid kind collisions when several teams load schemas into one instance. The concept was only documented at field level (a one-line note in Nodes & attributes + the Node reference table); this gives it a home.

## Covers

- How a `kind` is formed by concatenating `namespace` + `name` (cross-links Nodes & attributes rather than re-explaining)
- Naming rules: `^[A-Z][a-z0-9]+$`, length 3–64, with the two rejected patterns (underscores, interior uppercase)
- Uniqueness on the (`namespace`, `name`) pair
- The reserved namespaces
- Using the namespace as a team prefix for multi-team / multi-repo setups

## Reviewer attention

- **Reserved-namespace list** — sourced verbatim from `backend/infrahub/core/constants/__init__.py` (`RESTRICTED_NAMESPACES`). Please confirm it's complete/current for the target release.
- **Regex + length** — `NAMESPACE_REGEX` and the min/max from the Node schema reference. Confirm 3–64 is right.

## Verification

- markdownlint (repo config) and Vale: clean
- All internal links + the `../reference/schema/node` target verified
- Docusaurus build not run locally (fresh worktree, no `node_modules`) — relying on CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Namespaces concept page to the schema docs to explain how a `kind` is formed from `namespace` + `name`, the naming rules (`^[A-Z][a-z0-9]+$`, 3–64 chars), reserved namespaces, and how to use namespaces across teams. Added to the sidebar after "Nodes & attributes".

<sup>Written for commit 32900fb8bd6945ffd625df4bec37e2c0fb34768e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

