### PR TITLE
fix(frontend): stop clipping input focus ring in node forms

### DIFF
--- a/changelog/+node-form-input-focus-ring-clipping.fixed.md
+++ b/changelog/+node-form-input-focus-ring-clipping.fixed.md
@@ -1,0 +1,1 @@
+Fixed the focus ring on text inputs being clipped on the left and right edges when an object form is opened inside a sheet (for example the "Add object" form). The form no longer adds its own redundant scroll container, so the ring is drawn in full.

--- a/frontend/app/src/shared/components/form/node-form.tsx
+++ b/frontend/app/src/shared/components/form/node-form.tsx
@@ -9,7 +9,6 @@ import { getCreateMutationFromFormData } from "@/shared/components/form/utils/mu
 import { shouldAllowEmptySubmission } from "@/shared/components/form/utils/shouldAllowEmptySubmission";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
-import { classNames } from "@/shared/utils/common";
 
 import { useAuth } from "@/entities/authentication/ui/auth-provider";
 import type {
@@ -123,7 +122,7 @@ export const NodeForm = ({
       onSubmit={(formData: Record<string, FormFieldValue>) =>
         onSubmit ? onSubmit({ formData, fields, profiles }) : onSubmitCreate(formData)
       }
-      className={classNames("overflow-auto", className)}
+      className={className}
       {...props}
     />
   );


### PR DESCRIPTION
## Before
<img width="888" height="180" alt="image" src="https://github.com/user-attachments/assets/d7fc12a4-8db9-483c-a624-6edc4e6edbf9" />

## After
<img width="888" height="180" alt="image" src="https://github.com/user-attachments/assets/eba99ef0-68c3-4594-8a2b-ba20a1fceaf6" />


# Why

When an object form (e.g. the "Add object" form) is opened inside a sheet, the focus ring on text inputs is visibly clipped on the left and right edges, so a focused field looks cut off.

## What changed

- Focused inputs in node forms now show a complete focus ring on all four sides when the form is opened inside a sheet.

Root cause: `NodeForm` applied `overflow-auto` to the `<form>` element, which had no horizontal padding. Inputs are `w-full`, so their `focus-visible:ring-2` extended 2px beyond the form's content box and was clipped left/right by the overflow (it survived top/bottom thanks to `space-y-4`). The form never actually scrolled itself — it has no height constraint, and scrolling is owned by the sheet's dialog (`overflow-auto` with `p-3` padding) — so the `overflow-auto` on the form was redundant. Removing it lets the ring render in full.

- No API/schema changes; only a CSS/layout class removed.

## How to review

Traced all ~15 render sites of `ObjectForm`/`NodeForm`/`GenericObjectForm`: each sits inside either a `<Sheet>` (`AriaDialog`, `overflow-auto p-3`) or `GroupPanelBody` (`grow overflow-auto`), so no call site loses scrolling. The only non-sheet site (bulk-edit) already passed `className="p-4"`, so its ring was never clipped and its behavior is unchanged.

## How to test

1. `cd frontend/app && pnpm dev`
2. Open any object list (e.g. Device) → "Add …" → focus a text input.
3. The blue focus ring is complete on all four sides (previously cut off on the left/right).

## Impact & rollout

- **Backward compatibility:** none — visual-only fix.
- **Deployment notes:** safe to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

