### PR TITLE
inject observer metrics for rate limiting

### DIFF
--- a/backend/infrahub/api/admission/constants.py
+++ b/backend/infrahub/api/admission/constants.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class RejectionReason(StrEnum):
+    """Which mechanism shed a request. Doubles as the `reason` metric label."""
+
+    STRESS = "stress"
+    CODEL = "codel"
+    BACKSTOP = "backstop"

--- a/backend/infrahub/api/admission/controller.py
+++ b/backend/infrahub/api/admission/controller.py
@@ -45,12 +45,9 @@ def stress_tier(*, ratio: float, threshold: float) -> int:
     return 3
 
 
-def stress_shed_fraction(*, ratio: float, threshold: float) -> float:
-    """Fraction of requests to shed for a class given the stress ratio and the class's trigger.
-
-    Returns ``0.0`` below the trigger, then steps up as the ratio climbs to 2x, 5x, and beyond.
-    """
-    return _SHED_FRACTION_BY_TIER[stress_tier(ratio=ratio, threshold=threshold)]
+def stress_shed_fraction(*, tier: int) -> float:
+    """Fraction of a class's requests to shed at a given severity tier."""
+    return _SHED_FRACTION_BY_TIER[tier]
 
 
 @dataclass(frozen=True)
@@ -139,7 +136,7 @@ class AdmissionController:
         # a random fraction of its requests, and a shed one gets its fast 429 without waiting behind
         # a saturated pool or consuming waiter capacity. CoDel keys off the measured sojourn, so it
         # can only run once a slot is held — a request shed here never reaches it.
-        if tier >= 1 and self._rng() < _SHED_FRACTION_BY_TIER[tier]:
+        if tier >= 1 and self._rng() < stress_shed_fraction(tier=tier):
             metrics.REJECTED_TOTAL.labels(priority=priority.label, reason="stress").inc()
             return Rejected(reason="stress", retry_after=self._retry_policy.retry_after(tier=tier))
 

--- a/backend/infrahub/api/admission/controller.py
+++ b/backend/infrahub/api/admission/controller.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import random
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Callable, Generator, Protocol
 
 from infrahub.database.load_signal import UNSTRESSED_RATIO
+from infrahub.log import get_logger
 
-from . import metrics
+from .constants import RejectionReason
 
 if TYPE_CHECKING:
     from infrahub.database.load_signal import LoadSignal
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
     from .priority import Priority
     from .retry_policy import RetryAfterPolicy
     from .slot_pool import Acquisition, PrioritySlotPool
+
+log = get_logger()
 
 # Backstop shedding (waiter queue saturated) is unambiguous overload, so its retry-after hint
 # always uses the top intensity tier regardless of the current stress ratio.
@@ -61,11 +65,32 @@ class Admitted:
 class Rejected:
     """Decision to shed the request, with the reason and a Retry-After hint (seconds)."""
 
-    reason: Literal["stress", "codel", "backstop"]
+    reason: RejectionReason
     retry_after: int
 
 
 AdmissionDecision = Admitted | Rejected
+
+
+@contextmanager
+def _contained_observer_failure() -> Generator[None]:
+    """Log whatever one observer raises instead of letting it reach the admission path."""
+    try:
+        yield
+    except Exception:
+        log.warning("admission observer raised; continuing", exc_info=True)
+
+
+class AdmissionObserver(Protocol):
+    """Sink notified as a request moves through the admission decision."""
+
+    def on_offered(self, *, priority: Priority) -> None: ...
+
+    def on_admitted(self, *, priority: Priority) -> None: ...
+
+    def on_rejected(self, *, priority: Priority, reason: RejectionReason) -> None: ...
+
+    def on_sojourn(self, *, priority: Priority, seconds: float) -> None: ...
 
 
 class AdmissionController:
@@ -96,10 +121,12 @@ class AdmissionController:
         stress_thresholds: dict[Priority, float],
         stress_min_samples: int,
         retry_policy: RetryAfterPolicy,
+        observers: list[AdmissionObserver],
         rng: Callable[[], float] = random.random,
     ) -> None:
         self._slot_pool = slot_pool
         self._retry_policy = retry_policy
+        self._observers = observers
         self._backstop_max_waiters = backstop_max_waiters
         self._stress_signal = stress_signal
         self._stress_thresholds = stress_thresholds
@@ -118,7 +145,7 @@ class AdmissionController:
             ``Admitted`` carrying the held slot, or ``Rejected`` with the shed reason.
 
         """
-        metrics.OFFERED_TOTAL.labels(priority=priority.label).inc()
+        self._observe_offered(priority=priority)
 
         # The stress ratio is the shared server-load proxy: it drives the graduated shed decision
         # and, via the retry policy, both the adaptive Retry-After and the sustained-load clock.
@@ -128,34 +155,56 @@ class AdmissionController:
         tier = stress_tier(ratio=ratio, threshold=self._stress_thresholds[priority])
 
         if self._slot_pool.waiters(priority=priority) >= self._backstop_max_waiters[priority]:
-            metrics.REJECTED_TOTAL.labels(priority=priority.label, reason="backstop").inc()
+            self._observe_rejected(priority=priority, reason=RejectionReason.BACKSTOP)
             # A saturated waiter queue is unambiguous overload, so the hint uses the top tier.
-            return Rejected(reason="backstop", retry_after=self._retry_policy.retry_after(tier=_BACKSTOP_TIER))
+            return Rejected(
+                reason=RejectionReason.BACKSTOP, retry_after=self._retry_policy.retry_after(tier=_BACKSTOP_TIER)
+            )
 
         # Database stress is evaluated before the request queues for a slot: a stressed class sheds
         # a random fraction of its requests, and a shed one gets its fast 429 without waiting behind
         # a saturated pool or consuming waiter capacity. CoDel keys off the measured sojourn, so it
         # can only run once a slot is held — a request shed here never reaches it.
         if tier >= 1 and self._rng() < stress_shed_fraction(tier=tier):
-            metrics.REJECTED_TOTAL.labels(priority=priority.label, reason="stress").inc()
-            return Rejected(reason="stress", retry_after=self._retry_policy.retry_after(tier=tier))
+            self._observe_rejected(priority=priority, reason=RejectionReason.STRESS)
+            return Rejected(reason=RejectionReason.STRESS, retry_after=self._retry_policy.retry_after(tier=tier))
 
         acquisition = await self._slot_pool.acquire(priority=priority)
         # Once a slot is held, any exception before returning Admitted would strand it (the
         # caller only releases what it receives), so guard the whole window and release on error.
         try:
-            metrics.SOJOURN_SECONDS.labels(priority=priority.label).observe(acquisition.sojourn)
+            self._observe_sojourn(priority=priority, seconds=acquisition.sojourn)
 
             if self._codel_priority_map[priority].should_drop(sojourn=acquisition.sojourn):
                 self._slot_pool.release(acquisition=acquisition)
-                metrics.REJECTED_TOTAL.labels(priority=priority.label, reason="codel").inc()
-                return Rejected(reason="codel", retry_after=self._retry_policy.retry_after(tier=tier))
+                self._observe_rejected(priority=priority, reason=RejectionReason.CODEL)
+                return Rejected(reason=RejectionReason.CODEL, retry_after=self._retry_policy.retry_after(tier=tier))
 
-            metrics.ADMITTED_TOTAL.labels(priority=priority.label).inc()
+            self._observe_admitted(priority=priority)
             return Admitted(acquisition=acquisition)
         except Exception:
             self._slot_pool.release(acquisition=acquisition)
             raise
+
+    def _observe_offered(self, *, priority: Priority) -> None:
+        for observer in self._observers:
+            with _contained_observer_failure():
+                observer.on_offered(priority=priority)
+
+    def _observe_admitted(self, *, priority: Priority) -> None:
+        for observer in self._observers:
+            with _contained_observer_failure():
+                observer.on_admitted(priority=priority)
+
+    def _observe_rejected(self, *, priority: Priority, reason: RejectionReason) -> None:
+        for observer in self._observers:
+            with _contained_observer_failure():
+                observer.on_rejected(priority=priority, reason=reason)
+
+    def _observe_sojourn(self, *, priority: Priority, seconds: float) -> None:
+        for observer in self._observers:
+            with _contained_observer_failure():
+                observer.on_sojourn(priority=priority, seconds=seconds)
 
     def _current_stress_ratio(self) -> float:
         # Below the sample floor the ratio is unreliable (a cold or outlier floor would distort

--- a/backend/infrahub/api/admission/controller.py
+++ b/backend/infrahub/api/admission/controller.py
@@ -4,7 +4,8 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Literal
 
-from infrahub.database.load_signal import UNSTRESSED_RATIO, get_reference_query_load_tracker
+from infrahub.database.load_signal import UNSTRESSED_RATIO
+from infrahub.database.load_signal_registry import get_reference_query_load_tracker
 
 from . import metrics
 from .capacity import derive_max_concurrency
@@ -17,7 +18,8 @@ if TYPE_CHECKING:
     from infrahub import config
     from infrahub.database.load_signal import LoadSignal
 
-    from .slot_pool import Acquisition
+    from .retry_policy import RetryPolicyObserver
+    from .slot_pool import Acquisition, SlotPoolObserver
 
 # Backstop shedding (waiter queue saturated) is unambiguous overload, so its retry-after hint
 # always uses the top intensity tier regardless of the current stress ratio.
@@ -106,14 +108,7 @@ class AdmissionController:
         rng: Callable[[], float] = random.random,
     ) -> None:
         self._slot_pool = slot_pool
-        # Publish the live gauges straight from the pool's own state transitions, so a class's
-        # waiter count is reflected the moment a request enqueues. The sink is a plain function
-        # fed the counts by the pool, so nothing reads back into the pool.
-        self._slot_pool.set_observer(_publish_slot_metrics)
-        # Publish the sustained-load gauge the same way: the policy pushes the duration to a plain
-        # sink, so it carries no metrics dependency of its own.
         self._retry_policy = retry_policy
-        self._retry_policy.set_observer(_publish_sustained_load_metric)
         self._backstop_max_waiters = backstop_max_waiters
         self._stress_signal = stress_signal
         self._stress_thresholds = stress_thresholds
@@ -180,31 +175,34 @@ class AdmissionController:
         return self._stress_signal.stress_ratio_median()
 
     def release(self, *, acquisition: Acquisition) -> None:
-        """Return a served request's slot; the pool observer refreshes the live gauges.
+        """Return a served request's slot; the pool's observers refresh the live gauges.
 
-        The release flows through the pool, whose observer drives ``in_flight``/``waiters``
+        The release flows through the pool, whose observers drive ``in_flight``/``waiters``
         back down, so a finished request is reflected immediately rather than lingering
         until the next admit.
         """
         self._slot_pool.release(acquisition=acquisition)
 
 
-def _publish_slot_metrics(priority: Priority, *, in_flight: int, waiters: int) -> None:
-    """Pool observer sink: mirror a class's live in-flight and waiter counts onto the gauges."""
-    metrics.IN_FLIGHT.labels(priority=priority.label).set(in_flight)
-    metrics.WAITERS.labels(priority=priority.label).set(waiters)
-
-
-def _publish_sustained_load_metric(sustained_seconds: float) -> None:
-    """Retry-policy observer sink: mirror the current sustained-load duration onto the gauge."""
-    metrics.SUSTAINED_LOAD_SECONDS.set(sustained_seconds)
-
-
-def build_admission_controller(settings: config.Settings) -> AdmissionController:
-    """Build the default admission controller from the given settings.
+def build_admission_controller(
+    *,
+    settings: config.Settings,
+    slot_pool_observers: list[SlotPoolObserver],
+    retry_policy_observers: list[RetryPolicyObserver],
+) -> AdmissionController:
+    """Build the default admission controller from the given settings and observers.
 
     Keeps settings resolution out of ``AdmissionController`` itself: the class stays
     settings-free and testable while this factory owns the wiring of the defaults.
+
+    The observers arrive as arguments rather than being chosen here, so the concrete sinks are
+    named only by the caller that owns the application's wiring.
+
+    Args:
+        settings: Source of every tuning value the object graph needs.
+        slot_pool_observers: Sinks notified as a class's in-flight and waiter counts change.
+        retry_policy_observers: Sinks notified with the current sustained-load duration.
+
     """
     max_concurrency = derive_max_concurrency(
         pool_size=settings.database.max_connection_pool_size,
@@ -213,7 +211,7 @@ def build_admission_controller(settings: config.Settings) -> AdmissionController
     # Set the gauge wherever the controller is actually built, so it reflects the derived cap
     # in use rather than being frozen at some earlier import.
     metrics.MAX_CONCURRENCY.set(max_concurrency)
-    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency)
+    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=slot_pool_observers)
 
     # The stress window lives on the shared tracker; apply the configured length here, where
     # settings are available, rather than at the tracker's construction.
@@ -247,6 +245,7 @@ def build_admission_controller(settings: config.Settings) -> AdmissionController
         ),
     }
     retry_policy = RetryAfterPolicy(
+        observers=retry_policy_observers,
         level1_seconds=settings.api.backpressure_retry_after_level1_seconds,
         level2_seconds=settings.api.backpressure_retry_after_level2_seconds,
         level3_seconds=settings.api.backpressure_retry_after_level3_seconds,

--- a/backend/infrahub/api/admission/controller.py
+++ b/backend/infrahub/api/admission/controller.py
@@ -5,21 +5,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Literal
 
 from infrahub.database.load_signal import UNSTRESSED_RATIO
-from infrahub.database.load_signal_registry import get_reference_query_load_tracker
 
 from . import metrics
-from .capacity import derive_max_concurrency
-from .codel import CoDelController
-from .priority import Priority
-from .retry_policy import RetryAfterPolicy
-from .slot_pool import PrioritySlotPool
 
 if TYPE_CHECKING:
-    from infrahub import config
     from infrahub.database.load_signal import LoadSignal
 
-    from .retry_policy import RetryPolicyObserver
-    from .slot_pool import Acquisition, SlotPoolObserver
+    from .codel import CoDelController
+    from .priority import Priority
+    from .retry_policy import RetryAfterPolicy
+    from .slot_pool import Acquisition, PrioritySlotPool
 
 # Backstop shedding (waiter queue saturated) is unambiguous overload, so its retry-after hint
 # always uses the top intensity tier regardless of the current stress ratio.
@@ -80,9 +75,8 @@ class AdmissionController:
     """Turns a priority class into an admit/shed decision.
 
     Composes the shared slot pool, one CoDel controller per priority class, a per-class
