### PR TITLE
test(backend): merge/rebase recompute of cross-rel HFID + label cascade

### DIFF
--- a/backend/tests/component/merge_recompute_coalescing/test_merge_submits_cross_relationship_hfid.py
+++ b/backend/tests/component/merge_recompute_coalescing/test_merge_submits_cross_relationship_hfid.py
@@ -1,0 +1,141 @@
+"""A human-friendly id reading a peer across the relationship is recomputed on merge and rebase.
+
+When the id reads only the node's own name a peer rename never touches it. When the id reads the
+peer across the relationship the peer rename has to schedule an HFID recompute like the other two
+families. These assert the latter, the case a self-only id never exercises.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from infrahub import lock
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core.branch.tasks import merge_branch, rebase_branch
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.workers.dependencies import build_cache, build_database, build_event_service, build_workflow
+from infrahub.workflows.catalogue import (
+    COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
+    DISPLAY_LABELS_PROCESS_JINJA2,
+    HFID_PROCESS,
+)
+from tests.adapters.cache import MemoryCache
+from tests.adapters.event import MemoryInfrahubEvent
+from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.merge_recompute.dataset import load_profile_schema, seed_branch
+
+if TYPE_CHECKING:
+    from fast_depends import Provider
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+async def test_merge_submits_hfid_recompute_when_hfid_crosses_relationship(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    dependency_provider: Provider,
+) -> None:
+    lock.initialize_lock(local_only=True)
+    await load_profile_schema(db=db, cross_relationship_hfid=True)
+
+    changed_nodes = 8
+    seeded = await seed_branch(
+        db=db,
+        default_branch=default_branch,
+        branch_name="coalesced_merge_hfid",
+        changed_nodes=changed_nodes,
+        mutate_target="branch",
+        mutate_kind="peer",
+    )
+
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=seeded.branch)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=seeded.branch)
+
+    workflow_recorder = WorkflowRecorder()
+    event_recorder = MemoryInfrahubEvent()
+    cache = MemoryCache()
+    context = InfrahubContext.init(
+        branch=default_branch,
+        account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+    )
+
+    with (
+        dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+        dependency_provider.scope(build_event_service, lambda: event_recorder),
+        dependency_provider.scope(build_workflow, lambda: workflow_recorder),
+        dependency_provider.scope(build_cache, lambda: cache),
+    ):
+        await merge_branch(branch=seeded.branch_name, context=context)
+
+    computed = workflow_recorder.get_submit_calls_for(COMPUTED_ATTRIBUTE_PROCESS_JINJA2)
+    display = workflow_recorder.get_submit_calls_for(DISPLAY_LABELS_PROCESS_JINJA2)
+    hfid = workflow_recorder.get_submit_calls_for(HFID_PROCESS)
+
+    # The peer rename reaches the human-friendly id because the id reads the peer across the
+    # relationship, so the merge coalesces one HFID recompute alongside the other two families.
+    assert len(computed) == 1
+    assert len(display) == 1
+    assert len(hfid) == 1
+
+    # A merge recomputes on the destination branch.
+    assert computed[0]["parameters"]["branch_name"] == default_branch.name
+    assert display[0]["parameters"]["branch_name"] == default_branch.name
+    assert hfid[0]["parameters"]["branch_name"] == default_branch.name
+
+
+async def test_rebase_submits_hfid_recompute_when_hfid_crosses_relationship(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    dependency_provider: Provider,
+) -> None:
+    lock.initialize_lock(local_only=True)
+    await load_profile_schema(db=db, cross_relationship_hfid=True)
+
+    changed_nodes = 6
+    # Rebase replays the default branch's intervening changes, so the peers are mutated on default.
+    seeded = await seed_branch(
+        db=db,
+        default_branch=default_branch,
+        branch_name="coalesced_rebase_hfid",
+        changed_nodes=changed_nodes,
+        mutate_target="default",
+        mutate_kind="peer",
+    )
+
+    workflow_recorder = WorkflowRecorder()
+    event_recorder = MemoryInfrahubEvent()
+    cache = MemoryCache()
+    context = InfrahubContext.init(
+        branch=default_branch,
+        account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+    )
+
+    with (
+        dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+        dependency_provider.scope(build_event_service, lambda: event_recorder),
+        dependency_provider.scope(build_workflow, lambda: workflow_recorder),
+        dependency_provider.scope(build_cache, lambda: cache),
+    ):
+        await rebase_branch(branch=seeded.branch_name, context=context, send_events=True)
+
+    computed = workflow_recorder.get_submit_calls_for(COMPUTED_ATTRIBUTE_PROCESS_JINJA2)
+    display = workflow_recorder.get_submit_calls_for(DISPLAY_LABELS_PROCESS_JINJA2)
+    hfid = workflow_recorder.get_submit_calls_for(HFID_PROCESS)
+
+    assert len(computed) == 1
+    assert len(display) == 1
+    assert len(hfid) == 1
+
+    # A rebase recomputes on the user branch, not the destination.
+    assert computed[0]["parameters"]["branch_name"] == seeded.branch_name
+    assert display[0]["parameters"]["branch_name"] == seeded.branch_name
+    assert hfid[0]["parameters"]["branch_name"] == seeded.branch_name

--- a/backend/tests/helpers/merge_recompute/dataset.py
+++ b/backend/tests/helpers/merge_recompute/dataset.py
@@ -22,8 +22,12 @@ PROFILE_NODE_KIND = "TestingProfileNode"
 PROFILE_PEER_KIND = "TestingProfilePeer"
 
 
-def build_profile_schema() -> SchemaRoot:
-    """Two kinds: a peer, and a main node carrying all three derived families."""
+def build_profile_schema(cross_relationship_hfid: bool = False) -> SchemaRoot:
+    """Two kinds: a peer, and a main node carrying all three derived families.
+
+    With ``cross_relationship_hfid`` the node's human-friendly id reads the peer across the
+    relationship instead of only its own name, so a peer rename has to refresh the stored HFID.
+    """
     peer = NodeSchema(
         name="ProfilePeer",
         namespace=PROFILE_NAMESPACE,
@@ -41,7 +45,7 @@ def build_profile_schema() -> SchemaRoot:
         label="Profile Node",
         default_filter="name__value",
         display_label="{{ name__value }} via {{ peer__name__value }}",
-        human_friendly_id=["name__value"],
+        human_friendly_id=["name__value", "peer__name__value"] if cross_relationship_hfid else ["name__value"],
         uniqueness_constraints=[["name__value"]],
         attributes=[
             AttributeSchema(name="name", kind="Text", optional=False, unique=True),
@@ -68,9 +72,16 @@ def build_profile_schema() -> SchemaRoot:
     return SchemaRoot(nodes=[peer, node])
 
 
-async def load_profile_schema(db: InfrahubDatabase, branch_name: str | None = None) -> None:
+async def load_profile_schema(
+    db: InfrahubDatabase, branch_name: str | None = None, cross_relationship_hfid: bool = False
+) -> None:
     """Register the profile schema and persist it so real nodes can be created."""
-    await load_schema(db=db, schema=build_profile_schema(), branch_name=branch_name, update_db=True)
+    await load_schema(
+        db=db,
+        schema=build_profile_schema(cross_relationship_hfid=cross_relationship_hfid),
+        branch_name=branch_name,
+        update_db=True,
+    )
 
 
 def build_profile_schema_dict() -> dict:
@@ -231,6 +242,99 @@ def build_chain_schema_dict(levels: int = 3) -> dict:
             ]
         nodes.append(node)
     return {"version": "1.0", "nodes": nodes}
+
+
+INTERFACE_NAMESPACE = "Testing"
+DEVICE_KIND = "TestingDevice"
+INTERFACE_KIND = "TestingInterface"
+
+
+def build_interface_hfid_schema_dict() -> dict:
+    """A device and an interface whose identity reads the device across the relationship.
+
+    The interface's human-friendly id and display label both include the device name, so the
+    interface's stored identity depends on a peer attribute. Renaming the device must rewrite the
+    interface's stored HFID, the cross-relationship case a self-only HFID never reaches.
+    """
+    return {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": INTERFACE_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+            },
+            {
+                "name": "Interface",
+                "namespace": INTERFACE_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ device__name__value }} :: {{ name__value }}",
+                "human_friendly_id": ["name__value", "device__name__value"],
+                "uniqueness_constraints": [["device", "name__value"]],
+                "attributes": [{"name": "name", "kind": "Text", "optional": False}],
+                "relationships": [{"name": "device", "peer": DEVICE_KIND, "optional": False, "cardinality": "one"}],
+            },
+        ],
+    }
+
+
+LOCATION_NAMESPACE = "Testing"
+METRO_KIND = "TestingMetro"
+SITE_KIND = "TestingSite"
+RACK_KIND = "TestingRack"
+
+
+def build_location_cascade_schema_dict() -> dict:
+    """A metro -> site -> rack chain that propagates a top-level rename two hops.
+
+    The site's short name is a computed attribute reading the metro name across the relationship.
+    The site display label reads the metro directly, so it refreshes on the first hop. The rack
+    display label reads the site's short name across its own relationship, so it moves only after
+    the site's short name is rewritten: the recompute has to chain from that write to the rack. A
+    self-only display label never exercises this second hop.
+    """
+    return {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Metro",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+            },
+            {
+                "name": "Site",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ metro__name__value }}-{{ name__value }}",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "optional": False, "unique": True},
+                    {
+                        "name": "shortname",
+                        "kind": "Text",
+                        "optional": True,
+                        "read_only": True,
+                        "computed_attribute": {
+                            "kind": "Jinja2",
+                            "jinja2_template": "{{ metro__name__value }}-{{ name__value }}",
+                        },
+                    },
+                ],
+                "relationships": [{"name": "metro", "peer": METRO_KIND, "optional": False, "cardinality": "one"}],
+            },
+            {
+                "name": "Rack",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ site__shortname__value }} :: {{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+                "relationships": [{"name": "site", "peer": SITE_KIND, "optional": False, "cardinality": "one"}],
+            },
+        ],
+    }
 
 
 @dataclass(frozen=True)

--- a/backend/tests/integration_docker/test_merge_recompute.py
+++ b/backend/tests/integration_docker/test_merge_recompute.py
@@ -10,9 +10,16 @@ from infrahub_sdk.branch import BranchStatus
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 
 from tests.helpers.merge_recompute.dataset import (
+    DEVICE_KIND,
+    INTERFACE_KIND,
+    METRO_KIND,
     PROFILE_NODE_KIND,
     PROFILE_PEER_KIND,
+    RACK_KIND,
+    SITE_KIND,
     build_chain_schema_dict,
+    build_interface_hfid_schema_dict,
+    build_location_cascade_schema_dict,
     build_profile_schema_dict,
     chain_kind,
 )
@@ -67,6 +74,14 @@ class TestMergeRecompute(TestInfrahubDockerClient):
     @pytest.fixture(scope="class")
     def chain_schema(self) -> dict:
         return build_chain_schema_dict(levels=3)
+
+    @pytest.fixture(scope="class")
+    def interface_hfid_schema(self) -> dict:
+        return build_interface_hfid_schema_dict()
+
+    @pytest.fixture(scope="class")
+    def location_cascade_schema(self) -> dict:
+        return build_location_cascade_schema_dict()
 
     @pytest.fixture(scope="class")
     def delete_peer_schema(self) -> dict:
@@ -218,6 +233,95 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         assert final.summary.value == "cnode on gamma"
         assert final.display_label == "cnode via gamma"
         assert final.hfid == ["cnode"]
+
+    # Cross-relationship human-friendly id: the node's identity reads a peer across the relationship.
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "a cross-relationship human-friendly id is not refreshed by the coalesced merge "
+            "recompute: the display label and computed attribute that read the same renamed peer "
+            "refresh, but the stored hfid keeps the old peer value"
+        ),
+    )
+    async def test_merge_recomputes_cross_relationship_hfid(
+        self, client: InfrahubClient, interface_hfid_schema: dict
+    ) -> None:
+        """A peer rename must rewrite the reader's stored human-friendly id after merge."""
+        loaded = await client.schema.load(schemas=[interface_hfid_schema], wait_until_converged=True)
+        assert loaded.schema_updated
+
+        device = await client.create(kind=DEVICE_KIND, data={"name": "device-a"})
+        await device.save()
+        interface = await client.create(kind=INTERFACE_KIND, data={"name": "eth1", "device": device})
+        await interface.save()
+
+        async def _interface_initial() -> bool:
+            refreshed = await client.get(kind=INTERFACE_KIND, id=interface.id)
+            return refreshed.hfid == ["eth1", "device-a"]
+
+        await _wait_until(_interface_initial)
+
+        branch = await client.branch.create(branch_name="hfid-merge-correctness")
+        device_on_branch = await client.get(kind=DEVICE_KIND, id=device.id, branch=branch.name)
+        device_on_branch.name.value = "device-b"
+        await device_on_branch.save()
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+        await _wait_until_merged(client=client, branch_name=branch.name)
+
+        async def _hfid_recomputed() -> bool:
+            refreshed = await client.get(kind=INTERFACE_KIND, id=interface.id)
+            return refreshed.hfid == ["eth1", "device-b"]
+
+        # The stored human-friendly id reads the peer across the relationship, so the rename must
+        # refresh it. The display label reading the same peer does refresh, so a stale hfid here is
+        # hfid-specific, not a wholesale recompute failure.
+        assert await _became_true(_hfid_recomputed, seconds=90)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "a cross-relationship human-friendly id is not refreshed by the coalesced rebase "
+            "recompute: the display label and computed attribute that read the same renamed peer "
+            "refresh, but the stored hfid keeps the old peer value"
+        ),
+    )
+    async def test_rebase_recomputes_cross_relationship_hfid(
+        self, client: InfrahubClient, interface_hfid_schema: dict
+    ) -> None:
+        """A rebase that replays a peer rename must rewrite a user-branch reader's stored human-friendly id."""
+        await client.schema.load(schemas=[interface_hfid_schema], wait_until_converged=True)
+
+        device = await client.create(kind=DEVICE_KIND, data={"name": "rdevice-a"})
+        await device.save()
+
+        branch = await client.branch.create(branch_name="hfid-rebase-correctness")
+
+        # Rename the device on the default branch; the rebase replays this onto the user branch.
+        device.name.value = "rdevice-b"
+        await device.save()
+
+        # The interface lives only on the user branch, so only the rebase recompute can refresh it.
+        interface = await client.create(
+            kind=INTERFACE_KIND, data={"name": "reth1", "device": device}, branch=branch.name
+        )
+        await interface.save()
+
+        async def _interface_initial() -> bool:
+            refreshed = await client.get(kind=INTERFACE_KIND, id=interface.id, branch=branch.name)
+            return refreshed.hfid == ["reth1", "rdevice-a"]
+
+        await _wait_until(_interface_initial)
+
+        await client.branch.rebase(branch_name=branch.name)
+
+        async def _hfid_recomputed() -> bool:
+            refreshed = await client.get(kind=INTERFACE_KIND, id=interface.id, branch=branch.name)
+            return refreshed.hfid == ["reth1", "rdevice-b"]
+
+        assert await _became_true(_hfid_recomputed, seconds=90)
 
     @pytest.mark.xfail(
         strict=True,
@@ -383,6 +487,92 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         final_tip = await client.get(kind=l3, id=tip.id, branch=branch.name)
         assert final_mid.summary.value == "rroot-edited"
         assert final_tip.summary.value == "rroot-edited"
+
+    # Display-label cascade: a rename two hops up must refresh display labels down the chain.
+
+    async def test_merge_recomputes_two_level_display_label_cascade(
+        self, client: InfrahubClient, location_cascade_schema: dict
+    ) -> None:
+        """A top-level rename must refresh both levels' display labels below it after merge."""
+        loaded = await client.schema.load(schemas=[location_cascade_schema], wait_until_converged=True)
+        assert loaded.schema_updated
+
+        metro = await client.create(kind=METRO_KIND, data={"name": "metro-a"})
+        await metro.save()
+        site = await client.create(kind=SITE_KIND, data={"name": "site1", "metro": metro})
+        await site.save()
+        rack = await client.create(kind=RACK_KIND, data={"name": "rack1", "site": site})
+        await rack.save()
+
+        async def _labels_are(metro_name: str) -> bool:
+            site_node = await client.get(kind=SITE_KIND, id=site.id)
+            rack_node = await client.get(kind=RACK_KIND, id=rack.id)
+            return (
+                site_node.display_label == f"{metro_name}-site1"
+                and rack_node.display_label == f"{metro_name}-site1 :: rack1"
+            )
+
+        await _wait_until(lambda: _labels_are("metro-a"))
+
+        branch = await client.branch.create(branch_name="cascade-merge-correctness")
+        metro_on_branch = await client.get(kind=METRO_KIND, id=metro.id, branch=branch.name)
+        metro_on_branch.name.value = "metro-b"
+        await metro_on_branch.save()
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+        await _wait_until_merged(client=client, branch_name=branch.name)
+
+        await _wait_until(lambda: _labels_are("metro-b"))
+
+        final_site = await client.get(kind=SITE_KIND, id=site.id)
+        final_rack = await client.get(kind=RACK_KIND, id=rack.id)
+        # First hop: the site reads the metro across its relationship. Second hop: the rack reads the
+        # site's short name, which only moves once the site's recompute writes it, so the rack
+        # refreshes only if the recompute chains from the site's write to the rack.
+        assert final_site.shortname.value == "metro-b-site1"
+        assert final_site.display_label == "metro-b-site1"
+        assert final_rack.display_label == "metro-b-site1 :: rack1"
+
+    async def test_rebase_recomputes_two_level_display_label_cascade(
+        self, client: InfrahubClient, location_cascade_schema: dict
+    ) -> None:
+        """A rebase that replays a top-level rename must refresh both levels' display labels on the user branch."""
+        await client.schema.load(schemas=[location_cascade_schema], wait_until_converged=True)
+
+        metro = await client.create(kind=METRO_KIND, data={"name": "rmetro-a"})
+        await metro.save()
+
+        branch = await client.branch.create(branch_name="cascade-rebase-correctness")
+        # The site and rack live only on the user branch, so only the rebase recompute can refresh them.
+        site = await client.create(kind=SITE_KIND, data={"name": "rsite1", "metro": metro}, branch=branch.name)
+        await site.save()
+        rack = await client.create(kind=RACK_KIND, data={"name": "rrack1", "site": site}, branch=branch.name)
+        await rack.save()
+
+        async def _labels_on_branch_are(metro_name: str) -> bool:
+            site_node = await client.get(kind=SITE_KIND, id=site.id, branch=branch.name)
+            rack_node = await client.get(kind=RACK_KIND, id=rack.id, branch=branch.name)
+            return (
+                site_node.display_label == f"{metro_name}-rsite1"
+                and rack_node.display_label == f"{metro_name}-rsite1 :: rrack1"
+            )
+
+        await _wait_until(lambda: _labels_on_branch_are("rmetro-a"))
+
+        # The rebase replays the default branch's metro rename onto the user branch.
+        metro.name.value = "rmetro-b"
+        await metro.save()
+
+        await client.branch.rebase(branch_name=branch.name)
+
+        await _wait_until(lambda: _labels_on_branch_are("rmetro-b"))
+
+        final_site = await client.get(kind=SITE_KIND, id=site.id, branch=branch.name)
+        final_rack = await client.get(kind=RACK_KIND, id=rack.id, branch=branch.name)
+        assert final_site.shortname.value == "rmetro-b-rsite1"
+        assert final_site.display_label == "rmetro-b-rsite1"
+        assert final_rack.display_label == "rmetro-b-rsite1 :: rrack1"
 
     # Delete a read peer: the merge must complete instead of erroring on the missing peer.
 


### PR DESCRIPTION
## What

Adds `integration_docker` coverage for two merge/rebase recompute cases the existing suite missed — its synthetic schema used a self-only HFID and self-only chain labels, so neither a cross-relationship HFID nor a display-label cascade was exercised:

1. **Cross-relationship HFID** — an interface whose `human_friendly_id` reads its device across the relationship (`["name__value", "device__name__value"]`). Rename the device, merge/rebase, expect the stored HFID to refresh.
2. **Two-level display-label cascade** — metro → site → rack; rename the metro, expect both levels' display labels to refresh two hops down (through a computed short-name).

Plus a component-level check that the coalesced builder *schedules* an HFID recompute for a cross-relationship HFID (vs none for a self-only HFID).

## Results on `develop`

| Case | merge | rebase |
|---|:---:|:---:|
| Cross-relationship HFID | ❌ stale | ❌ stale |
| Two-level label cascade | ✅ | ✅ |

- **Label cascade: fixed** by the coalescing — both pass.
- **Cross-relationship HFID: broken** — after the merge/rebase the stored HFID keeps the *old* peer value, while the display label on the same node (reading the same renamed peer) refreshes correctly. The coalesced builder *does* schedule the HFID recompute; the gap is downstream in the render/write step. Filed as **IFC-2937**.

The two HFID tests are committed as `@pytest.mark.xfail(strict=True)`, so they document the intended behavior and turn into a hard failure the moment the bug is fixed — remove the marker then.

## Notes

- **Draft** — opened to carry the repro alongside IFC-2937; not intended to merge as-is.
- Test-only change; no changelog fragment.
- `integration_docker` tier (full stack). Run:
  `uv run pytest backend/tests/integration_docker/test_merge_recompute.py -k "cross_relationship_hfid or two_level_display_label_cascade"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `integration_docker` and component tests to verify recompute behavior for a cross-relationship HFID and a two-level display-label cascade on merge/rebase. The cascade passes; the cross-relationship HFID stays stale and is tracked in IFC-2937 (tests are marked xfail, strict).

- **New Features**
  - Integration tests:
    - Cross-relationship HFID (interface reads device): rename device, then merge/rebase; expect HFID refresh. Currently fails on `develop` and is xfail (IFC-2937).
    - Two-level label cascade (metro → site → rack): top-level rename refreshes both levels’ labels. Passes.
  - Component test: verifies the coalesced builder schedules an HFID recompute for cross-relationship HFID on merge and rebase.
  - Test helpers: add schema variants for device/interface HFID and location cascade, plus a flag to build a cross-relationship HFID in the profile schema.

<sup>Written for commit 2541c40203db652f71ee673d26c7ee184f9c5b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

