### PR TITLE
ci: dispatch Infrahub releases to infrahub-demo-sp

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -36,6 +36,7 @@ jobs:
         # Either a literal path, or the name of a secret...
         repo:
           - "opsmill/infrahub-demo-dc"
+          - "opsmill/infrahub-demo-sp"
           - "INFRAHUB_PACKER_REPOSITORY"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"


### PR DESCRIPTION
## Why

`opsmill/infrahub-demo-sp` already carries the receiving `update-infrahub.yml` and `update-infrahub-sdk.yml` workflows, but it was never added to the dispatch matrix here — so neither has ever fired (`gh run list` on both returns zero runs). This adds it.

## What

One line in `.github/workflows/repository-dispatch.yml`:

```yaml
repo:
  - "opsmill/infrahub-demo-dc"
  - "opsmill/infrahub-demo-sp"   # <-- added
  - "INFRAHUB_PACKER_REPOSITORY"
  ...
```

## Effect

A new Infrahub release now opens a `main-<version>` version-bump PR on infrahub-demo-sp, the same way it already does on infrahub-demo-dc. That PR's CI runs the demo's end-to-end integration suite against the new release, so a red PR is the signal that the release breaks the SP demo.

## Sequencing

This is safe to merge independently. infrahub-demo-sp is gaining that integration suite in a companion PR; until it lands, a dispatched bump PR simply runs lint plus unit tests, which is harmless.

The demo-sp side is verified locally against 1.10.6: 18/18 end-to-end tests pass (bootstrap, repository sync, both generators, 12 artifacts Ready, group-triggered generator on a branch, 17 proposed-change validators green, merge to main).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

