### PR TITLE
fix(regeneration): profile-aware kind selection for post-merge and proposed-change regeneration

### DIFF
--- a/backend/infrahub/core/merge/selective_regen/gate.py
+++ b/backend/infrahub/core/merge/selective_regen/gate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.regeneration.models import DefinitionSelect
-from infrahub.core.regeneration.predicates import definition_changed, query_changed
+from infrahub.core.regeneration.predicates import definition_changed, query_changed, reads_kind
 
 from .models import GateResult
 
@@ -40,7 +40,7 @@ class DefinitionGate:
                 self.log.debug(outcome.reason)
         regenerate_all_members = query_outcome.matched or definition_outcome.matched
 
-        matches_modified_kind = any(definition.reads_kind(changed_model) for changed_model in modified_kinds)
+        matches_modified_kind = any(reads_kind(definition, changed_model) for changed_model in modified_kinds)
 
         select = DefinitionSelect.NONE
         select = select.add_flag(current=select, flag=DefinitionSelect.QUERY_CHANGED, condition=query_outcome.matched)

--- a/backend/infrahub/core/merge/selective_regen/orchestrator.py
+++ b/backend/infrahub/core/merge/selective_regen/orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
+from infrahub.core.regeneration.profiles import SchemaProfileExpander
 from infrahub.proposed_change.branch_diff import get_modified_kinds
 
 from .definition_selector.artifact_selector import ArtifactSelector
@@ -18,6 +19,8 @@ if TYPE_CHECKING:
 
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
+
+    from infrahub.core.regeneration.profiles import ModifiedKindsExpander
 
     from .models import CascadeSourceOutput, DefinitionModel, FullRegeneration, RegenerationRequest
     from .participant import CascadeParticipant
