### PR TITLE
chore: release 1.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
-## [Infrahub - v1.10.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.10.6) - 2026-07-27
+## [Infrahub - v1.10.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.10.6) - 2026-07-28
 
 ### Changed
 
@@ -25,6 +25,8 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 - Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own. ([#10010](https://github.com/opsmill/infrahub/issues/10010))
 - Fixed the object creation form when adding a component from its parent's tab (e.g. adding an interface from a device): the parent is now pre-selected and the create form opens directly, even when the component's parent relationship points to a generic rather than a concrete node.
 - The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.
+- Fixed schema updates that remove a node with an object template leaving the branch schema permanently out of sync across workers ([#10049](https://github.com/opsmill/infrahub/issues/10049))
+- Branch rebase and merge no longer validate schema constraints for attributes and relationships that were not actually modified on the branch. The query collecting the changed fields of a diff could match nodes belonging to other branches' diffs and to already-merged diffs, which would inflate the set of constraints to check.
 
 ## [Infrahub - v1.10.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.10.5) - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.10.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.10.6) - 2026-07-27
+
+### Changed
+
+- Node creation no longer issues a redundant database query to resolve peers for empty many-cardinality relationships, since a newly created node has none stored yet. This removes hundreds of round-trips during the first-time database initialization and speeds up node creation.
+
+### Fixed
+
+- Deleting a repository now cascades to the objects it manages (transforms, checks, GraphQL queries, generators, and their artifact definitions, artifacts, and validators), so a repository can be removed in a single operation instead of deleting each dependent object by hand. ([#3076](https://github.com/opsmill/infrahub/issues/3076))
+- Following an IP prefix or address link from the relationship tabs of an IPAM namespace now keeps you in that namespace, instead of redirecting to the default namespace. ([#9892](https://github.com/opsmill/infrahub/issues/9892))
+- Fixed git-sync repository import getting stuck on the previous commit when a check definition removed from the repository was still referenced by a proposed change. ([#9934](https://github.com/opsmill/infrahub/issues/9934))
+- Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own. ([#10010](https://github.com/opsmill/infrahub/issues/10010))
+- Fixed the object creation form when adding a component from its parent's tab (e.g. adding an interface from a device): the parent is now pre-selected and the create form opens directly, even when the component's parent relationship points to a generic rather than a concrete node.
+- The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.
+
 ## [Infrahub - v1.10.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.10.5) - 2026-07-15
 
 ### Fixed

--- a/changelog/+diff-field-summary-cross-diff-leak.fixed.md
+++ b/changelog/+diff-field-summary-cross-diff-leak.fixed.md
@@ -1,1 +1,0 @@
-Branch rebase and merge no longer validate schema constraints for attributes and relationships that were not actually modified on the branch. The query collecting the changed fields of a diff could match nodes belonging to other branches' diffs and to already-merged diffs, which would inflate the set of constraints to check.

--- a/changelog/+faster-node-creation-empty-relationships.changed.md
+++ b/changelog/+faster-node-creation-empty-relationships.changed.md
@@ -1,1 +1,0 @@
-Node creation no longer issues a redundant database query to resolve peers for empty many-cardinality relationships, since a newly created node has none stored yet. This removes hundreds of round-trips during the first-time database initialization and speeds up node creation.

--- a/changelog/+generic-parent-preselect.fixed.md
+++ b/changelog/+generic-parent-preselect.fixed.md
@@ -1,1 +1,0 @@
-Fixed the object creation form when adding a component from its parent's tab (e.g. adding an interface from a device): the parent is now pre-selected and the create form opens directly, even when the component's parent relationship points to a generic rather than a concrete node.

--- a/changelog/+proposed-changes-list-order.fixed.md
+++ b/changelog/+proposed-changes-list-order.fixed.md
@@ -1,1 +1,0 @@
-The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.

--- a/changelog/10010.fixed.md
+++ b/changelog/10010.fixed.md
@@ -1,1 +1,0 @@
-Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own.

--- a/changelog/10049.fixed.md
+++ b/changelog/10049.fixed.md
@@ -1,1 +1,0 @@
-Fixed schema updates that remove a node with an object template leaving the branch schema permanently out of sync across workers

--- a/changelog/3076.fixed.md
+++ b/changelog/3076.fixed.md
@@ -1,1 +1,0 @@
-Deleting a repository now cascades to the objects it manages (transforms, checks, GraphQL queries, generators, and their artifact definitions, artifacts, and validators), so a repository can be removed in a single operation instead of deleting each dependent object by hand.

--- a/changelog/9892.fixed.md
+++ b/changelog/9892.fixed.md
@@ -1,1 +1,0 @@
-Following an IP prefix or address link from the relationship tabs of an IPAM namespace now keeps you in that namespace, instead of redirecting to the default namespace.

--- a/changelog/9934.fixed.md
+++ b/changelog/9934.fixed.md
@@ -1,1 +1,0 @@
-Fixed git-sync repository import getting stuck on the previous commit when a check definition removed from the repository was still referenced by a proposed change.

--- a/docs/docs/release-notes/infrahub/release-1_10_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_10_6.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.10.6
-release_date: 2026-07-27
+release_date: 2026-07-28
 release_type: patch
 description: "Speeds up node creation by avoiding a redundant peer query for empty relationships, and fixes repository cascade deletion, IPAM namespace link navigation, git-sync import, and diff-tree rendering."
 ---
@@ -12,7 +12,7 @@ description: "Speeds up node creation by avoiding a redundant peer query for emp
     </tr>
     <tr>
       <th>Release Date</th>
-      <td>July 27th, 2026</td>
+      <td>July 28th, 2026</td>
     </tr>
     <tr>
       <th>Tag</th>
@@ -33,3 +33,5 @@ description: "Speeds up node creation by avoiding a redundant peer query for emp
 - Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own. ([#10010](https://github.com/opsmill/infrahub/issues/10010))
 - Fixed the object creation form when adding a component from its parent's tab (e.g. adding an interface from a device): the parent is now pre-selected and the create form opens directly, even when the component's parent relationship points to a generic rather than a concrete node.
 - The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.
+- Fixed schema updates that remove a node with an object template leaving the branch schema permanently out of sync across workers ([#10049](https://github.com/opsmill/infrahub/issues/10049))
+- Branch rebase and merge no longer validate schema constraints for attributes and relationships that were not actually modified on the branch. The query collecting the changed fields of a diff could match nodes belonging to other branches' diffs and to already-merged diffs, which would inflate the set of constraints to check.

--- a/docs/docs/release-notes/infrahub/release-1_10_6.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_10_6.mdx
@@ -1,0 +1,35 @@
+---
+title: Release 1.10.6
+release_date: 2026-07-27
+release_type: patch
+description: "Speeds up node creation by avoiding a redundant peer query for empty relationships, and fixes repository cascade deletion, IPAM namespace link navigation, git-sync import, and diff-tree rendering."
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.10.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>July 27th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.10.6](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.10.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Changed
+
+- Node creation no longer issues a redundant database query to resolve peers for empty many-cardinality relationships, since a newly created node has none stored yet. This removes hundreds of round-trips during the first-time database initialization and speeds up node creation.
+
+### Fixed
+
+- Deleting a repository now cascades to the objects it manages (transforms, checks, GraphQL queries, generators, and their artifact definitions, artifacts, and validators), so a repository can be removed in a single operation instead of deleting each dependent object by hand. ([#3076](https://github.com/opsmill/infrahub/issues/3076))
+- Following an IP prefix or address link from the relationship tabs of an IPAM namespace now keeps you in that namespace, instead of redirecting to the default namespace. ([#9892](https://github.com/opsmill/infrahub/issues/9892))
+- Fixed git-sync repository import getting stuck on the previous commit when a check definition removed from the repository was still referenced by a proposed change. ([#9934](https://github.com/opsmill/infrahub/issues/9934))
+- Fixed the branch and proposed change diff view not showing changed objects in the tree when their parent object had no changes of its own. ([#10010](https://github.com/opsmill/infrahub/issues/10010))
+- Fixed the object creation form when adding a component from its parent's tab (e.g. adding an interface from a device): the parent is now pre-selected and the create form opens directly, even when the component's parent relationship points to a generic rather than a concrete node.
+- The proposed changes list is now ordered by creation date with the newest first, on both the open and closed tabs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-server"
-version = "1.10.5"
+version = "1.10.6"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 requires-python = ">=3.12,<3.15"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.10.5"
+version = "1.10.6"
 requires-python = ">=3.10"
 
 description = "Testcontainers instance for Infrahub to easily build integration tests"

--- a/python_testcontainers/uv.lock
+++ b/python_testcontainers/uv.lock
@@ -521,7 +521,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.10.5"
+version = "1.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -751,8 +751,8 @@ name = "pendulum"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "python_full_version < '3.13'" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/7c/009c12b86c7cc6c403aec80f8a4308598dfc5995e5c523a5491faaa3952e/pendulum-3.1.0.tar.gz", hash = "sha256:66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015", size = 85930, upload-time = "2025-04-19T14:30:01.675Z" }
 wheels = [
@@ -1840,8 +1840,8 @@ name = "whenever"
 version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
-    { name = "tzlocal", marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzlocal", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/ae/dcbfee50237cedca9153cac045dff6d93b81886f44f82c86493856592d55/whenever-0.9.3.tar.gz", hash = "sha256:22e6f8366767ab3c8be6d9e21a27bc56be2e50f0f2c66d78e8ee86497b579f1a", size = 256933, upload-time = "2025-10-16T19:44:40.832Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1432,7 +1432,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-server"
-version = "1.10.5"
+version = "1.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },
@@ -2619,8 +2619,8 @@ name = "pendulum"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "python_full_version < '3.13'" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
 wheels = [


### PR DESCRIPTION
# Why

Release 1.10.6

## What changed

* Version bumps in pyproject.toml and uv.lock files
* Changelog files and release notes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

