### PR TITLE
chore(merge): name the post-merge generator capture diff with an identifiable prefix

### DIFF
--- a/backend/infrahub/core/merge/selective_regen/generator_diff_capturer.py
+++ b/backend/infrahub/core/merge/selective_regen/generator_diff_capturer.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 # A generator tracks the nodes it writes into a per-member group named "<definition name>-<md5 hex>".
 _TRACKING_HASH = re.compile(r"[0-9a-f]{32}$")
 
+# The tracking-id delimiter is ".", so the marker must not contain one.
+CAPTURE_DIFF_NAME_PREFIX = "selective-regen-capture--"
+
 
 class GeneratorMutationDiffCapturer(Protocol):
     """Capture, as a diff summary, the graph changes a post-merge generator wrote.
@@ -66,7 +69,7 @@ class GeneratorTrackingGroupDiffCapturer:
             diff_branch=self.branch,
             from_time=since,
             to_time=Timestamp(),
-            name=str(uuid4()),
+            name=f"{CAPTURE_DIFF_NAME_PREFIX}{uuid4()}",
         )
         filters = EnrichedDiffQueryFilters(ids=sorted(node_ids)) if node_ids else None
         enriched = await self.diff_repository.get_one(

--- a/backend/tests/unit/core/merge/selective_regen/test_generator_diff_capturer.py
+++ b/backend/tests/unit/core/merge/selective_regen/test_generator_diff_capturer.py
@@ -9,7 +9,10 @@ from infrahub.core.diff.model.path import EnrichedDiffRoot, EnrichedDiffRootMeta
 from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.diff.summary_serializer import DiffSummarySerializer
-from infrahub.core.merge.selective_regen.generator_diff_capturer import GeneratorTrackingGroupDiffCapturer
+from infrahub.core.merge.selective_regen.generator_diff_capturer import (
+    CAPTURE_DIFF_NAME_PREFIX,
+    GeneratorTrackingGroupDiffCapturer,
+)
 from infrahub.core.timestamp import Timestamp
 
 if TYPE_CHECKING:
@@ -40,11 +43,13 @@ def _group(name: str, member_ids: list[str]) -> SimpleNamespace:
 class _RecordingCoordinator(DiffCoordinator):
     def __init__(self) -> None:
         self.diff_branches: list[str] = []
+        self.names: list[str] = []
 
     async def create_or_update_arbitrary_timeframe_diff(
         self, base_branch: Branch, diff_branch: Branch, from_time: Timestamp, to_time: Timestamp, name: str
     ) -> EnrichedDiffRootMetadata:
         self.diff_branches.append(diff_branch.name)
+        self.names.append(name)
         return _empty_root(diff_branch.name)
 
 
@@ -158,3 +163,19 @@ async def test_capture_widens_when_any_definition_lacks_a_tracking_group() -> No
     # abandoning the second definition once the first resolved.
     assert client.queried_names == ["genA", "genB"]
     assert repository.filters_seen == [None]
+
+
+async def test_capture_marks_the_saved_diff_so_it_can_be_identified_later() -> None:
+    coordinator = _RecordingCoordinator()
+    capturer = GeneratorTrackingGroupDiffCapturer(
+        diff_coordinator=coordinator,
+        diff_repository=_RecordingRepository(),
+        serializer=_RecordingSerializer(),
+        client=cast("InfrahubClient", _FakeClient({})),
+        branch=Branch(name="main"),
+    )
+
+    await capturer.capture(since=Timestamp(), generator_definition_names=["set_description"])
+
+    assert len(coordinator.names) == 1
+    assert coordinator.names[0].startswith(CAPTURE_DIFF_NAME_PREFIX)


### PR DESCRIPTION
## Summary

The post-merge generator output capture computes a diff of a branch against itself and saves it to the database purely to select which artifacts a generator's output touched. It named that diff with a bare UUID, so the saved diff root is indistinguishable from a user-facing diff and there is no way to tell these internal diffs apart or remove them later.

This names the capture diff with a recognizable prefix (`selective-regen-capture--`) so the saved roots carry a `NameTrackingId` that can be matched by prefix and cleaned up later.

This is a stopgap to make the already-accumulating diffs identifiable while the full fix (which stops saving them at all) is prepared separately. It changes only how the diff is named — behavior is otherwise unchanged: the `uuid4()` suffix is kept, so each capture is still unique and nothing supersedes across calls.

## Identifying the marked diffs

```cypher
MATCH (r:DiffRoot) WHERE r.tracking_id STARTS WITH 'name.selective-regen-capture--'
```

## Notes

- Marks going forward only; diffs already saved keep their bare UUID names and remain identifiable by their structure (a `NameTrackingId` diff of a branch against itself).
- The marker contains no `.` because the tracking-id delimiter is `.`; the tracking-id round-trips cleanly.

## Test

- Unit test asserts the saved diff is named with the prefix.

## What's next

- A follow-up fix stops saving these diffs at all — the capture diff is computed in memory and discarded, so no root is left behind.
- That fix carries a migration to wipe the diffs already saved (bare-UUID and prefixed alike).
- The rebase self-diff path (`_get_diff_root`) leaks the same way and can be given the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