@@ -53,8 +56,9 @@ class MergeSelectiveRegeneration(RegenerationPlanner):
     dispatch. Adding a definition kind is one new participant in the injected list, with no change here.
     """
 
-    def __init__(self, participants: Sequence[CascadeParticipant[Any]]) -> None:
+    def __init__(self, participants: Sequence[CascadeParticipant[Any]], kinds_expander: ModifiedKindsExpander) -> None:
         self.participants = participants
+        self.kinds_expander = kinds_expander
 
     async def build_plan(self, diff_summary: list[NodeDiff], target_branch: str) -> SelectiveRegenerationPlan:
         entries = await self._plan(self.participants, diff_summary=diff_summary, target_branch=target_branch)
@@ -75,7 +79,10 @@ class MergeSelectiveRegeneration(RegenerationPlanner):
     async def _plan(
         self, participants: Sequence[CascadeParticipant[Any]], *, diff_summary: list[NodeDiff], target_branch: str
     ) -> list[PlannedRegeneration]:
-        modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=target_branch)
+        modified_kinds = self.kinds_expander.expand(
+            modified_kinds=get_modified_kinds(diff_summary=diff_summary, branch=target_branch),
+            branch=target_branch,
+        )
         loaded_by_participant = [
             (participant, await participant.load(target_branch=target_branch)) for participant in participants
         ]
@@ -146,5 +153,6 @@ def build_merge_selective_regeneration(
                 output=generator_output,
             ),
             CascadeTerminal(ArtifactSelector(client=client, gate=gate, impacted_resolver=impacted_resolver, log=log)),
-        ]
+        ],
+        kinds_expander=SchemaProfileExpander(),
     )

--- a/backend/infrahub/core/merge/selective_regen/orchestrator.py
+++ b/backend/infrahub/core/merge/selective_regen/orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
+from infrahub.core import registry
 from infrahub.core.regeneration.profiles import SchemaProfileExpander
 from infrahub.proposed_change.branch_diff import get_modified_kinds
 
@@ -154,5 +155,5 @@ def build_merge_selective_regeneration(
             ),
             CascadeTerminal(ArtifactSelector(client=client, gate=gate, impacted_resolver=impacted_resolver, log=log)),
         ],
-        kinds_expander=SchemaProfileExpander(),
+        kinds_expander=SchemaProfileExpander(schema_manager=registry.schema),
     )

--- a/backend/infrahub/core/regeneration/models.py
+++ b/backend/infrahub/core/regeneration/models.py
@@ -73,6 +73,7 @@ class RegenerationDefinition(Protocol):
     definition_name: str
     query_id: str
     query_name: str
+    query_models: list[str]
     dependencies: list[str] | None
     dependencies_complete: bool | None
 

--- a/backend/infrahub/core/regeneration/predicates.py
+++ b/backend/infrahub/core/regeneration/predicates.py
@@ -90,6 +90,11 @@ def relevant_node_changes(
     return relevant_node_ids
 
 
+def reads_kind(definition: RegenerationDefinition, kind: str) -> bool:
+    """Whether a data change to ``kind`` is relevant because the definition's query reads that kind."""
+    return kind in definition.query_models
+
+
 def query_changed(
     definition: RegenerationDefinition,
     diff_summary: list[NodeDiff],

--- a/backend/infrahub/core/regeneration/profiles.py
+++ b/backend/infrahub/core/regeneration/profiles.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from infrahub.core import registry
+
+
+class ModifiedKindsExpander(Protocol):
+    """Widens the changed kinds a regeneration selection considers, beyond those literally in the diff."""
+
+    def expand(self, *, modified_kinds: list[str], branch: str) -> list[str]: ...
+
+
+class SchemaProfileExpander:
+    """Widen changed kinds with the node kind behind each changed profile, from a branch's live schema.
+
+    A profile holds attribute values that apply to the nodes it targets, so changing a profile node
+    effectively changes those nodes. A profile schema's name is the kind of the node it targets, so a
+    changed profile widens the set to that node kind; a kind that names no profile passes through.
+    """
+
+    def expand(self, *, modified_kinds: list[str], branch: str) -> list[str]:
+        schema_branch = registry.schema.get_schema_branch(name=branch)
+        expanded = set(modified_kinds)
+        for kind in modified_kinds:
+            if kind in schema_branch.profiles:
+                expanded.add(schema_branch.get_profile(name=kind, duplicate=False).name)
+        return list(expanded)

--- a/backend/infrahub/core/regeneration/profiles.py
+++ b/backend/infrahub/core/regeneration/profiles.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from infrahub.core import registry
+if TYPE_CHECKING:
+    from infrahub.core.schema.manager import SchemaManager
 
 
 class ModifiedKindsExpander(Protocol):
@@ -19,8 +20,11 @@ class SchemaProfileExpander:
     changed profile widens the set to that node kind; a kind that names no profile passes through.
     """
 
+    def __init__(self, schema_manager: SchemaManager) -> None:
+        self._schema_manager = schema_manager
+
     def expand(self, *, modified_kinds: list[str], branch: str) -> list[str]:
-        schema_branch = registry.schema.get_schema_branch(name=branch)
+        schema_branch = self._schema_manager.get_schema_branch(name=branch)
         expanded = set(modified_kinds)
         for kind in modified_kinds:
             if kind in schema_branch.profiles:

--- a/backend/infrahub/generators/models.py
+++ b/backend/infrahub/generators/models.py
@@ -103,14 +103,6 @@ class ProposedChangeGeneratorDefinition(GeneratorDefinitionModel):
     def instance_noun(self) -> str:
         return "instances"
 
-    def reads_kind(self, kind: str) -> bool:
-        """Whether a data change to ``kind`` is relevant because the query reads that kind.
-
-        Profile changes are matched by widening the changed kinds to the profiled node kind before
-        this check, so a profile read need not be reconstructed here.
-        """
-        return kind in self.query_models
-
 
 def build_generator_definition(generator: CoreGeneratorDefinition) -> ProposedChangeGeneratorDefinition:
     """Map a fetched generator definition node onto the model the run pipeline carries.

--- a/backend/infrahub/generators/models.py
+++ b/backend/infrahub/generators/models.py
@@ -104,7 +104,11 @@ class ProposedChangeGeneratorDefinition(GeneratorDefinitionModel):
         return "instances"
 
     def reads_kind(self, kind: str) -> bool:
-        """Whether a data change to ``kind`` is relevant because the query reads that kind."""
+        """Whether a data change to ``kind`` is relevant because the query reads that kind.
+
+        Profile changes are matched by widening the changed kinds to the profiled node kind before
+        this check, so a profile read need not be reconstructed here.
+        """
         return kind in self.query_models
 
 

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -137,14 +137,6 @@ class ProposedChangeArtifactDefinition(BaseModel):
     def instance_noun(self) -> str:
         return "artifacts"
 
-    def reads_kind(self, kind: str) -> bool:
-        """Whether a data change to ``kind`` is relevant because the query reads that kind.
-
-        Profile changes are matched by widening the changed kinds to the profiled node kind before
-        this check, so a profile read need not be reconstructed here.
-        """
-        return kind in self.query_models
-
     @property
     def transform_location(self) -> str:
         if self.transform_kind == InfrahubKind.TRANSFORMJINJA2:

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -140,11 +140,10 @@ class ProposedChangeArtifactDefinition(BaseModel):
     def reads_kind(self, kind: str) -> bool:
         """Whether a data change to ``kind`` is relevant because the query reads that kind.
 
-        An artifact query may read a kind through its Profile, so the profile-stripped kind matches too.
+        Profile changes are matched by widening the changed kinds to the profiled node kind before
+        this check, so a profile read need not be reconstructed here.
         """
-        return kind in self.query_models or (
-            kind.startswith("Profile") and kind.replace("Profile", "", 1) in self.query_models
-        )
+        return kind in self.query_models
 
     @property
     def transform_location(self) -> str:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -59,6 +59,7 @@ from infrahub.core.regeneration.models import DefinitionSelect
 from infrahub.core.regeneration.predicates import (
     definition_changed,
     query_changed,
+    reads_kind,
     repo_diff_or_none,
     transform_changed,
 )
@@ -461,7 +462,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             select = select.add_flag(
                 current=select,
                 flag=DefinitionSelect.MODIFIED_KINDS,
-                condition=generator_definition.reads_kind(changed_model),
+                condition=reads_kind(generator_definition, changed_model),
             )
 
         if select:
@@ -1368,7 +1369,7 @@ async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, contex
             select = select.add_flag(
                 current=select,
                 flag=DefinitionSelect.MODIFIED_KINDS,
-                condition=artifact_definition.reads_kind(changed_model),
+                condition=reads_kind(artifact_definition, changed_model),
             )
 
         if select:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -62,6 +62,7 @@ from infrahub.core.regeneration.predicates import (
     repo_diff_or_none,
     transform_changed,
 )
+from infrahub.core.regeneration.profiles import SchemaProfileExpander
 from infrahub.core.timestamp import Timestamp
 from infrahub.core.validators.checks_runner import run_checks_and_update_validator
 from infrahub.core.validators.constraint_merge import build_constraint_info_merger
@@ -420,7 +421,10 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
     ]
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
+    modified_kinds = SchemaProfileExpander().expand(
+        modified_kinds=get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch),
+        branch=model.source_branch,
+    )
 
     for generator_definition in generator_definitions:
         # Select a generator definition when its query node or definition node was modified, when a
