### PR TITLE
docs: add local development and evaluation sizing to hardware requirements

### DIFF
--- a/changelog/+docs-hardware-local-eval.added.md
+++ b/changelog/+docs-hardware-local-eval.added.md
@@ -1,0 +1,1 @@
+Added a "Local development and evaluation" section to the hardware requirements page, with starting-point CPU, memory, and disk figures for running Infrahub Community on a single machine for evaluation or proof-of-value work.

--- a/changelog/+docs-hardware-local-eval.added.md
+++ b/changelog/+docs-hardware-local-eval.added.md
@@ -1,1 +1,0 @@
-Added a "Local development and evaluation" section to the hardware requirements page, with starting-point CPU, memory, and disk figures for running Infrahub Community on a single machine for evaluation or proof-of-value work.

--- a/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
+++ b/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
@@ -27,6 +27,25 @@ For cloud deployments, use at least the following machine types:
 | Oracle Cloud Infrastructure | VM.Standard.E6     |
 | Alibaba Cloud               | ecs.g9a.xlarge     |
 
+## Local development and evaluation
+
+To evaluate Infrahub or build a proof-of-value on a single machine, use the community docker-compose deployment. The requirements below apply to that setup, not to production.
+
+:::warning
+
+These are starting points, not a measured specification. Real resource use depends on your dataset size and pipeline concurrency. Validate against your own data with a load test — schema load, data import, and a proposed-change merge — before you treat any figure as a hard requirement.
+
+:::
+
+| Resource      | Minimum (light evaluation) | Recommended | Notes                                                                                                     |
+|---------------|----------------------------|-------------|----------------------------------------------------------------------------------------------------------|
+| RAM           | 8 GB                       | 16 GB       | Recommended matches the general requirements above.                                                       |
+| CPU           | 4 cores                    | 6 cores     | A proposed-change or merge pipeline uses up to 4 cores concurrently.                                      |
+| Disk          | 20 GB                      | 40 GB       | SSD. Container images require 1.3 GB; data volumes grow with your data and graph history.                 |
+| Storage class | SSD                        | SSD         | Neo4j and PostgreSQL are latency-sensitive, so the storage class matters more than a specific IOPS target. |
+
+As your dataset grows, large merges and imports slow down on Community Edition — the signal that a single machine is no longer enough. For production scale and performance, see [Community vs enterprise](../../overview/community-vs-enterprise.mdx).
+
 ## Task manager database (PostgreSQL) storage
 
 The storage figures in the tables above size the Neo4j graph database. The task manager (Prefect) keeps its own [PostgreSQL database](../../overview/architecture.mdx#task-manager), which you size separately.

--- a/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
+++ b/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
@@ -40,7 +40,7 @@ These are starting points, not a measured specification. Real resource use depen
 | Resource      | Minimum (light evaluation) | Recommended | Notes                                                                                                     |
 |---------------|----------------------------|-------------|----------------------------------------------------------------------------------------------------------|
 | RAM           | 8 GB                       | 16 GB       | Recommended matches the general requirements above.                                                       |
-| CPU           | 4 cores                    | 6 cores     | A proposed-change or merge pipeline uses up to 4 cores concurrently.                                      |
+| CPU           | 6 cores                    | 8 cores     | A proposed-change or merge pipeline uses several cores concurrently, so provision headroom.               |
 | Disk          | 20 GB                      | 40 GB       | SSD. Container images require 1.3 GB; data volumes grow with your data and graph history.                 |
 | Storage class | SSD                        | SSD         | Neo4j and PostgreSQL are latency-sensitive, so the storage class matters more than a specific IOPS target. |
 


### PR DESCRIPTION
## What

Adds a **Local development and evaluation** section to the hardware requirements page, with starting-point CPU, RAM, and disk figures for running Infrahub Community on a single machine for evaluation or proof-of-value work.

## Why

The page previously carried only the general and enterprise sizing tables. There was no guidance for the common case of evaluating Infrahub or building a proof-of-value on one machine, which field teams are regularly asked about.

## Reviewer attention

- The figures are **starting points, not a measured specification** — called out in a warning admonition. A follow-up load test (schema load + import + proposed-change merge) should firm them up.
- **No physical-core-vs-vCPU definition** was added — deliberately out of scope for this change.
- Links to the existing *Community vs enterprise* page for the scaling story rather than duplicating it.
- Uses `SSD` and `PostgreSQL` to stay consistent with the rest of the page (vale passes).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

