### PR TITLE
docs(schema): clarify on_delete default is derived from relationship kind

### DIFF
--- a/docs/docs/schema/relationships.mdx
+++ b/docs/docs/schema/relationships.mdx
@@ -45,7 +45,7 @@ This ensures a strong relationship in both directions, where the parent node can
 
 :::warning Cascade deletion
 
-Relationships of kind `Component` include an implicit `on_delete: cascade`. This means that if you delete a node with a `Component` relationship, the related nodes connected by this relationship will also be deleted.
+When `on_delete` is not set explicitly, its default is derived from the relationship kind: `Component` relationships default to `cascade`, and all other kinds default to `no-action`. As a result, deleting a node with a `Component` relationship also deletes the related nodes connected by it. Set `on_delete` explicitly on any relationship to override this default — deletion behavior is driven by the resolved `on_delete` value, not by the relationship kind directly.
 
 :::
 


### PR DESCRIPTION
## What

Clarify the relationship `on_delete` default in the Relationships topic.

The topic previously stated that `Component` relationships include an *implicit* `on_delete: cascade`, without noting that this is a **kind-derived default** an explicit value overrides. The schema reference separately states a flat "Default is no-action". Both are incomplete on their own.

## Change

- **`docs/docs/schema/relationships.mdx`** — rewrite the "Cascade deletion" note: when `on_delete` is unset the default is derived from the relationship kind (`cascade` for `Component`, `no-action` for all other kinds), an explicit value overrides, and deletion is driven by the resolved `on_delete` value rather than the kind directly.

Docs-only — no backend or generated files are touched.

## Note

The generated schema reference (`reference/schema/relationship.mdx`) still shows the terser "Default is no-action" because that wording is generated from the backend attribute description in `internal.py`. Updating it would require a backend + regeneration change, which is intentionally out of scope here; it can be handled separately.

## Draft

Docs lint (Vale + markdownlint) runs in CI.