### PR TITLE
docs: link hardware requirements from Community install page

### DIFF
--- a/changelog/+docs-community-install-hardware-link.changed.md
+++ b/changelog/+docs-community-install-hardware-link.changed.md
@@ -1,0 +1,1 @@
+Added a link to the hardware requirements page from the Install Infrahub Community page, pointing readers to the sizing guidance before they install.

--- a/changelog/+docs-community-install-hardware-link.changed.md
+++ b/changelog/+docs-community-install-hardware-link.changed.md
@@ -1,1 +1,0 @@
-Added a link to the hardware requirements page from the Install Infrahub Community page, pointing readers to the sizing guidance before they install.

--- a/docs/docs/deploy-manage/install-configure/install/community.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/community.mdx
@@ -10,6 +10,8 @@ import ReferenceLink from "../../../../src/components/Card";
 
 Infrahub Community is deployed as a container-based architecture and can be installed using several methods.
 
+Before you install, review the [hardware requirements](../hardware-requirements.mdx), including the local development and evaluation sizing.
+
 <Tabs groupId="install-method" queryString>
 <TabItem value="Docker compose via curl" default>
 


### PR DESCRIPTION
## What

Adds a link to the [hardware requirements](../hardware-requirements.mdx) page from the *Install Infrahub Community* page, so readers see the sizing guidance (including the local development and evaluation figures) before they install.

## Why

The Community install page stated only a Docker version prerequisite and gave no pointer to CPU/RAM/disk sizing. Readers had no in-flow link to the requirements before spinning up the stack.

## Reviewer attention

- Single sentence added below the intro; no structural change.
- Complements the hardware requirements local-evaluation section (separate PR).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

