### PR TITLE
Remove resolved violations that were previously ignored

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1270,7 +1270,6 @@ no-matching-overload = "ignore"
 not-subscriptable = "ignore"
 possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
-unresolved-import = "ignore"
 unresolved-reference = "ignore"
 unsupported-operator = "ignore"
 
@@ -1298,7 +1297,6 @@ include = ["utilities/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-possibly-missing-attribute = "ignore"
 possibly-missing-submodule = "ignore"
 unresolved-import = "ignore"
 
@@ -1315,8 +1313,6 @@ invalid-assignment = "ignore"
 missing-argument = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
-possibly-missing-attribute = "ignore"
-too-many-positional-arguments = "ignore"
 unresolved-attribute = "ignore"
 unresolved-import = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
@@ -1335,16 +1331,6 @@ possibly-missing-submodule = "ignore"
 too-many-positional-arguments = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
-
-[[tool.ty.overrides]]
-include = ["backend/infrahub/core/query/standard_node.py"]
-
-[tool.ty.overrides.rules]
-##################################################################################################
-# The ignored rules below should be removed once the code has been updated, they are included    #
-# like this so that we can reactivate them one by one.                                           #
-##################################################################################################
-type-assertion-failure = "ignore"
 
 [[tool.ty.overrides]]
 include = ["backend/infrahub/core/**"]
@@ -1686,10 +1672,8 @@ include = ["backend/infrahub/git/**"]
 ##################################################################################################
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
-invalid-await = "ignore"
 invalid-return-type = "ignore"
 no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1701,9 +1685,7 @@ include = ["backend/infrahub/database/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-possibly-missing-attribute = "ignore"
 invalid-argument-type = "ignore"
-invalid-assignment = "ignore"
 invalid-return-type = "ignore"
 invalid-type-form = "ignore"
 unresolved-attribute = "ignore"
@@ -1717,9 +1699,7 @@ include = ["backend/infrahub/services/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-deprecated = "ignore"
 invalid-await = "ignore"
-unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1730,7 +1710,6 @@ include = ["backend/infrahub/services/adapters/**/nats.py"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-possibly-missing-attribute = "ignore"
 possibly-missing-submodule = "ignore"
 
 [[tool.ty.overrides]]
@@ -1743,9 +1722,6 @@ include = ["backend/infrahub/proposed_change/**"]
 ##################################################################################################
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
-invalid-await = "ignore"
-no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1758,9 +1734,6 @@ include = ["backend/infrahub/generators/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-argument-type = "ignore"
-invalid-await = "ignore"
-no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1775,7 +1748,6 @@ include = ["backend/infrahub/git_credential/**"]
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1789,7 +1761,6 @@ include = ["backend/infrahub/webhook/**"]
 ##################################################################################################
 invalid-argument-type = "ignore"
 no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1801,8 +1772,6 @@ include = ["backend/infrahub/cli/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-invalid-argument-type = "ignore"
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1813,7 +1782,6 @@ include = ["backend/infrahub/telemetry/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1824,9 +1792,7 @@ include = ["backend/infrahub/computed_attribute/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-invalid-argument-type = "ignore"
 no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1839,7 +1805,6 @@ include = ["backend/infrahub/workers/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-argument-type = "ignore"
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1850,7 +1815,6 @@ include = ["backend/infrahub/trigger/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1861,7 +1825,6 @@ include = ["backend/infrahub/workflows/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1872,7 +1835,6 @@ include = ["backend/infrahub/message_bus/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-call-non-callable = "ignore"
 call-top-callable = "ignore"
 invalid-await = "ignore"
 no-matching-overload = "ignore"
@@ -1898,7 +1860,6 @@ include = ["backend/infrahub/artifacts/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1910,7 +1871,6 @@ include = ["backend/infrahub/tasks/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 missing-argument = "ignore"
-no-matching-overload = "ignore"
 unknown-argument = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1933,9 +1893,7 @@ include = ["backend/infrahub/profiles/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
-no-matching-overload = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -1971,7 +1929,6 @@ include = ["backend/infrahub/actions/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-argument-type = "ignore"
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1982,7 +1939,6 @@ include = ["backend/infrahub/branch/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1993,7 +1949,6 @@ include = ["backend/infrahub/schema/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -2007,10 +1962,6 @@ include = ["backend/infrahub/*.py"]
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-method-override = "ignore"
-invalid-return-type = "ignore"
-no-matching-overload = "ignore"
-not-subscriptable = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
@@ -2093,7 +2044,6 @@ include = ["backend/infrahub/task_manager/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-invalid-argument-type = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -2112,7 +2062,6 @@ missing-argument = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
 not-iterable = "ignore"
-possibly-missing-attribute = "ignore"
 unknown-argument = "ignore"
 unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
@@ -2141,11 +2090,9 @@ include = ["backend/tests/integration/**"]
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-await = "ignore"
-invalid-method-override = "ignore"
 invalid-return-type = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
@@ -2163,7 +2110,6 @@ invalid-assignment = "ignore"
 invalid-return-type = "ignore"
 no-matching-overload = "ignore"
 not-iterable = "ignore"
-possibly-missing-attribute = "ignore"
 unknown-argument = "ignore"
 unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
@@ -2180,7 +2126,6 @@ include = ["backend/tests/integration_docker/**"]
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-return-type = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 
 [[tool.ty.overrides]]
@@ -2193,7 +2138,6 @@ include = ["backend/tests/scale/**"]
 ##################################################################################################
 invalid-assignment = "ignore"
 not-iterable = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unresolved-import = "ignore"
 unsupported-operator = "ignore"
@@ -2206,8 +2150,6 @@ include = ["backend/tests/fixtures/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unresolved-import = "ignore"
 invalid-argument-type = "ignore"
@@ -2242,9 +2184,7 @@ include = ["backend/tests/query_benchmark/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-return-type = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
-unresolved-import = "ignore"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
# Why

Remove `ty` ignore violations that have already been resolved, the goal is to prevent new violations from slipping in.

## What changed

* ty rules in pyproject.toml

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

