### PR TITLE
fix: omit task related nodes that are missing from the graph

### DIFF
--- a/backend/infrahub/task_manager/models.py
+++ b/backend/infrahub/task_manager/models.py
@@ -52,14 +52,16 @@ class RelatedNodesInfo(BaseModel):
         self.flows[flow_id][node_id] = self.nodes[node_id]
 
     def get_related_nodes(self, flow_id: UUID) -> list[RelatedNodeInfo]:
-        if flow_id not in self.flows or len(self.flows[flow_id].keys()) == 0:
-            return []
-        return list(self.flows[flow_id].values())
+        """Return the related nodes of a flow that still exist in the graph.
+
+        A task outlives the nodes it references, and a node whose vertex is gone has no
+        resolvable kind. Those references are dropped rather than exposed as partial
+        entries; their ids remain readable from the flow run tags they are derived from.
+        """
+        return [node for node in self.flows.get(flow_id, {}).values() if node.kind is not None]
 
     def get_related_nodes_as_dict(self, flow_id: UUID) -> list[dict[str, str | None]]:
-        if flow_id not in self.flows or len(self.flows[flow_id].keys()) == 0:
-            return []
-        return [item.model_dump() for item in list(self.flows[flow_id].values())]
+        return [item.model_dump() for item in self.get_related_nodes(flow_id=flow_id)]
 
     def get_first_related_node(self, flow_id: UUID) -> RelatedNodeInfo | None:
         if nodes := self.get_related_nodes(flow_id=flow_id):

--- a/backend/tests/component/graphql/queries/test_task.py
+++ b/backend/tests/component/graphql/queries/test_task.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator, Generator
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from graphql import ExecutionResult
@@ -796,6 +797,43 @@ async def test_task_query_progress(
             "workflow": "dummy-flow",
         }
     }