-    waiter backstop, and a database-stress signal. All tuning is passed in, so the class
-    carries no dependency on global settings and is directly testable; the module-level
-    factory wires the defaults.
+    waiter backstop, and a database-stress signal. Every collaborator and tuning value is
+    injected, so the class carries no dependency on global settings and is directly testable.
 
     Two independent signals shed a request. Database stress (how much slower the reference query
     is than its all-time best) sheds a growing fraction of a class as the ratio climbs past that
@@ -182,84 +176,3 @@ class AdmissionController:
         until the next admit.
         """
         self._slot_pool.release(acquisition=acquisition)
-
-
-def build_admission_controller(
-    *,
-    settings: config.Settings,
-    slot_pool_observers: list[SlotPoolObserver],
-    retry_policy_observers: list[RetryPolicyObserver],
-) -> AdmissionController:
-    """Build the default admission controller from the given settings and observers.
-
-    Keeps settings resolution out of ``AdmissionController`` itself: the class stays
-    settings-free and testable while this factory owns the wiring of the defaults.
-
-    The observers arrive as arguments rather than being chosen here, so the concrete sinks are
-    named only by the caller that owns the application's wiring.
-
-    Args:
-        settings: Source of every tuning value the object graph needs.
-        slot_pool_observers: Sinks notified as a class's in-flight and waiter counts change.
-        retry_policy_observers: Sinks notified with the current sustained-load duration.
-
-    """
-    max_concurrency = derive_max_concurrency(
-        pool_size=settings.database.max_connection_pool_size,
-        factor=settings.api.backpressure_max_concurrency_factor,
-    )
-    # Set the gauge wherever the controller is actually built, so it reflects the derived cap
-    # in use rather than being frozen at some earlier import.
-    metrics.MAX_CONCURRENCY.set(max_concurrency)
-    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=slot_pool_observers)
-
-    # The stress window lives on the shared tracker; apply the configured length here, where
-    # settings are available, rather than at the tracker's construction.
-    tracker = get_reference_query_load_tracker()
-    tracker.window_seconds = settings.api.backpressure_stress_window_seconds
-
-    base_backstop = settings.api.backpressure_backstop_max_waiters
-    backstop_max_waiters = {
-        Priority.HIGH: max(1, int(base_backstop * settings.api.backpressure_backstop_high_multiplier)),
-        Priority.MEDIUM: base_backstop,
-        Priority.LOW: max(1, int(base_backstop * settings.api.backpressure_backstop_low_multiplier)),
-    }
-    stress_thresholds = {
-        Priority.HIGH: settings.api.backpressure_shed_high_stress_ratio,
-        Priority.MEDIUM: settings.api.backpressure_shed_medium_stress_ratio,
-        Priority.LOW: settings.api.backpressure_shed_low_stress_ratio,
-    }
-    # HIGH gets a larger effective target so it sheds last; MEDIUM and LOW share the base target.
-    codel = {
-        Priority.HIGH: CoDelController(
-            target=settings.api.backpressure_codel_target_seconds * settings.api.backpressure_high_target_multiplier,
-            interval=settings.api.backpressure_codel_interval_seconds,
-        ),
-        Priority.MEDIUM: CoDelController(
-            target=settings.api.backpressure_codel_target_seconds,
-            interval=settings.api.backpressure_codel_interval_seconds,
-        ),
-        Priority.LOW: CoDelController(
-            target=settings.api.backpressure_codel_target_seconds,
-            interval=settings.api.backpressure_codel_interval_seconds,
-        ),
-    }
-    retry_policy = RetryAfterPolicy(
-        observers=retry_policy_observers,
-        level1_seconds=settings.api.backpressure_retry_after_level1_seconds,
-        level2_seconds=settings.api.backpressure_retry_after_level2_seconds,
-        level3_seconds=settings.api.backpressure_retry_after_level3_seconds,
-        max_seconds=settings.api.backpressure_retry_after_max_seconds,
-        significant_load_ratio=settings.api.backpressure_significant_load_stress_ratio,
-        sustained_warn_seconds=settings.api.backpressure_sustained_load_warn_seconds,
-        sustained_high_seconds=settings.api.backpressure_sustained_load_high_seconds,
-    )
-    return AdmissionController(
-        slot_pool=slot_pool,
-        codel_priority_map=codel,
-        backstop_max_waiters=backstop_max_waiters,
-        stress_signal=tracker,
-        stress_thresholds=stress_thresholds,
-        stress_min_samples=settings.api.backpressure_stress_min_samples,
-        retry_policy=retry_policy,
-    )

--- a/backend/infrahub/api/admission/factory.py
+++ b/backend/infrahub/api/admission/factory.py
@@ -45,10 +45,8 @@ def build_admission_controller(
     metrics.MAX_CONCURRENCY.set(max_concurrency)
     slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=slot_pool_observers)
 
-    # The stress window lives on the shared tracker; apply the configured length here, where
-    # settings are available, rather than at the tracker's construction.
+    # The database layer feeds this same instance, so the gate reads the signal the queries write.
     tracker = get_reference_query_load_tracker()
-    tracker.window_seconds = settings.api.backpressure_stress_window_seconds
 
     base_backstop = settings.api.backpressure_backstop_max_waiters
     backstop_max_waiters = {

--- a/backend/infrahub/api/admission/factory.py
+++ b/backend/infrahub/api/admission/factory.py
@@ -15,6 +15,7 @@ from .slot_pool import PrioritySlotPool
 if TYPE_CHECKING:
     from infrahub import config
 
+    from .controller import AdmissionObserver
     from .retry_policy import RetryPolicyObserver
     from .slot_pool import SlotPoolObserver
 
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 def build_admission_controller(
     *,
     settings: config.Settings,
+    admission_observers: list[AdmissionObserver],
     slot_pool_observers: list[SlotPoolObserver],
     retry_policy_observers: list[RetryPolicyObserver],
 ) -> AdmissionController:
@@ -32,6 +34,7 @@ def build_admission_controller(
 
     Args:
         settings: Source of every tuning value the object graph needs.
+        admission_observers: Sinks notified as each request is offered, admitted, or shed.
         slot_pool_observers: Sinks notified as a class's in-flight and waiter counts change.
         retry_policy_observers: Sinks notified with the current sustained-load duration.
 
@@ -92,4 +95,5 @@ def build_admission_controller(
         stress_thresholds=stress_thresholds,
         stress_min_samples=settings.api.backpressure_stress_min_samples,
         retry_policy=retry_policy,
+        observers=admission_observers,
     )

--- a/backend/infrahub/api/admission/factory.py
+++ b/backend/infrahub/api/admission/factory.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.database.load_signal_registry import get_reference_query_load_tracker
+
+from . import metrics
+from .capacity import derive_max_concurrency
+from .codel import CoDelController
+from .controller import AdmissionController
+from .priority import Priority
+from .retry_policy import RetryAfterPolicy
+from .slot_pool import PrioritySlotPool
+
+if TYPE_CHECKING:
+    from infrahub import config
+
+    from .retry_policy import RetryPolicyObserver
+    from .slot_pool import SlotPoolObserver
+
+
+def build_admission_controller(
+    *,
+    settings: config.Settings,
+    slot_pool_observers: list[SlotPoolObserver],
+    retry_policy_observers: list[RetryPolicyObserver],
+) -> AdmissionController:
+    """Build the default admission controller from the given settings and observers.
+
+    Keeps settings resolution out of ``AdmissionController`` itself: the decision logic stays
+    settings-free and directly testable while this module owns the wiring of the defaults.
+
+    Args:
+        settings: Source of every tuning value the object graph needs.
+        slot_pool_observers: Sinks notified as a class's in-flight and waiter counts change.
+        retry_policy_observers: Sinks notified with the current sustained-load duration.
+
+    """
+    max_concurrency = derive_max_concurrency(
+        pool_size=settings.database.max_connection_pool_size,
+        factor=settings.api.backpressure_max_concurrency_factor,
+    )
+    # Set the gauge wherever the controller is actually built, so it reflects the derived cap
+    # in use rather than being frozen at some earlier import.
+    metrics.MAX_CONCURRENCY.set(max_concurrency)
+    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=slot_pool_observers)
+
+    # The stress window lives on the shared tracker; apply the configured length here, where
+    # settings are available, rather than at the tracker's construction.
+    tracker = get_reference_query_load_tracker()
+    tracker.window_seconds = settings.api.backpressure_stress_window_seconds
+
+    base_backstop = settings.api.backpressure_backstop_max_waiters
+    backstop_max_waiters = {
+        Priority.HIGH: max(1, int(base_backstop * settings.api.backpressure_backstop_high_multiplier)),
+        Priority.MEDIUM: base_backstop,
+        Priority.LOW: max(1, int(base_backstop * settings.api.backpressure_backstop_low_multiplier)),
+    }
+    stress_thresholds = {
+        Priority.HIGH: settings.api.backpressure_shed_high_stress_ratio,
+        Priority.MEDIUM: settings.api.backpressure_shed_medium_stress_ratio,
+        Priority.LOW: settings.api.backpressure_shed_low_stress_ratio,
+    }
+    # HIGH gets a larger effective target so it sheds last; MEDIUM and LOW share the base target.
+    codel = {
+        Priority.HIGH: CoDelController(
+            target=settings.api.backpressure_codel_target_seconds * settings.api.backpressure_high_target_multiplier,
+            interval=settings.api.backpressure_codel_interval_seconds,
+        ),
+        Priority.MEDIUM: CoDelController(
+            target=settings.api.backpressure_codel_target_seconds,
+            interval=settings.api.backpressure_codel_interval_seconds,
+        ),
+        Priority.LOW: CoDelController(
+            target=settings.api.backpressure_codel_target_seconds,
+            interval=settings.api.backpressure_codel_interval_seconds,
+        ),
+    }
+    retry_policy = RetryAfterPolicy(
+        observers=retry_policy_observers,
+        level1_seconds=settings.api.backpressure_retry_after_level1_seconds,
+        level2_seconds=settings.api.backpressure_retry_after_level2_seconds,
+        level3_seconds=settings.api.backpressure_retry_after_level3_seconds,
+        max_seconds=settings.api.backpressure_retry_after_max_seconds,
+        significant_load_ratio=settings.api.backpressure_significant_load_stress_ratio,
+        sustained_warn_seconds=settings.api.backpressure_sustained_load_warn_seconds,
+        sustained_high_seconds=settings.api.backpressure_sustained_load_high_seconds,
+    )
+    return AdmissionController(
+        slot_pool=slot_pool,
+        codel_priority_map=codel,
+        backstop_max_waiters=backstop_max_waiters,
+        stress_signal=tracker,
+        stress_thresholds=stress_thresholds,
+        stress_min_samples=settings.api.backpressure_stress_min_samples,
+        retry_policy=retry_policy,
+    )

--- a/backend/infrahub/api/admission/observers.py
+++ b/backend/infrahub/api/admission/observers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import metrics
+
+if TYPE_CHECKING:
+    from .priority import Priority
+
+
+class SlotPoolMetricsObserver:
+    """Mirrors a class's live in-flight and waiter counts onto the Prometheus gauges."""
+
+    def on_counts_changed(self, priority: Priority, *, in_flight: int, waiters: int) -> None:
+        metrics.IN_FLIGHT.labels(priority=priority.label).set(in_flight)
+        metrics.WAITERS.labels(priority=priority.label).set(waiters)
+
+
+class SustainedLoadMetricsObserver:
+    """Mirrors the current sustained-load duration onto the Prometheus gauge."""
+
+    def on_sustained_load(self, *, sustained_seconds: float) -> None:
+        metrics.SUSTAINED_LOAD_SECONDS.set(sustained_seconds)

--- a/backend/infrahub/api/admission/observers.py
+++ b/backend/infrahub/api/admission/observers.py
@@ -5,7 +5,24 @@ from typing import TYPE_CHECKING
 from . import metrics
 
 if TYPE_CHECKING:
+    from .constants import RejectionReason
     from .priority import Priority
+
+
+class AdmissionMetricsObserver:
+    """Mirrors each admission decision onto the Prometheus counters and the sojourn histogram."""
+
+    def on_offered(self, *, priority: Priority) -> None:
+        metrics.OFFERED_TOTAL.labels(priority=priority.label).inc()
+
+    def on_admitted(self, *, priority: Priority) -> None:
+        metrics.ADMITTED_TOTAL.labels(priority=priority.label).inc()
+
+    def on_rejected(self, *, priority: Priority, reason: RejectionReason) -> None:
+        metrics.REJECTED_TOTAL.labels(priority=priority.label, reason=reason).inc()
+
+    def on_sojourn(self, *, priority: Priority, seconds: float) -> None:
+        metrics.SOJOURN_SECONDS.labels(priority=priority.label).observe(seconds)
 
 
 class SlotPoolMetricsObserver:

--- a/backend/infrahub/api/admission/retry_policy.py
+++ b/backend/infrahub/api/admission/retry_policy.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
 import time
-from typing import Callable
+from typing import Callable, Protocol
+
+from infrahub.log import get_logger
+
+log = get_logger()
 
 # Persistence multipliers applied to the per-priority intensity base by how long load has been
 # sustained. The base reflects the current intensity; these stretch a client's bounded retry
 # budget across a longer real-time window when overload does not clear.
 _SUSTAINED_MULTIPLIER_WARN = 2
 _SUSTAINED_MULTIPLIER_HIGH = 3
+
+
+class RetryPolicyObserver(Protocol):
+    """Sink notified with the current sustained-load duration after each observation.
+
+    Receives the duration as an argument, so it never reads back from the policy: the
+    dependency runs one way, from policy to sink.
+    """
+
+    def on_sustained_load(self, *, sustained_seconds: float) -> None: ...
 
 
 class RetryAfterPolicy:
@@ -20,14 +34,15 @@ class RetryAfterPolicy:
     ratios below that line are a warm-up zone that never accrues sustained time. The per-tier base
     is multiplied by the persistence factor and clamped to a maximum.
 
