### PR TITLE
Verify cross-relationship HFID refresh on merge and rebase

### DIFF
--- a/backend/tests/helpers/merge_recompute/dataset.py
+++ b/backend/tests/helpers/merge_recompute/dataset.py
@@ -22,8 +22,12 @@ PROFILE_NODE_KIND = "TestingProfileNode"
 PROFILE_PEER_KIND = "TestingProfilePeer"
 
 
-def build_profile_schema() -> SchemaRoot:
-    """Two kinds: a peer, and a main node carrying all three derived families."""
+def build_profile_schema(cross_relationship_hfid: bool = False) -> SchemaRoot:
+    """Two kinds: a peer, and a main node carrying all three derived families.
+
+    With ``cross_relationship_hfid`` the node's human-friendly id reads the peer across the
+    relationship instead of only its own name, so a peer rename has to refresh the stored HFID.
+    """
     peer = NodeSchema(
         name="ProfilePeer",
         namespace=PROFILE_NAMESPACE,
@@ -41,7 +45,7 @@ def build_profile_schema() -> SchemaRoot:
         label="Profile Node",
         default_filter="name__value",
         display_label="{{ name__value }} via {{ peer__name__value }}",
-        human_friendly_id=["name__value"],
+        human_friendly_id=["name__value", "peer__name__value"] if cross_relationship_hfid else ["name__value"],
         uniqueness_constraints=[["name__value"]],
         attributes=[
             AttributeSchema(name="name", kind="Text", optional=False, unique=True),
@@ -231,6 +235,99 @@ def build_chain_schema_dict(levels: int = 3) -> dict:
             ]
         nodes.append(node)
     return {"version": "1.0", "nodes": nodes}
+
+
+INTERFACE_NAMESPACE = "Testing"
+DEVICE_KIND = "TestingDevice"
+INTERFACE_KIND = "TestingInterface"
+
+
+def build_interface_hfid_schema_dict() -> dict:
+    """A device and an interface whose identity reads the device across the relationship.
+
+    The interface's human-friendly id and display label both read the device name, so its stored
+    identity depends on a peer attribute. Renaming the device must rewrite the stored id, the
+    cross-relationship case that a self-only id never reaches.
+    """
+    return {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": INTERFACE_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+            },
+            {
+                "name": "Interface",
+                "namespace": INTERFACE_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ device__name__value }} :: {{ name__value }}",
+                "human_friendly_id": ["name__value", "device__name__value"],
+                "uniqueness_constraints": [["device", "name__value"]],
+                "attributes": [{"name": "name", "kind": "Text", "optional": False}],
+                "relationships": [{"name": "device", "peer": DEVICE_KIND, "optional": False, "cardinality": "one"}],
+            },
+        ],
+    }
+
+
+LOCATION_NAMESPACE = "Testing"
+METRO_KIND = "TestingMetro"
+SITE_KIND = "TestingSite"
+RACK_KIND = "TestingRack"
+
+
+def build_location_cascade_schema_dict() -> dict:
+    """A metro -> site -> rack chain that propagates a top-level rename two hops.
+
+    The site's short name is a computed attribute reading the metro name across the relationship.
+    The site display label reads the metro directly, so it refreshes on the first hop. The rack
+    display label reads the site's short name across its own relationship, so it moves only after
+    the site's short name is rewritten: the recompute has to chain from that write to the rack. A
+    self-only display label never exercises this second hop.
+    """
+    return {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Metro",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+            },
+            {
+                "name": "Site",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ metro__name__value }}-{{ name__value }}",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "optional": False, "unique": True},
+                    {
+                        "name": "shortname",
+                        "kind": "Text",
+                        "optional": True,
+                        "read_only": True,
+                        "computed_attribute": {
+                            "kind": "Jinja2",
+                            "jinja2_template": "{{ metro__name__value }}-{{ name__value }}",
+                        },
+                    },
+                ],
+                "relationships": [{"name": "metro", "peer": METRO_KIND, "optional": False, "cardinality": "one"}],
+            },
+            {
+                "name": "Rack",
+                "namespace": LOCATION_NAMESPACE,
+                "default_filter": "name__value",
+                "display_label": "{{ site__shortname__value }} :: {{ name__value }}",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False, "unique": True}],
+                "relationships": [{"name": "site", "peer": SITE_KIND, "optional": False, "cardinality": "one"}],
+            },
+        ],
+    }
 
 
 @dataclass(frozen=True)