+
+
+async def test_task_query_related_node_missing_from_graph(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    prefect_client: PrefectClient,
+    register_core_models_schema: None,
+    delete_flow_runs: None,
+) -> None:
+    # An id with no vertex in the graph is indistinguishable from one whose node was
+    # removed: neither can resolve a kind.
+    missing_node_id = str(uuid4())
+    flow = await prefect_client.create_flow_run(
+        flow=dummy_flow,
+        name="dummy-completed-missing-node",
+        parameters={"firstname": "xxxx", "lastname": "yyy"},
+        tags=[TAG_NAMESPACE, WorkflowTag.RELATED_NODE.render(identifier=missing_node_id)],
+        state=State(type="COMPLETED"),
+    )
+
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_TASK,
+        variables={"related_nodes": [missing_node_id]},
+    )
+
+    assert result.errors is None
+    assert result.data
+
+    node = result.data["InfrahubTask"]["edges"][0]["node"]
+    assert node["id"] == str(flow.id)
+    assert node["related_nodes"] == []
+    assert node["related_node"] is None
+    assert node["related_node_kind"] is None
+    # The reference itself is not lost: related nodes are derived from these tags.
+    assert WorkflowTag.RELATED_NODE.render(identifier=missing_node_id) in node["tags"]
 
 
 async def test_task_no_count(

--- a/backend/tests/unit/task_manager/test_models.py
+++ b/backend/tests/unit/task_manager/test_models.py
@@ -1,4 +1,6 @@
-from infrahub.task_manager.models import InfrahubEventFilter
+from uuid import uuid4
+
+from infrahub.task_manager.models import InfrahubEventFilter, RelatedNodesInfo
 
 
 class TestInfrahubEventFilter:
@@ -26,3 +28,38 @@ class TestInfrahubEventFilter:
         event_filter.add_event_type_filter()
 
         assert event_filter.event is None
+
+
+class TestRelatedNodesInfo:
+    def test_related_nodes_without_a_kind_are_omitted(self) -> None:
+        """A node whose vertex is gone from the graph has no kind and cannot be described."""
+        flow_id = uuid4()
+        related_nodes = RelatedNodesInfo()
+        related_nodes.add_nodes(flow_id=flow_id, node_ids=["resolvable", "missing"])
+        related_nodes.nodes["resolvable"].kind = "BuiltinTag"
+
+        assert [node.id for node in related_nodes.get_related_nodes(flow_id=flow_id)] == ["resolvable"]
+        assert related_nodes.get_related_nodes_as_dict(flow_id=flow_id) == [{"id": "resolvable", "kind": "BuiltinTag"}]
+
+    def test_first_related_node_skips_those_without_a_kind(self) -> None:
+        """The deprecated single-node fields stay consistent with the related nodes list."""
+        flow_id = uuid4()
+        related_nodes = RelatedNodesInfo()
+        related_nodes.add_nodes(flow_id=flow_id, node_ids=["missing", "resolvable"])
+        related_nodes.nodes["resolvable"].kind = "BuiltinTag"
+
+        first = related_nodes.get_first_related_node(flow_id=flow_id)
+
+        assert first is not None
+        assert first.id == "resolvable"
+
+    def test_no_related_node_has_a_kind(self) -> None:
+        flow_id = uuid4()
+        related_nodes = RelatedNodesInfo()
+        related_nodes.add_nodes(flow_id=flow_id, node_ids=["missing"])
+
+        assert related_nodes.get_related_nodes(flow_id=flow_id) == []
+        assert related_nodes.get_first_related_node(flow_id=flow_id) is None
+
+    def test_unknown_flow_has_no_related_nodes(self) -> None:
+        assert RelatedNodesInfo().get_related_nodes(flow_id=uuid4()) == []

--- a/changelog/+task-list-related-node-kind.fixed.md
+++ b/changelog/+task-list-related-node-kind.fixed.md
@@ -1,0 +1,1 @@
+Fixed an error when browsing the task list where a task referenced a node that no longer exists in the graph. A deleted node's kind cannot be resolved, which made the whole query fail. Such references are now omitted from a task's related nodes; their ids remain visible in the task's tags.


### PR DESCRIPTION
## Problem

Browsing the task list could fail with `Something went wrong when fetching list.`

Related nodes are derived from a flow run's tags: ids are pulled out of `infrahub.app/node/<uuid>`
tags and their kinds are then looked up in the graph. A task outlives the nodes it references, so
when a related node's vertex is gone the lookup finds nothing and the resolver returned `None` for
`TaskRelatedNode.kind`, which was declared `String!`. GraphQL raised a non-null violation and the
tasks domain layer, which throws on any `errors` entry, turned that into a full-page error screen.

Tasks are sorted by start time descending, so the oldest tasks land on the last page — which is
where this surfaced most often. It is not last-page-specific: any page holding such a task fails.

Note for reviewers: soft-deleted nodes are unaffected. The delete query keeps the active edge and
the kind lookup runs without a branch filter, so those still resolve. The unrecoverable case is a
node whose vertex was physically removed, which happens when the branch it was created on is
deleted.

## Change

`RelatedNodesInfo.get_related_nodes` now returns only the references whose kind resolved.
`get_related_nodes_as_dict` and `get_first_related_node` both delegate to it, so `related_nodes` and
the deprecated `related_node` / `related_node_kind` pair stay consistent with each other.

**Nothing is lost.** `related_nodes` is a projection of the flow run's tags, and `tags` is exposed
on the same type — the id of a dropped reference is still readable there. The new component test
asserts exactly that.

The upshot is that `kind` stays honestly `String!`: a reference the server returns is always one it
could describe. Consequently the GraphQL schema, the three generated frontend codegen artifacts, the
frontend itself and the Python SDK are all untouched.

## Why not make `kind` nullable

That was this branch's first approach, since squashed away. It required relaxing the
schema, regenerating three codegen artifacts, filtering the unusable entries at three frontend render
boundaries, and a companion SDK change (opsmill/infrahub-sdk-python#1219, now closed) because the
SDK's Pydantic model would otherwise raise a `ValidationError` on the very tasks being fixed.

That is a lot of surface area to carry a value that the only client then discarded. Filtering at the
source is smaller, keeps a truthful non-null contract, and takes the SDK out of the blast radius.

The trade-off: if we later want to *show* dangling references — "this task touched an object that has
since been deleted" — the nullable field is the natural vehicle and this would need revisiting. The
tags keep that option open, and the closed SDK branch is still there.

## Tests

- `test_task_query_related_node_missing_from_graph` (component) — a flow run tagged with an id that
  has no vertex. Verified to fail without the fix with the original production error, `Cannot return
  null for non-nullable field TaskRelatedNode.kind`. Asserts the reference is omitted, the deprecated
  fields agree, and the id is still present in `tags`.
- `TestRelatedNodesInfo` (unit) — four cases covering the filter, the `get_first_related_node`
  consistency, the all-unresolvable case, and an unknown flow. The class had no unit coverage before.

Gates run locally: `ruff check`, `ruff format --check`, `ty check`, the 15 tests in
`test_task.py`, and the 18 in `tests/unit/task_manager`.

## Known follow-ups, not filed as issues

- **Legacy table.** The tasks list still uses the legacy `Table` (3 remaining call sites vs 9 on
  `DataTable`). Unrelated to this bug — the failure happened before any table rendered — and
  migrating means swapping offset pagination for infinite scroll.
- **`TaskLog.task_id`** is declared non-null and never populated by the resolver. Latent only
  because no client selects it; the first one that does will fail outright.
- **`Task.created_at` / `Task.updated_at`** are declared non-null while Prefect types them
  `Optional`. The server always populates them in practice, so there is no reproducible failure.
- **The domain layer's `if (errors) throw`**, repeated across ~30 frontend domain functions. Left
  alone deliberately: with this fix the query reports no error, so relaxing it would be a separate
  error-handling policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