@@ -457,7 +461,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             select = select.add_flag(
                 current=select,
                 flag=DefinitionSelect.MODIFIED_KINDS,
-                condition=changed_model in generator_definition.query_models,
+                condition=generator_definition.reads_kind(changed_model),
             )
 
         if select:
@@ -1331,7 +1335,10 @@ async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, contex
         definitions=definition_information[InfrahubKind.ARTIFACTDEFINITION]["edges"]
     )
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
+    modified_kinds = SchemaProfileExpander().expand(
+        modified_kinds=get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch),
+        branch=model.source_branch,
+    )
 
     for artifact_definition in artifact_definitions:
         select = DefinitionSelect.NONE

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -421,7 +421,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
     ]
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    modified_kinds = SchemaProfileExpander().expand(
+    modified_kinds = SchemaProfileExpander(schema_manager=registry.schema).expand(
         modified_kinds=get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch),
         branch=model.source_branch,
     )
@@ -1335,7 +1335,7 @@ async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, contex
         definitions=definition_information[InfrahubKind.ARTIFACTDEFINITION]["edges"]
     )
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    modified_kinds = SchemaProfileExpander().expand(
+    modified_kinds = SchemaProfileExpander(schema_manager=registry.schema).expand(
         modified_kinds=get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch),
         branch=model.source_branch,
     )

