### PR TITLE
docs(generators): add remove-a-generator guide

### DIFF
--- a/docs/docs/generators/remove.mdx
+++ b/docs/docs/generators/remove.mdx
@@ -1,0 +1,45 @@
+---
+title: Remove a generator
+---
+
+# Remove a generator
+
+Removing a Generator involves two separate things: the **Generator definition** registered from `.infrahub.yml`, and the **objects the Generator created** in Infrahub. Removing the definition stops the Generator from running, but it does not delete the objects it already created — those stay in Infrahub until you remove them.
+
+Handle the objects first, then the definition.
+
+## Delete the objects the Generator created
+
+A Generator removes its own obsolete objects only when it runs, through the [SDK tracking feature]($(base_url)python-sdk/topics/tracking). Once the definition is gone the Generator never runs again, so it can no longer remove the objects it created. Delete or reassign those objects — through the UI, GraphQL, or the SDK — while the definition still exists.
+
+To identify what a Generator created, see [Generator instances](./overview#generator-instances).
+
+## Remove the definition from `.infrahub.yml`
+
+On a branch, delete the Generator's entry from the `generator_definitions` list in your repository's `.infrahub.yml`:
+
+```yaml
+generator_definitions:
+  # Remove the block for the Generator you are retiring:
+  - name: <your_generator>
+    file_path: "generators/<your_generator>.py"
+    targets: <your_target_group>
+    query: <your_query>
+    class_name: YourGenerator
+```
+
+Remove the Generator's Python file, and any query used only by this Generator. Commit the changes and merge the branch through a [Proposed Change](../proposed-changes/overview). Infrahub removes the `CoreGeneratorDefinition` registration on the next repository sync.
+
+## Verify the removal
+
+```shell
+infrahubctl generator --list
+```
+
+The retired Generator no longer appears in the list. In the UI, confirm it is gone from Actions → Generator Definitions.
+
+## Related
+
+- [Build a generator](./build) — create a Generator
+- [About Generators](./overview) — concept, instances, and tracking
+- [infrahub.yml configuration](../git-integration/infrahub-yml) — the `generator_definitions` syntax

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -281,6 +281,7 @@ const sidebars: SidebarsConfig = {
           link: { type: 'doc', id: 'generators/overview' }, // hub
           items: [
             { type: 'doc', id: 'generators/build', label: 'Build a generator' },
+            { type: 'doc', id: 'generators/remove', label: 'Remove a generator' },
             { type: 'doc', id: 'generators/modular', label: 'Modular generators' },
             { type: 'doc', id: 'generators/modular-best-practices', label: 'Modular generator best practices' },
           ],


### PR DESCRIPTION
## What

Adds a how-to page, **Remove a generator**, under Design & Integrate › Generators (`docs/docs/generators/remove.mdx`), and wires it into the sidebar after "Build a generator".

## Why

Recurring customer question about decommissioning a Generator. The gotcha — objects a Generator created **persist** after the definition is removed, because a Generator only cleans up its obsolete objects when it *runs* (SDK tracking) — was undocumented. The generators section covered creating but not removing.

## Covers

- The two things involved: the definition (registered from `.infrahub.yml`) vs. the objects it created
- Delete/reassign the created objects **first**, then remove the definition
- Removing the `generator_definitions` block on a branch + merge → registration removed on next sync
- Verifying with `infrahubctl generator --list` and the UI

## Reviewer attention

- **Ordering claim** — "a removed Generator can no longer remove the objects it created" is based on `generators/overview.mdx` (obsolete-object removal happens via SDK tracking on a run). Confirm this matches current behavior.
- Section-style (not numbered steps) mirrors the sibling `build.mdx`.

## Verification

- markdownlint (repo config) and Vale: clean
- All internal links + the `./overview#generator-instances` anchor verified
- Docusaurus build not run locally (fresh worktree, no `node_modules`) — relying on CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Remove a generator" guide that shows how to decommission a Generator safely: clean up created objects first, then remove the `generator_definitions` entry in `.infrahub.yml`. Also adds the guide to the Generators sidebar.

- **New Features**
  - New doc `docs/docs/generators/remove.mdx` in the Generators section; linked in the sidebar after "Build a generator".
  - Explains object persistence and SDK tracking: delete or reassign created objects before removing the definition.
  - Shows how to remove the `generator_definitions` entry and related files; `CoreGeneratorDefinition` cleared on the next repo sync.
  - Provides verification steps with `infrahubctl generator --list` and the UI.

<sup>Written for commit 327f4f9f80d5eb8d2f4a68a36d50308507bede3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