-    The current sustained-load duration is pushed to a registered observer (e.g. a metric gauge)
-    after each observation, so the primitive itself stays free of any metrics dependency. State is
-    per worker on a single event loop, so it takes no lock.
+    The current sustained-load duration is pushed to the observers after each observation, so the
+    primitive itself stays free of any metrics dependency. State is per worker on a single event
+    loop, so it takes no lock.
     """
 
     def __init__(
         self,
         *,
+        observers: list[RetryPolicyObserver],
         level1_seconds: int = 1,
         level2_seconds: int = 5,
         level3_seconds: int = 10,
@@ -46,18 +61,10 @@ class RetryAfterPolicy:
         # Monotonic timestamp when the current continuous overload episode began, or None while
         # the ratio is below the significant-load line.
         self._overload_since: float | None = None
-        self._on_sustained_load: Callable[[float], None] | None = None
-
-    def set_observer(self, on_change: Callable[[float], None] | None) -> None:
-        """Register a callback invoked with the current sustained-load seconds after each observation.
-
-        Lets an external sink (e.g. a metric gauge) track the episode without the policy depending
-        on that sink.
-        """
-        self._on_sustained_load = on_change
+        self._observers = observers
 
     def observe(self, *, ratio: float) -> None:
-        """Update the overload episode from the latest stress ratio and notify the observer.
+        """Update the overload episode from the latest stress ratio and notify the observers.
 
         A ratio at or above the significant-load line starts the episode (if not already running);
         anything below resets it. Ratios in the warm-up zone therefore never accrue sustained time.
@@ -68,8 +75,20 @@ class RetryAfterPolicy:
                 self._overload_since = now
         else:
             self._overload_since = None
-        if self._on_sustained_load is not None:
-            self._on_sustained_load(self._sustained_seconds(now))
+        self._notify(sustained_seconds=self._sustained_seconds(now))
+
+    def _notify(self, *, sustained_seconds: float) -> None:
+        """Push the current sustained-load duration to every observer.
+
+        Each observer is isolated on its own: the sinks are best-effort and this runs on the
+        admission path of every request, so a failing sink must neither shed nor fail a request
+        that would otherwise be admitted, nor skip the observers behind it.
+        """
+        for observer in self._observers:
+            try:
+                observer.on_sustained_load(sustained_seconds=sustained_seconds)
+            except Exception:
+                log.warning("admission retry-policy observer raised; continuing", exc_info=True)
 
     def retry_after(self, *, tier: int) -> int:
         """Seconds to advise a shed request to wait: the per-tier base scaled by sustained load.

--- a/backend/infrahub/api/admission/slot_pool.py
+++ b/backend/infrahub/api/admission/slot_pool.py
@@ -22,7 +22,7 @@ class SlotPoolObserver(Protocol):
     dependency runs one way, from pool to sink.
     """
 
-    def __call__(self, priority: Priority, *, in_flight: int, waiters: int) -> None: ...
+    def on_counts_changed(self, priority: Priority, *, in_flight: int, waiters: int) -> None: ...
 
 
 class Acquisition:
@@ -53,34 +53,36 @@ class PrioritySlotPool:
     re-releases that slot to the next eligible waiter so no slot is ever leaked.
     """
 
