### PR TITLE
docs(git-integration): clarify one-way model, repo types, and sync_with_git

### DIFF
--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -4,7 +4,7 @@ title: Git Integration
 
 import ReferenceLink from "../../src/components/Card";
 
-Connect an external Git repository to keep the code that drives Infrahub — schemas, transformations, generators, checks, GraphQL queries, and artifact definitions — under version control, next to your infrastructure data. Infrahub imports that code and keeps it in sync as the repository changes.
+Connect an external Git repository to keep the code that drives Infrahub — schemas, Transformations, Generators, checks, GraphQL queries, and artifact definitions — under version control, next to your infrastructure data. Infrahub imports that code and keeps it in sync as the repository changes.
 
 To set one up, see [connect a repository](./connect-repository.mdx), [configure `.infrahub.yml`](./infrahub-yml.mdx), and [filter which branches sync](./branch-synchronization.mdx).
 
@@ -13,7 +13,7 @@ To set one up, see [connect a repository](./connect-repository.mdx), [configure 
 Infrahub has two separate version-control systems, and understanding the split is the key to the rest of this section.
 
 - **The graph** — your infrastructure data (objects) and schema. Infrahub versions the graph itself: you branch it, change it, review the diff in a [Proposed Change](../proposed-changes/overview.mdx), and merge. This is Git-like version control, but the store is Infrahub's database, not a Git repository.
-- **Git** — the code that describes intent: schemas, transformations, generators, checks, GraphQL queries, and artifact definitions, declared in [`.infrahub.yml`](./infrahub-yml.mdx). Infrahub reads this code from the repository and imports it.
+- **Git** — the code that describes intent: schemas, Transformations, Generators, checks, GraphQL queries, and artifact definitions, declared in [`.infrahub.yml`](./infrahub-yml.mdx). Infrahub reads this code from the repository and imports it.
 
 The link between the two runs one way: from Git into Infrahub. Git is where you author code intent; Infrahub imports it and applies it to the graph. Data moves the other way only inside Infrahub — when you merge a branch, the change is applied to the graph, not pushed back to Git. A read-write repository does write one thing back to Git, and only one; the [repository types](#read-only-vs-core) section covers it.
 
@@ -32,7 +32,7 @@ Infrahub supports two distinct repository connection types, each designed for sp
 
 ### Repository: read-write integration
 
-The standard **Repository** type gives Infrahub read-write access to Git. Infrahub imports code from every branch automatically, and on a Proposed Change merge it updates the repository's default branch in Git.
+The standard **Repository** type gives Infrahub read-write access to Git. Infrahub imports code from every branch automatically, and on a Proposed Change merge it updates the linked Git branch — for branches that sync with Git (see [Controlling whether a branch reaches Git](#controlling-whether-a-branch-reaches-git)).
 
 **Design principles:**
 
@@ -50,7 +50,7 @@ When you create a Repository connection, Infrahub:
 4. Runs background synchronization tasks every few seconds to detect changes
 5. Parses the `.infrahub.yml` file to determine which resources to import
 
-When you merge a Proposed Change and the source branch is set to sync with Git, Infrahub merges the corresponding branch in the Git repository and pushes the result to the remote. By default this is a fast-forward, so no merge commit is created (see [merging branches](#merging-branches)). Only the code tracked in Git moves; your infrastructure data stays in the graph.
+When you merge a Proposed Change and the source branch is set to sync with Git, Infrahub merges the corresponding branch in the Git repository and pushes the result to the remote. By default this is a fast-forward when possible, so no merge commit is created (see [merging branches](#merging-branches)). Only the code tracked in Git moves; your infrastructure data stays in the graph.
 
 ### Read-only Repository: controlled unidirectional flow
 
@@ -108,7 +108,7 @@ This separation ensures that Git operations don't block API requests and enables
 
 **This applies only to standard repositories:**
 
-By default, Infrahub performs fast-forward only (ff-only) merges between branches. When merging a branch linked to Git, Infrahub updates the destination branch pointer without creating a merge commit.
+By default, Infrahub runs a standard `git merge`, which fast-forwards when the history allows it. When merging a branch linked to Git, Infrahub moves the destination branch pointer forward without creating a merge commit; if the branches have diverged, Git falls back to a merge commit.
 
 You can configure Infrahub to always create a merge commit by setting the `INFRAHUB_GIT_USE_EXPLICIT_MERGE_COMMIT` environment variable to `true`. This approach maintains a more explicit commit history and improves auditability.
 

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -4,11 +4,18 @@ title: Git Integration
 
 import ReferenceLink from "../../src/components/Card";
 
-Git Integration in Infrahub connects your data layer to external Git repositories, letting you store and version-control the code that drives Infrahub — transformations, generators, checks, and other automation resources — alongside your infrastructure data. This page covers the underlying concepts; specific tasks like [connecting a repository](./connect-repository.mdx), [configuring `.infrahub.yml`](./infrahub-yml.mdx), and [filtering which branches sync](./branch-synchronization.mdx) live in the pages below.
+Connect an external Git repository to keep the code that drives Infrahub — schemas, transformations, generators, checks, GraphQL queries, and artifact definitions — under version control, next to your infrastructure data. Infrahub imports that code and keeps it in sync as the repository changes.
 
-## Understanding Git repositories in Infrahub
+To set one up, see [connect a repository](./connect-repository.mdx), [configure `.infrahub.yml`](./infrahub-yml.mdx), and [filter which branches sync](./branch-synchronization.mdx).
 
-Infrahub integrates with external Git repositories to enable comprehensive version-controlled infrastructure management. This integration allows you to store and manage transformations, queries, Generators, and other automation resources alongside your infrastructure data. This topic explains how Infrahub's Git integration works, the available repository types, and the architectural decisions behind these features.
+## Two version-control planes
+
+Infrahub has two separate version-control systems, and understanding the split is the key to the rest of this section.
+
+- **The graph** — your infrastructure data (objects) and schema. Infrahub versions the graph itself: you branch it, change it, review the diff in a [Proposed Change](../proposed-changes/overview.mdx), and merge. This is Git-like version control, but the store is Infrahub's database, not a Git repository.
+- **Git** — the code that describes intent: schemas, transformations, generators, checks, GraphQL queries, and artifact definitions, declared in [`.infrahub.yml`](./infrahub-yml.mdx). Infrahub reads this code from the repository and imports it.
+
+The link between the two runs one way: from Git into Infrahub. Git is where you author code intent; Infrahub imports it and applies it to the graph. Data moves the other way only inside Infrahub — when you merge a branch, the change is applied to the graph, not pushed back to Git. A read-write repository does write one thing back to Git, and only one; the [repository types](#read-only-vs-core) section covers it.
 
 ## Why Git integration matters
 
@@ -23,15 +30,15 @@ Modern infrastructure management requires both structured data (network configur
 
 Infrahub supports two distinct repository connection types, each designed for specific use cases and operational requirements.
 
-### Repository: full bidirectional integration
+### Repository: read-write integration
 
-The standard **Repository** type provides comprehensive, bidirectional integration between Infrahub and Git. This design choice fulfills the need for truly unified version control across infrastructure data and code.
+The standard **Repository** type gives Infrahub read-write access to Git. Infrahub imports code from every branch automatically, and on a Proposed Change merge it updates the repository's default branch in Git.
 
 **Design principles:**
 
-- **Branch parity**: Every branch in the external repository will have a corresponding branch in Infrahub
-- **Automatic synchronization**: Changes from Git are pulled automatically via background tasks
-- **Bidirectional flow**: Changes can flow from Git to Infrahub and from Infrahub back to Git (via Proposed Changes)
+- **Branch parity**: each branch in the Git repository has a corresponding branch in Infrahub
+- **Automatic import**: Infrahub imports changes from Git in the background, without a manual trigger
+- **One write-back on merge**: merging a Proposed Change updates the linked branch in Git (see [merging branches](#merging-branches) below); this moves code intent, never your infrastructure data
 
 **How it works internally:**
 
@@ -43,7 +50,7 @@ When you create a Repository connection, Infrahub:
 4. Runs background synchronization tasks every few seconds to detect changes
 5. Parses the `.infrahub.yml` file to determine which resources to import
 
-The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
+When you merge a Proposed Change and the source branch is set to sync with Git, Infrahub merges the corresponding branch in the Git repository and pushes the result to the remote. By default this is a fast-forward, so no merge commit is created (see [merging branches](#merging-branches)). Only the code tracked in Git moves; your infrastructure data stays in the graph.
 
 ### Read-only Repository: controlled unidirectional flow
 
@@ -51,16 +58,16 @@ The **Read-only Repository** type offers a simpler, unidirectional integration d
 
 **Design principles:**
 
-- **Single reference tracking**: Links one specific Git ref (branch, tag, or commit)
-- **Manual synchronization**: Updates only happen when the `ref` property is changed
-- **Protection of external resources**: Guarantees no modifications to the external repository
+- **Single reference tracking**: links one specific Git ref (branch, tag, or commit)
+- **Manual synchronization**: Infrahub does not poll a read-only repository; you update it by changing the `ref` or using the **Import latest commit** action
+- **Protection of external resources**: guarantees no modifications to the external repository
 
 **How it works internally:**
 
 Read-only repositories:
 
 1. Track a single Git reference rather than all branches
-2. Pull changes only when the `ref` property is updated
+2. Import changes only when you change the `ref` or run **Import latest commit** — Infrahub does not poll read-only repositories
 3. Import resources according to the `.infrahub.yml` configuration
 4. Maintain a simpler state model without complex branch synchronization logic
 
@@ -106,6 +113,12 @@ By default, Infrahub performs fast-forward only (ff-only) merges between branche
 You can configure Infrahub to always create a merge commit by setting the `INFRAHUB_GIT_USE_EXPLICIT_MERGE_COMMIT` environment variable to `true`. This approach maintains a more explicit commit history and improves auditability.
 
 <ReferenceLink title="Enabling explicit merge commits" url="/git-integration/connect-repository#customizing-git-merge-behavior"/>
+
+### Controlling whether a branch reaches Git
+
+Each Infrahub branch has a `sync_with_git` property, chosen when you create the branch. It controls whether a branch **created in Infrahub** is extended to Git: when it is on, Infrahub creates a matching branch in every read-write repository and, on a Proposed Change merge, merges that branch in Git. When it is off, the branch stays inside Infrahub's graph.
+
+The name reads as if it governs importing Git branches into Infrahub — it does not. Import always runs from Git to Infrahub regardless of this property; `sync_with_git` only affects branches going the other way, from Infrahub out to Git. Many data-only changes never need a Git branch at all, since that data lives only in the graph.
 
 ## The `.infrahub.yml` configuration file {#infrahub-yaml}
 
@@ -175,6 +188,12 @@ The polling-based synchronization approach:
 - Provides near-real-time updates (within seconds)
 - Avoids webhook complexity and firewall issues
 - May introduce slight delays compared to push-based systems
+
+## Common misconceptions
+
+- **Merging a change in Infrahub pushes data to Git.** It does not. A data merge is applied to the graph. The only thing a merge writes to Git is the code-intent branch of a read-write repository, updated on a Proposed Change merge.
+- **`sync_with_git` controls importing Git branches into Infrahub.** It does not. It controls whether a branch created in Infrahub is extended out to Git. Import always runs from Git to Infrahub.
+- **A read-write repository has an "Import latest commit" button.** It does not. Read-write repositories import automatically in the background; **Import latest commit** is a read-only repository action, used because read-only repositories are not polled.
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

Correct and expand the Git Integration overview so it matches how the integration actually behaves. The page previously described the read-write Repository type as "full bidirectional integration" with data flowing "from Infrahub back to Git" — this is inaccurate (and contradicted the page's own ff-only merge statement), and it is the single most common customer misconception hit in the field.

Use case: smaller update / feature improvement (no structural change).

## Content changes (all in `git-integration/overview.mdx`)

- **Two version-control planes** (new section) — establishes the graph (data + schema, versioned in Infrahub's DB) vs Git (code intent) split, and that the link runs one way, Git → Infrahub.
- **Repository types** — reframed the standard type from "full bidirectional integration" to read-write integration: automatic Git → Infrahub import plus a single narrow write-back (the linked branch's default ref) on Proposed Change merge. Fixed the "creates a merge commit / pushes it back" paragraph to match the ff-only default and to state that only code intent moves, never data.
- **Read-only repositories** — clarified that they are not polled; you update via `ref` change or **Import latest commit**.
- **Controlling whether a branch reaches Git** (new subsection) — documents the per-branch `sync_with_git` flag and the common misreading of its name.
- **Common misconceptions** (new section) — three verified pitfalls.

## What needs reviewer attention

New prose to read carefully (the rest is small edits to existing lines):

- **"Two version-control planes".** Mental model; claims verified against `core/branch/models.py`, `git/tasks.py:696` (`merge_git_repository`), `git/repository.py:271` (`merge` + push).
- **`sync_with_git` subsection.** Matches the field description in `core/branch/models.py:40-42` and the PC-merge gate in `core/merge/branch_merger.py:286`.

## What didn't change

- No claims invented; every new statement traces to backend code.
- The `~60s` poll interval from field notes was intentionally **not** added — it isn't sourced from code, and the page already hedges ("multiple times per minute").

## Out of scope (deferred, not touched)

- Pre-existing voice drift ("bridges these two worlds"; "simpler, unidirectional") left as-is to keep this PR scoped. Small follow-up.
- Multi-environment promotion content (three pages in flight elsewhere).

## Verification

- `markdownlint-cli2` (repo `.markdownlint-cli2.yaml`): 0 issues.
- Vale: 0 errors, 0 warnings, 0 suggestions.
- Word check (`simple`/`easy`/`just`): none in new content.
- `cd docs && npm run build` **not** run locally — docs deps not installed in this checkout; relying on CI for the render check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