--- a/backend/tests/component/proposed_change/test_generator_regen_selection.py
+++ b/backend/tests/component/proposed_change/test_generator_regen_selection.py
@@ -412,6 +412,29 @@ class TestGeneratorRegenSelection(GeneratorRegenTestBase):
         )
         assert selected == ["device-gen-a", "device-gen-a2", "device-gen-b", "device-gen-source-only"]
 
+    async def test_profile_change_selects_generators_reading_profiled_kind(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        memory_cache: MemoryCache,
+        workflow_recorder: WorkflowRecorder,
+    ) -> None:
+        """A change touching only a profile selects every generator whose query reads the profiled kind.
+
+        The diff carries the profile kind alone; the profiled node kind is what the queries read, so the
+        selection widens the profile to that node kind and dispatches every generator reading it.
+        """
+        selected = await self._selected_definitions(
+            dataset=dataset,
+            default_branch=default_branch,
+            admin_account=admin_account,
+            memory_cache=memory_cache,
+            workflow_recorder=workflow_recorder,
+            diff_summary=[make_node_diff(str(uuid.uuid4()), "ProfileTestNetworkDevice", SOURCE_BRANCH, ["color"])],
+        )
+        assert selected == ["device-gen-a", "device-gen-a2", "device-gen-b", "device-gen-source-only"]
+
     async def test_new_definition_on_source_branch_is_selected(
         self,
         dataset: dict[str, Any],

--- a/backend/tests/helpers/selective_regen.py
+++ b/backend/tests/helpers/selective_regen.py
@@ -140,3 +140,20 @@ class ArtifactForcingSelector(
             artifact_definition_name=definition.definition_name,
             members=members,
         )
+
+
+class PassthroughExpander:
+    """A ModifiedKindsExpander that returns the changed kinds unchanged, isolating schema-driven widening."""
+
+    def expand(self, *, modified_kinds: list[str], branch: str) -> list[str]:
+        return modified_kinds
+
+
+class AppendingExpander:
+    """A ModifiedKindsExpander that widens the changed kinds with one extra kind, so its use is observable."""
+
+    def __init__(self, extra_kind: str) -> None:
+        self.extra_kind = extra_kind
+
+    def expand(self, *, modified_kinds: list[str], branch: str) -> list[str]:
+        return [*modified_kinds, self.extra_kind]

--- a/backend/tests/unit/core/merge/selective_regen/test_gate.py
+++ b/backend/tests/unit/core/merge/selective_regen/test_gate.py
@@ -101,16 +101,28 @@ GATE_CASES = [
         expected=GateResult(regenerate_all_members=False, selected=False),
     ),
     GateCase(
-        name="artifact_matches_profile_stripped_kind",
+        name="artifact_does_not_match_profile_kind_without_widening",
         is_artifact=True,
         modified_kinds=["ProfileTestDevice"],
-        expected=GateResult(regenerate_all_members=False, selected=True),
+        expected=GateResult(regenerate_all_members=False, selected=False),
     ),
     GateCase(
-        name="generator_ignores_profile_stripped_kind",
+        name="generator_does_not_match_profile_kind_without_widening",
         is_artifact=False,
         modified_kinds=["ProfileTestDevice"],
         expected=GateResult(regenerate_all_members=False, selected=False),
+    ),
+    GateCase(
+        name="widened_profile_base_kind_selects_artifact",
+        is_artifact=True,
+        modified_kinds=["ProfileTestDevice", "TestDevice"],
+        expected=GateResult(regenerate_all_members=False, selected=True),
+    ),
+    GateCase(
+        name="widened_profile_base_kind_selects_generator",
+        is_artifact=False,
+        modified_kinds=["ProfileTestDevice", "TestDevice"],
+        expected=GateResult(regenerate_all_members=False, selected=True),
     ),
 ]
 

--- a/backend/tests/unit/core/merge/selective_regen/test_orchestrator.py
+++ b/backend/tests/unit/core/merge/selective_regen/test_orchestrator.py
@@ -22,8 +22,10 @@ from infrahub.workflows.catalogue import (
 )
 from tests.helpers.diff_summary import node_diff
 from tests.helpers.selective_regen import (
+    AppendingExpander,
     ArtifactForcingSelector,
     GeneratorForcingSelector,
+    PassthroughExpander,
     StubCascadeSourceOutput,
 )
 
