### PR TITLE
refactor(frontend): extract isRelationshipSchema field type guard

### DIFF
--- a/changelog/+is-relationship-schema-guard.housekeeping.md
+++ b/changelog/+is-relationship-schema-guard.housekeeping.md
@@ -1,0 +1,1 @@
+Introduced a shared `isRelationshipSchema` type guard in the frontend schema entity and routed the previously inline `"peer" in fieldSchema` field-schema checks through it, so attribute/relationship discrimination now lives in one tested place instead of being duplicated across form, table, filter and detail components.

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -93,8 +93,8 @@ exports[`fix ts error`] = {
     "src/entities/nodes/convert/ui/convert-form.tsx:1982113281": [
       [41, 6, 8, "tsc: Type \'{}\' is not assignable to type \'Record<string, ConvertFieldMapping>\'.\\n  Index signature for type \'string\' is missing in type \'{}\'.", "1301887866"]
     ],
-    "src/entities/nodes/object/ui/filters/dynamic-filter-input.tsx:1945941723": [
-      [118, 25, 9, "tsc: Argument of type \'\\"NodeKind\\"\' is not assignable to parameter of type \'never\'.", "2512581423"]
+    "src/entities/nodes/object/ui/filters/dynamic-filter-input.tsx:593364690": [
+      [119, 25, 9, "tsc: Argument of type \'\\"NodeKind\\"\' is not assignable to parameter of type \'never\'.", "2512581423"]
     ],
     "src/entities/nodes/object/ui/filters/kind-combobox-list.tsx:2661968571": [
       [19, 8, 8, "tsc: Type \'(null | string | undefined)[]\' is not assignable to type \'string[]\'.\\n  Type \'string | null | undefined\' is not assignable to type \'string\'.\\n    Type \'undefined\' is not assignable to type \'string\'.", "3441362927"]
@@ -107,8 +107,8 @@ exports[`fix ts error`] = {
       [62, 28, 24, "tsc: \'objectDetailsData.object\' is possibly \'null\' or \'undefined\'.", "865142553"],
       [62, 53, 4, "tsc: Property \'node\' does not exist on type \'NodeAttribute<string | NodeRelationshipMany | NodeRelationshipOne | boolean | null> | number | string | string[] | string[]\'.\\n  Property \'node\' does not exist on type \'string\'.", "2087865285"]
     ],
-    "src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx:1242790340": [
-      [154, 75, 10, "tsc: Property \'properties\' does not exist on type \'NodeAttributeWithMetadata | NodeRelationshipManyWithMetadata | NodeRelationshipOneWithMetadata | string | string[]\'.\\n  Property \'properties\' does not exist on type \'string\'.", "408285988"]
+    "src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx:3545110285": [
+      [155, 75, 10, "tsc: Property \'properties\' does not exist on type \'NodeAttributeWithMetadata | NodeRelationshipManyWithMetadata | NodeRelationshipOneWithMetadata | string | string[]\'.\\n  Property \'properties\' does not exist on type \'string\'.", "408285988"]
     ],
     "src/entities/nodes/object/ui/object-details/object-data-display/object-relationship-row.test.tsx:3396911868": [
       [81, 9, 21, "tsc: Property \'objectKind\' is missing in type \'\\"Attribute\\" | \\"Component\\" | \\"Group\\" | \\"Hierarchy\\" | \\"Parent\\" | \\"Profile\\" | \\"Template\\"; label?: string | \\"absent\\"; name: string; peer: string; kind: \\"Generic\\" | \\"agnostic\\" | \\"any\\"; read_only: boolean; deprecation?: string | \\"aware\\" | \\"cascade\\" | \\"extra\\"; }; relationshipData: NodeRelationshipOneWithMetadata; permission: Permission; } | \\"inbound\\"; hierarchical?: string | \\"many\\"; min_count: number; max_count: number; common_parent?: string | \\"outbound\\" | null | null | null | null | null | null | null | null | null | null | null | undefined; allow_override: \\"none\\" | undefined; cardinality: \\"one\\" | undefined; common_relatives?: string[] | undefined; description?: string | undefined; display: \\"default\\" | undefined; identifier?: string | undefined; inherited: boolean; direction: \\"bidirectional\\" | undefined; on_delete?: \\"no-action\\" | undefined; optional: boolean; branch?: \\"local\\" | undefined; order_weight?: number | undefined; state: \\"present\\" | { relationshipSchema: { id?: string\' but required in type \'ObjectRelationshipRowProps\'.", "417292446"],

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
@@ -24,6 +24,7 @@ import type {
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 interface IpPrefixDetailsHeaderProps extends RowProps {
   ipPrefixSchema: ModelSchema;
@@ -61,7 +62,7 @@ export function IpamDetailsHeader({
         {orderedFields.map((field, index) => {
           let displayValue: React.ReactNode = "-";
 
-          if ("peer" in field) {
+          if (isRelationshipSchema(field)) {
             if (field.cardinality === "many") {
               const relData = ipPrefixNode[field.name] as NodeRelationshipMany | undefined;
               if (relData && relData.edges?.length > 0) {

--- a/frontend/app/src/entities/nodes/object/ui/filters/dynamic-filter-input.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/dynamic-filter-input.tsx
@@ -15,6 +15,7 @@ import type {
   AttributeSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 export interface DynamicFilterInputProps {
   fieldSchema: AttributeSchema | RelationshipSchema;
@@ -23,7 +24,7 @@ export interface DynamicFilterInputProps {
 }
 
 export function DynamicFilterInput({ fieldSchema, value, onChange }: DynamicFilterInputProps) {
-  if ("peer" in fieldSchema) {
+  if (isRelationshipSchema(fieldSchema)) {
     return <RelationshipFilterCombobox peer={fieldSchema.peer} value={value} onChange={onChange} />;
   }
 

--- a/frontend/app/src/entities/nodes/object/ui/filters/get-filter-definitions.ts
+++ b/frontend/app/src/entities/nodes/object/ui/filters/get-filter-definitions.ts
@@ -41,12 +41,13 @@ import type {
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
 import { isOfKind } from "@/entities/schema/domain/rules/is-of-kind";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 function mapFieldToDefinition(
   schemaKind: ModelSchema["kind"],
   field: AttributeSchema | RelationshipSchema
 ): FilterDefinition {
-  if ("peer" in field) {
+  if (isRelationshipSchema(field)) {
     return { type: "relationship", schema: field };
   }
 

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-display.tsx
@@ -23,6 +23,7 @@ import type {
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 interface ObjectDataDisplayProps {
   objectSchema: ModelSchema;
@@ -84,7 +85,7 @@ export function ObjectDataDisplay({
 
         const objectKind = objectSchema.kind!;
 
-        if ("peer" in field) {
+        if (isRelationshipSchema(field)) {
           const relationshipData = resolveRelationshipData({
             relationshipName: fieldName,
             objectSchema,

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
@@ -6,6 +6,7 @@ import { Row } from "@/shared/components/container";
 import { classNames } from "@/shared/utils/common";
 
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 import { SchemaViewerModal } from "@/entities/schema/ui/schema-viewer-modal";
@@ -21,7 +22,7 @@ export function ObjectDataRow({ value, className, objectKind, fieldSchema }: Obj
   const { schema } = useSchema(objectKind);
 
   const fieldName = fieldSchema.label ?? fieldSchema.name;
-  const isRelationship = "peer" in fieldSchema;
+  const isRelationship = isRelationshipSchema(fieldSchema);
   const defaultTab = isRelationship ? "relationships" : "attributes";
 
   return (

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
@@ -32,6 +32,7 @@ import type {
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
@@ -52,7 +53,7 @@ export function TableColumnHeader({
     return <TableColumnHeaderSimple columnSchema={columnSchema} className={className} />;
   }
 
-  if (schema && !("peer" in columnSchema) && isSortableAttribute(columnSchema)) {
+  if (schema && !isRelationshipSchema(columnSchema) && isSortableAttribute(columnSchema)) {
     return (
       <SortableAttributeColumnHeader
         schema={schema}
@@ -62,7 +63,7 @@ export function TableColumnHeader({
     );
   }
 
-  if (schema && "peer" in columnSchema && isSortableRelationship(columnSchema)) {
+  if (schema && isRelationshipSchema(columnSchema) && isSortableRelationship(columnSchema)) {
     return (
       <SortableRelationshipColumnHeader
         schema={schema}
@@ -262,7 +263,7 @@ function ColumnHeaderMenu({
         onOpenChange={setShowFilterForm}
         placement="bottom start"
       >
-        {"peer" in columnSchema ? (
+        {isRelationshipSchema(columnSchema) ? (
           <RelationshipFilterForm relationshipSchema={columnSchema} onSuccess={closeFilterForm} />
         ) : (
           <AttributeFilterForm attributeSchema={columnSchema} onSuccess={closeFilterForm} />

--- a/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/utils/get-object-table-columns.tsx
@@ -34,6 +34,7 @@ import {
 import { getToggleSelectedRowHandler } from "@/entities/nodes/object/ui/object-table/utils/get-toggle-selected-row-handler";
 import type { ModelSchema } from "@/entities/schema/domain/model/schema";
 import { isGenericSchema } from "@/entities/schema/domain/rules/is-generic-schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 const columnHelper = createColumnHelper<NodeObject>();
 
@@ -109,7 +110,7 @@ export function getObjectFieldsColumns(
       },
       cell: ({ cell, row }) => {
         const value = cell.getValue();
-        if ("peer" in columnSchema) {
+        if (isRelationshipSchema(columnSchema)) {
           return (
             <TableCell>
               <TableRelationshipCell

--- a/frontend/app/src/entities/nodes/sort/domain/rules/find-sort-for-field.ts
+++ b/frontend/app/src/entities/nodes/sort/domain/rules/find-sort-for-field.ts
@@ -1,6 +1,7 @@
 import type { Sort } from "@/entities/nodes/sort/domain/model/sort";
 import { buildAttributeSortField } from "@/entities/nodes/sort/domain/rules/sort-field";
 import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 /**
  * The single active sort targeting the given schema field: returned only when
@@ -16,7 +17,7 @@ export function findSortForField(
   const sort = sorts?.length === 1 ? sorts[0] : undefined;
   if (!sort) return null;
 
-  if ("peer" in fieldSchema) {
+  if (isRelationshipSchema(fieldSchema)) {
     const [relationshipName] = sort.field.split("__");
     return relationshipName === fieldSchema.name ? sort : null;
   }

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter.tsx
@@ -15,6 +15,7 @@ import type {
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 import { FieldSchemaIcon } from "@/entities/schema/ui/field-schema-icon";
 
 export interface TableColumnHeaderProps extends PopoverTriggerProps {
@@ -61,7 +62,7 @@ export function ProposedChangeTableFilter({
         <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-gray-200 border-b-0 bg-white px-2 py-1 font-semibold">
           Filter by {columnSchema.label ?? columnSchema.name}
         </div>
-        {"peer" in columnSchema ? (
+        {isRelationshipSchema(columnSchema) ? (
           <RelationshipFilterForm relationshipSchema={columnSchema} onSuccess={closePopover} />
         ) : (
           <AttributeFilterForm attributeSchema={columnSchema} onSuccess={closePopover} />

--- a/frontend/app/src/entities/schema/domain/rules/is-relationship-schema.test.ts
+++ b/frontend/app/src/entities/schema/domain/rules/is-relationship-schema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
+
+import {
+  generateAttributeSchema,
+  generateRelationshipSchema,
+} from "../../../../../tests/fake/schema";
+
+describe("isRelationshipSchema", () => {
+  it("should return true for a relationship schema", () => {
+    // GIVEN
+    const schema = generateRelationshipSchema();
+
+    // WHEN
+    const result = isRelationshipSchema(schema);
+
+    // THEN
+    expect(result).toBe(true);
+  });
+
+  it("should return false for an attribute schema", () => {
+    // GIVEN
+    const schema = generateAttributeSchema();
+
+    // WHEN
+    const result = isRelationshipSchema(schema);
+
+    // THEN
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/app/src/entities/schema/domain/rules/is-relationship-schema.ts
+++ b/frontend/app/src/entities/schema/domain/rules/is-relationship-schema.ts
@@ -1,0 +1,7 @@
+import type { AttributeSchema, RelationshipSchema } from "@/entities/schema/domain/model/schema";
+
+export const isRelationshipSchema = (
+  fieldSchema: AttributeSchema | RelationshipSchema
+): fieldSchema is RelationshipSchema => {
+  return "peer" in fieldSchema;
+};

--- a/frontend/app/src/entities/schema/ui/field-schema-icon.tsx
+++ b/frontend/app/src/entities/schema/ui/field-schema-icon.tsx
@@ -6,6 +6,7 @@ import type {
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
 import { getSchemaIcon } from "@/entities/schema/domain/rules/get-schema-icon";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 
 export const ATTRIBUTE_ICONS: Record<AttributeKind, string> = {
@@ -38,7 +39,7 @@ interface FieldSchemaIconProps {
 }
 
 export function FieldSchemaIcon({ fieldSchema }: FieldSchemaIconProps) {
-  if ("peer" in fieldSchema) {
+  if (isRelationshipSchema(fieldSchema)) {
     return <RelationshipFieldIcon relationshipSchema={fieldSchema} />;
   }
 

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
@@ -253,10 +253,12 @@ export const getDefaultValueFromTemplate = (
 export const getDefaultValueFromSchema = (
   fieldSchema: FieldSchema
 ): AttributeValueFromUser | null => {
-  return isRelationshipSchema(fieldSchema)
-    ? null
-    : {
-        source: { type: "schema" },
-        value: fieldSchema.default_value as AttributeValueFromUser["value"],
-      };
+  if (isRelationshipSchema(fieldSchema)) {
+    return null;
+  }
+
+  return {
+    source: { type: "schema" },
+    value: fieldSchema.default_value as AttributeValueFromUser["value"],
+  };
 };

--- a/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getFieldDefaultValue.ts
@@ -22,6 +22,7 @@ import type {
 } from "@/entities/nodes/object/domain/model/node";
 import { getNodeLabel } from "@/entities/nodes/object/domain/rules/get-node-label";
 import { isPoolSchema } from "@/entities/schema/domain/rules/is-pool-schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 import { isTemplateSchema } from "@/entities/schema/domain/rules/is-template-schema";
 import { getSchema } from "@/entities/schema/domain/use-cases/get-schema";
 
@@ -252,10 +253,10 @@ export const getDefaultValueFromTemplate = (
 export const getDefaultValueFromSchema = (
   fieldSchema: FieldSchema
 ): AttributeValueFromUser | null => {
-  return "default_value" in fieldSchema
-    ? {
+  return isRelationshipSchema(fieldSchema)
+    ? null
+    : {
         source: { type: "schema" },
         value: fieldSchema.default_value as AttributeValueFromUser["value"],
-      }
-    : null;
+      };
 };

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
@@ -20,6 +20,7 @@ import type {
   ModelSchema,
   RelationshipSchema,
 } from "@/entities/schema/domain/model/schema";
+import { isRelationshipSchema } from "@/entities/schema/domain/rules/is-relationship-schema";
 
 interface GetFormFieldsFromSchema extends FormContextType {
   schema: ModelSchema;
@@ -59,7 +60,7 @@ export const getFormFieldsFromSchema = ({
   const orderedFields = sortByOrderWeight(unorderedFields);
 
   return orderedFields.reduce((acc: Array<DynamicFieldProps>, field) => {
-    if ("peer" in field) {
+    if (isRelationshipSchema(field)) {
       if (isBulkUpdate && field.cardinality === "many") {
         return [
           ...acc,


### PR DESCRIPTION
# Why

Field-schema discrimination between attributes and relationships was duplicated as an inline `"peer" in fieldSchema` check across a dozen form, table, filter and detail components — untested, easy to get subtly wrong, and with no single place to document the invariant.

## What changed

- Added a shared, tested `isRelationshipSchema` type guard under the schema entity's domain rules (`entities/schema/domain/rules/`), alongside the existing `isNodeSchema` / `isGenericSchema` guards.
- Routed all inline `"peer" in fieldSchema` narrowing through it (11 call sites: form field generation, sort resolution, dynamic filter input, filter definitions, table columns/headers, object detail rows, field icon, proposed-change and IPAM headers).
- Swapped the positive `"default_value" in fieldSchema` attribute check in `getDefaultValueFromSchema` for `!isRelationshipSchema(...)` — behaviour identical, discrimination now type-safe.

**What stayed the same:** no behavioural change — the guard narrows exactly as the inline `in` checks did (true → `RelationshipSchema`, false → `AttributeSchema`).

## How to test

```bash
cd frontend/app
pnpm test src/entities/schema/domain/rules/is-relationship-schema.test.ts
pnpm exec biome ci . && pnpm exec betterer ci
```

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`+is-relationship-schema-guard.housekeeping.md`)
- [ ] External docs updated — n/a (internal refactor, no user-facing change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `isRelationshipSchema` type guard and replaced duplicated "peer" checks across forms, tables, filters, and detail views. This centralizes attribute/relationship discrimination with tests and keeps behavior unchanged.

- **Refactors**
  - Added `isRelationshipSchema` under schema domain rules with unit tests.
  - Routed all inline checks through the guard at 11 call sites (form field gen, sort, dynamic filter input/definitions, table columns/headers, object detail rows, field icon, proposed-change and IPAM headers).
  - Updated `getDefaultValueFromSchema` to use the guard and early-return style; behavior identical and now type-safe.

<sup>Written for commit 5fa1ec4bce3580eac21b2a83118dca3474202a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

