### PR TITLE
fix: show changed nodes in diff tree when their parent is unchanged

### DIFF
--- a/changelog/10010.fixed.md
+++ b/changelog/10010.fixed.md
@@ -1,0 +1,1 @@
+Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own.

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -38,9 +38,9 @@ exports[`fix ts error`] = {
       [354, 22, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
       [356, 32, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"]
     ],
-    "src/entities/diff/ui/node-diff/index.tsx:1381887161": [
+    "src/entities/diff/ui/node-diff/index.tsx:1948456003": [
       [88, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
-      [118, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
+      [123, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],
     "src/entities/diff/ui/node-diff/node-property.tsx:3639994513": [
       [27, 22, 17, "tsc: Property \'base_branch_label\' does not exist on type \'DiffConflict\'. Did you mean \'base_branch_value\'?", "1959743778"],

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -54,9 +54,6 @@ exports[`fix ts error`] = {
       [137, 22, 13, "tsc: Type \'Element | null | string\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1656119487"],
       [141, 22, 8, "tsc: Type \'Element | null | string\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "288015442"]
     ],
-    "src/entities/diff/utils/build-diff-tree-items.ts:2745435919": [
-      [86, 66, 24, "tsc: Not all code paths return a value.", "3673565821"]
-    ],
     "src/entities/events/ui/filters/global-branch-filter.tsx:4154549494": [
       [82, 14, 7, "tsc: Type \'{ label: string; name: string; }[]\' is not assignable to type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; }[] | { id?: string\'.\\n  Property \'state\' is missing in type \'{ label: string; name: string; }\' but required in type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; } | { id?: string\'.", "3821181085"]
     ],

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -38,9 +38,9 @@ exports[`fix ts error`] = {
       [354, 22, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
       [356, 32, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"]
     ],
-    "src/entities/diff/ui/node-diff/index.tsx:1948456003": [
+    "src/entities/diff/ui/node-diff/index.tsx:1183151977": [
       [88, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
-      [123, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
+      [122, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],
     "src/entities/diff/ui/node-diff/node-property.tsx:3639994513": [
       [27, 22, 17, "tsc: Property \'base_branch_label\' does not exist on type \'DiffConflict\'. Did you mean \'base_branch_value\'?", "1959743778"],

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -38,9 +38,9 @@ exports[`fix ts error`] = {
       [354, 22, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
       [356, 32, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"]
     ],
-    "src/entities/diff/ui/node-diff/index.tsx:3336968364": [
+    "src/entities/diff/ui/node-diff/index.tsx:1381887161": [
       [88, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
-      [114, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
+      [118, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],
     "src/entities/diff/ui/node-diff/node-property.tsx:3639994513": [
       [27, 22, 17, "tsc: Property \'base_branch_label\' does not exist on type \'DiffConflict\'. Did you mean \'base_branch_value\'?", "1959743778"],
@@ -54,8 +54,8 @@ exports[`fix ts error`] = {
       [137, 22, 13, "tsc: Type \'Element | null | string\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1656119487"],
       [141, 22, 8, "tsc: Type \'Element | null | string\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "288015442"]
     ],
-    "src/entities/diff/utils/build-diff-tree-items.ts:3247801260": [
-      [73, 66, 24, "tsc: Not all code paths return a value.", "3673565821"]
+    "src/entities/diff/utils/build-diff-tree-items.ts:2745435919": [
+      [86, 66, 24, "tsc: Not all code paths return a value.", "3673565821"]
     ],
     "src/entities/events/ui/filters/global-branch-filter.tsx:4154549494": [
       [82, 14, 7, "tsc: Type \'{ label: string; name: string; }[]\' is not assignable to type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; }[] | { id?: string\'.\\n  Property \'state\' is missing in type \'{ label: string; name: string; }\' but required in type \'\\"absent\\"; name: string; description?: string | null | null | null | null | undefined; color?: string | undefined; label?: string | undefined; state: \\"present\\" | undefined; } | { id?: string\'.", "3821181085"]

--- a/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
@@ -1,0 +1,112 @@
+import { beforeAll, describe, expect, test, vi } from "vitest";
+
+import { store } from "@/shared/stores";
+
+import { getDiffTreeFromApi } from "@/entities/diff/api/get-diff-tree-from-api";
+import { getDiffTreeSummaryFromApi } from "@/entities/diff/api/get-diff-tree-summary-from-api";
+import { NodeDiff } from "@/entities/diff/ui/node-diff";
+import type { DiffNode } from "@/entities/diff/ui/node-diff/types";
+import { nodeSchemasAtom } from "@/entities/schema/stores/schema.atom";
+
+import { render } from "../../../../../tests/components/render";
+import { generateNodeSchema } from "../../../../../tests/fake/schema";
+
+vi.mock("@/entities/diff/api/get-diff-tree-from-api");
+vi.mock("@/entities/diff/api/get-diff-tree-summary-from-api");
+
+describe("NodeDiff", () => {
+  const getDiffTreeFromApiMock = vi.mocked(getDiffTreeFromApi);
+  const getDiffTreeSummaryFromApiMock = vi.mocked(getDiffTreeSummaryFromApi);
+
+  beforeAll(() => {
+    store.set(nodeSchemasAtom, [
+      generateNodeSchema({ kind: "TestDevice", label: "Device" }),
+      generateNodeSchema({ kind: "TestInterface", label: "Interface" }),
+    ]);
+  });
+
+  test("shows a changed node in the diff tree when its parent node is unchanged", async () => {
+    // GIVEN a diff where an updated interface belongs to a device without changes,
+    // returned by the backend as hierarchy context with status UNCHANGED (include_parents)
+    const unchangedParent: DiffNode = {
+      uuid: "device-1",
+      kind: "TestDevice",
+      label: "atl1-edge1",
+      status: "UNCHANGED",
+      parent: null,
+      attributes: [],
+      relationships: [],
+      contains_conflict: false,
+      conflict: null,
+      path_identifier: "",
+      last_changed_at: "2026-07-22T00:00:00Z",
+    };
+    const updatedChild: DiffNode = {
+      uuid: "interface-1",
+      kind: "TestInterface",
+      label: "Ethernet1",
+      status: "UPDATED",
+      parent: { uuid: "device-1", kind: "TestDevice", relationship_name: "interfaces" },
+      attributes: [
+        {
+          uuid: "attribute-1",
+          name: "description",
+          contains_conflict: false,
+          conflict: null,
+          path_identifier: "",
+          properties: [
+            {
+              property_type: "HAS_VALUE",
+              new_value: "new description",
+              previous_value: "old description",
+              status: "UPDATED",
+              conflict: null,
+              path_identifier: "",
+              last_changed_at: "2026-07-22T00:00:00Z",
+            },
+          ],
+        },
+      ],
+      relationships: [],
+      contains_conflict: false,
+      conflict: null,
+      path_identifier: "",
+      last_changed_at: "2026-07-22T00:00:00Z",
+    };
+
+    getDiffTreeFromApiMock.mockResolvedValue({
+      data: {
+        DiffTree: {
+          nodes: [unchangedParent, updatedChild],
+          to_time: "2026-07-22T00:00:00Z",
+          from_time: "2026-07-21T00:00:00Z",
+          base_branch: "main",
+          diff_branch: "test-branch",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof getDiffTreeFromApi>>);
+    getDiffTreeSummaryFromApiMock.mockResolvedValue({
+      data: {
+        DiffTreeSummary: { num_added: 0, num_updated: 1, num_removed: 0, num_conflicts: 0 },
+      },
+    } as unknown as Awaited<ReturnType<typeof getDiffTreeSummaryFromApi>>);
+
+    // WHEN
+    const component = await render(<NodeDiff branch="test-branch" />);
+
+    // THEN the updated interface is listed in the right-hand diff list
+    await expect.element(component.getByRole("link", { name: "Ethernet1" })).toBeVisible();
+
+    // THEN its unchanged parent device appears in the left tree as hierarchy context
+    const parentRow = component.getByRole("row", { name: /atl1-edge1/ });
+    await expect.element(parentRow).toBeVisible();
+
+    // WHEN expanding the parent device and its relationship group
+    await parentRow.getByRole("button").click();
+    const relationshipRow = component.getByRole("row", { name: /interfaces/ });
+    await relationshipRow.getByRole("button").click();
+
+    // THEN the updated interface appears in the left tree, nested under its parent
+    await expect.element(component.getByRole("row", { name: /Ethernet1/ })).toBeVisible();
+  });
+});

--- a/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import { store } from "@/shared/stores";
 
@@ -18,11 +18,21 @@ describe("NodeDiff", () => {
   const getDiffTreeFromApiMock = vi.mocked(getDiffTreeFromApi);
   const getDiffTreeSummaryFromApiMock = vi.mocked(getDiffTreeSummaryFromApi);
 
+  const initialNodeSchemas = store.get(nodeSchemasAtom);
+
   beforeAll(() => {
     store.set(nodeSchemasAtom, [
       generateNodeSchema({ kind: "TestDevice", label: "Device" }),
       generateNodeSchema({ kind: "TestInterface", label: "Interface" }),
     ]);
+  });
+
+  afterAll(() => {
+    store.set(nodeSchemasAtom, initialNodeSchemas);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   test("shows a changed node in the diff tree when its parent node is unchanged", async () => {

--- a/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.test.tsx
@@ -33,6 +33,7 @@ describe("NodeDiff", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    window.history.replaceState(null, "", window.location.pathname);
   });
 
   test("shows a changed node in the diff tree when its parent node is unchanged", async () => {
@@ -117,6 +118,112 @@ describe("NodeDiff", () => {
     await relationshipRow.getByRole("button").click();
 
     // THEN the updated interface appears in the left tree, nested under its parent
+    await expect.element(component.getByRole("row", { name: /Ethernet1/ })).toBeVisible();
+  });
+
+  test("shows a conflicted node in both panes when its parent is unchanged and the conflicts filter is active", async () => {
+    // GIVEN the conflicts filter is active
+    window.history.replaceState(null, "", "?status=CONFLICT");
+
+    // AND a diff where a conflicted interface belongs to an unchanged device
+    // (contains_conflict never propagates to ancestor nodes), next to an updated
+    // device without conflicts
+    const unchangedParent: DiffNode = {
+      uuid: "device-1",
+      kind: "TestDevice",
+      label: "atl1-edge1",
+      status: "UNCHANGED",
+      parent: null,
+      attributes: [],
+      relationships: [],
+      contains_conflict: false,
+      conflict: null,
+      path_identifier: "",
+      last_changed_at: "2026-07-22T00:00:00Z",
+    };
+    const conflictedChild: DiffNode = {
+      uuid: "interface-1",
+      kind: "TestInterface",
+      label: "Ethernet1",
+      status: "UPDATED",
+      parent: { uuid: "device-1", kind: "TestDevice", relationship_name: "interfaces" },
+      attributes: [
+        {
+          uuid: "attribute-1",
+          name: "description",
+          contains_conflict: true,
+          conflict: null,
+          path_identifier: "",
+          properties: [
+            {
+              property_type: "HAS_VALUE",
+              new_value: "new description",
+              previous_value: "old description",
+              status: "UPDATED",
+              conflict: null,
+              path_identifier: "",
+              last_changed_at: "2026-07-22T00:00:00Z",
+            },
+          ],
+        },
+      ],
+      relationships: [],
+      contains_conflict: true,
+      conflict: null,
+      path_identifier: "",
+      last_changed_at: "2026-07-22T00:00:00Z",
+    };
+    const updatedNodeWithoutConflict: DiffNode = {
+      uuid: "device-2",
+      kind: "TestDevice",
+      label: "atl1-edge2",
+      status: "UPDATED",
+      parent: null,
+      attributes: [],
+      relationships: [],
+      contains_conflict: false,
+      conflict: null,
+      path_identifier: "",
+      last_changed_at: "2026-07-22T00:00:00Z",
+    };
+
+    getDiffTreeFromApiMock.mockResolvedValue({
+      data: {
+        DiffTree: {
+          nodes: [unchangedParent, conflictedChild, updatedNodeWithoutConflict],
+          to_time: "2026-07-22T00:00:00Z",
+          from_time: "2026-07-21T00:00:00Z",
+          base_branch: "main",
+          diff_branch: "test-branch",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof getDiffTreeFromApi>>);
+    getDiffTreeSummaryFromApiMock.mockResolvedValue({
+      data: {
+        DiffTreeSummary: { num_added: 0, num_updated: 2, num_removed: 0, num_conflicts: 1 },
+      },
+    } as unknown as Awaited<ReturnType<typeof getDiffTreeSummaryFromApi>>);
+
+    // WHEN
+    const component = await render(<NodeDiff branch="test-branch" />);
+
+    // THEN the conflicted interface is listed in the right-hand diff list,
+    // while the updated device without conflicts is filtered out
+    await expect.element(component.getByRole("link", { name: "Ethernet1" })).toBeVisible();
+    await expect
+      .element(component.getByRole("link", { name: "atl1-edge2" }))
+      .not.toBeInTheDocument();
+
+    // THEN its unchanged parent device appears in the left tree as hierarchy context
+    const parentRow = component.getByRole("row", { name: /atl1-edge1/ });
+    await expect.element(parentRow).toBeVisible();
+
+    // WHEN expanding the parent device and its relationship group
+    await parentRow.getByRole("button").click();
+    const relationshipRow = component.getByRole("row", { name: /interfaces/ });
+    await relationshipRow.getByRole("button").click();
+
+    // THEN the conflicted interface appears in the left tree, nested under its parent
     await expect.element(component.getByRole("row", { name: /Ethernet1/ })).toBeVisible();
   });
 });

--- a/frontend/app/src/entities/diff/ui/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.tsx
@@ -93,15 +93,19 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
     );
   }
 
+  // UNCHANGED nodes are kept: the backend returns them (include_parents) so the tree
+  // can nest changed nodes under their unchanged parents as hierarchy context
   const nodes =
     data.pages
       .flatMap((page) => page?.nodes)
       .flatMap((node) => {
-        if (!node || node.status === "UNCHANGED") return [];
+        if (!node) return [];
         // Manually filter conflicts items since it's not available yet in the backend filters
         if (qspStatus === DIFF_STATUS.CONFLICT && !node.contains_conflict) return [];
         return node as unknown as DiffNodeType;
       }) ?? [];
+
+  const changedNodes = nodes.filter((node) => node.status !== "UNCHANGED");
 
   return (
     <div className="flex h-[calc(100vh-14rem)] flex-col overflow-hidden">
@@ -128,8 +132,8 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
         </nav>
 
         <main className="col-start-2 col-end-5 space-y-4 overflow-auto bg-stone-100 p-4">
-          {nodes.length ? (
-            nodes.map((node) => (
+          {changedNodes.length ? (
+            changedNodes.map((node) => (
               <DiffNode
                 key={node.uuid}
                 node={node}

--- a/frontend/app/src/entities/diff/ui/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.tsx
@@ -95,17 +95,22 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
 
   // UNCHANGED nodes are kept: the backend returns them (include_parents) so the tree
   // can nest changed nodes under their unchanged parents as hierarchy context
-  const nodes =
+  const allNodes =
     data.pages
       .flatMap((page) => page?.nodes)
-      .flatMap((node) => {
-        if (!node) return [];
-        // Manually filter conflicts items since it's not available yet in the backend filters
-        if (qspStatus === DIFF_STATUS.CONFLICT && !node.contains_conflict) return [];
-        return node as unknown as DiffNodeType;
-      }) ?? [];
+      .flatMap((node) => (node ? [node as unknown as DiffNodeType] : [])) ?? [];
 
-  const changedNodes = nodes.filter((node) => node.status !== "UNCHANGED");
+  // The CONFLICT filter is client-side only (buildFilters excludes it from the backend
+  // status filter) and contains_conflict never propagates to ancestor nodes, so the
+  // tree keeps conflicted nodes plus their ancestor chains as hierarchy context
+  const nodes =
+    qspStatus === DIFF_STATUS.CONFLICT ? keepConflictNodesWithAncestors(allNodes) : allNodes;
+
+  const changedNodes = nodes.filter(
+    (node) =>
+      node.status !== "UNCHANGED" &&
+      (qspStatus !== DIFF_STATUS.CONFLICT || node.contains_conflict)
+  );
 
   return (
     <div className="flex h-[calc(100vh-14rem)] flex-col overflow-hidden">
@@ -149,3 +154,20 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
     </div>
   );
 };
+
+function keepConflictNodesWithAncestors(nodes: Array<DiffNodeType>): Array<DiffNodeType> {
+  const nodesByUuid = new Map(nodes.map((node) => [node.uuid, node]));
+  const keptUuids = new Set<string>();
+
+  const markNodeAndAncestors = (node?: DiffNodeType) => {
+    if (!node || keptUuids.has(node.uuid)) return;
+    keptUuids.add(node.uuid);
+    if (node.parent) markNodeAndAncestors(nodesByUuid.get(node.parent.uuid));
+  };
+
+  for (const node of nodes) {
+    if (node.contains_conflict) markNodeAndAncestors(node);
+  }
+
+  return nodes.filter((node) => keptUuids.has(node.uuid));
+}

--- a/frontend/app/src/entities/diff/ui/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.tsx
@@ -108,8 +108,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
 
   const changedNodes = nodes.filter(
     (node) =>
-      node.status !== "UNCHANGED" &&
-      (qspStatus !== DIFF_STATUS.CONFLICT || node.contains_conflict)
+      node.status !== "UNCHANGED" && (qspStatus !== DIFF_STATUS.CONFLICT || node.contains_conflict)
   );
 
   return (

--- a/frontend/app/src/entities/diff/utils/build-diff-tree-items.test.ts
+++ b/frontend/app/src/entities/diff/utils/build-diff-tree-items.test.ts
@@ -225,6 +225,120 @@ describe("buildDiffTreeItems", () => {
     expect(result).toEqual(treeItems);
   });
 
+  it("attaches nodes to a multi-level parent chain regardless of input order", () => {
+    // GIVEN a grandchild listed before its parent, itself listed before the root
+    const nodes: Array<DiffNode> = [
+      {
+        uuid: "3",
+        kind: "TestNode2",
+        label: "Grandchild Node",
+        status: "ADDED",
+        attributes: [],
+        relationships: [],
+        contains_conflict: false,
+        conflict: null,
+        path_identifier: "grandchild",
+        parent: {
+          uuid: "2",
+          relationship_name: "rel2",
+          kind: "TestNode2",
+        },
+      },
+      {
+        uuid: "2",
+        kind: "TestNode2",
+        label: "Child Node",
+        status: "UPDATED",
+        attributes: [],
+        relationships: [],
+        contains_conflict: false,
+        conflict: null,
+        path_identifier: "child",
+        parent: {
+          uuid: "1",
+          relationship_name: "rel1",
+          kind: "TestNode",
+        },
+      },
+      {
+        uuid: "1",
+        kind: "TestNode",
+        label: "Root Node",
+        status: "UNCHANGED",
+        attributes: [],
+        relationships: [],
+        contains_conflict: false,
+        conflict: null,
+        path_identifier: "root",
+        parent: null,
+      },
+    ];
+
+    // WHEN
+    const result = buildDiffTreeItems(nodes);
+
+    // THEN
+    const treeItems: Array<DiffTreeItem> = [
+      {
+        id: "TestNode",
+        label: "Test Node",
+        kind: "TestNode",
+        icon: "mdi:tag-multiple",
+        isNode: false,
+        children: [
+          {
+            isNode: true,
+            id: "1",
+            kind: "TestNode",
+            label: "Root Node",
+            status: "UNCHANGED",
+            hasConflicts: false,
+            children: [
+              {
+                isNode: false,
+                id: "1-rel1",
+                kind: "TestNode2",
+                label: "rel1",
+                icon: "mdi:tag-multiple",
+                children: [
+                  {
+                    isNode: true,
+                    id: "2",
+                    kind: "TestNode2",
+                    label: "Child Node",
+                    status: "UPDATED",
+                    hasConflicts: false,
+                    children: [
+                      {
+                        isNode: false,
+                        id: "2-rel2",
+                        kind: "TestNode2",
+                        label: "rel2",
+                        icon: "mdi:tag-multiple",
+                        children: [
+                          {
+                            isNode: true,
+                            id: "3",
+                            kind: "TestNode2",
+                            label: "Grandchild Node",
+                            status: "ADDED",
+                            hasConflicts: false,
+                            children: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(result).toEqual(treeItems);
+  });
+
   it("returns tree items for nodes with parent relationships", () => {
     // GIVEN
     const nodes: Array<DiffNode> = [

--- a/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
+++ b/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
@@ -29,11 +29,17 @@ export function buildDiffTreeItems(nodes: Array<DiffNode>): Array<DiffTreeItem> 
 
   const [nodesWithoutParent, nodesWithParent] = partition(nodes, (node) => !node.parent);
 
+  // Pre-create one tree item per node so a parent can be found in O(1) even when
+  // it appears after its children in the input
+  const nodeTreeItemsByUuid = new Map(
+    nodes.map((node) => [node.uuid, createNodeTreeItemFromDiffNode(node)])
+  );
+
   const baseTreeItems = nodesWithoutParent.reduce<DiffTreeItem[]>((acc, node) => {
     const { kind } = node;
     const topLevelKindTreeItem = acc.find((treeItem) => treeItem.kind === kind);
 
-    const newDiffTreeItem = createNodeTreeItemFromDiffNode(node);
+    const newDiffTreeItem = nodeTreeItemsByUuid.get(node.uuid)!;
 
     if (!topLevelKindTreeItem) {
       const newKindTreeItem = createGroupTreeItemFromDiffNode(node);
@@ -45,56 +51,33 @@ export function buildDiffTreeItems(nodes: Array<DiffNode>): Array<DiffTreeItem> 
     return acc;
   }, []);
 
-  // Attach nodes in as many passes as needed: a node can only be attached once its
-  // parent is in the tree, and parents may appear after their children in the input
-  let pendingNodes = nodesWithParent;
-  while (pendingNodes.length) {
-    const remainingNodes = pendingNodes.filter(
-      (node) => !attachNodeToParent(baseTreeItems, node)
+  for (const node of nodesWithParent) {
+    // Nodes whose parent is not part of the diff payload are skipped, along with
+    // their own children: their subtree is never linked to the returned tree
+    const parentTreeItem = nodeTreeItemsByUuid.get(node.parent!.uuid);
+    if (!parentTreeItem) continue;
+
+    const newDiffTreeItem = nodeTreeItemsByUuid.get(node.uuid)!;
+    const relationshipName = node.parent!.relationship_name as string;
+    const relationshipTreeItem = parentTreeItem.children.find(
+      (rel) => !rel.isNode && rel.label === relationshipName
     );
-    if (remainingNodes.length === pendingNodes.length) break;
-    pendingNodes = remainingNodes;
+
+    if (!relationshipTreeItem) {
+      // Create new relationship group if it doesn't exist
+      const newRelationshipTreeItem = createGroupTreeItemFromDiffNode(node);
+      newRelationshipTreeItem.id = `${node.parent!.uuid}-${relationshipName}`;
+      newRelationshipTreeItem.label = relationshipName;
+      newRelationshipTreeItem.children.push(newDiffTreeItem);
+      parentTreeItem.children.push(newRelationshipTreeItem);
+      continue;
+    }
+
+    // Add to existing relationship group
+    relationshipTreeItem.children.push(newDiffTreeItem);
   }
 
   return baseTreeItems;
-}
-
-function attachNodeToParent(treeItems: DiffTreeItem[], node: DiffNode): boolean {
-  const parentTreeItem = findTreeItemById(treeItems, node.parent!.uuid);
-  if (!parentTreeItem) return false;
-
-  const newDiffTreeItem = createNodeTreeItemFromDiffNode(node);
-  const relationshipName = node.parent!.relationship_name as string;
-  const relationshipTreeItem = parentTreeItem.children.find(
-    (rel) => !rel.isNode && rel.label === relationshipName
-  );
-
-  if (!relationshipTreeItem) {
-    // Create new relationship group if it doesn't exist
-    const newRelationshipTreeItem = createGroupTreeItemFromDiffNode(node);
-    newRelationshipTreeItem.id = `${node.parent!.uuid}-${relationshipName}`;
-    newRelationshipTreeItem.label = relationshipName;
-    newRelationshipTreeItem.children.push(newDiffTreeItem);
-    parentTreeItem.children.push(newRelationshipTreeItem);
-    return true;
-  }
-
-  // Add to existing relationship group
-  relationshipTreeItem.children.push(newDiffTreeItem);
-  return true;
-}
-
-function findTreeItemById(treeItems: DiffTreeItem[], id: string): DiffTreeItem | undefined {
-  for (const item of treeItems) {
-    if (item.id === id) return item;
-
-    for (const child of item.children) {
-      if (child.id === id) return child;
-
-      const found = findTreeItemById([child], id);
-      if (found) return found;
-    }
-  }
 }
 
 function createNodeTreeItemFromDiffNode(node: DiffNode): NodeTreeItem {

--- a/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
+++ b/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
@@ -27,37 +27,41 @@ export type DiffTreeItem = NodeTreeItem | GroupTreeItem;
 export function buildDiffTreeItems(nodes: Array<DiffNode>): Array<DiffTreeItem> {
   if (!nodes.length) return [];
 
-  const [nodesWithoutParent, nodesWithParent] = partition(nodes, (node) => !node.parent);
-
-  // Pre-create one tree item per node so a parent can be found in O(1) even when
-  // it appears after its children in the input
+  // Pair each node with its tree item upfront so a parent item can be found in O(1)
+  // even when it appears after its children in the input
+  const nodeEntries = nodes.map((node) => ({
+    node,
+    treeItem: createNodeTreeItemFromDiffNode(node),
+  }));
   const nodeTreeItemsByUuid = new Map(
-    nodes.map((node) => [node.uuid, createNodeTreeItemFromDiffNode(node)])
+    nodeEntries.map(({ node, treeItem }) => [node.uuid, treeItem])
   );
 
-  const baseTreeItems = nodesWithoutParent.reduce<DiffTreeItem[]>((acc, node) => {
-    const { kind } = node;
-    const topLevelKindTreeItem = acc.find((treeItem) => treeItem.kind === kind);
+  const [entriesWithoutParent, entriesWithParent] = partition(
+    nodeEntries,
+    ({ node }) => !node.parent
+  );
 
-    const newDiffTreeItem = nodeTreeItemsByUuid.get(node.uuid)!;
+  const baseTreeItems = entriesWithoutParent.reduce<DiffTreeItem[]>((acc, { node, treeItem }) => {
+    const { kind } = node;
+    const topLevelKindTreeItem = acc.find((item) => item.kind === kind);
 
     if (!topLevelKindTreeItem) {
       const newKindTreeItem = createGroupTreeItemFromDiffNode(node);
-      newKindTreeItem.children.push(newDiffTreeItem);
+      newKindTreeItem.children.push(treeItem);
       return [...acc, newKindTreeItem];
     }
 
-    topLevelKindTreeItem.children.push(newDiffTreeItem);
+    topLevelKindTreeItem.children.push(treeItem);
     return acc;
   }, []);
 
-  for (const node of nodesWithParent) {
+  for (const { node, treeItem } of entriesWithParent) {
     // Nodes whose parent is not part of the diff payload are skipped, along with
     // their own children: their subtree is never linked to the returned tree
     const parentTreeItem = nodeTreeItemsByUuid.get(node.parent!.uuid);
     if (!parentTreeItem) continue;
 
-    const newDiffTreeItem = nodeTreeItemsByUuid.get(node.uuid)!;
     const relationshipName = node.parent!.relationship_name as string;
     const relationshipTreeItem = parentTreeItem.children.find(
       (rel) => !rel.isNode && rel.label === relationshipName
@@ -68,13 +72,13 @@ export function buildDiffTreeItems(nodes: Array<DiffNode>): Array<DiffTreeItem> 
       const newRelationshipTreeItem = createGroupTreeItemFromDiffNode(node);
       newRelationshipTreeItem.id = `${node.parent!.uuid}-${relationshipName}`;
       newRelationshipTreeItem.label = relationshipName;
-      newRelationshipTreeItem.children.push(newDiffTreeItem);
+      newRelationshipTreeItem.children.push(treeItem);
       parentTreeItem.children.push(newRelationshipTreeItem);
       continue;
     }
 
     // Add to existing relationship group
-    relationshipTreeItem.children.push(newDiffTreeItem);
+    relationshipTreeItem.children.push(treeItem);
   }
 
   return baseTreeItems;

--- a/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
+++ b/frontend/app/src/entities/diff/utils/build-diff-tree-items.ts
@@ -45,30 +45,43 @@ export function buildDiffTreeItems(nodes: Array<DiffNode>): Array<DiffTreeItem> 
     return acc;
   }, []);
 
-  return nodesWithParent.reduce<DiffTreeItem[]>((acc, node) => {
-    const parentTreeItem = findTreeItemById(baseTreeItems, node.parent!.uuid);
-    if (!parentTreeItem) return acc;
-
-    const newDiffTreeItem = createNodeTreeItemFromDiffNode(node);
-    const relationshipName = node.parent!.relationship_name as string;
-    const relationshipTreeItem = parentTreeItem.children.find(
-      (rel) => !rel.isNode && rel.label === relationshipName
+  // Attach nodes in as many passes as needed: a node can only be attached once its
+  // parent is in the tree, and parents may appear after their children in the input
+  let pendingNodes = nodesWithParent;
+  while (pendingNodes.length) {
+    const remainingNodes = pendingNodes.filter(
+      (node) => !attachNodeToParent(baseTreeItems, node)
     );
+    if (remainingNodes.length === pendingNodes.length) break;
+    pendingNodes = remainingNodes;
+  }
 
-    if (!relationshipTreeItem) {
-      // Create new relationship group if it doesn't exist
-      const newRelationshipTreeItem = createGroupTreeItemFromDiffNode(node);
-      newRelationshipTreeItem.id = `${node.parent!.uuid}-${relationshipName}`;
-      newRelationshipTreeItem.label = relationshipName;
-      newRelationshipTreeItem.children.push(newDiffTreeItem);
-      parentTreeItem.children.push(newRelationshipTreeItem);
-      return acc;
-    }
+  return baseTreeItems;
+}
 
-    // Add to existing relationship group
-    relationshipTreeItem.children.push(newDiffTreeItem);
-    return acc;
-  }, baseTreeItems);
+function attachNodeToParent(treeItems: DiffTreeItem[], node: DiffNode): boolean {
+  const parentTreeItem = findTreeItemById(treeItems, node.parent!.uuid);
+  if (!parentTreeItem) return false;
+
+  const newDiffTreeItem = createNodeTreeItemFromDiffNode(node);
+  const relationshipName = node.parent!.relationship_name as string;
+  const relationshipTreeItem = parentTreeItem.children.find(
+    (rel) => !rel.isNode && rel.label === relationshipName
+  );
+
+  if (!relationshipTreeItem) {
+    // Create new relationship group if it doesn't exist
+    const newRelationshipTreeItem = createGroupTreeItemFromDiffNode(node);
+    newRelationshipTreeItem.id = `${node.parent!.uuid}-${relationshipName}`;
+    newRelationshipTreeItem.label = relationshipName;
+    newRelationshipTreeItem.children.push(newDiffTreeItem);
+    parentTreeItem.children.push(newRelationshipTreeItem);
+    return true;
+  }
+
+  // Add to existing relationship group
+  relationshipTreeItem.children.push(newDiffTreeItem);
+  return true;
 }
 
 function findTreeItemById(treeItems: DiffTreeItem[], id: string): DiffTreeItem | undefined {


### PR DESCRIPTION
# Why

On the branch/proposed-change diff Data view, the left-hand tree silently omitted changed nodes whenever their hierarchical parent had no changes of its own — while the right-hand diff list showed them correctly, so the two panes disagreed. The drop was transitive: a changed parent that was itself dropped took its changed children with it. Regression since #5676 (1c4a0f9ce), originally reported by a customer whose updated Loadbalancer Pool Member had no entry in the tree because its pool was unchanged.

This PR makes every changed node visible in the right-hand diff list also appear in the left tree, nested under its (unchanged) parent — as it did before the regression. Per review, it also fixes the same pane disagreement under the Conflicts filter (`?status=CONFLICT`), where unchanged ancestors were dropped because `contains_conflict` never propagates to them.

Non-goals: no backend or GraphQL changes (the backend already returns unchanged parents on purpose via `include_parents: true`), no change to `contains_conflict` semantics, no pagination changes.

Closes #10010

## What changed

Behavioral changes:

- The diff tree again renders `UNCHANGED` parent nodes as hierarchy context, so changed nodes nest under them instead of disappearing.
- With the Conflicts filter active, the tree keeps conflicted nodes plus their ancestor chains, so a conflicted node under an unchanged parent stays anchored; the right pane shows only changed nodes with conflicts, as before.
- The right-hand diff list and its empty state are otherwise unaffected: they still show only changed nodes.
- Multi-level parent chains no longer depend on the order nodes arrive in: `buildDiffTreeItems` pre-creates one tree item per node in a `Map` keyed by `uuid`, so ancestors delivered after descendants (possible across infinite-query pages) no longer cause drops.

Implementation notes:

- Root cause: #5676 moved the `UNCHANGED` filter from the right-pane render into the shared `nodes` computation feeding **both** panes, starving `buildDiffTreeItems` of the parents it needs to anchor children (`if (!parentTreeItem) return acc;` then silently dropped them).
- Fix restores the pre-regression split of concerns in `node-diff/index.tsx`: the tree receives all nodes, a `changedNodes` list feeds the right pane. The client-side CONFLICT QSP filter is likewise split: `contains_conflict` filters only the right pane, while the tree keeps conflicted nodes plus their ancestor chains (`keepConflictNodesWithAncestors`: a `Map` of nodes by `uuid`, recursive marking of each conflicted node's parents, then a filter to the marked set).
- `buildDiffTreeItems` pairs each node with its tree item upfront (`{ node, treeItem }`), indexes the items in a `Map` keyed by `uuid`, then attaches children in a single `for...of` pass — the parent item always exists in the `Map` regardless of input order, so no retry passes are needed.
- Nodes whose parent genuinely never appears in the payload are still skipped, as before.

What stayed the same: no schema or API changes; no changes to `DiffTree` rendering — the `UNCHANGED` badge variant already existed from the pre-regression behavior.

## How to review

- `frontend/app/src/entities/diff/ui/node-diff/index.tsx` — the root-cause fix (filter split, for both the `UNCHANGED` and CONFLICT filters).
- `frontend/app/src/entities/diff/utils/build-diff-tree-items.ts` — order-independent single-pass attach via a `Map` of pre-created tree items.
- `frontend/app/src/entities/diff/ui/node-diff/index.test.tsx` — replication tests written first and verified failing before the fix (component-level, mocks only the two GraphQL API functions): changed node under unchanged parent, and conflicted node under unchanged parent with `?status=CONFLICT`.
- `frontend/app/.betterer.results` — mechanical fingerprint/line shifts for the edited files, no new type issues.

## How to test

```bash
cd frontend/app && pnpm run test src/entities/diff
```

The new tests fail without the fix and pass on this branch. Manual verification: on a demo dataset, open **Branches › `jfk1-update-edge-ips` › Data** — the updated `Interface L3 Ethernet1` nodes (under unchanged devices) and the updated/added IP prefixes (under an unchanged root prefix) now appear in the left tree.

Full gates run locally: frontend suite (118 files / 807 tests), backend unit tests (1400), `biome ci`, `knip`, `betterer ci`.

## Impact & rollout

- **Backward compatibility:** none — frontend-only rendering fix restoring intended behavior.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (not needed — restores documented/expected behavior)
- [ ] Internal .md docs updated (not needed — no architectural change)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the diff tree dropping changed nodes under UNCHANGED parents and keeps conflicted nodes anchored when the Conflicts filter is active. Children stay visible even if their parent arrives later. Addresses #10010.

- **Bug Fixes**
  - Keep UNCHANGED parents in the tree; under `?status=CONFLICT`, keep conflicted nodes with their ancestors. The right pane still shows only changed nodes (and only conflicted ones under the filter).
  - Attachment is order-independent across pages; sibling order follows input.

- **Refactors**
  - Rewrote `buildDiffTreeItems` to a single pass with a `Map` keyed by `uuid`, removing the recursive lookup and a tracked type error; tests added/updated.
  - Formatted `node-diff/index.tsx` to match CI; updated Betterer results.

<sup>Written for commit 042b0d5b13f47d4dd98cd82e5f29a243fc9c73fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