@@ -122,7 +124,8 @@ async def test_build_plan_shares_modified_kinds_and_assembles_plan() -> None:
         participants=[
             CascadeSource(generator_selector, output=generator_output),
             CascadeTerminal(artifact_selector),
-        ]
+        ],
+        kinds_expander=PassthroughExpander(),
     ).build_plan(diff_summary=diff_summary, target_branch=TARGET_BRANCH)
 
     assert [(entry.workflow, entry.cascade_role, entry.requests, entry.output) for entry in plan.entries] == [
@@ -138,6 +141,29 @@ async def test_build_plan_shares_modified_kinds_and_assembles_plan() -> None:
         assert recorded_diff is diff_summary
         assert recorded_branch == TARGET_BRANCH
         assert set(recorded_kinds) == {"TestDevice", "TestSite"}
+
+
+async def test_build_plan_passes_expanded_kinds_to_selectors() -> None:
+    """The kinds the expander widens the diff to are the kinds every selector receives."""
+    diff_summary = [_node_diff(node_id="n1", kind="TestDevice")]
+    generator_selector = _RecordingSelector[ProposedChangeGeneratorDefinition, RequestGeneratorDefinitionRun](
+        result=[], workflow=REQUEST_GENERATOR_DEFINITION_RUN
+    )
+    artifact_selector = _RecordingSelector[ProposedChangeArtifactDefinition, RequestArtifactDefinitionGenerate](
+        result=[], workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE
+    )
+
+    await MergeSelectiveRegeneration(
+        participants=[
+            CascadeSource(generator_selector, output=StubCascadeSourceOutput()),
+            CascadeTerminal(artifact_selector),
+        ],
+        kinds_expander=AppendingExpander(extra_kind="TestProfiled"),
+    ).build_plan(diff_summary=diff_summary, target_branch=TARGET_BRANCH)
+
+    for selector in (generator_selector, artifact_selector):
+        _, _, recorded_kinds = selector.calls[0]
+        assert set(recorded_kinds) == {"TestDevice", "TestProfiled"}
 
 
 async def test_reselect_from_cascade_output_excludes_cascade_sources() -> None:
@@ -160,7 +186,8 @@ async def test_reselect_from_cascade_output_excludes_cascade_sources() -> None:
         participants=[
             CascadeSource(generator_selector, output=StubCascadeSourceOutput()),
             CascadeTerminal(artifact_selector),
-        ]
+        ],
+        kinds_expander=PassthroughExpander(),
     ).reselect_from_cascade_output(diff_summary=diff_summary, target_branch=TARGET_BRANCH)
 
     assert generator_selector.calls == []
@@ -184,7 +211,8 @@ async def test_reselect_from_cascade_output_escalates_across_terminals_sharing_a
     )
 
     entries = await MergeSelectiveRegeneration(
-        participants=[CascadeTerminal(unpopulated_terminal), CascadeTerminal(populated_terminal)]
+        participants=[CascadeTerminal(unpopulated_terminal), CascadeTerminal(populated_terminal)],
+        kinds_expander=PassthroughExpander(),
     ).reselect_from_cascade_output(diff_summary=[], target_branch=TARGET_BRANCH)
 
     assert [len(entry.requests) for entry in entries] == [1, 1]
@@ -219,7 +247,8 @@ async def test_consolidate_submissions_routes_each_workflow_to_its_selector() ->
         participants=[
             CascadeSource(generator_selector, output=StubCascadeSourceOutput()),
             CascadeTerminal(artifact_selector),
-        ]
+        ],
+        kinds_expander=PassthroughExpander(),
     ).consolidate_submissions(entries)
 
     assert generator_selector.consolidate_calls == [[generator_run]]
@@ -238,9 +267,9 @@ def test_terminal_full_regenerations_cover_every_terminal_and_exclude_sources() 
     )
     terminal = CascadeTerminal(ArtifactForcingSelector(definitions=[], member_ids=[], subscriber_by_member={}))
 
