### PR TITLE
docs: document Community single-core Neo4j limitation

### DIFF
--- a/changelog/+docs-community-single-core-neo4j.changed.md
+++ b/changelog/+docs-community-single-core-neo4j.changed.md
@@ -1,1 +1,0 @@
-Documented the Community Edition single-core Neo4j limitation on the community vs enterprise page: Community runs Neo4j on a single CPU core, which bounds large merge and import performance, while Enterprise runs Neo4j across multiple cores.

--- a/changelog/+docs-community-single-core-neo4j.changed.md
+++ b/changelog/+docs-community-single-core-neo4j.changed.md
@@ -1,0 +1,1 @@
+Documented the Community Edition single-core Neo4j limitation on the community vs enterprise page: Community runs Neo4j on a single CPU core, which bounds large merge and import performance, while Enterprise runs Neo4j across multiple cores.

--- a/docs/docs/overview/community-vs-enterprise.mdx
+++ b/docs/docs/overview/community-vs-enterprise.mdx
@@ -153,6 +153,7 @@ This area represents one of the most significant differences between the edition
 #### Community edition characteristics
 
 - **Scale capacity**: Suitable for infrastructures up to ~1,000 devices
+- **Database concurrency**: Neo4j runs on a single CPU core, so large merges and imports are bound by single-core performance regardless of how many cores the host has
 - **Database optimization**: Standard optimization suitable for moderate workloads
 - **Caching**: Basic caching and query optimization
 - **Deployment model**: Single-instance deployment patterns
@@ -165,6 +166,7 @@ Community Edition is fully capable of handling production workloads for small to
 #### Enterprise edition enhancements
 
 - **Scale capacity**: Optimized for environments with 10,000+ devices
+- **Database concurrency**: Multi-core Neo4j for parallel query and merge execution
 - **Database performance**: Advanced tuning, indexing strategies, and query optimization
 - **Caching architecture**: Enhanced multi-layer caching for improved performance
 - **High availability**: Built-in clustering support for resilience

--- a/docs/docs/overview/community-vs-enterprise.mdx
+++ b/docs/docs/overview/community-vs-enterprise.mdx
@@ -153,7 +153,7 @@ This area represents one of the most significant differences between the edition
 #### Community edition characteristics
 
 - **Scale capacity**: Suitable for infrastructures up to ~1,000 devices
-- **Database concurrency**: Neo4j runs on a single CPU core, so large merges and imports are bound by single-core performance regardless of how many cores the host has
+- **Database concurrency**: Neo4j Community runs on a single CPU core, so large merges and imports are bound by single-core performance regardless of how many cores the host has
 - **Database optimization**: Standard optimization suitable for moderate workloads
 - **Caching**: Basic caching and query optimization
 - **Deployment model**: Single-instance deployment patterns


### PR DESCRIPTION
## What

Documents the Community Edition single-core Neo4j limitation on the *Community vs enterprise* page. Adds a **Database concurrency** point to both the Community characteristics and Enterprise enhancements lists:

- Community: Neo4j runs on a single CPU core, so large merges and imports are bound by single-core performance regardless of host core count.
- Enterprise: multi-core Neo4j for parallel query and merge execution.

## Why

This is the concrete mechanism behind the edition performance difference, and it was not stated anywhere in the docs (a repo-wide search for "single core" returned nothing). The page previously explained the gap only in general terms (device counts, vertical vs horizontal scaling), leaving readers without the actual reason large merges slow down on Community.

## Reviewer attention

- Placed as a factual bullet in the existing Performance and scalability lists — no structural change.
- Pairs with the hardware requirements local-evaluation section (separate PR), which links here for the scaling story.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