--- a/backend/tests/integration_docker/test_merge_recompute.py
+++ b/backend/tests/integration_docker/test_merge_recompute.py
@@ -10,9 +10,16 @@ from infrahub_sdk.branch import BranchStatus
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 
 from tests.helpers.merge_recompute.dataset import (
+    DEVICE_KIND,
+    INTERFACE_KIND,
+    METRO_KIND,
     PROFILE_NODE_KIND,
     PROFILE_PEER_KIND,
+    RACK_KIND,
+    SITE_KIND,
     build_chain_schema_dict,
+    build_interface_hfid_schema_dict,
+    build_location_cascade_schema_dict,
     build_profile_schema_dict,
     chain_kind,
 )
@@ -67,6 +74,14 @@ class TestMergeRecompute(TestInfrahubDockerClient):
     @pytest.fixture(scope="class")
     def chain_schema(self) -> dict:
         return build_chain_schema_dict(levels=3)
+
+    @pytest.fixture(scope="class")
+    def interface_hfid_schema(self) -> dict:
+        return build_interface_hfid_schema_dict()
+
+    @pytest.fixture(scope="class")
+    def location_cascade_schema(self) -> dict:
+        return build_location_cascade_schema_dict()
 
     @pytest.fixture(scope="class")
     def delete_peer_schema(self) -> dict:
@@ -218,6 +233,75 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         assert final.summary.value == "cnode on gamma"
         assert final.display_label == "cnode via gamma"
         assert final.hfid == ["cnode"]