-    regenerations = MergeSelectiveRegeneration(participants=[source, terminal]).terminal_full_regenerations(
-        TARGET_BRANCH
-    )
+    regenerations = MergeSelectiveRegeneration(
+        participants=[source, terminal], kinds_expander=PassthroughExpander()
+    ).terminal_full_regenerations(TARGET_BRANCH)
 
     assert [(regeneration.workflow, regeneration.parameters) for regeneration in regenerations] == [
         (TRIGGER_ARTIFACT_DEFINITION_GENERATE, {"branch": TARGET_BRANCH}),
@@ -309,7 +338,8 @@ async def test_missing_generator_fingerprint_escalates_a_sibling_artifact_in_the
         participants=[
             CascadeSource(generator_selector, output=StubCascadeSourceOutput()),
             CascadeTerminal(artifact_selector),
-        ]
+        ],
+        kinds_expander=PassthroughExpander(),
     ).build_plan(diff_summary=[], target_branch=TARGET_BRANCH)
 
     generator_entries = plan.for_role(CascadeRole.SOURCE)

--- a/backend/tests/unit/core/regeneration/test_predicates.py
+++ b/backend/tests/unit/core/regeneration/test_predicates.py
@@ -9,6 +9,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.regeneration.predicates import (
     definition_changed,
     query_changed,
+    reads_kind,
     repo_diff_or_none,
     transform_changed,
 )
@@ -391,3 +392,10 @@ def test_repo_diff_or_none_returns_none_for_absent_repository() -> None:
     """
     branch_diff = ProposedChangeBranchDiff(repositories=[_build_repo_diff()], pipeline_id=uuid.uuid4())
     assert repo_diff_or_none(branch_diff, "00000000-0000-0000-0000-000000000000") is None
+
+
+def test_reads_kind_matches_only_a_kind_the_query_reads() -> None:
+    """reads_kind is true for a kind the definition's query reads, false otherwise."""
+    definition = _build_definition()
+    assert reads_kind(definition, "TestNetworkDevice") is True
+    assert reads_kind(definition, "TestOtherKind") is False