-    def __init__(self, *, max_concurrency: int, clock: Callable[[], float] = time.monotonic) -> None:
+    def __init__(
+        self,
+        *,
+        max_concurrency: int,
+        observers: list[SlotPoolObserver],
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
         self._max_concurrency = max_concurrency
         self._available = max_concurrency
         self._clock = clock
         self._waiters: dict[Priority, deque[Future[bool]]] = {priority: deque() for priority in Priority}
         self._in_flight: dict[Priority, int] = dict.fromkeys(Priority, 0)
-        self._on_change: SlotPoolObserver | None = None
-
-    def set_observer(self, on_change: SlotPoolObserver | None) -> None:
-        """Register a callback invoked with a class and its current counts whenever they change.
-
-        The pool passes the up-to-date in-flight and waiter counts as arguments, so an external
-        observer (e.g. metric gauges) tracks queue depth the moment a request enqueues or leaves
-        the queue without reading back from the pool. The primitive itself stays free of any
-        metrics dependency.
-        """
-        self._on_change = on_change
+        self._observers = observers
 
     def _notify(self, priority: Priority) -> None:
-        if self._on_change is None:
+        """Push a class's current counts to every observer.
+
+        Each observer is isolated on its own: the sinks are best-effort and run mid-transition,
+        so a failing one must neither corrupt admission state (leak a slot, strand a waiter),
+        surface to the caller, nor skip the observers behind it.
+        """
+        if not self._observers:
             return
-        try:
-            self._on_change(priority, in_flight=self._in_flight[priority], waiters=len(self._waiters[priority]))
-        except Exception:
-            # The observer is a best-effort metrics sink invoked mid-transition: a failing
-            # callback must never corrupt admission state (leak a slot, strand a waiter) or
-            # surface to the caller, so its failure is swallowed after being logged.
-            log.warning("admission slot-pool observer raised; continuing", exc_info=True)
+        in_flight = self._in_flight[priority]
+        waiters = len(self._waiters[priority])
+        for observer in self._observers:
+            try:
+                observer.on_counts_changed(priority, in_flight=in_flight, waiters=waiters)
+            except Exception:
+                log.warning("admission slot-pool observer raised; continuing", exc_info=True)
 
     @property
     def max_concurrency(self) -> int:

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -554,13 +554,22 @@ class ApiSettings(BaseSettings):
         description="Kill-switch for priority-aware API backpressure; when disabled every request passes through.",
     )
     backpressure_codel_target_seconds: float = Field(
-        default=0.005, gt=0, description="CoDel target sojourn in seconds before shedding is considered."
+        default=0.005,
+        gt=0,
+        allow_inf_nan=False,
+        description="CoDel target sojourn in seconds before shedding is considered.",
     )
     backpressure_codel_interval_seconds: float = Field(
-        default=0.1, gt=0, description="CoDel interval in seconds the sojourn must stay above target before dropping."
+        default=0.1,
+        gt=0,
+        allow_inf_nan=False,
+        description="CoDel interval in seconds the sojourn must stay above target before dropping.",
     )
     backpressure_high_target_multiplier: float = Field(
-        default=4.0, ge=1, description="Multiplier applied to the CoDel target for the high-priority class."
+        default=4.0,
+        ge=1,
+        allow_inf_nan=False,
+        description="Multiplier applied to the CoDel target for the high-priority class.",
     )
     backpressure_backstop_max_waiters: int = Field(
         default=1000, ge=1, description="Per-class hard cap on queued waiters before requests are rejected."
@@ -606,6 +615,7 @@ class ApiSettings(BaseSettings):
     backpressure_stress_window_seconds: float = Field(
         default=20.0,
         gt=0,
+        allow_inf_nan=False,
         description="Rolling window, in seconds, over which the database-stress signal is measured.",
     )
     backpressure_stress_min_samples: int = Field(
@@ -616,28 +626,58 @@ class ApiSettings(BaseSettings):
     backpressure_shed_low_stress_ratio: float = Field(
         default=10.0,
         ge=1,
+        allow_inf_nan=False,
         description="Database-stress ratio at or above which low-priority requests become eligible for shedding.",
     )
     backpressure_shed_medium_stress_ratio: float = Field(
         default=25.0,
         ge=1,
+        allow_inf_nan=False,
         description="Database-stress ratio at or above which medium-priority requests become eligible for shedding.",
     )
     backpressure_shed_high_stress_ratio: float = Field(
         default=100.0,
         ge=1,
+        allow_inf_nan=False,
         description="Database-stress ratio at or above which high-priority requests become eligible for shedding.",
     )
     backpressure_backstop_low_multiplier: float = Field(
         default=0.5,
         gt=0,
+        le=1,
+        allow_inf_nan=False,
         description="Scales the base backstop waiter cap for the low-priority class.",
     )
     backpressure_backstop_high_multiplier: float = Field(
         default=4.0,
-        gt=0,
+        ge=1,
+        allow_inf_nan=False,
         description="Scales the base backstop waiter cap for the high-priority class.",
     )
+
+    @model_validator(mode="after")
+    def validate_shed_stress_ratios_ordered_by_priority(self) -> Self:
+        """Require each class to start shedding no earlier than the one below it.
+
+        A class sheds once the database-stress ratio reaches its own trigger, so the whole point of
+        the feature — interactive traffic surviving longest — inverts silently if a higher-priority
+        class is given a lower trigger.
+
+        Raises:
+            ValueError: If the triggers are not ordered from low to high priority.
+
+        """
+        if not (
+            self.backpressure_shed_low_stress_ratio
+            <= self.backpressure_shed_medium_stress_ratio
+            <= self.backpressure_shed_high_stress_ratio
+        ):
+            raise ValueError(
+                "'backpressure_shed_low_stress_ratio' must not exceed "
+                "'backpressure_shed_medium_stress_ratio', which must not exceed "
+                "'backpressure_shed_high_stress_ratio', so lower-priority traffic sheds first"
+            )
+        return self
 
 
 class GitSettings(BaseSettings):

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -39,7 +39,7 @@ from infrahub.exceptions import DatabaseError, QueryTimeoutError
 from infrahub.log import get_logger
 from infrahub.utils import InfrahubStringEnum
 
-from .load_signal import get_reference_query_load_tracker
+from .load_signal_registry import get_reference_query_load_tracker
 from .metrics import (
     CONNECTION_POOL_USAGE,
     QUERY_EXECUTION_METRICS,

--- a/backend/infrahub/database/load_signal.py
+++ b/backend/infrahub/database/load_signal.py
@@ -71,7 +71,7 @@ class ReferenceQueryLoadTracker:
         window_seconds: float = DEFAULT_STRESS_WINDOW_SECONDS,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
-        self.window_seconds = window_seconds
+        self._window_seconds = window_seconds
         self._clock = clock
         self._floor: float | None = None
         # In-window samples in arrival order, so eviction knows which value ages out next.
@@ -122,7 +122,7 @@ class ReferenceQueryLoadTracker:
                 log.warning("database load-signal observer raised; continuing", exc_info=True)
 
     def _evict(self, *, now: float) -> None:
-        horizon = now - self.window_seconds
+        horizon = now - self._window_seconds
         while self._samples and self._samples[0][0] <= horizon:
             _, value = self._samples.popleft()
             del self._sorted[bisect.bisect_left(self._sorted, value)]
@@ -136,6 +136,11 @@ class ReferenceQueryLoadTracker:
         the current time before answering.
         """
         self._evict(now=self._clock())
+
+    @property
+    def window_seconds(self) -> float:
+        """Length of the rolling window, fixed for the tracker's lifetime."""
+        return self._window_seconds
 
     def floor(self) -> float | None:
         """The all-time minimum observation, or ``None`` before any observation."""

--- a/backend/infrahub/database/load_signal.py
+++ b/backend/infrahub/database/load_signal.py
@@ -5,11 +5,9 @@ import time
 from collections import deque
 from typing import Callable, Protocol
 
-from .metrics import (
-    REFERENCE_QUERY_FLOOR_SECONDS,
-    REFERENCE_QUERY_STRESS_RATIO_MEDIAN,
-    REFERENCE_QUERY_WINDOW_MIN_SECONDS,
-)
+from infrahub.log import get_logger
+
+log = get_logger()
 
 DEFAULT_STRESS_WINDOW_SECONDS = 20.0
 
@@ -35,6 +33,12 @@ class LoadSignal(Protocol):
     def stress_ratio_median(self) -> float: ...
 
     def sample_count(self) -> int: ...
+
+
+class LoadSignalObserver(Protocol):
+    """Sink notified with the derived signal after each recorded observation."""
+
+    def on_observation(self, *, floor: float | None, window_min: float | None, stress_ratio_median: float) -> None: ...
 
 
 class ReferenceQueryLoadTracker:
@@ -63,6 +67,7 @@ class ReferenceQueryLoadTracker:
     def __init__(
         self,
         *,
+        observers: list[LoadSignalObserver],
         window_seconds: float = DEFAULT_STRESS_WINDOW_SECONDS,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
@@ -73,15 +78,7 @@ class ReferenceQueryLoadTracker:
         self._samples: deque[tuple[float, float]] = deque()
         # The same in-window values kept sorted: front is the minimum, middle is the median.
         self._sorted: list[float] = []
-        self._observer: Callable[[ReferenceQueryLoadTracker], None] | None = None
-
-    def set_observer(self, observer: Callable[[ReferenceQueryLoadTracker], None] | None) -> None:
-        """Register a callback invoked after each recorded observation.
-
-        Lets an external sink (the metric gauges) refresh from the latest state without the
-        tracker depending on that sink.
-        """
-        self._observer = observer
+        self._observers = observers
 
     def record(self, execution_seconds: float) -> None:
         """Record one reference-query observation and refresh the derived signal.
@@ -104,9 +101,25 @@ class ReferenceQueryLoadTracker:
         bisect.insort(self._sorted, observation)
 
         self._evict(now=now)
+        self._notify()
 
-        if self._observer is not None:
-            self._observer(self)
+    def _notify(self) -> None:
+        """Push the freshly derived signal to every observer.
+
+        Each observer is isolated on its own: the sinks are best-effort and ``record`` runs on
+        the database query path, so a failing sink must neither fail the query that fed the
+        observation nor skip the observers behind it.
+        """
+        if not self._observers:
+            return
+        floor = self._floor
+        window_min = self._sorted[0] if self._sorted else None
+        stress_ratio_median = self.stress_ratio_median()
+        for observer in self._observers:
+            try:
+                observer.on_observation(floor=floor, window_min=window_min, stress_ratio_median=stress_ratio_median)
+            except Exception:
+                log.warning("database load-signal observer raised; continuing", exc_info=True)
 
     def _evict(self, *, now: float) -> None:
         horizon = now - self.window_seconds
@@ -159,32 +172,3 @@ class ReferenceQueryLoadTracker:
         if value is None or self._floor is None or self._floor <= 0:
             return UNSTRESSED_RATIO
         return value / self._floor
-
-
-def _publish_metrics(tracker: ReferenceQueryLoadTracker) -> None:
-    floor = tracker.floor()
-    if floor is not None:
-        REFERENCE_QUERY_FLOOR_SECONDS.set(floor)
-    window_min = tracker.window_min()
-    if window_min is not None:
-        REFERENCE_QUERY_WINDOW_MIN_SECONDS.set(window_min)
-    REFERENCE_QUERY_STRESS_RATIO_MEDIAN.set(tracker.stress_ratio_median())
-
-
-_reference_query_load_tracker: ReferenceQueryLoadTracker | None = None
-
-
-def get_reference_query_load_tracker() -> ReferenceQueryLoadTracker:
-    """Return the process-global stress tracker, building and wiring it on first use.
-
-    The database layer feeds it and the admission layer reads it, so both must share one
-    instance. Building it lazily here — rather than at import — keeps importing this module
-    free of side effects and defers attaching the metrics sink until it is first needed. It
-    starts with the default window; the startup wiring overrides that from settings.
-    """
-    global _reference_query_load_tracker
-    if _reference_query_load_tracker is None:
-        tracker = ReferenceQueryLoadTracker()
-        tracker.set_observer(_publish_metrics)
-        _reference_query_load_tracker = tracker
-    return _reference_query_load_tracker

--- a/backend/infrahub/database/load_signal_metrics.py
+++ b/backend/infrahub/database/load_signal_metrics.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .metrics import (
+    REFERENCE_QUERY_FLOOR_SECONDS,
+    REFERENCE_QUERY_STRESS_RATIO_MEDIAN,
+    REFERENCE_QUERY_WINDOW_MIN_SECONDS,
+)
+
+
+class LoadSignalMetricsObserver:
+    """Publishes the derived database-stress signal onto the Prometheus gauges."""
+
+    def on_observation(self, *, floor: float | None, window_min: float | None, stress_ratio_median: float) -> None:
+        # A gauge is left untouched rather than zeroed while the corresponding value is still
+        # undefined, so an unset figure never reads as a real measurement of zero.
+        if floor is not None:
+            REFERENCE_QUERY_FLOOR_SECONDS.set(floor)
+        if window_min is not None:
+            REFERENCE_QUERY_WINDOW_MIN_SECONDS.set(window_min)
+        REFERENCE_QUERY_STRESS_RATIO_MEDIAN.set(stress_ratio_median)

--- a/backend/infrahub/database/load_signal_registry.py
+++ b/backend/infrahub/database/load_signal_registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from infrahub import config
+
 from .load_signal import ReferenceQueryLoadTracker
 from .load_signal_metrics import LoadSignalMetricsObserver
 
@@ -12,10 +14,17 @@ def get_reference_query_load_tracker() -> ReferenceQueryLoadTracker:
     The database layer feeds it and the admission layer reads it, so both must share one
     instance. The wiring lives in this module, apart from the tracker itself, so importing the
     signal primitive never drags the metrics sink into the import chain. Building it lazily —
-    rather than at import — keeps importing this module free of side effects. It starts with the
-    default window; the startup wiring overrides that from settings.
+    rather than at import — keeps importing this module free of side effects, and defers the
+    settings read until the configuration is loaded.
+
+    Raises:
+        InitializationError: If the configuration has not been loaded yet.
+
     """
     global _reference_query_load_tracker
     if _reference_query_load_tracker is None:
-        _reference_query_load_tracker = ReferenceQueryLoadTracker(observers=[LoadSignalMetricsObserver()])
+        _reference_query_load_tracker = ReferenceQueryLoadTracker(
+            observers=[LoadSignalMetricsObserver()],
+            window_seconds=config.SETTINGS.api.backpressure_stress_window_seconds,
+        )
     return _reference_query_load_tracker

--- a/backend/infrahub/database/load_signal_registry.py
+++ b/backend/infrahub/database/load_signal_registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .load_signal import ReferenceQueryLoadTracker
+from .load_signal_metrics import LoadSignalMetricsObserver
+
+_reference_query_load_tracker: ReferenceQueryLoadTracker | None = None
+
+
+def get_reference_query_load_tracker() -> ReferenceQueryLoadTracker:
+    """Return the process-global stress tracker, building and wiring it on first use.
+
+    The database layer feeds it and the admission layer reads it, so both must share one
+    instance. The wiring lives in this module, apart from the tracker itself, so importing the
+    signal primitive never drags the metrics sink into the import chain. Building it lazily —
+    rather than at import — keeps importing this module free of side effects. It starts with the
+    default window; the startup wiring overrides that from settings.
+    """
+    global _reference_query_load_tracker
+    if _reference_query_load_tracker is None:
+        _reference_query_load_tracker = ReferenceQueryLoadTracker(observers=[LoadSignalMetricsObserver()])
+    return _reference_query_load_tracker

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -22,6 +22,7 @@ from infrahub import __version__, config
 from infrahub.api import router as api
 from infrahub.api.admission.controller import build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
+from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
 from infrahub.api.exception_handlers import generic_api_exception_handler, log_forwarding_exception_handler
 from infrahub.components import ComponentType
 from infrahub.constants.environment import INSTALLATION_TYPE
@@ -58,8 +59,13 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
 
     # Build the admission controller once here, at startup, and publish it (with the kill-switch)
     # on app.state for the outermost AdmissionMiddleware to read. Constructing it at the app entry
-    # point keeps settings resolution and the controller's object graph out of the middleware.
-    application.state.admission_controller = build_admission_controller(settings=config.SETTINGS.active_settings)
+    # point keeps settings resolution and the controller's object graph out of the middleware, and
+    # naming the metric sinks here keeps them out of the admission internals' import chain.
+    application.state.admission_controller = build_admission_controller(
+        settings=config.SETTINGS.active_settings,
+        slot_pool_observers=[SlotPoolMetricsObserver()],
+        retry_policy_observers=[SustainedLoadMetricsObserver()],
+    )
     application.state.admission_enabled = config.SETTINGS.api.backpressure_enabled
 
     # Initialize trace

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -22,7 +22,11 @@ from infrahub import __version__, config
 from infrahub.api import router as api
 from infrahub.api.admission.factory import build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
-from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
+from infrahub.api.admission.observers import (
+    AdmissionMetricsObserver,
+    SlotPoolMetricsObserver,
+    SustainedLoadMetricsObserver,
+)
 from infrahub.api.exception_handlers import generic_api_exception_handler, log_forwarding_exception_handler
 from infrahub.components import ComponentType
 from infrahub.constants.environment import INSTALLATION_TYPE
@@ -63,6 +67,7 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
     # naming the metric sinks here keeps them out of the admission internals' import chain.
     application.state.admission_controller = build_admission_controller(
         settings=config.SETTINGS.active_settings,
+        admission_observers=[AdmissionMetricsObserver()],
         slot_pool_observers=[SlotPoolMetricsObserver()],
         retry_policy_observers=[SustainedLoadMetricsObserver()],
     )

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -20,7 +20,7 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 from infrahub import __version__, config
 from infrahub.api import router as api
-from infrahub.api.admission.controller import build_admission_controller
+from infrahub.api.admission.factory import build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
 from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
 from infrahub.api.exception_handlers import generic_api_exception_handler, log_forwarding_exception_handler

--- a/backend/tests/component/api/test_admission_middleware.py
+++ b/backend/tests/component/api/test_admission_middleware.py
@@ -14,6 +14,7 @@ from infrahub.api.admission.capacity import derive_max_concurrency
 from infrahub.api.admission.codel import CoDelController
 from infrahub.api.admission.controller import AdmissionController, build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
+from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 from infrahub.api.admission.slot_pool import PrioritySlotPool
@@ -133,14 +134,14 @@ def _build_app() -> FastAPI:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=MAX_CONCURRENCY),
+        slot_pool=PrioritySlotPool(max_concurrency=MAX_CONCURRENCY, observers=[SlotPoolMetricsObserver()]),
         # A large HIGH target keeps the interactive stream admitted while LOW is shed.
         codel_priority_map=_codel_controllers(target=0.005, interval=0.02, high_target_multiplier=20.0),
         backstop_max_waiters=_backstop(1000),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -192,13 +193,13 @@ async def test_all_admitted_when_capacity_available(priority: str) -> None:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=10),
+        slot_pool=PrioritySlotPool(max_concurrency=10, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(1000),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(app, controller, enabled=True)
 
@@ -225,14 +226,14 @@ async def test_shed_backstop_returns_rest_envelope() -> None:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=0),
+        slot_pool=PrioritySlotPool(max_concurrency=0, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(0),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         # Backstop sheds at the top tier; pin level-3 so the wired-through Retry-After is 7.
-        retry_policy=RetryAfterPolicy(level3_seconds=7),
+        retry_policy=RetryAfterPolicy(observers=[], level3_seconds=7),
     )
     _install_admission(app, controller, enabled=True)
 
@@ -274,7 +275,7 @@ async def test_shed_codel_returns_429() -> None:
         await release.wait()
         return {"ok": True}
 
-    slot_pool = PrioritySlotPool(max_concurrency=1, clock=_StepClock(step=1.0))
+    slot_pool = PrioritySlotPool(max_concurrency=1, observers=[SlotPoolMetricsObserver()], clock=_StepClock(step=1.0))
     controller = AdmissionController(
         slot_pool=slot_pool,
         codel_priority_map=_codel_controllers(
@@ -285,7 +286,7 @@ async def test_shed_codel_returns_429() -> None:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         # Unstressed CoDel shed lands at tier 0, which floors to level 1; pin it to 3.
-        retry_policy=RetryAfterPolicy(level1_seconds=3),
+        retry_policy=RetryAfterPolicy(observers=[], level1_seconds=3),
     )
     _install_admission(app, controller, enabled=True)
 
@@ -351,13 +352,13 @@ async def test_capacity_and_burst() -> None:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=max_concurrency),
+        slot_pool=PrioritySlotPool(max_concurrency=max_concurrency, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=interval, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(1000),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     # The gauge is set at server wiring time, not by constructing a controller; set it the same
     # way the wiring does so the invariant is observable here.
@@ -400,13 +401,13 @@ def _admit_app() -> FastAPI:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=10),
+        slot_pool=PrioritySlotPool(max_concurrency=10, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(1000),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -421,13 +422,13 @@ def _backstop_app() -> FastAPI:
         return {"ok": True}
 
     controller = AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=0),
+        slot_pool=PrioritySlotPool(max_concurrency=0, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(0),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -480,7 +481,7 @@ async def test_metrics() -> None:
         await release.wait()
         return {"ok": True}
 
-    slot_pool = PrioritySlotPool(max_concurrency=1, clock=_StepClock(step=1.0))
+    slot_pool = PrioritySlotPool(max_concurrency=1, observers=[SlotPoolMetricsObserver()], clock=_StepClock(step=1.0))
     controller = AdmissionController(
         slot_pool=slot_pool,
         codel_priority_map=_codel_controllers(
@@ -490,7 +491,7 @@ async def test_metrics() -> None:
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(codel_app, controller, enabled=True)
 
@@ -556,13 +557,13 @@ def _offered_total() -> float:
 def _shed_everything_controller() -> AdmissionController:
     """Controller with no slots and no waiter budget: every admitted attempt is shed."""
     return AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=0),
+        slot_pool=PrioritySlotPool(max_concurrency=0, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
         backstop_max_waiters=_backstop(0),
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
 
 
@@ -715,7 +716,7 @@ async def test_handler_exception_releases_slot() -> None:
     async def work() -> dict[str, bool]:
         return {"ok": True}
 
-    slot_pool = PrioritySlotPool(max_concurrency=1)
+    slot_pool = PrioritySlotPool(max_concurrency=1, observers=[SlotPoolMetricsObserver()])
     controller = AdmissionController(
         slot_pool=slot_pool,
         codel_priority_map=_codel_controllers(target=0.005, interval=0.1, high_target_multiplier=4.0),
@@ -723,7 +724,7 @@ async def test_handler_exception_releases_slot() -> None:
         stress_signal=_UNSTRESSED,
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
     _install_admission(app, controller, enabled=True)
 
@@ -746,7 +747,11 @@ async def test_handler_exception_releases_slot() -> None:
 
 async def test_build_admission_controller_sets_gauge() -> None:
     """The real settings-reading factory returns a usable controller and sets the max-concurrency gauge."""
-    controller = build_admission_controller(settings=config.SETTINGS.active_settings)
+    controller = build_admission_controller(
+        settings=config.SETTINGS.active_settings,
+        slot_pool_observers=[SlotPoolMetricsObserver()],
+        retry_policy_observers=[SustainedLoadMetricsObserver()],
+    )
 
     assert isinstance(controller, AdmissionController)
     expected = derive_max_concurrency(

--- a/backend/tests/component/api/test_admission_middleware.py
+++ b/backend/tests/component/api/test_admission_middleware.py
@@ -12,7 +12,8 @@ from infrahub import config
 from infrahub.api.admission import metrics
 from infrahub.api.admission.capacity import derive_max_concurrency
 from infrahub.api.admission.codel import CoDelController
-from infrahub.api.admission.controller import AdmissionController, build_admission_controller
+from infrahub.api.admission.controller import AdmissionController
+from infrahub.api.admission.factory import build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
 from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
 from infrahub.api.admission.priority import Priority

--- a/backend/tests/component/api/test_admission_middleware.py
+++ b/backend/tests/component/api/test_admission_middleware.py
@@ -15,7 +15,11 @@ from infrahub.api.admission.codel import CoDelController
 from infrahub.api.admission.controller import AdmissionController
 from infrahub.api.admission.factory import build_admission_controller
 from infrahub.api.admission.middleware import AdmissionMiddleware
-from infrahub.api.admission.observers import SlotPoolMetricsObserver, SustainedLoadMetricsObserver
+from infrahub.api.admission.observers import (
+    AdmissionMetricsObserver,
+    SlotPoolMetricsObserver,
+    SustainedLoadMetricsObserver,
+)
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 from infrahub.api.admission.slot_pool import PrioritySlotPool
@@ -143,6 +147,7 @@ def _build_app() -> FastAPI:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -201,6 +206,7 @@ async def test_all_admitted_when_capacity_available(priority: str) -> None:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
 
@@ -235,6 +241,7 @@ async def test_shed_backstop_returns_rest_envelope() -> None:
         stress_min_samples=0,
         # Backstop sheds at the top tier; pin level-3 so the wired-through Retry-After is 7.
         retry_policy=RetryAfterPolicy(observers=[], level3_seconds=7),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
 
@@ -288,6 +295,7 @@ async def test_shed_codel_returns_429() -> None:
         stress_min_samples=0,
         # Unstressed CoDel shed lands at tier 0, which floors to level 1; pin it to 3.
         retry_policy=RetryAfterPolicy(observers=[], level1_seconds=3),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
 
@@ -360,6 +368,7 @@ async def test_capacity_and_burst() -> None:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     # The gauge is set at server wiring time, not by constructing a controller; set it the same
     # way the wiring does so the invariant is observable here.
@@ -409,6 +418,7 @@ def _admit_app() -> FastAPI:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -430,6 +440,7 @@ def _backstop_app() -> FastAPI:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
     return app
@@ -493,6 +504,7 @@ async def test_metrics() -> None:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(codel_app, controller, enabled=True)
 
@@ -565,6 +577,7 @@ def _shed_everything_controller() -> AdmissionController:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
 
 
@@ -726,6 +739,7 @@ async def test_handler_exception_releases_slot() -> None:
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
     _install_admission(app, controller, enabled=True)
 
@@ -750,6 +764,7 @@ async def test_build_admission_controller_sets_gauge() -> None:
     """The real settings-reading factory returns a usable controller and sets the max-concurrency gauge."""
     controller = build_admission_controller(
         settings=config.SETTINGS.active_settings,
+        admission_observers=[AdmissionMetricsObserver()],
         slot_pool_observers=[SlotPoolMetricsObserver()],
         retry_policy_observers=[SustainedLoadMetricsObserver()],
     )

--- a/backend/tests/component/api/test_cors_priority.py
+++ b/backend/tests/component/api/test_cors_priority.py
@@ -7,6 +7,7 @@ from starlette.middleware.cors import CORSMiddleware
 from infrahub.api.admission.codel import CoDelController
 from infrahub.api.admission.controller import AdmissionController
 from infrahub.api.admission.middleware import AdmissionMiddleware
+from infrahub.api.admission.observers import SlotPoolMetricsObserver
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 from infrahub.api.admission.slot_pool import PrioritySlotPool
@@ -28,7 +29,7 @@ class _FakeLoadSignal:
 def _shed_everything_controller() -> AdmissionController:
     """Controller with no slots and no waiter budget: every admitted attempt is shed."""
     return AdmissionController(
-        slot_pool=PrioritySlotPool(max_concurrency=0),
+        slot_pool=PrioritySlotPool(max_concurrency=0, observers=[SlotPoolMetricsObserver()]),
         codel_priority_map={
             Priority.HIGH: CoDelController(target=0.005 * 4.0, interval=0.1),
             Priority.MEDIUM: CoDelController(target=0.005, interval=0.1),
@@ -38,7 +39,7 @@ def _shed_everything_controller() -> AdmissionController:
         stress_signal=_FakeLoadSignal(),
         stress_thresholds=dict.fromkeys(Priority, 1.0),
         stress_min_samples=0,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
     )
 
 

--- a/backend/tests/component/api/test_cors_priority.py
+++ b/backend/tests/component/api/test_cors_priority.py
@@ -7,7 +7,7 @@ from starlette.middleware.cors import CORSMiddleware
 from infrahub.api.admission.codel import CoDelController
 from infrahub.api.admission.controller import AdmissionController
 from infrahub.api.admission.middleware import AdmissionMiddleware
-from infrahub.api.admission.observers import SlotPoolMetricsObserver
+from infrahub.api.admission.observers import AdmissionMetricsObserver, SlotPoolMetricsObserver
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 from infrahub.api.admission.slot_pool import PrioritySlotPool
@@ -40,6 +40,7 @@ def _shed_everything_controller() -> AdmissionController:
         stress_thresholds=dict.fromkeys(Priority, 1.0),
         stress_min_samples=0,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=[AdmissionMetricsObserver()],
     )
 
 

--- a/backend/tests/unit/api/admission/helpers.py
+++ b/backend/tests/unit/api/admission/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from infrahub.api.admission.priority import Priority
+
 
 class FakeClock:
     """Manually advanced monotonic clock so admission timing is deterministic in tests."""
@@ -12,3 +14,24 @@ class FakeClock:
 
     def advance(self, seconds: float) -> None:
         self.now += seconds
+
+
+class RecordingSlotPoolObserver:
+    """Slot-pool sink that keeps the counts last pushed for each priority class."""
+
+    def __init__(self) -> None:
+        self.in_flight: dict[Priority, int] = dict.fromkeys(Priority, 0)
+        self.waiters: dict[Priority, int] = dict.fromkeys(Priority, 0)
+        self.calls = 0
+
+    def on_counts_changed(self, priority: Priority, *, in_flight: int, waiters: int) -> None:
+        self.in_flight[priority] = in_flight
+        self.waiters[priority] = waiters
+        self.calls += 1
+
+
+class FailingSlotPoolObserver:
+    """Slot-pool sink that raises on every transition, to prove failures stay contained."""
+
+    def on_counts_changed(self, priority: Priority, *, in_flight: int, waiters: int) -> None:
+        raise RuntimeError("observer blew up")

--- a/backend/tests/unit/api/admission/helpers.py
+++ b/backend/tests/unit/api/admission/helpers.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from infrahub.api.admission.priority import Priority
+
+if TYPE_CHECKING:
+    from infrahub.api.admission.constants import RejectionReason
 
 
 class FakeClock:
@@ -28,6 +33,43 @@ class RecordingSlotPoolObserver:
         self.in_flight[priority] = in_flight
         self.waiters[priority] = waiters
         self.calls += 1
+
+
+class RecordingAdmissionObserver:
+    """Admission sink that keeps every event pushed to it, in order."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Priority]] = []
+        self.sojourns: list[float] = []
+
+    def on_offered(self, *, priority: Priority) -> None:
+        self.events.append(("offered", priority))
+
+    def on_admitted(self, *, priority: Priority) -> None:
+        self.events.append(("admitted", priority))
+
+    def on_rejected(self, *, priority: Priority, reason: RejectionReason) -> None:
+        self.events.append((f"rejected:{reason}", priority))
+
+    def on_sojourn(self, *, priority: Priority, seconds: float) -> None:
+        self.events.append(("sojourn", priority))
+        self.sojourns.append(seconds)
+
+
+class FailingAdmissionObserver:
+    """Admission sink that raises on every event, to prove failures stay contained."""
+
+    def on_offered(self, *, priority: Priority) -> None:
+        raise RuntimeError("observer blew up")
+
+    def on_admitted(self, *, priority: Priority) -> None:
+        raise RuntimeError("observer blew up")
+
+    def on_rejected(self, *, priority: Priority, reason: RejectionReason) -> None:
+        raise RuntimeError("observer blew up")
+
+    def on_sojourn(self, *, priority: Priority, seconds: float) -> None:
+        raise RuntimeError("observer blew up")
 
 
 class FailingSlotPoolObserver:

--- a/backend/tests/unit/api/admission/test_controller.py
+++ b/backend/tests/unit/api/admission/test_controller.py
@@ -55,7 +55,7 @@ class _FakeLoadSignal:
 def _build(
     *, ratio: float, samples: int, rng_value: float = 0.0, max_concurrency: int = 1, min_samples: int = 1
 ) -> tuple[AdmissionController, PrioritySlotPool]:
-    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, clock=_StepClock(step=1.0))
+    slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=[], clock=_StepClock(step=1.0))
     # Neutralise the per-class CoDel target so nothing but the signal under test differs.
     codel_clock = _StepClock(step=1.0)
     controller = AdmissionController(
@@ -67,7 +67,7 @@ def _build(
         stress_signal=_FakeLoadSignal(ratio=ratio, samples=samples),
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=min_samples,
-        retry_policy=RetryAfterPolicy(),
+        retry_policy=RetryAfterPolicy(observers=[]),
         rng=lambda: rng_value,
     )
     return controller, slot_pool

--- a/backend/tests/unit/api/admission/test_controller.py
+++ b/backend/tests/unit/api/admission/test_controller.py
@@ -11,6 +11,7 @@ from infrahub.api.admission.controller import (
     Admitted,
     Rejected,
     stress_shed_fraction,
+    stress_tier,
 )
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
@@ -74,29 +75,34 @@ def _build(
 
 
 @dataclass
-class _FractionCase:
+class _TierCase:
     name: str
     ratio: float
     threshold: float
-    expected: float
+    expected: int
 
 
-_FRACTION_CASES = [
-    _FractionCase(name="below_trigger_sheds_nothing", ratio=0.5, threshold=1.0, expected=0.0),
-    _FractionCase(name="at_trigger_is_mild", ratio=1.0, threshold=1.0, expected=0.20),
-    _FractionCase(name="just_under_2x_is_mild", ratio=1.9, threshold=1.0, expected=0.20),
-    _FractionCase(name="at_2x_is_moderate", ratio=2.0, threshold=1.0, expected=0.50),
-    _FractionCase(name="just_under_5x_is_moderate", ratio=4.9, threshold=1.0, expected=0.50),
-    _FractionCase(name="at_5x_is_severe", ratio=5.0, threshold=1.0, expected=0.80),
-    _FractionCase(name="far_past_trigger_is_severe", ratio=100.0, threshold=1.0, expected=0.80),
-    _FractionCase(name="scales_with_threshold", ratio=40.0, threshold=20.0, expected=0.50),
-    _FractionCase(name="non_positive_threshold_sheds_nothing", ratio=10.0, threshold=0.0, expected=0.0),
+_TIER_CASES = [
+    _TierCase(name="below_trigger_is_untiered", ratio=0.5, threshold=1.0, expected=0),
+    _TierCase(name="at_trigger_is_mild", ratio=1.0, threshold=1.0, expected=1),
+    _TierCase(name="just_under_2x_is_mild", ratio=1.9, threshold=1.0, expected=1),
+    _TierCase(name="at_2x_is_moderate", ratio=2.0, threshold=1.0, expected=2),
+    _TierCase(name="just_under_5x_is_moderate", ratio=4.9, threshold=1.0, expected=2),
+    _TierCase(name="at_5x_is_severe", ratio=5.0, threshold=1.0, expected=3),
+    _TierCase(name="far_past_trigger_is_severe", ratio=100.0, threshold=1.0, expected=3),
+    _TierCase(name="scales_with_threshold", ratio=40.0, threshold=20.0, expected=2),
+    _TierCase(name="non_positive_threshold_is_untiered", ratio=10.0, threshold=0.0, expected=0),
 ]
 
 
-@pytest.mark.parametrize("case", _FRACTION_CASES, ids=[case.name for case in _FRACTION_CASES])
-def test_stress_shed_fraction(case: _FractionCase) -> None:
-    assert stress_shed_fraction(ratio=case.ratio, threshold=case.threshold) == case.expected
+@pytest.mark.parametrize("case", _TIER_CASES, ids=[case.name for case in _TIER_CASES])
+def test_stress_tier(case: _TierCase) -> None:
+    assert stress_tier(ratio=case.ratio, threshold=case.threshold) == case.expected
+
+
+def test_shed_fraction_escalates_by_tier() -> None:
+    # The whole schedule, so an accidental edit to one entry fails rather than passing silently.
+    assert {tier: stress_shed_fraction(tier=tier) for tier in (0, 1, 2, 3)} == {0: 0.0, 1: 0.20, 2: 0.50, 3: 0.80}
 
 
 @dataclass

--- a/backend/tests/unit/api/admission/test_controller.py
+++ b/backend/tests/unit/api/admission/test_controller.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass
 import pytest
 
 from infrahub.api.admission.codel import CoDelController
+from infrahub.api.admission.constants import RejectionReason
 from infrahub.api.admission.controller import (
     AdmissionController,
+    AdmissionObserver,
     Admitted,
     Rejected,
     stress_shed_fraction,
@@ -16,6 +18,7 @@ from infrahub.api.admission.controller import (
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 from infrahub.api.admission.slot_pool import PrioritySlotPool
+from tests.unit.api.admission.helpers import FailingAdmissionObserver, RecordingAdmissionObserver
 
 # Per-class stress triggers (the ratio at which a class starts shedding).
 _THRESHOLDS = {Priority.HIGH: 100.0, Priority.MEDIUM: 20.0, Priority.LOW: 5.0}
@@ -53,8 +56,14 @@ class _FakeLoadSignal:
         return self._samples
 
 
-def _build(
-    *, ratio: float, samples: int, rng_value: float = 0.0, max_concurrency: int = 1, min_samples: int = 1
+def _build(  # noqa: PLR0913
+    *,
+    ratio: float,
+    samples: int,
+    rng_value: float = 0.0,
+    max_concurrency: int = 1,
+    min_samples: int = 1,
+    observers: list[AdmissionObserver] | None = None,
 ) -> tuple[AdmissionController, PrioritySlotPool]:
     slot_pool = PrioritySlotPool(max_concurrency=max_concurrency, observers=[], clock=_StepClock(step=1.0))
     # Neutralise the per-class CoDel target so nothing but the signal under test differs.
@@ -69,6 +78,7 @@ def _build(
         stress_thresholds=_THRESHOLDS,
         stress_min_samples=min_samples,
         retry_policy=RetryAfterPolicy(observers=[]),
+        observers=observers if observers is not None else [],
         rng=lambda: rng_value,
     )
     return controller, slot_pool
@@ -170,7 +180,7 @@ async def test_stress_sheds_a_fraction_without_queueing(case: _StressCase) -> No
         assert case.expect_shed is False
     else:
         assert case.expect_shed is True
-        assert result.reason == "stress"
+        assert result.reason == RejectionReason.STRESS
 
 
 async def _second_follower(
@@ -207,7 +217,7 @@ async def test_codel_sheds_independent_of_stress() -> None:
     result = await _second_follower(controller, slot_pool, priority=Priority.LOW)
 
     assert isinstance(result, Rejected)
-    assert result.reason == "codel"
+    assert result.reason == RejectionReason.CODEL
 
 
 async def test_retry_after_reflects_per_priority_stress_tier() -> None:
@@ -220,14 +230,14 @@ async def test_retry_after_reflects_per_priority_stress_tier() -> None:
     low_controller, _ = _build(ratio=60.0, samples=100, rng_value=0.0, max_concurrency=10)
     low = await low_controller.admit(priority=Priority.LOW)
     assert isinstance(low, Rejected)
-    assert low.reason == "stress"
+    assert low.reason == RejectionReason.STRESS
     assert low.retry_after == 10
 
     # MEDIUM trigger is 20. Same ratio 60 -> 3x -> moderate (tier 2) -> level-2 base (5s).
     medium_controller, _ = _build(ratio=60.0, samples=100, rng_value=0.0, max_concurrency=10)
     medium = await medium_controller.admit(priority=Priority.MEDIUM)
     assert isinstance(medium, Rejected)
-    assert medium.reason == "stress"
+    assert medium.reason == RejectionReason.STRESS
     assert medium.retry_after == 5
 
 
@@ -248,8 +258,57 @@ async def test_stress_sheds_before_queueing_for_a_slot() -> None:
     result = await controller.admit(priority=Priority.LOW)
 
     assert isinstance(result, Rejected)
-    assert result.reason == "stress"
+    assert result.reason == RejectionReason.STRESS
     # The shed took the fast path: the request never enqueued behind the held slot.
     assert slot_pool.waiters(priority=Priority.LOW) == 0
 
     controller.release(acquisition=holder.acquisition)
+
+
+async def test_admitted_request_emits_offered_sojourn_admitted() -> None:
+    observer = RecordingAdmissionObserver()
+    controller, _ = _build(ratio=1.0, samples=100, max_concurrency=1, observers=[observer])
+
+    assert isinstance(await controller.admit(priority=Priority.MEDIUM), Admitted)
+
+    assert observer.events == [
+        ("offered", Priority.MEDIUM),
+        ("sojourn", Priority.MEDIUM),
+        ("admitted", Priority.MEDIUM),
+    ]
+    # The fast path acquires without waiting, so the reported sojourn is zero rather than absent.
+    assert observer.sojourns == [0.0]
+
+
+async def test_shed_request_emits_offered_then_rejected_only() -> None:
+    observer = RecordingAdmissionObserver()
+    # LOW's trigger is 5; at 10x that is tier 2 (a 50% fraction) and the draw is forced below it.
+    controller, _ = _build(ratio=50.0, samples=100, rng_value=0.0, max_concurrency=1, observers=[observer])
+
+    assert isinstance(await controller.admit(priority=Priority.LOW), Rejected)
+
+    # A request shed before it reaches the pool has no sojourn to report and was never admitted.
+    assert observer.events == [("offered", Priority.LOW), ("rejected:stress", Priority.LOW)]
+    assert observer.sojourns == []
+
+
+async def test_failing_observer_does_not_affect_the_decision() -> None:
+    survivor = RecordingAdmissionObserver()
+    # The failing sink is ordered first, so a shared guard would swallow the survivor too.
+    controller, slot_pool = _build(
+        ratio=1.0, samples=100, max_concurrency=1, observers=[FailingAdmissionObserver(), survivor]
+    )
+
+    result = await controller.admit(priority=Priority.HIGH)
+
+    assert isinstance(result, Admitted)
+    # Isolation is per observer: the sink behind the failing one saw every event.
+    assert survivor.events == [
+        ("offered", Priority.HIGH),
+        ("sojourn", Priority.HIGH),
+        ("admitted", Priority.HIGH),
+    ]
+
+    # A failing sink mid-decision must not strand the slot it was holding.
+    controller.release(acquisition=result.acquisition)
+    assert slot_pool.available == slot_pool.max_concurrency

--- a/backend/tests/unit/api/admission/test_observers.py
+++ b/backend/tests/unit/api/admission/test_observers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from infrahub.api.admission import metrics
+from infrahub.api.admission.constants import RejectionReason
+from infrahub.api.admission.observers import AdmissionMetricsObserver, SustainedLoadMetricsObserver
+from infrahub.api.admission.priority import Priority
+
+
+def _rejected(*, priority: str, reason: str) -> float:
+    return metrics.REJECTED_TOTAL.labels(priority=priority, reason=reason)._value.get()
+
+
+def test_rejection_reason_labels_the_counter_by_its_value() -> None:
+    observer = AdmissionMetricsObserver()
+    # The reason reaches the gauge as an enum member but is scraped as a label string, so a
+    # plain-string lookup has to find the very same counter the observer incremented.
+    before = _rejected(priority="low", reason="backstop")
+
+    observer.on_rejected(priority=Priority.LOW, reason=RejectionReason.BACKSTOP)
+
+    assert _rejected(priority="low", reason="backstop") - before == 1.0
+
+
+def test_each_reason_increments_its_own_counter() -> None:
+    observer = AdmissionMetricsObserver()
+    before = {reason: _rejected(priority="medium", reason=reason) for reason in RejectionReason}
+
+    for reason in RejectionReason:
+        observer.on_rejected(priority=Priority.MEDIUM, reason=reason)
+
+    after = {reason: _rejected(priority="medium", reason=reason) for reason in RejectionReason}
+    assert {reason: after[reason] - before[reason] for reason in RejectionReason} == dict.fromkeys(RejectionReason, 1.0)
+
+
+def test_sustained_load_reaches_its_gauge() -> None:
+    observer = SustainedLoadMetricsObserver()
+
+    observer.on_sustained_load(sustained_seconds=45.0)
+    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 45.0
+
+    # A cleared episode reports zero, so the gauge has to fall back rather than latch its peak.
+    observer.on_sustained_load(sustained_seconds=0.0)
+    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 0.0

--- a/backend/tests/unit/api/admission/test_retry_policy.py
+++ b/backend/tests/unit/api/admission/test_retry_policy.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from infrahub.api.admission import metrics
-from infrahub.api.admission.observers import SustainedLoadMetricsObserver
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 
 
@@ -158,18 +156,3 @@ def test_failing_observer_does_not_fail_the_observation() -> None:
     assert survivor.sustained_seconds == [0.0, 120.0]
     # The episode still tracked through the failures, so escalation is unaffected.
     assert policy.retry_after(tier=1) == 2
-
-
-def test_metrics_observer_publishes_the_sustained_duration_to_the_gauge() -> None:
-    clock = FakeClock()
-    policy = RetryAfterPolicy(observers=[SustainedLoadMetricsObserver()], significant_load_ratio=20.0, clock=clock)
-
-    policy.observe(ratio=25.0)
-    clock.advance(45)
-    policy.observe(ratio=25.0)
-
-    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 45.0
-
-    # Load clearing resets the gauge, so a finished episode never reads as still ongoing.
-    policy.observe(ratio=1.0)
-    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 0.0

--- a/backend/tests/unit/api/admission/test_retry_policy.py
+++ b/backend/tests/unit/api/admission/test_retry_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from infrahub.api.admission import metrics
+from infrahub.api.admission.observers import SustainedLoadMetricsObserver
 from infrahub.api.admission.retry_policy import RetryAfterPolicy
 
 
@@ -16,9 +18,28 @@ class FakeClock:
         self.now += seconds
 
 
+class RecordingRetryPolicyObserver:
+    """Retry-policy sink that keeps every sustained-load duration pushed to it."""
+
+    def __init__(self) -> None:
+        self.sustained_seconds: list[float] = []
+
+    def on_sustained_load(self, *, sustained_seconds: float) -> None:
+        self.sustained_seconds.append(sustained_seconds)
+
+
+class FailingRetryPolicyObserver:
+    """Retry-policy sink that raises on every observation, to prove failures stay contained."""
+
+    def on_sustained_load(self, *, sustained_seconds: float) -> None:
+        raise RuntimeError("observer blew up")
+
+
 def _policy(clock: FakeClock | None = None) -> tuple[RetryAfterPolicy, list[float]]:
     """Build a policy plus a recorder capturing the sustained-load values it pushes to its observer."""
+    observer = RecordingRetryPolicyObserver()
     policy = RetryAfterPolicy(
+        observers=[observer],
         level1_seconds=1,
         level2_seconds=5,
         level3_seconds=10,
@@ -28,9 +49,7 @@ def _policy(clock: FakeClock | None = None) -> tuple[RetryAfterPolicy, list[floa
         sustained_high_seconds=300.0,
         clock=clock or FakeClock(),
     )
-    recorded: list[float] = []
-    policy.set_observer(recorded.append)
-    return policy, recorded
+    return policy, observer.sustained_seconds
 
 
 def test_tier_maps_to_level_seconds_without_sustained_load() -> None:
@@ -82,7 +101,7 @@ def test_sustained_load_escalates_by_duration() -> None:
 
 def test_result_is_clamped_to_max() -> None:
     clock = FakeClock()
-    policy = RetryAfterPolicy(level3_seconds=10, max_seconds=20, clock=clock)
+    policy = RetryAfterPolicy(observers=[], level3_seconds=10, max_seconds=20, clock=clock)
 
     policy.observe(ratio=25.0)
     clock.advance(400)  # high tier -> x3 -> 30, above the cap
@@ -105,3 +124,52 @@ def test_episode_resets_when_load_clears() -> None:
 
     assert recorded[-1] == 0.0
     assert policy.retry_after(tier=1) == 1  # back to x1
+
+
+def test_every_observer_receives_the_sustained_duration() -> None:
+    clock = FakeClock()
+    first = RecordingRetryPolicyObserver()
+    second = RecordingRetryPolicyObserver()
+    policy = RetryAfterPolicy(observers=[first, second], significant_load_ratio=20.0, clock=clock)
+
+    policy.observe(ratio=25.0)
+    clock.advance(30)
+    policy.observe(ratio=25.0)
+
+    # Both sinks track the same episode: the policy fans out rather than keeping one slot.
+    assert first.sustained_seconds == [0.0, 30.0]
+    assert second.sustained_seconds == [0.0, 30.0]
+
+
+def test_failing_observer_does_not_fail_the_observation() -> None:
+    clock = FakeClock()
+    survivor = RecordingRetryPolicyObserver()
+    # The failing sink is ordered first, so a shared guard would swallow the survivor too.
+    policy = RetryAfterPolicy(
+        observers=[FailingRetryPolicyObserver(), survivor], significant_load_ratio=20.0, clock=clock
+    )
+
+    # observe() runs on the admission path of every request, so a raising sink must not propagate
+    # into a request that would otherwise be admitted, and must not skip the sinks behind it.
+    policy.observe(ratio=25.0)
+    clock.advance(120)
+    policy.observe(ratio=25.0)
+
+    assert survivor.sustained_seconds == [0.0, 120.0]
+    # The episode still tracked through the failures, so escalation is unaffected.
+    assert policy.retry_after(tier=1) == 2
+
+
+def test_metrics_observer_publishes_the_sustained_duration_to_the_gauge() -> None:
+    clock = FakeClock()
+    policy = RetryAfterPolicy(observers=[SustainedLoadMetricsObserver()], significant_load_ratio=20.0, clock=clock)
+
+    policy.observe(ratio=25.0)
+    clock.advance(45)
+    policy.observe(ratio=25.0)
+
+    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 45.0
+
+    # Load clearing resets the gauge, so a finished episode never reads as still ongoing.
+    policy.observe(ratio=1.0)
+    assert metrics.SUSTAINED_LOAD_SECONDS._value.get() == 0.0

--- a/backend/tests/unit/api/admission/test_slot_pool.py
+++ b/backend/tests/unit/api/admission/test_slot_pool.py
@@ -4,7 +4,7 @@ import asyncio
 
 from infrahub.api.admission.priority import Priority
 from infrahub.api.admission.slot_pool import PrioritySlotPool
-from tests.unit.api.admission.helpers import FakeClock
+from tests.unit.api.admission.helpers import FailingSlotPoolObserver, FakeClock, RecordingSlotPoolObserver
 
 
 async def _wait_until_waiting(pool: PrioritySlotPool, *, priority: Priority, count: int) -> None:
@@ -23,7 +23,7 @@ async def _wait_until_waiting(pool: PrioritySlotPool, *, priority: Priority, cou
 
 
 async def test_freed_slot_goes_to_highest_priority_waiter() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
+    pool = PrioritySlotPool(max_concurrency=1, observers=[])
     events: list[str] = []
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
@@ -51,7 +51,7 @@ async def test_freed_slot_goes_to_highest_priority_waiter() -> None:
 
 
 async def test_within_class_fifo() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
+    pool = PrioritySlotPool(max_concurrency=1, observers=[])
     events: list[str] = []
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
@@ -75,7 +75,7 @@ async def test_within_class_fifo() -> None:
 
 async def test_cancelled_waiter_leaks_no_slot() -> None:
     clock = FakeClock()
-    pool = PrioritySlotPool(max_concurrency=1, clock=clock)
+    pool = PrioritySlotPool(max_concurrency=1, observers=[], clock=clock)
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
 
@@ -117,9 +117,8 @@ async def test_cancelled_waiter_leaks_no_slot() -> None:
 
 
 async def test_observer_reflects_waiters_while_still_queued() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
-    observed: dict[Priority, int] = dict.fromkeys(Priority, 0)
-    pool.set_observer(lambda priority, **counts: observed.__setitem__(priority, counts["waiters"]))
+    observer = RecordingSlotPoolObserver()
+    pool = PrioritySlotPool(max_concurrency=1, observers=[observer])
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
 
@@ -132,18 +131,33 @@ async def test_observer_reflects_waiters_while_still_queued() -> None:
 
     # The observer must see the queue depth build up while the tasks are still parked,
     # before any slot is released — not only once a waiter is later dequeued.
-    assert observed[Priority.LOW] == 3
+    assert observer.waiters[Priority.LOW] == 3
 
     pool.release(acquisition=holder)
     await asyncio.gather(*tasks)
     # Draining brings the observed depth back to zero.
-    assert observed[Priority.LOW] == 0
+    assert observer.waiters[Priority.LOW] == 0
+
+
+async def test_every_observer_receives_the_counts() -> None:
+    first = RecordingSlotPoolObserver()
+    second = RecordingSlotPoolObserver()
+    pool = PrioritySlotPool(max_concurrency=2, observers=[first, second])
+
+    holder = await pool.acquire(priority=Priority.HIGH)
+
+    # Both sinks track the same transition: the pool fans out rather than keeping one slot.
+    assert first.in_flight[Priority.HIGH] == 1
+    assert second.in_flight[Priority.HIGH] == 1
+
+    pool.release(acquisition=holder)
+    assert first.in_flight[Priority.HIGH] == 0
+    assert second.in_flight[Priority.HIGH] == 0
 
 
 async def test_observer_reflects_cancelled_waiter_leaving_queue() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
-    observed: dict[Priority, int] = dict.fromkeys(Priority, 0)
-    pool.set_observer(lambda priority, **counts: observed.__setitem__(priority, counts["waiters"]))
+    observer = RecordingSlotPoolObserver()
+    pool = PrioritySlotPool(max_concurrency=1, observers=[observer])
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
 
@@ -152,27 +166,25 @@ async def test_observer_reflects_cancelled_waiter_leaving_queue() -> None:
 
     victim = asyncio.create_task(cancellable())
     await _wait_until_waiting(pool, priority=Priority.LOW, count=1)
-    assert observed[Priority.LOW] == 1
+    assert observer.waiters[Priority.LOW] == 1
 
     victim.cancel()
     results = await asyncio.gather(victim, return_exceptions=True)
     assert isinstance(results[0], asyncio.CancelledError)
 
     # Leaving the queue via cancellation must refresh the observer, not leave it stale at 1.
-    assert observed[Priority.LOW] == 0
+    assert observer.waiters[Priority.LOW] == 0
     pool.release(acquisition=holder)
 
 
 async def test_failing_observer_does_not_corrupt_admission_state() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
+    survivor = RecordingSlotPoolObserver()
+    # The failing sink is ordered first, so a shared guard would swallow the survivor too.
+    pool = PrioritySlotPool(max_concurrency=1, observers=[FailingSlotPoolObserver(), survivor])
 
-    def boom(priority: Priority, **counts: int) -> None:
-        raise RuntimeError("observer blew up")
-
-    pool.set_observer(boom)
-
-    # Acquire and release must both complete despite the observer raising on every transition,
-    # and the slot must be returned so a following waiter is served rather than deadlocked.
+    # Acquire and release must both complete despite the first observer raising on every
+    # transition, and the slot must be returned so a following waiter is served rather than
+    # deadlocked.
     holder = await pool.acquire(priority=Priority.MEDIUM)
     assert pool.available == 0
 
@@ -181,6 +193,10 @@ async def test_failing_observer_does_not_corrupt_admission_state() -> None:
     assert pool.available == pool.max_concurrency
     assert all(pool.in_flight(priority=priority) == 0 for priority in Priority)
 
+    # Isolation is per observer: the sink behind the failing one still saw both transitions.
+    assert survivor.calls == 2
+    assert survivor.in_flight[Priority.MEDIUM] == 0
+
     # A fresh acquire still succeeds on the recovered slot.
     again = await pool.acquire(priority=Priority.LOW)
     pool.release(acquisition=again)
@@ -188,7 +204,7 @@ async def test_failing_observer_does_not_corrupt_admission_state() -> None:
 
 
 async def test_cancel_after_handoff_rereleases_slot() -> None:
-    pool = PrioritySlotPool(max_concurrency=1)
+    pool = PrioritySlotPool(max_concurrency=1, observers=[])
 
     holder = await pool.acquire(priority=Priority.MEDIUM)
 

--- a/backend/tests/unit/config/test_config.py
+++ b/backend/tests/unit/config/test_config.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from infrahub.config import (
     SETTINGS,
+    ApiSettings,
     DatabaseSettings,
     GitSettings,
     MainSettings,
@@ -48,6 +49,76 @@ def test_load_sso_config(helper: TestHelper) -> None:
 def test_default_cors_allow_headers_includes_x_priority() -> None:
     """The shipped CORS allow-list lets cross-origin browsers send the X-Priority header."""
     assert "x-priority" in default_cors_allow_headers()
+
+
+# no inf/nan values allowed for backpressure settings
+_NON_FINITE_BACKPRESSURE_FIELDS = [
+    "backpressure_codel_target_seconds",
+    "backpressure_codel_interval_seconds",
+    "backpressure_high_target_multiplier",
+    "backpressure_stress_window_seconds",
+    "backpressure_shed_low_stress_ratio",
+    "backpressure_shed_medium_stress_ratio",
+    "backpressure_shed_high_stress_ratio",
+    "backpressure_backstop_low_multiplier",
+    "backpressure_backstop_high_multiplier",
+    "backpressure_max_concurrency_factor",
+    "backpressure_significant_load_stress_ratio",
+    "backpressure_sustained_load_warn_seconds",
+    "backpressure_sustained_load_high_seconds",
+]
+
+
+@pytest.mark.parametrize("field", _NON_FINITE_BACKPRESSURE_FIELDS)
+def test_backpressure_floats_reject_non_finite_values(field: str) -> None:
+    for value in (float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValidationError):
+            ApiSettings.model_validate({field: value})
+
+
+def test_backstop_multipliers_keep_the_caps_ordered_by_priority() -> None:
+    # MEDIUM's cap is the unscaled base, so a high multiplier below 1 or a low multiplier above 1
+    # would leave a higher-priority class with less waiter room than a lower-priority one.
+    with pytest.raises(ValidationError):
+        ApiSettings(backpressure_backstop_high_multiplier=0.5)
+    with pytest.raises(ValidationError):
+        ApiSettings(backpressure_backstop_low_multiplier=2.0)
+
+    # A cap equal to the base is the boundary and stays legal for both classes.
+    settings = ApiSettings(backpressure_backstop_high_multiplier=1.0, backpressure_backstop_low_multiplier=1.0)
+    assert settings.backpressure_backstop_high_multiplier == 1.0
+    assert settings.backpressure_backstop_low_multiplier == 1.0
+
+
+def test_shed_stress_ratios_must_be_ordered_by_priority() -> None:
+    message = re.escape("so lower-priority traffic sheds first")
+    # HIGH triggering before LOW would shed interactive traffic first — the inverse of the feature.
+    with pytest.raises(ValidationError, match=message):
+        ApiSettings(backpressure_shed_low_stress_ratio=100.0, backpressure_shed_high_stress_ratio=5.0)
+    # MEDIUM may not overtake HIGH either.
+    with pytest.raises(ValidationError, match=message):
+        ApiSettings(backpressure_shed_medium_stress_ratio=200.0)
+
+
+def test_shed_stress_ratios_may_be_equal() -> None:
+    # Collapsing the triggers makes every class shed together, which is degenerate but coherent.
+    settings = ApiSettings(
+        backpressure_shed_low_stress_ratio=20.0,
+        backpressure_shed_medium_stress_ratio=20.0,
+        backpressure_shed_high_stress_ratio=20.0,
+    )
+    assert settings.backpressure_shed_medium_stress_ratio == 20.0
+
+
+def test_shipped_backpressure_defaults_satisfy_the_priority_ordering() -> None:
+    settings = ApiSettings()
+
+    assert (
+        settings.backpressure_shed_low_stress_ratio
+        < settings.backpressure_shed_medium_stress_ratio
+        < settings.backpressure_shed_high_stress_ratio
+    )
+    assert settings.backpressure_backstop_low_multiplier <= 1 <= settings.backpressure_backstop_high_multiplier
 
 
 def test_valid_git_settings__sync_branch_names() -> None:

--- a/backend/tests/unit/database/test_load_signal.py
+++ b/backend/tests/unit/database/test_load_signal.py
@@ -6,8 +6,8 @@ from infrahub.database.load_signal import (
     MIN_OBSERVATION_SECONDS,
     UNSTRESSED_RATIO,
     ReferenceQueryLoadTracker,
-    _publish_metrics,
 )
+from infrahub.database.load_signal_metrics import LoadSignalMetricsObserver
 from infrahub.database.metrics import (
     REFERENCE_QUERY_FLOOR_SECONDS,
     REFERENCE_QUERY_STRESS_RATIO_MEDIAN,
@@ -30,8 +30,25 @@ class FakeClock:
         self.now += seconds
 
 
+class RecordingLoadSignalObserver:
+    """Load-signal sink that keeps every set of derived values pushed to it."""
+
+    def __init__(self) -> None:
+        self.observations: list[dict[str, float | None]] = []
+
+    def on_observation(self, *, floor: float | None, window_min: float | None, stress_ratio_median: float) -> None:
+        self.observations.append({"floor": floor, "window_min": window_min, "stress_ratio_median": stress_ratio_median})
+
+
+class FailingLoadSignalObserver:
+    """Load-signal sink that raises on every observation, to prove failures stay contained."""
+
+    def on_observation(self, *, floor: float | None, window_min: float | None, stress_ratio_median: float) -> None:
+        raise RuntimeError("observer blew up")
+
+
 def test_empty_tracker_reads_as_unstressed() -> None:
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=FakeClock())
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=FakeClock())
 
     assert tracker.floor() is None
     assert tracker.window_min() is None
@@ -41,7 +58,7 @@ def test_empty_tracker_reads_as_unstressed() -> None:
 
 
 def test_floor_is_absolute_running_minimum() -> None:
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=FakeClock())
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=FakeClock())
 
     tracker.record(0.010)
     assert tracker.floor() == 0.010
@@ -56,7 +73,7 @@ def test_floor_is_absolute_running_minimum() -> None:
 
 def test_window_evicts_samples_older_than_the_window() -> None:
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.010)  # t=0
     clock.advance(10)
@@ -73,7 +90,7 @@ def test_window_evicts_samples_older_than_the_window() -> None:
 
 def test_window_min_recovers_when_the_minimum_sample_is_evicted() -> None:
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.002)  # t=0 (the eventual floor)
     clock.advance(5)
@@ -93,7 +110,7 @@ def test_reads_expire_stale_window_after_idle_without_recording() -> None:
     # the window stayed "stressed" through an idle gap — long enough to shed the first request that
     # arrived after the lull, before it could refresh the signal. A read must age the window itself.
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.001)  # sets the floor
     for _ in range(5):
@@ -114,7 +131,7 @@ def test_reads_expire_stale_window_after_idle_without_recording() -> None:
 
 def test_stress_ratio_reflects_window_relative_to_floor() -> None:
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.001)  # t=0, sets the floor
     assert tracker.stress_ratio_median() == 1.0
@@ -131,7 +148,7 @@ def test_window_median_ignores_outliers() -> None:
     # The whole reason for a median: a lone slow sample among fast ones barely moves it, so the
     # stress signal does not spike on a single GC pause or scheduling blip.
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     for _ in range(9):
         tracker.record(0.002)
@@ -143,7 +160,7 @@ def test_window_median_ignores_outliers() -> None:
 
 def test_sub_resolution_observations_are_clamped_to_the_floor() -> None:
     # A query timed faster than the clamp resolution must not become the floor.
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=FakeClock())
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=FakeClock())
 
     tracker.record(0.0)
     assert tracker.floor() == MIN_OBSERVATION_SECONDS
@@ -155,7 +172,7 @@ def test_zero_baseline_then_load_still_moves_the_ratio() -> None:
     # Regression: a near-zero observation used to pin the floor to 0, which pinned every stress
     # ratio to 1.0 for the life of the process even under heavy load.
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
+    tracker = ReferenceQueryLoadTracker(observers=[], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.0)  # healthy, sub-resolution → clamped to the resolution floor
     assert tracker.stress_ratio_median() == 1.0
@@ -172,8 +189,7 @@ def test_zero_baseline_then_load_still_moves_the_ratio() -> None:
 
 def test_observer_publishes_the_derived_signal_to_the_gauges() -> None:
     clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(window_seconds=WINDOW, clock=clock)
-    tracker.set_observer(_publish_metrics)
+    tracker = ReferenceQueryLoadTracker(observers=[LoadSignalMetricsObserver()], window_seconds=WINDOW, clock=clock)
 
     tracker.record(0.002)  # a calm baseline sets the floor
     clock.advance(WINDOW + 1)  # age it out so the window reflects only the load
@@ -182,3 +198,34 @@ def test_observer_publishes_the_derived_signal_to_the_gauges() -> None:
     assert REFERENCE_QUERY_FLOOR_SECONDS._value.get() == 0.002
     assert REFERENCE_QUERY_WINDOW_MIN_SECONDS._value.get() == 0.050
     assert REFERENCE_QUERY_STRESS_RATIO_MEDIAN._value.get() == pytest.approx(25.0)
+
+
+def test_every_observer_receives_the_derived_signal() -> None:
+    first = RecordingLoadSignalObserver()
+    second = RecordingLoadSignalObserver()
+    tracker = ReferenceQueryLoadTracker(observers=[first, second], window_seconds=WINDOW, clock=FakeClock())
+
+    tracker.record(0.004)
+
+    # Both sinks are pushed the derived values, so neither has to read back into the tracker.
+    for observer in (first, second):
+        assert observer.observations == [
+            {"floor": 0.004, "window_min": 0.004, "stress_ratio_median": 1.0},
+        ]
+
+
+def test_failing_observer_does_not_fail_the_recording() -> None:
+    survivor = RecordingLoadSignalObserver()
+    # The failing sink is ordered first, so a shared guard would swallow the survivor too.
+    tracker = ReferenceQueryLoadTracker(
+        observers=[FailingLoadSignalObserver(), survivor], window_seconds=WINDOW, clock=FakeClock()
+    )
+
+    # record() runs on the database query path, so a raising sink must not propagate into the
+    # query that fed the observation, and must not skip the sinks behind it.
+    tracker.record(0.004)
+
+    assert tracker.floor() == 0.004
+    assert survivor.observations == [
+        {"floor": 0.004, "window_min": 0.004, "stress_ratio_median": 1.0},
+    ]

--- a/backend/tests/unit/database/test_load_signal.py
+++ b/backend/tests/unit/database/test_load_signal.py
@@ -7,12 +7,6 @@ from infrahub.database.load_signal import (
     UNSTRESSED_RATIO,
     ReferenceQueryLoadTracker,
 )
-from infrahub.database.load_signal_metrics import LoadSignalMetricsObserver
-from infrahub.database.metrics import (
-    REFERENCE_QUERY_FLOOR_SECONDS,
-    REFERENCE_QUERY_STRESS_RATIO_MEDIAN,
-    REFERENCE_QUERY_WINDOW_MIN_SECONDS,
-)
 
 WINDOW = 30.0
 
@@ -187,19 +181,6 @@ def test_zero_baseline_then_load_still_moves_the_ratio() -> None:
     assert tracker.stress_ratio_median() == pytest.approx(0.020 / MIN_OBSERVATION_SECONDS)
 
 
-def test_observer_publishes_the_derived_signal_to_the_gauges() -> None:
-    clock = FakeClock()
-    tracker = ReferenceQueryLoadTracker(observers=[LoadSignalMetricsObserver()], window_seconds=WINDOW, clock=clock)
-
-    tracker.record(0.002)  # a calm baseline sets the floor
-    clock.advance(WINDOW + 1)  # age it out so the window reflects only the load
-    tracker.record(0.050)
-
-    assert REFERENCE_QUERY_FLOOR_SECONDS._value.get() == 0.002
-    assert REFERENCE_QUERY_WINDOW_MIN_SECONDS._value.get() == 0.050
-    assert REFERENCE_QUERY_STRESS_RATIO_MEDIAN._value.get() == pytest.approx(25.0)
-
-
 def test_every_observer_receives_the_derived_signal() -> None:
     first = RecordingLoadSignalObserver()
     second = RecordingLoadSignalObserver()
@@ -229,3 +210,21 @@ def test_failing_observer_does_not_fail_the_recording() -> None:
     assert survivor.observations == [
         {"floor": 0.004, "window_min": 0.004, "stress_ratio_median": 1.0},
     ]
+
+
+def test_reads_do_not_notify_observers() -> None:
+    clock = FakeClock()
+    observer = RecordingLoadSignalObserver()
+    tracker = ReferenceQueryLoadTracker(observers=[observer], window_seconds=WINDOW, clock=clock)
+
+    tracker.record(0.004)
+
+    # Age the sample out, so the reads below genuinely mutate the window by pruning it — eviction
+    # is the tempting place to notify from, and the admission gate reads the signal per request.
+    clock.advance(WINDOW + 1)
+    assert tracker.sample_count() == 0
+    assert tracker.window_min() is None
+    assert tracker.stress_ratio_median() == UNSTRESSED_RATIO
+
+    # Recording is the only trigger, so the sink still holds exactly what that one record pushed.
+    assert observer.observations == [{"floor": 0.004, "window_min": 0.004, "stress_ratio_median": 1.0}]

--- a/backend/tests/unit/database/test_load_signal_metrics.py
+++ b/backend/tests/unit/database/test_load_signal_metrics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from infrahub.database.load_signal_metrics import LoadSignalMetricsObserver
+from infrahub.database.metrics import (
+    REFERENCE_QUERY_FLOOR_SECONDS,
+    REFERENCE_QUERY_STRESS_RATIO_MEDIAN,
+    REFERENCE_QUERY_WINDOW_MIN_SECONDS,
+)
+
+
+def test_derived_signal_reaches_its_gauges() -> None:
+    LoadSignalMetricsObserver().on_observation(floor=0.002, window_min=0.050, stress_ratio_median=25.0)
+
+    assert REFERENCE_QUERY_FLOOR_SECONDS._value.get() == 0.002
+    assert REFERENCE_QUERY_WINDOW_MIN_SECONDS._value.get() == 0.050
+    assert REFERENCE_QUERY_STRESS_RATIO_MEDIAN._value.get() == 25.0
+
+
+def test_undefined_values_leave_their_gauges_untouched() -> None:
+    observer = LoadSignalMetricsObserver()
+    observer.on_observation(floor=0.004, window_min=0.010, stress_ratio_median=2.5)
+
+    # A tracker with an empty window reports no floor and no window minimum. Zeroing those gauges
+    # would read as a genuine measurement of zero, so the last known values have to stand.
+    observer.on_observation(floor=None, window_min=None, stress_ratio_median=1.0)
+
+    assert REFERENCE_QUERY_FLOOR_SECONDS._value.get() == 0.004
+    assert REFERENCE_QUERY_WINDOW_MIN_SECONDS._value.get() == 0.010
+    # The ratio is always defined, so it does follow the new observation.
+    assert REFERENCE_QUERY_STRESS_RATIO_MEDIAN._value.get() == 1.0

--- a/backend/tests/unit/database/test_load_signal_registry.py
+++ b/backend/tests/unit/database/test_load_signal_registry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from infrahub import config
+from infrahub.database.load_signal_registry import get_reference_query_load_tracker
+
+
+def test_tracker_is_shared_across_callers() -> None:
+    # The database layer feeds the tracker and the admission gate reads it, so the gate would
+    # decide against an empty signal if repeated calls handed back separate instances.
+    assert get_reference_query_load_tracker() is get_reference_query_load_tracker()
+
+
+def test_tracker_window_comes_from_settings() -> None:
+    tracker = get_reference_query_load_tracker()
+
+    assert tracker.window_seconds == config.SETTINGS.api.backpressure_stress_window_seconds

--- a/dev/knowledge/backend/api-backpressure.md
+++ b/dev/knowledge/backend/api-backpressure.md
@@ -36,7 +36,8 @@ Everything lives in `backend/infrahub/api/admission/`:
 | File | Responsibility |
 |---|---|
 | `middleware.py` | `AdmissionMiddleware`, the outermost pure-ASGI gate |
-| `controller.py` | `AdmissionController`, the admit/shed decision, and its settings-reading factory |
+| `controller.py` | `AdmissionController`, the admit/shed decision |
+| `factory.py` | `build_admission_controller`, the settings-reading wiring of the object graph |
 | `slot_pool.py` | `PrioritySlotPool`, bounded concurrency with per-class FIFO waiter queues |
 | `codel.py` | `CoDelController`, the pure CoDel state machine |
 | `capacity.py` | `derive_max_concurrency`, the slot-cap derivation |

--- a/dev/knowledge/backend/api-backpressure.md
+++ b/dev/knowledge/backend/api-backpressure.md
@@ -41,9 +41,29 @@ Everything lives in `backend/infrahub/api/admission/`:
 | `codel.py` | `CoDelController`, the pure CoDel state machine |
 | `capacity.py` | `derive_max_concurrency`, the slot-cap derivation |
 | `priority.py` | the `Priority` enum and `X-Priority` header parsing |
+| `retry_policy.py` | `RetryAfterPolicy`, the adaptive `Retry-After` computation |
 | `metrics.py` | the `infrahub_admission_*` Prometheus families |
+| `observers.py` | the sinks that publish the live gauges |
 
-The database-stress signal it consumes lives in `backend/infrahub/database/load_signal.py`.
+The database-stress signal it consumes lives in `backend/infrahub/database/load_signal.py`, with its
+metrics sink in `load_signal_metrics.py` and the process-global instance in `load_signal_registry.py`.
+
+## Where metrics attach
+
+Three primitives feed gauges: the slot pool, the retry policy, and the stress tracker. None of them
+imports a metrics module. Each takes `observers` as a required constructor argument and *pushes*
+values to them — counts, a duration, the derived signal — so a sink never reads back into the
+primitive it observes.
+
+The concrete sinks in `observers.py` are named only where the object graph is wired: `server.py`
+passes them to `build_admission_controller`, which takes them as arguments rather than choosing them,
+and `load_signal_registry` wires the tracker's. Nothing under `api/admission/` outside that entry
+point imports them, which is what keeps the sinks out of the primitives' import chain and makes every
+gauge visible at the point of construction.
+
+Observer failures are contained per observer, so one broken sink can neither skip the sinks behind
+it, corrupt admission state, shed a request that would have been admitted, nor fail the database
+query that fed an observation.
 
 ## The request path
 

--- a/dev/knowledge/backend/api-backpressure.md
+++ b/dev/knowledge/backend/api-backpressure.md
@@ -42,6 +42,7 @@ Everything lives in `backend/infrahub/api/admission/`:
 | `codel.py` | `CoDelController`, the pure CoDel state machine |
 | `capacity.py` | `derive_max_concurrency`, the slot-cap derivation |
 | `priority.py` | the `Priority` enum and `X-Priority` header parsing |
+| `constants.py` | the `RejectionReason` enum, which doubles as the `reason` metric label |
 | `retry_policy.py` | `RetryAfterPolicy`, the adaptive `Retry-After` computation |
 | `metrics.py` | the `infrahub_admission_*` Prometheus families |
 | `observers.py` | the sinks that publish the live gauges |
@@ -51,10 +52,15 @@ metrics sink in `load_signal_metrics.py` and the process-global instance in `loa
 
 ## Where metrics attach
 
-Three primitives feed gauges: the slot pool, the retry policy, and the stress tracker. None of them
-imports a metrics module. Each takes `observers` as a required constructor argument and *pushes*
-values to them — counts, a duration, the derived signal — so a sink never reads back into the
-primitive it observes.
+Four components feed metrics: the admission controller, the slot pool, the retry policy, and the
+stress tracker. None of them imports a metrics module. Each takes `observers` as a required
+constructor argument and *pushes* values to them — decision events, counts, a duration, the derived
+signal — so a sink never reads back into the component it observes.
+
+`AdmissionObserver` is one interface with four events (`on_offered`, `on_admitted`, `on_rejected`,
+`on_sojourn`) rather than one interface per metric: they describe a single request's passage through
+one decision, so a sink implements them together. Separate interfaces belong to separate components,
+which is why the pool, the policy, and the tracker each have their own.
 
 The concrete sinks in `observers.py` are named only where the object graph is wired: `server.py`
 passes them to `build_admission_controller`, which takes them as arguments rather than choosing them,
@@ -65,6 +71,9 @@ gauge visible at the point of construction.
 Observer failures are contained per observer, so one broken sink can neither skip the sinks behind
 it, corrupt admission state, shed a request that would have been admitted, nor fail the database
 query that fed an observation.
+
+The one metric still incremented outside a sink is `missing_priority_total`, in `middleware.py`
+where the header is parsed.
 
 ## The request path
 


### PR DESCRIPTION
# Why

The API backpressure layer wired its Prometheus sinks by handing components a mutable observer slot
after construction — `PrioritySlotPool.set_observer()`, `RetryAfterPolicy.set_observer()`, and a
`ReferenceQueryLoadTracker.set_observer()` called from the tracker's own module. That inverted the
dependency direction three ways:

- **The primitives owned their sinks.** `database/load_signal.py` imported `database/metrics.py` at
  module level, so importing the stress-signal primitive the admission gate codes against pulled
  Prometheus gauge registration into the import chain.
- **Consumers mutated injected collaborators.** `AdmissionController.__init__` reached back into the
  pool and the policy it had just been handed to install callbacks defined in `controller.py`. The
  pool called *into* its consumer at runtime while the consumer imported *it* at compile time, and
  the wiring was invisible at the application entry point.
- **One sink per component.** A single mutable slot meant two controllers sharing a pool silently
  clobbered each other's observer, and no component could have a second sink.

**Goal:** every component that feeds a metric receives its sinks as a required constructor argument
and pushes values to them, so the concrete sinks are named only where the object graph is wired and
Prometheus stays out of the primitives' import chain.

**Non-goals:** no change to the shed decision itself — the tiers, thresholds, CoDel behaviour, slot
accounting, `Retry-After` computation, and every metric name and label are unchanged. This is a
dependency-direction refactor plus configuration hardening, not a behaviour change.

## What changed

**Behavioral changes**

- Non-finite (`inf`) values are now rejected for every backpressure float setting. Previously
  `inf` passed the `gt=0`/`ge=1` bounds and then crashed startup with `OverflowError` inside
  `int(base * multiplier)`, disabled window eviction entirely (`horizon = now - inf`), or silently
  exempted a priority class from shedding (`ratio / inf` → tier 0).
- The backstop multipliers and shed-stress ratios must now be ordered by priority. A misordered
  config used to invert the whole feature — HIGH backstop-rejected while LOW kept queueing, or HIGH
  shedding at a *lower* stress ratio than LOW — and startup accepted it silently.
- Worker processes now honour `backpressure_stress_window_seconds`. The window was applied by
  mutating the tracker inside the admission factory, which only runs on API servers, so any process
  without an admission gate kept the hard-coded 20s default and published stress gauges computed
  over the wrong window.
- Observer failures are contained per observer, on all three components. A raising sink can no
  longer corrupt admission state, shed a request that would have been admitted, fail the database
  query that fed an observation, or skip the sinks behind it.

**Implementation notes**

- Four observer protocols, one per component: `AdmissionObserver` (four events — offered, admitted,
  rejected, sojourn), `SlotPoolObserver`, `RetryPolicyObserver`, `LoadSignalObserver`. Each pushes
  values as arguments, so a sink never reads back into the component it observes. `AdmissionObserver`
  is one interface with four events rather than one per metric, because they describe a single
  request's passage through one decision.
- Concrete sinks live in `api/admission/observers.py` and `database/load_signal_metrics.py`. Nothing
  under `api/admission/` outside the entry point imports them: `server.py` passes them to
  `build_admission_controller`, which takes them as arguments rather than choosing them.
- `build_admission_controller` moved out of `controller.py` into a new `factory.py`. That leaves the
  decision logic importing nothing from its own package at runtime.
- The process-global tracker moved out of `load_signal.py` into `load_signal_registry.py`, which
  reads the window from settings at construction. `window_seconds` is now a read-only property —
  resizing a live window would reinterpret the samples already in it.
- `RejectionReason` became a `StrEnum` in `constants.py`, so the three reason strings exist in one
  place and both the controller and the sink import the type from a leaf module.

**What stayed the same**

- Metric names, labels, and semantics — `infrahub_admission_*` and `infrahub_db_reference_query_*`
  are byte-for-byte identical, so dashboards and alerts are unaffected.
- The `429` response envelope, `Retry-After` values, excluded paths, and the CORS-preflight bypass.
- Default values for every setting. The new constraints only reject configurations that were already
  incoherent.

## How to review

Suggested order:

1. `slot_pool.py`, `retry_policy.py`, `load_signal.py` — the primitives. Each gained a protocol and a
   required `observers` argument, and lost its `set_observer`. Note the failure guard sits *inside*
   the per-observer loop; moving it outside would silently downgrade isolation from per-observer to
   per-event.
2. `controller.py` — largest diff. Six inline metric calls became four `_observe_*` methods over the
   injected list, each guarding per observer via the `_contained_observer_failure()` context manager.
3. `factory.py`, `server.py`, `load_signal_registry.py` — the wiring, and the only places that name a
   concrete sink.
4. `config.py` — the new constraints and the `validate_shed_stress_ratios_ordered_by_priority`
   validator.
5. Tests. Recording and failing adapter sinks live in `tests/unit/api/admission/helpers.py`; no
   mocks.

Worth extra scrutiny:

- **`middleware.py:94` still increments `MISSING_PRIORITY_TOTAL` directly.** It is the one metric in
  the package written outside a sink — deliberate, since it fires during header parsing before a
  controller is involved, but it means the package is not 100% consistent.
- **`get_reference_query_load_tracker()` now raises `InitializationError` if settings are unloaded.**
  Unreachable in practice (the tracker is only reached from the reference query, which requires a
  configured database), and chosen over a silent fallback that would diverge from config.
- **`inf` is no longer a way to express "never shed this class."** A large finite ratio still is. If
  that needs to be first-class, it deserves an explicit representation.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry — n/a, API backpressure is unreleased and this refactors it before ship
- [ ] External docs updated — n/a, the generated config reference is unchanged (constraints do not
      appear in it)
- [x] Internal .md docs updated (`dev/knowledge/backend/api-backpressure.md`)
- [x] I have reviewed AI generated content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject metrics via observers across the rate limiting path to decouple Prometheus sinks from admission logic and keep failures contained. Moves controller wiring to a factory, shares the DB load-signal via a registry, and tightens backpressure config validation.

- **Refactors**
  - Introduced observer interfaces: `AdmissionObserver`, `RetryPolicyObserver`, `SlotPoolObserver`, `LoadSignalObserver`.
  - Added metric sinks: `AdmissionMetricsObserver`, `SlotPoolMetricsObserver`, `SustainedLoadMetricsObserver`, `LoadSignalMetricsObserver`.
  - `AdmissionController`, `PrioritySlotPool`, `RetryAfterPolicy`, and `ReferenceQueryLoadTracker` now take `observers` and isolate sink failures.
  - Moved `build_admission_controller` to `factory.py`; `server.py` wires observers at startup.
  - New `load_signal_registry.py` provides the shared tracker; `load_signal_metrics.py` publishes its gauges; window length comes from settings.
  - Replaced string reasons with `RejectionReason` enum (used as the `reason` metric label).
  - `stress_shed_fraction()` now takes a `tier`; tests updated accordingly.
  - Backpressure settings guarded: shed stress ratios must be ordered by priority, non‑finite floats are rejected, and backstop multipliers are bounded (`low` ≤ 1 ≤ `high`).

<sup>Written for commit 333ad80492570d2bf32cdbc1b250e75f025cd643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

