### PR TITLE
fix(frontend): prefill parent when adding a child to a hierarchical object

### DIFF
--- a/changelog/+hierarchical-child-parent-prefill.fixed.md
+++ b/changelog/+hierarchical-child-parent-prefill.fixed.md
@@ -1,0 +1,1 @@
+When adding a child to a hierarchical object (for example a Country under a Continent), the creation form now pre-fills the parent field with that object, so the parent no longer has to be selected by hand.

--- a/frontend/app/src/shared/components/form/utils/getParentRelationship.ts
+++ b/frontend/app/src/shared/components/form/utils/getParentRelationship.ts
@@ -1,11 +1,12 @@
+import type { RelationshipSchema } from "@/entities/schema/domain/model/schema";
 import { getSchema } from "@/entities/schema/domain/use-cases/get-schema";
 
-export const getParentRelationship = (peer: string) => {
+export const getParentRelationship = (peer: string): RelationshipSchema | null => {
   const peerSchema = getSchema(peer);
 
   const parentRelationship = peerSchema?.schema?.relationships?.find(
     (rel) => rel.kind === "Parent"
   );
 
-  return parentRelationship;
+  return parentRelationship ?? null;
 };

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.test.ts
@@ -970,6 +970,135 @@ describe("getRelationshipDefaultValue", () => {
     });
   });
 
