### PR TITLE
docs(branches): clarify Infrahub rebase vs git rebase

### DIFF
--- a/docs/docs/branches/rebase.mdx
+++ b/docs/docs/branches/rebase.mdx
@@ -6,7 +6,7 @@ Rebasing is a powerful operation that updates a branch with the latest changes f
 
 :::note
 
-Rebasing acts on the Infrahub branch in Infrahub's versioned graph database. It is distinct from `git rebase`: it does not rebase a connected Git repository, rewrite Git history, or push to a Git remote. Infrahub only writes back to Git when a [Proposed Change](../proposed-changes/overview.mdx) merges — see [Git integration](../git-integration/overview.mdx#read-only-vs-core).
+Rebasing acts on the Infrahub branch in Infrahub's versioned graph database. It is distinct from `git rebase`: it does not rebase a connected Git repository, rewrite Git history, or push to a Git remote. For how Infrahub synchronizes with connected Git repositories, see [Git integration](../git-integration/overview.mdx#read-only-vs-core).
 
 :::
 

--- a/docs/docs/branches/rebase.mdx
+++ b/docs/docs/branches/rebase.mdx
@@ -4,6 +4,12 @@ title: Rebase a branch
 
 Rebasing is a powerful operation that updates a branch with the latest changes from its parent branch. This is essential for maintaining branch health and ensuring smooth integration of changes.
 
+:::note
+
+Rebasing acts on the Infrahub branch in Infrahub's versioned graph database. It is distinct from `git rebase`: it does not rebase a connected Git repository, rewrite Git history, or push to a Git remote. Infrahub only writes back to Git when a [Proposed Change](../proposed-changes/overview.mdx) merges — see [Git integration](../git-integration/overview.mdx#read-only-vs-core).
+
+:::
+
 ## Why rebase
 
 Rebasing serves several important purposes:

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -43,7 +43,7 @@ When you create a Repository connection, Infrahub:
 4. Runs background synchronization tasks every few seconds to detect changes
 5. Parses the `.infrahub.yml` file to determine which resources to import
 
-The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository. You do not merge the change in Git yourself — once the commit appears on the remote's default branch, delete your feature branch. Git-side merging is your responsibility only for a Read-only Repository, which Infrahub never writes to.
+The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
 
 ### Read-only Repository: controlled unidirectional flow
 

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -43,7 +43,7 @@ When you create a Repository connection, Infrahub:
 4. Runs background synchronization tasks every few seconds to detect changes
 5. Parses the `.infrahub.yml` file to determine which resources to import
 
-The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
+The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository. You do not merge the change in Git yourself — once the commit appears on the remote's default branch, delete your feature branch. Git-side merging is your responsibility only for a Read-only Repository, which Infrahub never writes to.
 
 ### Read-only Repository: controlled unidirectional flow
 


### PR DESCRIPTION
## What

`branches/rebase.mdx` — adds a note that Infrahub rebase acts on the Infrahub branch in the versioned graph database and is distinct from `git rebase`: it does not rebase a connected Git repository, rewrite Git history, or push to a Git remote. Infrahub writes back to Git only when a Proposed Change merges.

## Why

Recurring customer question (Telenet, `#telenet`): whether "Infrahub rebase" touches the connected Git repo. The boundary was implicit in the docs.

## Scope note

An earlier revision of this PR also touched `git-integration/overview.mdx` with post-merge git-branch guidance. That guidance was incorrect and has been reverted — this PR now scopes to the rebase clarification only.

## Verification

- markdownlint (repo config) and Vale: clean
- Cross-links (`../proposed-changes/overview`, `../git-integration/overview#read-only-vs-core`) verified
- Docusaurus build not run locally (fresh worktree, no \`node_modules\`) — relying on CI