--- a/backend/tests/unit/core/regeneration/test_profiles.py
+++ b/backend/tests/unit/core/regeneration/test_profiles.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.regeneration.profiles import SchemaProfileExpander
+from infrahub.core.schema.manager import SchemaManager
+from infrahub.core.schema.schema_branch import SchemaBranch
+from tests.helpers.merge_recompute.dataset import PROFILE_NODE_KIND, build_profile_schema
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+BRANCH = "test-profile-expander"
+PROFILE_KIND = f"Profile{PROFILE_NODE_KIND}"
+
+
+@pytest.fixture
+def profile_schema_registered() -> Generator[None, None, None]:
+    """Register a schema branch that generates profiles, so the expander can resolve them by branch."""
+    original = registry._schema
+    manager = SchemaManager()
+    schema_branch = SchemaBranch(cache={}, name=BRANCH)
+    schema_branch.load_schema(schema=build_profile_schema())
+    schema_branch.process()
+    manager.set_schema_branch(name=BRANCH, schema=schema_branch)
+    registry.schema = manager
+    yield
+    registry._schema = original
+
+
+@dataclass(frozen=True, kw_only=True)
+class ExpandCase:
+    name: str
+    modified_kinds: list[str]
+    expected: set[str]
+
+
+EXPAND_CASES = [
+    ExpandCase(
+        name="profile_kind_widens_to_its_node_kind",
+        modified_kinds=[PROFILE_KIND],
+        expected={PROFILE_KIND, PROFILE_NODE_KIND},
+    ),
+    ExpandCase(
+        name="non_profile_kinds_pass_through_unchanged",
+        modified_kinds=[PROFILE_NODE_KIND, "SomeUnrelatedKind"],
+        expected={PROFILE_NODE_KIND, "SomeUnrelatedKind"},
+    ),
+    ExpandCase(
+        name="empty_input_stays_empty",
+        modified_kinds=[],
+        expected=set(),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", EXPAND_CASES, ids=lambda case: case.name)
+@pytest.mark.usefixtures("profile_schema_registered")
+def test_schema_profile_expander(case: ExpandCase) -> None:
+    result = SchemaProfileExpander().expand(modified_kinds=case.modified_kinds, branch=BRANCH)
+
+    assert set(result) == case.expected

--- a/backend/tests/unit/core/regeneration/test_profiles.py
+++ b/backend/tests/unit/core/regeneration/test_profiles.py
@@ -1,35 +1,27 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub.core import registry
 from infrahub.core.regeneration.profiles import SchemaProfileExpander
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.schema_branch import SchemaBranch
 from tests.helpers.merge_recompute.dataset import PROFILE_NODE_KIND, build_profile_schema
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
 
 BRANCH = "test-profile-expander"
 PROFILE_KIND = f"Profile{PROFILE_NODE_KIND}"
 
 
 @pytest.fixture
-def profile_schema_registered() -> Generator[None, None, None]:
-    """Register a schema branch that generates profiles, so the expander can resolve them by branch."""
-    original = registry._schema
+def schema_manager() -> SchemaManager:
+    """A schema manager with a branch that generates profiles, so the expander can resolve them."""
     manager = SchemaManager()
     schema_branch = SchemaBranch(cache={}, name=BRANCH)
     schema_branch.load_schema(schema=build_profile_schema())
     schema_branch.process()
     manager.set_schema_branch(name=BRANCH, schema=schema_branch)
-    registry.schema = manager
-    yield
-    registry._schema = original
+    return manager
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -59,8 +51,9 @@ EXPAND_CASES = [
 
 
 @pytest.mark.parametrize("case", EXPAND_CASES, ids=lambda case: case.name)
-@pytest.mark.usefixtures("profile_schema_registered")
-def test_schema_profile_expander(case: ExpandCase) -> None:
-    result = SchemaProfileExpander().expand(modified_kinds=case.modified_kinds, branch=BRANCH)
+def test_schema_profile_expander(case: ExpandCase, schema_manager: SchemaManager) -> None:
+    result = SchemaProfileExpander(schema_manager=schema_manager).expand(
+        modified_kinds=case.modified_kinds, branch=BRANCH
+    )
 
     assert set(result) == case.expected


### PR DESCRIPTION
## Summary

Regeneration selection now widens a diff's changed kinds to include the node kind behind each changed profile, resolved from the branch's live schema. A change touching only a profile selects every generator and artifact whose query reads the profiled node kind — on both the post-merge selective regeneration and the proposed-change refresh.

## What changed

- **New `SchemaProfileExpander`** (`core/regeneration/profiles.py`): given a branch and a set of changed kinds, adds the profiled node kind for every changed profile kind, using the schema's profile→node relationship. A kind that names no profile passes through. The `SchemaManager` is a constructor dependency (resolved to `registry.schema` at the wiring sites), so the component no longer reaches into the global registry.
- **Wired into both selection paths** through one component: injected as the merge planner's `kinds_expander`, which runs it in the planner's shared plan step so both the initial plan and the cascade reselection widen alike; constructed at the proposed-change flow level for the generator and artifact loops. The proposed-change generator loop, which selected on raw `query_models` membership, now runs through the same widened kinds.
- **`reads_kind` moved to `predicates.py`**: with profile handling now living in the expander, it reduces to `kind in query_models`, so the name-stripping heuristic (`kind.replace("Profile", "", 1)`) is removed and the predicate lives beside `query_changed` / `definition_changed` as a free function over `RegenerationDefinition` — off the definition models, which stay plain data holders.

The widening only ever adds kinds, so the no-under-execution guarantee is preserved.

## Tests

- unit: `SchemaProfileExpander` against an injected in-memory schema branch that generates profiles
- unit: gate widening selects both a generator and an artifact for a profiled kind
- unit: the planner passes the expanded kinds to every selector
- unit: `reads_kind` matches only a kind the definition's query reads
- component: `run_generators` dispatches every generator reading a profiled kind on a profile-only change

## Notes

- Resolves https://opsmill.atlassian.net/browse/IFC-2907 in full — both items the ticket tracks: the fragile profile heuristic, and profile handling applied to artifacts but not generators.
- Rebased onto `pmi-20260727-refactor-selectors`, which is now participant/planner based; the profile-kind widening integrates into the planner's shared plan step, and the tests moved to the participant wiring. Review feedback addressed: `SchemaProfileExpander` takes an injected `SchemaManager` (no global registry), and `reads_kind` moved off the definition models into `predicates.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