+  describe("when adding a child to a hierarchical parent", () => {
+    // Country (child, parent cardinality "one") under Continent (parent, children "many").
+    const buildHierarchySchemas = () => {
+      const childSchema = generateNodeSchema({
+        kind: "LocationCountry",
+        display_labels: ["name__value"],
+        inherit_from: ["LocationGeneric"],
+        relationships: [
+          {
+            ...generateRelationshipSchema(),
+            kind: "Hierarchy",
+            name: "parent",
+            cardinality: "one",
+            peer: "LocationContinent",
+          },
+          {
+            ...generateRelationshipSchema(),
+            kind: "Hierarchy",
+            name: "children",
+            cardinality: "many",
+            peer: "LocationSite",
+          },
+        ],
+      });
+      const parentSchema = generateNodeSchema({
+        kind: "LocationContinent",
+        display_labels: ["name__value"],
+        inherit_from: ["LocationGeneric"],
+        relationships: [
+          {
+            ...generateRelationshipSchema(),
+            kind: "Hierarchy",
+            name: "parent",
+            cardinality: "one",
+            peer: "LocationGeneric",
+          },
+          {
+            ...generateRelationshipSchema(),
+            kind: "Hierarchy",
+            name: "children",
+            cardinality: "many",
+            peer: "LocationCountry",
+          },
+        ],
+      });
+      return { childSchema, parentSchema };
+    };
+
+    it("fills the child's parent field with the parent", () => {
+      // GIVEN
+      const { childSchema, parentSchema } = buildHierarchySchemas();
+      const parentData: NodeObject = {
+        id: "continent-id",
+        display_label: "Europe",
+        __typename: "LocationContinent",
+      };
+      store.set(nodeSchemasAtom, [parentSchema]);
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        objectTemplate: null,
+        relationshipName: "parent",
+        schema: childSchema,
+        parentSchema,
+        parentData,
+      });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({
+        source: { type: "user" },
+        value: {
+          id: parentData.id,
+          display_label: parentData.display_label,
+          __typename: parentData.__typename,
+        },
+      });
+    });
+
+    it("does not fill the child's own children field", () => {
+      // GIVEN
+      const { childSchema, parentSchema } = buildHierarchySchemas();
+      const parentData: NodeObject = {
+        id: "continent-id",
+        display_label: "Europe",
+        __typename: "LocationContinent",
+      };
+      store.set(nodeSchemasAtom, [parentSchema]);
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        objectTemplate: null,
+        relationshipName: "children",
+        schema: childSchema,
+        parentSchema,
+        parentData,
+      });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({ source: null, value: null });
+    });
+
+    it("does not fill the parent field when the object is not a valid parent kind", () => {
+      // GIVEN
+      const { childSchema } = buildHierarchySchemas(); // LocationCountry, parent peer LocationContinent
+      const unrelatedParentSchema = generateNodeSchema({
+        kind: "InfraDevice",
+        display_labels: ["name__value"],
+      });
+      const parentData: NodeObject = {
+        id: "device-id",
+        display_label: "device-1",
+        __typename: "InfraDevice",
+      };
+      store.set(nodeSchemasAtom, [unrelatedParentSchema]);
+
+      // WHEN
+      const defaultValue = getRelationshipDefaultValue({
+        objectTemplate: null,
+        relationshipName: "parent",
+        schema: childSchema,
+        parentSchema: unrelatedParentSchema,
+        parentData,
+      });
+
+      // THEN
+      expect(defaultValue).to.deep.equal({ source: null, value: null });
+    });
+  });
+
   describe("when profiles are provided", () => {
     const buildProfileData = (override: Partial<ProfileData> = {}): ProfileData => ({
       id: "profile-id",

--- a/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
+++ b/frontend/app/src/shared/components/form/utils/getRelationshipDefaultValue.ts
@@ -154,15 +154,22 @@ const getRelationshipValueFromParent = (
 ): RelationshipValueFromUser | null => {
   if (!parentSchema || !parentData || !schema) return null;
 
-  const relationshipToParent = schema.relationships?.find((r) => {
-    return r.kind === "Parent" && r.name === relationshipName;
-  });
+  const childRelationship = schema.relationships?.find((r) => r.name === relationshipName);
+  if (!childRelationship) return null;
 
-  const relationshipFromParent = parentSchema.relationships?.find((r) => {
-    return r.kind === "Component" && isOfKind(r.peer, schema);
-  });
+  // The reverse Component side is optional, so check it exists and accepts this child.
+  const isFlatParent =
+    childRelationship.kind === "Parent" &&
+    !!parentSchema.relationships?.some((r) => r.kind === "Component" && isOfKind(r.peer, schema));
 
-  if (relationshipToParent && relationshipFromParent) {
+  // Hierarchy always exists on both sides. "one" is the parent side (children is "many"),
+  // and isOfKind checks parentData is a kind this parent field accepts.
+  const isHierarchyParent =
+    childRelationship.kind === "Hierarchy" &&
+    childRelationship.cardinality === "one" &&
+    isOfKind(childRelationship.peer, parentSchema);
+
+  if (isFlatParent || isHierarchyParent) {
     return {
       source: { type: "user" },
       value: {


### PR DESCRIPTION
# Why

Adding a child to a hierarchical object (e.g. a Country under a Continent) was cumbersome: the create form opened from the object's Children tab left the required "Parent" field empty, so users had to manually reselect the parent they had just navigated from.

## What changed

- Adding a child from a hierarchical object's Children tab now pre-fills the child's Parent field with that object — no manual reselection.
- `getRelationshipValueFromParent` previously only handled the flat `Parent`/`Component` relationship pair; it now also handles the `Hierarchy` pattern. It stays directional (only the `cardinality: "one"` parent side is filled, never the child's own `children`) and validates the parent kind with `isOfKind` so an unrelated or wrong-level object is never filled in.
- Small type tightening on `getParentRelationship` (explicit return type).

## How to review

1. `getRelationshipDefaultValue.ts` — the hierarchy branch.
2. `getRelationshipDefaultValue.test.ts` — 3 added tests: fills the parent, skips the child's own `children`, skips an invalid parent kind.

Tests: `pnpm test src/shared/components/form/utils/getRelationshipDefaultValue.test.ts` (38 pass).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefills the Parent field when creating a child from a hierarchical object's Children tab, removing the need to reselect the parent. Updates defaulting logic to only auto-set valid parents.

- **Bug Fixes**
  - Extend default value logic to support `Hierarchy` relationships: treat `cardinality: "one"` as the parent side, validate with `isOfKind`, and do not populate a child's own `children`.
  - Tighten `getParentRelationship` return type and add tests for filling the parent, skipping `children`, and rejecting invalid parent kinds.

<sup>Written for commit bc9dd2b0ca258f87cbe55f552e197d1d888a7f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