+
+    # Cross-relationship human-friendly id: the reader's identity reads a peer across the relationship,
+    # so a peer rename must reindex the stored hfid that backs get_one_by_hfid. These assert the stored
+    # value through the id lookup, not the id the SDK recomputes client-side from the loaded peer.
+
+    async def test_merge_recomputes_cross_relationship_hfid(
+        self, client: InfrahubClient, interface_hfid_schema: dict
+    ) -> None:
+        """A merged peer rename reindexes the reader: it resolves under the new hfid and not the old one."""
+        loaded = await client.schema.load(schemas=[interface_hfid_schema], wait_until_converged=True)
+        assert loaded.schema_updated
+
+        device = await client.create(kind=DEVICE_KIND, data={"name": "device-a"})
+        await device.save()
+        interface = await client.create(kind=INTERFACE_KIND, data={"name": "eth1", "device": device})
+        await interface.save()
+
+        async def _resolves(hfid: list[str]) -> bool:
+            return await client.get(kind=INTERFACE_KIND, hfid=hfid, raise_when_missing=False) is not None
+
+        await _wait_until(lambda: _resolves(["eth1", "device-a"]))
+
+        branch = await client.branch.create(branch_name="hfid-merge-correctness")
+        device_on_branch = await client.get(kind=DEVICE_KIND, id=device.id, branch=branch.name)
+        device_on_branch.name.value = "device-b"
+        await device_on_branch.save()
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+        await _wait_until_merged(client=client, branch_name=branch.name)
+
+        assert await _became_true(lambda: _resolves(["eth1", "device-b"]), seconds=90)
+        assert (await client.get(kind=INTERFACE_KIND, hfid=["eth1", "device-b"])).id == interface.id
+        assert not await _resolves(["eth1", "device-a"])
+
+    async def test_rebase_recomputes_cross_relationship_hfid(
+        self, client: InfrahubClient, interface_hfid_schema: dict
+    ) -> None:
+        """A rebase that replays a peer rename reindexes a user-branch reader under its new hfid."""
+        await client.schema.load(schemas=[interface_hfid_schema], wait_until_converged=True)
+
+        device = await client.create(kind=DEVICE_KIND, data={"name": "rdevice-a"})
+        await device.save()
+
+        branch = await client.branch.create(branch_name="hfid-rebase-correctness")
+
+        # Rename the device on the default branch; the rebase replays this onto the user branch.
+        device.name.value = "rdevice-b"
+        await device.save()
+
+        # The interface lives only on the user branch, so only the rebase recompute can refresh it.
+        interface = await client.create(
+            kind=INTERFACE_KIND, data={"name": "reth1", "device": device}, branch=branch.name
+        )
+        await interface.save()
+
+        async def _resolves(hfid: list[str]) -> bool:
+            found = await client.get(kind=INTERFACE_KIND, hfid=hfid, branch=branch.name, raise_when_missing=False)
+            return found is not None
+
+        await _wait_until(lambda: _resolves(["reth1", "rdevice-a"]))
+
+        await client.branch.rebase(branch_name=branch.name)
+
+        assert await _became_true(lambda: _resolves(["reth1", "rdevice-b"]), seconds=90)
+        assert (
+            await client.get(kind=INTERFACE_KIND, hfid=["reth1", "rdevice-b"], branch=branch.name)
+        ).id == interface.id
+        assert not await _resolves(["reth1", "rdevice-a"])
 
     @pytest.mark.xfail(
         strict=True,
@@ -383,6 +467,92 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         final_tip = await client.get(kind=l3, id=tip.id, branch=branch.name)
         assert final_mid.summary.value == "rroot-edited"
         assert final_tip.summary.value == "rroot-edited"
+
+    # Display-label cascade: a rename two hops up must refresh display labels down the chain.
+
+    async def test_merge_recomputes_two_level_display_label_cascade(
+        self, client: InfrahubClient, location_cascade_schema: dict
+    ) -> None:
+        """A top-level rename must refresh both levels' display labels below it after merge."""
+        loaded = await client.schema.load(schemas=[location_cascade_schema], wait_until_converged=True)
+        assert loaded.schema_updated
+
+        metro = await client.create(kind=METRO_KIND, data={"name": "metro-a"})
+        await metro.save()
+        site = await client.create(kind=SITE_KIND, data={"name": "site1", "metro": metro})
+        await site.save()
+        rack = await client.create(kind=RACK_KIND, data={"name": "rack1", "site": site})
+        await rack.save()
+
+        async def _labels_are(metro_name: str) -> bool:
+            site_node = await client.get(kind=SITE_KIND, id=site.id)
+            rack_node = await client.get(kind=RACK_KIND, id=rack.id)
+            return (
+                site_node.display_label == f"{metro_name}-site1"
+                and rack_node.display_label == f"{metro_name}-site1 :: rack1"
+            )
+
+        await _wait_until(lambda: _labels_are("metro-a"))
+
+        branch = await client.branch.create(branch_name="cascade-merge-correctness")
+        metro_on_branch = await client.get(kind=METRO_KIND, id=metro.id, branch=branch.name)
+        metro_on_branch.name.value = "metro-b"
+        await metro_on_branch.save()
+
+        merged = await client.branch.merge(branch_name=branch.name)
+        assert merged
+        await _wait_until_merged(client=client, branch_name=branch.name)
+
+        await _wait_until(lambda: _labels_are("metro-b"))
+
+        final_site = await client.get(kind=SITE_KIND, id=site.id)
+        final_rack = await client.get(kind=RACK_KIND, id=rack.id)
+        # First hop: the site reads the metro across its relationship. Second hop: the rack reads the
+        # site's short name, which only moves once the site's recompute writes it, so the rack
+        # refreshes only if the recompute chains from the site's write to the rack.
+        assert final_site.shortname.value == "metro-b-site1"
+        assert final_site.display_label == "metro-b-site1"
+        assert final_rack.display_label == "metro-b-site1 :: rack1"
+
+    async def test_rebase_recomputes_two_level_display_label_cascade(
+        self, client: InfrahubClient, location_cascade_schema: dict
+    ) -> None:
+        """A rebase that replays a top-level rename must refresh both levels' display labels on the user branch."""
+        await client.schema.load(schemas=[location_cascade_schema], wait_until_converged=True)
+
+        metro = await client.create(kind=METRO_KIND, data={"name": "rmetro-a"})
+        await metro.save()
+
+        branch = await client.branch.create(branch_name="cascade-rebase-correctness")
+        # The site and rack live only on the user branch, so only the rebase recompute can refresh them.
+        site = await client.create(kind=SITE_KIND, data={"name": "rsite1", "metro": metro}, branch=branch.name)
+        await site.save()
+        rack = await client.create(kind=RACK_KIND, data={"name": "rrack1", "site": site}, branch=branch.name)
+        await rack.save()
+
+        async def _labels_on_branch_are(metro_name: str) -> bool:
+            site_node = await client.get(kind=SITE_KIND, id=site.id, branch=branch.name)
+            rack_node = await client.get(kind=RACK_KIND, id=rack.id, branch=branch.name)
+            return (
+                site_node.display_label == f"{metro_name}-rsite1"
+                and rack_node.display_label == f"{metro_name}-rsite1 :: rrack1"
+            )
+
+        await _wait_until(lambda: _labels_on_branch_are("rmetro-a"))
+
+        # The rebase replays the default branch's metro rename onto the user branch.
+        metro.name.value = "rmetro-b"
+        await metro.save()
+
+        await client.branch.rebase(branch_name=branch.name)
+
+        await _wait_until(lambda: _labels_on_branch_are("rmetro-b"))
+
+        final_site = await client.get(kind=SITE_KIND, id=site.id, branch=branch.name)
+        final_rack = await client.get(kind=RACK_KIND, id=rack.id, branch=branch.name)
+        assert final_site.shortname.value == "rmetro-b-rsite1"
+        assert final_site.display_label == "rmetro-b-rsite1"
+        assert final_rack.display_label == "rmetro-b-rsite1 :: rrack1"
 
     # Delete a read peer: the merge must complete instead of erroring on the missing peer.
 

--- a/backend/tests/unit/core/merge/test_build_coalesced_recompute.py
+++ b/backend/tests/unit/core/merge/test_build_coalesced_recompute.py
@@ -19,9 +19,9 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from tests.helpers.merge_recompute.dataset import PROFILE_NODE_KIND, PROFILE_PEER_KIND, build_profile_schema
 
 
-def _profile_schema_branch() -> SchemaBranch:
+def _profile_schema_branch(cross_relationship_hfid: bool = False) -> SchemaBranch:
     schema_branch = SchemaBranch(cache={}, name="test")
-    schema_branch.load_schema(schema=build_profile_schema())
+    schema_branch.load_schema(schema=build_profile_schema(cross_relationship_hfid=cross_relationship_hfid))
     schema_branch.process()
     return schema_branch
 
@@ -115,6 +115,24 @@ def test_hfid_does_not_fan_out_on_related_change() -> None:
     result = builder.build(changes=changes, branch="main")
 
     assert not any(target.family == HFID for target in result.targets)
+
+
+def test_hfid_fans_out_when_id_crosses_relationship() -> None:
+    """A human-friendly id that reads a peer across the relationship is recomputed by that peer's change.
+
+    A merge and a rebase reach the builder identically, so this one derivation covers both: the reader's
+    id is scheduled alongside the display label and computed attribute that read the same peer.
+    """
+    builder = CoalescedRecomputeBuilder(schema_branch=_profile_schema_branch(cross_relationship_hfid=True))
+    changes = [
+        MergeChange(node_id="peer-0", kind=PROFILE_PEER_KIND, action="updated", changed_fields=frozenset({"name"}))
+    ]
+
+    result = builder.build(changes=changes, branch="main")
+
+    hfid = _by_identity(result)[HFID, PROFILE_NODE_KIND, None]
+    assert hfid.reads_across_relationship is True
+    assert _lookups(hfid) == {(PROFILE_PEER_KIND, "peer__ids", frozenset({"peer-0"}))}
 
 
 def test_changes_to_same_target_are_deduplicated() -> None:


### PR DESCRIPTION
## What this does

IFC-2937 reported that a cross-relationship human-friendly id stays stale after a merge or
rebase. I could not reproduce it as a server bug on release-1.11. The coalesced recompute
already refreshes the stored hfid.

## What I checked

I built the release-1.11 image, ran the exact scenario on a real stack, and read the database,
the worker logs, and the GraphQL API:

- After the merge, the interface's stored human_friendly_id on main goes from
  `["eth1","device-a"]` to `["eth1","device-b"]`. The old value is closed and the new one active.
- `get_one_by_hfid` finds the interface by the new id and no longer by the old one.
- Same result for rebase.
- The worker produces and persists the hfid write, so the render and write step is not the gap.

## Why the reproduction looked like a bug

`InfrahubNode.hfid` is computed on the client side from the relationship peer, not read from the
server hfid field. The test client still had the old device in its store, so `refreshed.hfid`
returned the old value. The display label came fresh from the server, so it showed the new value.
That is why the same object showed a stale hfid and a fresh display label. A fresh client with
`prefetch_relationships=True` computes the new id correctly.

## Changes

- Keep the merge and rebase cross-relationship hfid tests, but assert the server value through
  `get_one_by_hfid` (found by the new id, not the old one). Remove the `xfail` markers so the
  tests guard the behavior.
- Replace the two builder-level component tests with one unit test that checks the builder
  schedules the hfid recompute for a cross-relationship id.
- Keep the two display-label cascade tests.

This replaces the xfail reproduction in the draft PR #10020, which asserted on the client-side hfid.

## Follow-up

`InfrahubNode.hfid` can read stale after a merge unless peers are prefetched, because it is
computed client-side. Worth a separate SDK ticket to make the SDK prefer the server hfid field.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

