### PR TITLE
final uniqueness-constraint related touchups

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -192,10 +192,10 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         )
 
         candidate_schema = schema_analyzer.get_candidate_schema()
-        determiner = build_constraint_validator_determiner(
-            db=db, branch=user_branch, schema_branch=candidate_schema, at=rebase_at
+        determiner = build_constraint_validator_determiner(db=db, branch=user_branch, at=rebase_at)
+        data_diff_constraints = await determiner.get_constraints(
+            schema_branch=candidate_schema, node_diffs=node_diff_field_summaries
         )
-        data_diff_constraints = await determiner.get_constraints(node_diffs=node_diff_field_summaries)
 
         # If there are some changes related to the schema between this branch and main, we need to
         #  - Run all the validations to ensure everything is correct before rebasing the branch
@@ -203,8 +203,8 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         schema_diff_constraints: list[SchemaUpdateConstraintInfo] = []
         if user_branch.has_schema_changes:
             schema_diff_constraints = await schema_analyzer.calculate_validations(target_schema=candidate_schema)
-        merger = build_constraint_info_merger(schema_branch=candidate_schema)
-        constraints = merger.merge(data_diff_constraints, schema_diff_constraints)
+        merger = build_constraint_info_merger()
+        constraints = merger.merge(candidate_schema, data_diff_constraints, schema_diff_constraints)
         if constraints:
             responses = await schema_validate_migrations(
                 message=SchemaValidateMigrationData(

--- a/backend/infrahub/core/merge/builder.py
+++ b/backend/infrahub/core/merge/builder.py
@@ -12,6 +12,8 @@ from infrahub.core.diff.summary_serializer import DiffSummarySerializer
 from infrahub.core.registry import registry
 from infrahub.core.rollback import GraphRollbacker
 from infrahub.core.schema.update_coordinator import SchemaUpdateCoordinator
+from infrahub.core.validators.constraint_merge import build_constraint_info_merger
+from infrahub.core.validators.determiner import build_constraint_validator_determiner
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.workers.dependencies import get_cache, get_event_service, get_workflow
@@ -65,9 +67,10 @@ async def build_branch_merge_orchestrator(
         schema_manager=registry.schema,
     )
     constraint_validator = MergeConstraintValidator(
-        db=db,
         branch=source_branch,
         diff_repository=diff_repository,
+        determiner=build_constraint_validator_determiner(db=db, branch=source_branch),
+        constraint_info_merger=build_constraint_info_merger(),
         migration_validator=schema_validate_migrations,
     )
     graph_merger = GraphMerger(

--- a/backend/infrahub/core/merge/constraints.py
+++ b/backend/infrahub/core/merge/constraints.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 
 from infrahub.core.diff.model.diff import SchemaConflict
 from infrahub.core.diff.model.path import BranchTrackingId
-from infrahub.core.validators.constraint_merge import build_constraint_info_merger
-from infrahub.core.validators.determiner import build_constraint_validator_determiner
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 
 if TYPE_CHECKING:
@@ -16,9 +14,10 @@ if TYPE_CHECKING:
     from infrahub.core.diff.repository.repository import DiffRepository
     from infrahub.core.models import SchemaUpdateConstraintInfo
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.core.validators.constraint_merge import ConstraintInfoMerger
+    from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
     from infrahub.core.validators.model import SchemaViolation
     from infrahub.core.validators.models.validate_migration import SchemaValidatorPathResponseData
-    from infrahub.database import InfrahubDatabase
 
     MigrationValidator = Callable[[SchemaValidateMigrationData], Awaitable[list[SchemaValidatorPathResponseData]]]
 
@@ -101,28 +100,30 @@ class MergeConstraintValidator:
 
     def __init__(
         self,
-        db: InfrahubDatabase,
         branch: Branch,
         diff_repository: DiffRepository,
+        determiner: ConstraintValidatorDeterminer,
+        constraint_info_merger: ConstraintInfoMerger,
         migration_validator: MigrationValidator,
     ) -> None:
-        self.db = db
         self.branch = branch
         self.diff_repository = diff_repository
+        self.determiner = determiner
+        self.constraint_info_merger = constraint_info_merger
         self.migration_validator = migration_validator
 
     async def validate(
         self, candidate_schema: SchemaBranch, schema_diff_constraints: list[SchemaUpdateConstraintInfo]
     ) -> MergeConstraintValidationResult:
-        determiner = build_constraint_validator_determiner(
-            db=self.db, branch=self.branch, schema_branch=candidate_schema
-        )
         node_field_summaries = await self.diff_repository.get_node_field_summaries(
             diff_branch_name=self.branch.name, tracking_id=BranchTrackingId(name=self.branch.name)
         )
-        data_diff_constraints = await determiner.get_constraints(node_diffs=node_field_summaries)
-        merger = build_constraint_info_merger(schema_branch=candidate_schema)
-        constraints = merger.merge(data_diff_constraints, schema_diff_constraints)
+        data_diff_constraints = await self.determiner.get_constraints(
+            schema_branch=candidate_schema, node_diffs=node_field_summaries
+        )
+        constraints = self.constraint_info_merger.merge(
+            candidate_schema, data_diff_constraints, schema_diff_constraints
+        )
         if not constraints:
             return MergeConstraintValidationResult()
 

--- a/backend/infrahub/core/validators/constraint_merge.py
+++ b/backend/infrahub/core/validators/constraint_merge.py
@@ -19,7 +19,9 @@ class ConstraintInfoMerger:
     def __init__(self, deduplicator: UniquenessConstraintDeduplicator) -> None:
         self.deduplicator = deduplicator
 
-    def merge(self, *constraint_lists: list[SchemaUpdateConstraintInfo]) -> list[SchemaUpdateConstraintInfo]:
+    def merge(
+        self, schema_branch: SchemaBranch, *constraint_lists: list[SchemaUpdateConstraintInfo]
+    ) -> list[SchemaUpdateConstraintInfo]:
         """Collapse the same constraint from multiple producers onto one entry.
 
         A constraint both broadened by a schema change (full population) and hit by a data change
@@ -42,8 +44,8 @@ class ConstraintInfoMerger:
                         update={"node_uuids": sorted(set(existing.node_uuids) | set(constraint.node_uuids))}
                     )
 
-        return self.deduplicator.deduplicate(list(merged.values()))
+        return self.deduplicator.deduplicate(schema_branch=schema_branch, constraints=list(merged.values()))
 
 
-def build_constraint_info_merger(schema_branch: SchemaBranch) -> ConstraintInfoMerger:
-    return ConstraintInfoMerger(deduplicator=UniquenessConstraintDeduplicator(schema_branch=schema_branch))
+def build_constraint_info_merger() -> ConstraintInfoMerger:
+    return ConstraintInfoMerger(deduplicator=UniquenessConstraintDeduplicator())

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -31,16 +31,14 @@ LOG = get_logger(__name__)
 class ConstraintValidatorDeterminer:
     def __init__(
         self,
-        schema_branch: SchemaBranch,
         node_diff_index: NodeDiffIndex,
         uniqueness_scoper: UniquenessConstraintScoper,
     ) -> None:
-        self.schema_branch = schema_branch
         self.node_diff_index = node_diff_index
         self.uniqueness_scoper = uniqueness_scoper
 
     async def get_constraints(
-        self, node_diffs: list[NodeDiffFieldSummary], filter_invalid: bool = True
+        self, schema_branch: SchemaBranch, node_diffs: list[NodeDiffFieldSummary], filter_invalid: bool = True
     ) -> list[SchemaUpdateConstraintInfo]:
         self.node_diff_index.initialize(node_diffs)
         self.uniqueness_scoper.reset()
@@ -48,10 +46,10 @@ class ConstraintValidatorDeterminer:
         if not node_diffs:
             return constraints
 
-        constraints.extend(await self._get_property_constraints_for_impacted_kinds())
+        constraints.extend(await self._get_property_constraints_for_impacted_kinds(schema_branch=schema_branch))
 
         for kind in self.node_diff_index.kinds:
-            schema = self._get_schema_or_none(kind=kind)
+            schema = self._get_schema_or_none(schema_branch=schema_branch, kind=kind)
             if schema is None:
                 # a branch can hold data changes for a kind whose schema it also deletes
                 LOG.info("Skipping constraints for kind absent from the schema", kind=kind)
@@ -80,13 +78,13 @@ class ConstraintValidatorDeterminer:
         constraints.extend(await self._get_relationship_constraints_for_one_schema(schema=schema))
         return constraints
 
-    def _get_schema_or_none(self, kind: str) -> MainSchemaTypes | None:
+    def _get_schema_or_none(self, schema_branch: SchemaBranch, kind: str) -> MainSchemaTypes | None:
         try:
-            return self.schema_branch.get(name=kind, duplicate=False)
+            return schema_branch.get(name=kind, duplicate=False)
         except SchemaNotFoundError:
             return None
 
-    def _get_impacted_kinds(self) -> set[str]:
+    def _get_impacted_kinds(self, schema_branch: SchemaBranch) -> set[str]:
         """Kinds with node-level property constraints that could be violated by the data diff.
 
         Includes the kinds present in the diff and the generics they inherit from, since a
@@ -94,14 +92,16 @@ class ConstraintValidatorDeterminer:
         """
         kinds: set[str] = set()
         for kind in self.node_diff_index.kinds:
-            schema = self._get_schema_or_none(kind=kind)
+            schema = self._get_schema_or_none(schema_branch=schema_branch, kind=kind)
             if schema is None:
                 continue
             kinds.add(kind)
             kinds.update(getattr(schema, "inherit_from", None) or [])
         return kinds
 
-    def _node_property_triggered_by_diff(self, schema: MainSchemaTypes, prop_name: str) -> bool:
+    def _node_property_triggered_by_diff(
+        self, schema_branch: SchemaBranch, schema: MainSchemaTypes, prop_name: str
+    ) -> bool:
         """Return True if the diff touches a field guarded by the node-level property `prop_name`.
 
         A node-level constraint may be defined on a kind without every data change to that kind
@@ -109,31 +109,35 @@ class ConstraintValidatorDeterminer:
         properties default to emitting so a newly-added node-level constraint is never missed.
         """
         if prop_name == "uniqueness_constraints":
-            return self.uniqueness_scoper.requires_validation(schema=schema)
+            return self.uniqueness_scoper.requires_validation(schema_branch=schema_branch, schema=schema)
         if prop_name in ("parent", "children"):
             return self.node_diff_index.has_relationship_diff(kind=schema.kind, name=prop_name)
         return True
 
-    async def _get_property_constraints_for_impacted_kinds(self) -> list[SchemaUpdateConstraintInfo]:
-        impacted_kinds = self._get_impacted_kinds()
+    async def _get_property_constraints_for_impacted_kinds(
+        self, schema_branch: SchemaBranch
+    ) -> list[SchemaUpdateConstraintInfo]:
+        impacted_kinds = self._get_impacted_kinds(schema_branch=schema_branch)
         schemas: list[MainSchemaTypes] = []
         for kind in impacted_kinds:
-            schema = self._get_schema_or_none(kind=kind)
+            schema = self._get_schema_or_none(schema_branch=schema_branch, kind=kind)
             if schema is not None:
                 schemas.append(schema)
-        for schema in self.schema_branch.get_all(duplicate=False).values():
+        for schema in schema_branch.get_all(duplicate=False).values():
             if schema.kind in impacted_kinds:
                 continue
-            if self.uniqueness_scoper.requires_validation(schema=schema):
+            if self.uniqueness_scoper.requires_validation(schema_branch=schema_branch, schema=schema):
                 schemas.append(schema)
 
         constraints: list[SchemaUpdateConstraintInfo] = []
         for schema in schemas:
-            constraints.extend(await self._get_property_constraints_for_one_schema(schema=schema))
+            constraints.extend(
+                await self._get_property_constraints_for_one_schema(schema_branch=schema_branch, schema=schema)
+            )
         return constraints
 
     async def _get_property_constraints_for_one_schema(
-        self, schema: MainSchemaTypes
+        self, schema_branch: SchemaBranch, schema: MainSchemaTypes
     ) -> list[SchemaUpdateConstraintInfo]:
         constraints: list[SchemaUpdateConstraintInfo] = []
         for prop_name, prop_field_info in schema.__class__.model_fields.items():
@@ -174,14 +178,18 @@ class ConstraintValidatorDeterminer:
             if not do_constraint_validation:
                 continue
 
-            if not self._node_property_triggered_by_diff(schema=schema, prop_name=prop_name):
+            if not self._node_property_triggered_by_diff(
+                schema_branch=schema_branch, schema=schema, prop_name=prop_name
+            ):
                 # the node-level constraint is defined on this kind, but no field it guards is in
                 # the diff, so a data change cannot violate it
                 continue
 
             node_uuids: list[str] | None = None
             if prop_name == "uniqueness_constraints":
-                node_uuids = await self.uniqueness_scoper.affected_node_uuids(schema=schema)
+                node_uuids = await self.uniqueness_scoper.affected_node_uuids(
+                    schema_branch=schema_branch, schema=schema
+                )
 
             constraints.append(
                 SchemaUpdateConstraintInfo(constraint_name=constraint_name, path=schema_path, node_uuids=node_uuids)
@@ -270,16 +278,12 @@ class ConstraintValidatorDeterminer:
 def build_constraint_validator_determiner(
     db: InfrahubDatabase,
     branch: Branch,
-    schema_branch: SchemaBranch,
     at: Timestamp | str | None = None,
 ) -> ConstraintValidatorDeterminer:
     """Wire a determiner with its node-diff index and uniqueness scoper for a single operation."""
     node_diff_index = NodeDiffIndex()
     uniqueness_scoper = UniquenessConstraintScoper(
-        schema_branch=schema_branch,
         dependent_resolver=UniquenessDependentResolver(db=db, branch=branch, at=at),
         node_diff_index=node_diff_index,
     )
-    return ConstraintValidatorDeterminer(
-        schema_branch=schema_branch, node_diff_index=node_diff_index, uniqueness_scoper=uniqueness_scoper
-    )
+    return ConstraintValidatorDeterminer(node_diff_index=node_diff_index, uniqueness_scoper=uniqueness_scoper)

--- a/backend/infrahub/core/validators/uniqueness/deduplicator.py
+++ b/backend/infrahub/core/validators/uniqueness/deduplicator.py
@@ -24,10 +24,9 @@ class UniquenessConstraintDeduplicator:
     (full-population) check is ever lost.
     """
 
-    def __init__(self, schema_branch: SchemaBranch) -> None:
-        self.schema_branch = schema_branch
-
-    def deduplicate(self, constraints: list[SchemaUpdateConstraintInfo]) -> list[SchemaUpdateConstraintInfo]:
+    def deduplicate(
+        self, schema_branch: SchemaBranch, constraints: list[SchemaUpdateConstraintInfo]
+    ) -> list[SchemaUpdateConstraintInfo]:
         uniqueness_infos = {
             constraint.path.schema_kind: constraint
             for constraint in constraints
@@ -40,7 +39,9 @@ class UniquenessConstraintDeduplicator:
         redundant_kinds = {
             kind
             for kind, info in uniqueness_infos.items()
-            if self._is_covered_by_generic(kind=kind, info=info, uniqueness_infos=uniqueness_infos)
+            if self._is_covered_by_generic(
+                schema_branch=schema_branch, kind=kind, info=info, uniqueness_infos=uniqueness_infos
+            )
         }
         if not redundant_kinds:
             return list(constraints)
@@ -53,9 +54,13 @@ class UniquenessConstraintDeduplicator:
         ]
 
     def _is_covered_by_generic(
-        self, kind: str, info: SchemaUpdateConstraintInfo, uniqueness_infos: dict[str, SchemaUpdateConstraintInfo]
+        self,
+        schema_branch: SchemaBranch,
+        kind: str,
+        info: SchemaUpdateConstraintInfo,
+        uniqueness_infos: dict[str, SchemaUpdateConstraintInfo],
     ) -> bool:
-        schema = self._get_schema_or_none(kind=kind)
+        schema = self._get_schema_or_none(schema_branch=schema_branch, kind=kind)
         if schema is None or isinstance(schema, GenericSchema):
             # a generic is the coverer, never the covered
             return False
@@ -70,7 +75,7 @@ class UniquenessConstraintDeduplicator:
                 continue
             if not self._scope_covers(node_info=info, generic_info=generic_info):
                 continue
-            generic_schema = self._get_schema_or_none(kind=generic_kind)
+            generic_schema = self._get_schema_or_none(schema_branch=schema_branch, kind=generic_kind)
             if generic_schema is None:
                 continue
             covered_groups |= self._constraint_groups(generic_schema)
@@ -92,8 +97,8 @@ class UniquenessConstraintDeduplicator:
     def _constraint_groups(self, schema: MainSchemaTypes) -> set[frozenset[str]]:
         return {frozenset(group) for group in schema.uniqueness_constraints or []}
 
-    def _get_schema_or_none(self, kind: str) -> MainSchemaTypes | None:
+    def _get_schema_or_none(self, schema_branch: SchemaBranch, kind: str) -> MainSchemaTypes | None:
         try:
-            return self.schema_branch.get(name=kind, duplicate=False)
+            return schema_branch.get(name=kind, duplicate=False)
         except SchemaNotFoundError:
             return None

--- a/backend/infrahub/core/validators/uniqueness/scope.py
+++ b/backend/infrahub/core/validators/uniqueness/scope.py
@@ -72,26 +72,25 @@ class UniquenessConstraintScoper:
 
     def __init__(
         self,
-        schema_branch: SchemaBranch,
         dependent_resolver: UniquenessDependentResolverInterface,
         node_diff_index: NodeDiffIndex,
     ) -> None:
-        self.schema_branch = schema_branch
         self.dependent_resolver = dependent_resolver
         self.node_diff_index = node_diff_index
         # scopes are recomputed for the same kind across the trigger check and the uuid resolution;
-        # the cache is valid only for the node-diff index's current contents
+        # the cache is valid only for the node-diff index's current contents and the schema branch
+        # the scopes were computed against
         self._scope_cache: dict[str, UniquenessScopeForKind] = {}
 
     def reset(self) -> None:
         """Drop cached scopes so the next lookup recomputes against the current node-diff index."""
         self._scope_cache = {}
 
-    def requires_validation(self, schema: MainSchemaTypes) -> bool:
-        return self._scope(schema=schema).requires_validation
+    def requires_validation(self, schema_branch: SchemaBranch, schema: MainSchemaTypes) -> bool:
+        return self._scope(schema_branch=schema_branch, schema=schema).requires_validation
 
-    async def affected_node_uuids(self, schema: MainSchemaTypes) -> list[str] | None:
-        scope = self._scope(schema=schema)
+    async def affected_node_uuids(self, schema_branch: SchemaBranch, schema: MainSchemaTypes) -> list[str] | None:
+        scope = self._scope(schema_branch=schema_branch, schema=schema)
         node_uuids = set(scope.object_uuids)
         for peer_change in scope.cross_kind_peer_changes:
             if not peer_change.changed_peer_uuids:
@@ -135,14 +134,14 @@ class UniquenessConstraintScoper:
                 uuids |= self.node_diff_index.get_uuids_for_attribute(kind=kind, name=field_name)
         return uuids
 
-    def _scope(self, schema: MainSchemaTypes) -> UniquenessScopeForKind:
+    def _scope(self, schema_branch: SchemaBranch, schema: MainSchemaTypes) -> UniquenessScopeForKind:
         cached = self._scope_cache.get(schema.kind)
         if cached is None:
-            cached = self._compute_scope(schema=schema)
+            cached = self._compute_scope(schema_branch=schema_branch, schema=schema)
             self._scope_cache[schema.kind] = cached
         return cached
 
-    def _compute_scope(self, schema: MainSchemaTypes) -> UniquenessScopeForKind:
+    def _compute_scope(self, schema_branch: SchemaBranch, schema: MainSchemaTypes) -> UniquenessScopeForKind:
         """Compute why and how a data change implicates `schema`'s uniqueness.
 
         Uniqueness spans single unique attributes and multi-field constraint groups, each element of
@@ -151,7 +150,7 @@ class UniquenessConstraintScoper:
         """
         fragments = [
             *self._unique_attribute_fragments(schema=schema),
-            *self._uniqueness_constraint_fragments(schema=schema),
+            *self._uniqueness_constraint_fragments(schema_branch=schema_branch, schema=schema),
         ]
         return UniquenessScopeForKind(
             requires_validation=bool(fragments),
@@ -168,12 +167,14 @@ class UniquenessConstraintScoper:
         )
         return [fragment for fragment in fragments if fragment is not None]
 
-    def _uniqueness_constraint_fragments(self, schema: MainSchemaTypes) -> list[UniquenessScopeFragment]:
+    def _uniqueness_constraint_fragments(
+        self, schema_branch: SchemaBranch, schema: MainSchemaTypes
+    ) -> list[UniquenessScopeFragment]:
         fragments: list[UniquenessScopeFragment] = []
         for constraint_group in schema.uniqueness_constraints or []:
             for constraint_path in constraint_group:
                 try:
-                    schema_path = schema.parse_schema_path(path=constraint_path, schema=self.schema_branch)
+                    schema_path = schema.parse_schema_path(path=constraint_path, schema=schema_branch)
                 except AttributePathParsingError:
                     LOG.warning(f"Cannot parse {schema.kind}.uniqueness_constraints element '{constraint_path}'")
                     continue

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -552,8 +552,8 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
         db=database, schema=candidate_schema, diff_summary=diff_summary, branch=source_branch
     )
     constraints_from_schema_diff = validation_result.constraints
-    merger = build_constraint_info_merger(schema_branch=candidate_schema)
-    constraints = merger.merge(constraints_from_data_diff, constraints_from_schema_diff)
+    merger = build_constraint_info_merger()
+    constraints = merger.merge(candidate_schema, constraints_from_data_diff, constraints_from_schema_diff)
 
     if not constraints:
         return
@@ -608,8 +608,10 @@ async def _get_proposed_change_schema_integrity_constraints(
                 field_summary.add_attribute_node_uuid(name=element_name, node_uuid=node_id)
 
     async with db.start_session(read_only=True) as session_db:
-        determiner = build_constraint_validator_determiner(db=session_db, branch=branch, schema_branch=schema)
-        return await determiner.get_constraints(node_diffs=list(node_diff_field_summary_map.values()))
+        determiner = build_constraint_validator_determiner(db=session_db, branch=branch)
+        return await determiner.get_constraints(
+            schema_branch=schema, node_diffs=list(node_diff_field_summary_map.values())
+        )
 
 
 @flow(name="proposed-changed-repository-checks", flow_run_name="Process user defined checks")

--- a/backend/tests/component/core/constraint_validators/test_determiner.py
+++ b/backend/tests/component/core/constraint_validators/test_determiner.py
@@ -35,14 +35,10 @@ class _NoDependentsResolver:
         return set()
 
 
-def _build_determiner(schema_branch: SchemaBranch) -> ConstraintValidatorDeterminer:
+def _build_determiner() -> ConstraintValidatorDeterminer:
     node_diff_index = NodeDiffIndex()
-    scoper = UniquenessConstraintScoper(
-        schema_branch=schema_branch, dependent_resolver=_NoDependentsResolver(), node_diff_index=node_diff_index
-    )
-    return ConstraintValidatorDeterminer(
-        schema_branch=schema_branch, node_diff_index=node_diff_index, uniqueness_scoper=scoper
-    )
+    scoper = UniquenessConstraintScoper(dependent_resolver=_NoDependentsResolver(), node_diff_index=node_diff_index)
+    return ConstraintValidatorDeterminer(node_diff_index=node_diff_index, uniqueness_scoper=scoper)
 
 
 def node_constraint(kind: str, property_name: str) -> SchemaUpdateConstraintInfo:
@@ -190,9 +186,9 @@ def person_cars_node_diff(
 class TestConstraintDeterminer:
     async def test_no_node_diffs(self, car_person_schema: SchemaBranch, default_branch: Branch) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
 
-        constraints = await determiner.get_constraints(node_diffs=[])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[])
 
         assert constraints == []
 
@@ -203,10 +199,10 @@ class TestConstraintDeterminer:
         person_name_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_name_node_diff
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         relevant_constraints = [
             c
@@ -224,10 +220,10 @@ class TestConstraintDeterminer:
         person_cars_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_cars_node_diff
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert len(constraints) == len(constraint_info_set)
         assert constraint_info_set == set(constraints)
@@ -245,7 +241,7 @@ class TestConstraintDeterminer:
         name_attr_schema.parameters.max_length = 30
         car_schema = schema_branch.get(name="TestCar", duplicate=False)
         car_schema.uniqueness_constraints = [["owner", "color__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_name_node_diff
         max_length_param_constraint_info = SchemaUpdateConstraintInfo(
             constraint_name=ConstraintIdentifier.ATTRIBUTE_PARAMETERS_MAX_LENGTH_UPDATE.value,
@@ -259,7 +255,7 @@ class TestConstraintDeterminer:
         constraint_info_set.add(node_uniqueness_constraint("TestPerson", node_uuids=[CHANGED_PERSON_UUID]))
         constraint_info_set.add(max_length_param_constraint_info)
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert set(constraints) == constraint_info_set
 
@@ -272,14 +268,14 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         car_schema = schema_branch.get(name="TestCar", duplicate=False)
         car_schema.uniqueness_constraints = [["owner__name", "color__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_name_node_diff
         constraint_info_set.add(node_uniqueness_constraint("TestPerson", node_uuids=[CHANGED_PERSON_UUID]))
         # TestCar's constraint reads the name attribute of the related TestPerson, so a TestPerson
         # data change can violate it even though TestCar itself has no diff.
         constraint_info_set.add(node_uniqueness_constraint("TestCar"))
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert set(constraints) == constraint_info_set
 
@@ -291,7 +287,7 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         generic_schema = schema_branch.get(name="TestCar", duplicate=False)
         generic_schema.uniqueness_constraints = [["name__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff = NodeDiffFieldSummary(kind="TestElectricCar", attribute_node_uuids={"nbr_engine": set()})
         # nbr_engine participates in no uniqueness path, so the uniqueness check must not be
         # triggered on the implementation or on its generic; only the nbr_engine field constraints remain
@@ -301,7 +297,7 @@ class TestConstraintDeterminer:
             attribute_constraint("TestElectricCar", "nbr_engine", "unique"),
         }
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert set(constraints) == constraint_info_set
 
@@ -313,7 +309,7 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         generic_schema = schema_branch.get(name="TestCar", duplicate=False)
         generic_schema.uniqueness_constraints = [["name__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         # `name` is inherited from the generic; a generic-level uniqueness check spans every
         # implementing node, so changing name on an implementation must trigger the check on the
         # generic (TestCar) as well as on the implementation (TestElectricCar)
@@ -321,7 +317,7 @@ class TestConstraintDeterminer:
             kind="TestElectricCar", attribute_node_uuids={"name": {CHANGED_ELECTRIC_CAR_UUID}}
         )
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         # both the generic and the implementation checks are scoped to the changed implementation node
         expected = {
@@ -344,10 +340,10 @@ class TestConstraintDeterminer:
         # reading the peer's `name` must fire when an implementation of that generic (LocationSite)
         # changes `name`, even though the peer kind named in the path (LocationGeneric) has no diff
         thing_schema.uniqueness_constraints = [["location__name"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff = NodeDiffFieldSummary(kind="LocationSite", attribute_node_uuids={"name": set()})
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert node_uniqueness_constraint("TestThing") in set(constraints)
 
@@ -359,13 +355,13 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         car_schema = schema_branch.get(name="TestCar", duplicate=False)
         car_schema.uniqueness_constraints = [["owner__name", "color__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         # TestCar's uniqueness constraints read TestPerson.name; a change to an unrelated
         # TestPerson attribute, height, does not participate, so neither kind's uniqueness
         # check should trigger
         node_diff = NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"height": set()})
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         constraint_set = set(constraints)
         assert node_uniqueness_constraint("TestCar") not in constraint_set
@@ -378,12 +374,13 @@ class TestConstraintDeterminer:
         person_name_node_diff: tuple[NodeDiffFieldSummary, set[SchemaUpdateConstraintInfo]],
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_name_node_diff
         constraint_info_set.add(node_uniqueness_constraint("TestPerson", node_uuids=[CHANGED_PERSON_UUID]))
 
         constraints = await determiner.get_constraints(
-            node_diffs=[NodeDiffFieldSummary(kind="TestDeleted", attribute_node_uuids={"name": set()}), node_diff]
+            schema_branch=schema_branch,
+            node_diffs=[NodeDiffFieldSummary(kind="TestDeleted", attribute_node_uuids={"name": set()}), node_diff],
         )
 
         # TestDeleted is absent from the schema, so it contributes nothing; only TestPerson remains
@@ -398,21 +395,22 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.register_schema(
             schema=SchemaRoot(**internal_schema), branch=default_branch.name
         )
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         node_diff, constraint_info_set = person_name_node_diff
         constraint_info_set.add(node_uniqueness_constraint("TestPerson", node_uuids=[CHANGED_PERSON_UUID]))
 
-        constraints = await determiner.get_constraints(node_diffs=[node_diff])
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
         # internal schema kinds are absent from the diff, so none contribute constraints
         assert set(constraints) == constraint_info_set
 
         internal_kinds = {"SchemaNode", "SchemaGeneric", "SchemaAttribute", "SchemaRelationship"}
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         constraints = await determiner.get_constraints(
+            schema_branch=schema_branch,
             node_diffs=[
                 node_diff,
                 *(NodeDiffFieldSummary(kind=kind, attribute_node_uuids={"name": set()}) for kind in internal_kinds),
-            ]
+            ],
         )
         # once an internal schema kind is in the diff, its uniqueness constraint must be validated
         # (this is what catches duplicate schema elements when a branch is merged)
@@ -426,7 +424,7 @@ class TestConstraintDeterminer:
         default_branch: Branch,
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         # A hierarchy edge change surfaces on both endpoints: the child (LocationRack) records its
         # `parent` change and the parent (LocationSite) records its `children` change. Each endpoint
         # emits only the hierarchy constraint whose relationship actually changed there, and no
@@ -442,7 +440,7 @@ class TestConstraintDeterminer:
             *(relationship_constraint("LocationSite", "children", p) for p in RELATIONSHIP_PROPERTIES),
         }
 
-        constraints = await determiner.get_constraints(node_diffs=node_diffs)
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=node_diffs)
 
         assert set(constraints) == expected
 
@@ -455,13 +453,13 @@ class TestConstraintDeterminer:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         person_schema = schema_branch.get(name="TestPerson", duplicate=False)
         person_schema.uniqueness_constraints = [["does_not_exist__value"]]
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         # `height` is not a unique attribute, so evaluating uniqueness must fall through to parsing
         # the (unparseable) constraint group rather than short-circuiting on a unique attribute.
         node_diff = NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"height": set()})
 
         with caplog.at_level(logging.WARNING):
-            constraints = await determiner.get_constraints(node_diffs=[node_diff])
+            constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=[node_diff])
 
         assert "Cannot parse TestPerson.uniqueness_constraints element 'does_not_exist__value'" in caplog.text
         # the unparseable element is skipped in isolation, so no uniqueness check is emitted for the kind
@@ -473,12 +471,12 @@ class TestConstraintDeterminer:
         default_branch: Branch,
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        determiner = _build_determiner(schema_branch=schema_branch)
+        determiner = _build_determiner()
         # Re-parenting a rack changes only its `parent` relationship, so only the parent hierarchy
         # constraint may be emitted for that kind, never the children one.
         node_diffs = [NodeDiffFieldSummary(kind="LocationSite", relationship_node_uuids={"parent": set()})]
 
-        constraints = await determiner.get_constraints(node_diffs=node_diffs)
+        constraints = await determiner.get_constraints(schema_branch=schema_branch, node_diffs=node_diffs)
 
         constraint_set = set(constraints)
         assert node_constraint("LocationSite", "parent") in constraint_set

--- a/backend/tests/component/core/constraint_validators/test_uniqueness_checker_node_scoped.py
+++ b/backend/tests/component/core/constraint_validators/test_uniqueness_checker_node_scoped.py
@@ -155,12 +155,12 @@ class TestUniquenessCheckerNodeScoped:
         registry.schema.register_schema(schema=SchemaRoot(nodes=[car_schema]), branch=branch.name)
         synced_schema = registry.schema.get_node_schema(name="TestCar", branch=branch, duplicate=False)
 
-        determiner = build_constraint_validator_determiner(
-            db=db, branch=branch, schema_branch=registry.schema.get_schema_branch(name=branch.name)
-        )
+        determiner = build_constraint_validator_determiner(db=db, branch=branch)
         person_change = NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"height": {person_john_main.id}})
 
-        constraints = await determiner.get_constraints(node_diffs=[person_change])
+        constraints = await determiner.get_constraints(
+            schema_branch=registry.schema.get_schema_branch(name=branch.name), node_diffs=[person_change]
+        )
 
         car_constraint = next(
             c

--- a/backend/tests/component/core/constraint_validators/test_uniqueness_scope.py
+++ b/backend/tests/component/core/constraint_validators/test_uniqueness_scope.py
@@ -26,12 +26,10 @@ class _RecordingResolver:
         return set(self.dependents)
 
 
-def _scoper(schema_branch: SchemaBranch, resolver: _RecordingResolver, node_diffs: list[NodeDiffFieldSummary]):
+def _scoper(resolver: _RecordingResolver, node_diffs: list[NodeDiffFieldSummary]):
     node_diff_index = NodeDiffIndex()
     node_diff_index.initialize(node_diffs)
-    return UniquenessConstraintScoper(
-        schema_branch=schema_branch, dependent_resolver=resolver, node_diff_index=node_diff_index
-    )
+    return UniquenessConstraintScoper(dependent_resolver=resolver, node_diff_index=node_diff_index)
 
 
 class TestUniquenessConstraintScoper:
@@ -40,14 +38,16 @@ class TestUniquenessConstraintScoper:
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         scoper = _scoper(
-            schema_branch,
             _RecordingResolver(dependents=set()),
             [NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"name": {"person-1", "person-2"}})],
         )
         person_schema = schema_branch.get(name="TestPerson")
 
-        assert scoper.requires_validation(schema=person_schema) is True
-        assert await scoper.affected_node_uuids(schema=person_schema) == ["person-1", "person-2"]
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=person_schema) is True
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=person_schema) == [
+            "person-1",
+            "person-2",
+        ]
 
     async def test_scopes_only_nodes_that_changed_the_unique_field(
         self, car_person_schema: SchemaBranch, default_branch: Branch
@@ -55,7 +55,6 @@ class TestUniquenessConstraintScoper:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         # person-1 changed the unique "name"; person-2 only changed the non-unique "height"
         scoper = _scoper(
-            schema_branch,
             _RecordingResolver(dependents=set()),
             [
                 NodeDiffFieldSummary(
@@ -66,23 +65,22 @@ class TestUniquenessConstraintScoper:
         )
         person_schema = schema_branch.get(name="TestPerson")
 
-        assert scoper.requires_validation(schema=person_schema) is True
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=person_schema) is True
         # only person-1 is scoped; person-2's change does not participate in uniqueness
-        assert await scoper.affected_node_uuids(schema=person_schema) == ["person-1"]
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=person_schema) == ["person-1"]
 
     async def test_triggered_without_node_uuids_falls_back_to_full_scan(
         self, car_person_schema: SchemaBranch, default_branch: Branch
     ) -> None:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         scoper = _scoper(
-            schema_branch,
             _RecordingResolver(dependents=set()),
             [NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"name": set()})],
         )
         person_schema = schema_branch.get(name="TestPerson")
 
-        assert scoper.requires_validation(schema=person_schema) is True
-        assert await scoper.affected_node_uuids(schema=person_schema) is None
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=person_schema) is True
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=person_schema) is None
 
     async def test_unrelated_field_change_does_not_trigger(
         self, car_person_schema: SchemaBranch, default_branch: Branch
@@ -90,14 +88,13 @@ class TestUniquenessConstraintScoper:
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         # height is not part of any TestPerson uniqueness constraint
         scoper = _scoper(
-            schema_branch,
             _RecordingResolver(dependents=set()),
             [NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"height": {"person-1"}})],
         )
         person_schema = schema_branch.get(name="TestPerson")
 
-        assert scoper.requires_validation(schema=person_schema) is False
-        assert await scoper.affected_node_uuids(schema=person_schema) is None
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=person_schema) is False
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=person_schema) is None
 
     async def test_cross_kind_peer_change_resolves_dependents(
         self, car_person_schema: SchemaBranch, default_branch: Branch
@@ -111,14 +108,13 @@ class TestUniquenessConstraintScoper:
         resolver = _RecordingResolver(dependents={"car-1", "car-2"})
         # a change to the peer kind's name, with no change to TestCar itself
         scoper = _scoper(
-            schema_branch,
             resolver,
             [NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"name": {"person-1"}})],
         )
         car_schema = schema_branch.get(name="TestCar")
 
-        assert scoper.requires_validation(schema=car_schema) is True
-        assert await scoper.affected_node_uuids(schema=car_schema) == ["car-1", "car-2"]
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=car_schema) is True
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=car_schema) == ["car-1", "car-2"]
         # the peer change is routed to the resolver as a single call carrying the changed peer uuids
         owner_relationship = car_schema.get_relationship(name="owner")
         assert resolver.calls == [
@@ -137,12 +133,11 @@ class TestUniquenessConstraintScoper:
         resolver = _RecordingResolver(dependents={"car-1"})
         # the peer changed but its node uuids are unknown, so the dependents cannot be resolved
         scoper = _scoper(
-            schema_branch,
             resolver,
             [NodeDiffFieldSummary(kind="TestPerson", attribute_node_uuids={"name": set()})],
         )
         car_schema = schema_branch.get(name="TestCar")
 
-        assert scoper.requires_validation(schema=car_schema) is True
-        assert await scoper.affected_node_uuids(schema=car_schema) is None
+        assert scoper.requires_validation(schema_branch=schema_branch, schema=car_schema) is True
+        assert await scoper.affected_node_uuids(schema_branch=schema_branch, schema=car_schema) is None
         assert not resolver.calls  # resolver is never called when the peer uuids are unknown

--- a/backend/tests/component/core/diff/test_coordinator_lock.py
+++ b/backend/tests/component/core/diff/test_coordinator_lock.py
@@ -20,6 +20,8 @@ from infrahub.core.node import Node
 from infrahub.core.rollback import GraphRollbacker
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
+from infrahub.core.validators.constraint_merge import build_constraint_info_merger
+from infrahub.core.validators.determiner import build_constraint_validator_determiner
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import get_component_registry
@@ -209,9 +211,10 @@ class TestDiffCoordinatorLocks:
                 schema_manager=registry.schema,
             ),
             constraint_validator=MergeConstraintValidator(
-                db=db,
                 branch=diff_branch,
                 diff_repository=diff_repository,
+                determiner=build_constraint_validator_determiner(db=db, branch=diff_branch),
+                constraint_info_merger=build_constraint_info_merger(),
                 migration_validator=schema_validate_migrations,
             ),
         )
@@ -267,9 +270,10 @@ class TestDiffCoordinatorLocks:
                 schema_manager=registry.schema,
             ),
             constraint_validator=MergeConstraintValidator(
-                db=db2,
                 branch=diff_branch,
                 diff_repository=diff_repository_2,
+                determiner=build_constraint_validator_determiner(db=db2, branch=diff_branch),
+                constraint_info_merger=build_constraint_info_merger(),
                 migration_validator=schema_validate_migrations,
             ),
         )

--- a/backend/tests/integration/merge/test_merge_uniqueness_field_scoping.py
+++ b/backend/tests/integration/merge/test_merge_uniqueness_field_scoping.py
@@ -1,0 +1,160 @@
+"""Merge-time uniqueness validation when only some changed fields participate in the constraint.
+
+The check is scoped to the nodes whose changed field participates in the kind's uniqueness, so a
+diff mixing a participating and a non-participating change must still reach the participating one.
+Both branches here change data only, keeping the node-scoped path in play — a branch that also
+carries a schema change is validated against the whole population instead.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema import SchemaRoot
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+BLOCKED_BRANCH = "uniqueness_scoping_relationship"
+CLEAN_BRANCH = "uniqueness_scoping_unrelated"
+
+BRANCH_MERGE_MUTATION = """
+mutation($branch: String!) {
+    BranchMerge(data: { name: $branch }) {
+        ok
+    }
+}
+"""
+
+
+async def _get_car(db: InfrahubDatabase, car_id: str, branch: Branch | str) -> Node:
+    return await NodeManager.get_one(db=db, id=car_id, branch=branch, kind=TestKind.CAR, raise_on_error=True)
+
+
+class TestMergeUniquenessFieldScoping(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    def car_schema_unique_owner_name(self) -> SchemaRoot:
+        """Cars made unique by their owner together with their name.
+
+        "owner" is a relationship and "name__value" an attribute, so a change to either half
+        implicates the constraint while "color"/"description" changes cannot.
+        """
+        schema = copy.deepcopy(CAR_SCHEMA)
+        car = next(node for node in schema.nodes if node.kind == TestKind.CAR)
+        car.uniqueness_constraints = [["owner", "name__value"]]
+        return schema
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+        prefect_test_fixture: None,
+        car_schema_unique_owner_name: SchemaRoot,
+    ) -> dict[str, str]:
+        """Two cars named "civic" kept distinct only by their owner, plus an unrelated "accord"."""
+        await load_schema(db, schema=car_schema_unique_owner_name)
+
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175)
+        await john.save(db=db)
+        jane = await Node.init(schema=TestKind.PERSON, db=db)
+        await jane.new(db=db, name="Jane", height=165)
+        await jane.save(db=db)
+        honda = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await honda.new(db=db, name="honda")
+        await honda.save(db=db)
+
+        civic_john = await Node.init(schema=TestKind.CAR, db=db)
+        await civic_john.new(db=db, name="civic", color="blue", owner=john, manufacturer=honda)
+        await civic_john.save(db=db)
+        civic_jane = await Node.init(schema=TestKind.CAR, db=db)
+        await civic_jane.new(db=db, name="civic", color="red", owner=jane, manufacturer=honda)
+        await civic_jane.save(db=db)
+        accord_john = await Node.init(schema=TestKind.CAR, db=db)
+        await accord_john.new(db=db, name="accord", color="green", owner=john, manufacturer=honda)
+        await accord_john.save(db=db)
+
+        return {
+            "john": john.id,
+            "jane": jane.id,
+            "civic_john": civic_john.id,
+            "civic_jane": civic_jane.id,
+            "accord_john": accord_john.id,
+        }
+
+    async def test_participating_relationship_change_blocks_merge(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, str],
+        client: InfrahubClient,
+    ) -> None:
+        """A re-owned car collides on (owner, name) even though no node changed the name attribute.
+
+        The branch also changes another car's color, a field no constraint group reads, so the
+        participating change is the relationship one and it is the only reason to validate.
+        """
+        await client.branch.create(branch_name=BLOCKED_BRANCH)
+
+        civic_jane_branch = await _get_car(db=db, car_id=initial_dataset["civic_jane"], branch=BLOCKED_BRANCH)
+        await civic_jane_branch.get_relationship("owner").update(db=db, data=initial_dataset["john"])
+        await civic_jane_branch.save(db=db)
+        accord_branch = await _get_car(db=db, car_id=initial_dataset["accord_john"], branch=BLOCKED_BRANCH)
+        accord_branch.get_attribute("color").value = "black"
+        await accord_branch.save(db=db)
+
+        with pytest.raises(GraphQLError) as exc:
+            await client.execute_graphql(query=BRANCH_MERGE_MUTATION, variables={"branch": BLOCKED_BRANCH})
+
+        message = exc.value.message
+        civic_john_branch = await _get_car(db=db, car_id=initial_dataset["civic_john"], branch=BLOCKED_BRANCH)
+        for car in (civic_jane_branch, civic_john_branch):
+            display_label = await car.get_display_label(db=db)
+            assert (
+                f"Node-level 'uniqueness_constraints' constraint violation on schema '{TestKind.CAR}'."
+                f" Node ({display_label}) is not compliant."
+            ) in message
+        # the car whose only change is a non-participating field is never implicated
+        assert await accord_branch.get_display_label(db=db) not in message
+
+        # main keeps both owners, so it never holds two cars named "civic" with the same owner
+        civic_jane_main = await _get_car(db=db, car_id=initial_dataset["civic_jane"], branch=default_branch)
+        owner_main = await civic_jane_main.get_relationship("owner").get_peer(db=db, raise_on_error=True)
+        assert owner_main.id == initial_dataset["jane"]
+        accord_main = await _get_car(db=db, car_id=initial_dataset["accord_john"], branch=default_branch)
+        assert accord_main.get_attribute("color").value == "green"
+
+    async def test_non_participating_change_alone_merges(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, str],
+        client: InfrahubClient,
+    ) -> None:
+        """A branch touching only a field outside every constraint group merges without a violation."""
+        await client.branch.create(branch_name=CLEAN_BRANCH)
+
+        civic_john_branch = await _get_car(db=db, car_id=initial_dataset["civic_john"], branch=CLEAN_BRANCH)
+        civic_john_branch.get_attribute("description").value = "the blue one"
+        await civic_john_branch.save(db=db)
+
+        await client.execute_graphql(query=BRANCH_MERGE_MUTATION, variables={"branch": CLEAN_BRANCH})
+
+        civic_john_main = await _get_car(db=db, car_id=initial_dataset["civic_john"], branch=default_branch)
+        assert civic_john_main.get_attribute("description").value == "the blue one"

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -186,9 +186,9 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
         with pytest.raises(GraphQLError) as exc:
             await client.branch.rebase(branch_name=branch_2.name)
 
-            assert initial_dataset["accord"] in exc.value.message
-            assert another_civic.id in exc.value.message
-            assert "node.uniqueness_constraints.update" in exc.value.message
+        assert initial_dataset["accord"] in exc.value.message
+        assert another_civic.id in exc.value.message
+        assert "node.uniqueness_constraints.update" in exc.value.message
 
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
         await verify_no_duplicate_relationships(db=db)

--- a/backend/tests/unit/core/validators/test_constraint_deduplicator.py
+++ b/backend/tests/unit/core/validators/test_constraint_deduplicator.py
@@ -77,91 +77,91 @@ def _remaining_uniqueness_kinds(constraints: list[SchemaUpdateConstraintInfo]) -
 
 class TestUniquenessConstraintDeduplicator:
     def test_inherited_node_dropped_when_generic_covers_it_full_population(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [_uniqueness_info("TestCar"), _uniqueness_info("TestElectricCar")]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar"}
 
     def test_all_implementers_dropped_when_generic_covers_them(self) -> None:
         # the generic's scope is the union of the implementers' changed nodes
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [
             _uniqueness_info("TestCar", node_uuids=["e1", "g1"]),
             _uniqueness_info("TestElectricCar", node_uuids=["e1"]),
             _uniqueness_info("TestGazCar", node_uuids=["g1"]),
         ]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar"}
 
     def test_node_with_own_group_is_kept(self) -> None:
         # SpecialCar has a `special` group the generic does not cover, so it cannot be dropped
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [_uniqueness_info("TestCar"), _uniqueness_info("TestSpecialCar")]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar", "TestSpecialCar"}
 
     def test_full_population_node_not_dropped_for_scoped_generic(self) -> None:
         # dropping a full-population node for a scoped generic would silently narrow the check
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [
             _uniqueness_info("TestCar", node_uuids=["e1"]),
             _uniqueness_info("TestElectricCar", node_uuids=None),
         ]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar", "TestElectricCar"}
 
     def test_node_not_dropped_when_generic_scope_does_not_cover_it(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [
             _uniqueness_info("TestCar", node_uuids=["other"]),
             _uniqueness_info("TestElectricCar", node_uuids=["e1"]),
         ]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar", "TestElectricCar"}
 
     def test_scoped_node_dropped_when_generic_scope_is_superset(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [
             _uniqueness_info("TestCar", node_uuids=["e1", "e2", "g1"]),
             _uniqueness_info("TestElectricCar", node_uuids=["e1", "e2"]),
         ]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar"}
 
     def test_node_kept_when_generic_absent_from_set(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [_uniqueness_info("TestElectricCar")]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestElectricCar"}
 
     def test_standalone_node_is_kept(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         constraints = [_uniqueness_info("TestCar"), _uniqueness_info("TestPerson")]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar", "TestPerson"}
 
     def test_non_uniqueness_constraints_pass_through(self) -> None:
-        deduplicator = UniquenessConstraintDeduplicator(schema_branch=_schema_branch())
+        deduplicator = UniquenessConstraintDeduplicator()
         attribute = _attribute_info("TestElectricCar")
         constraints = [_uniqueness_info("TestCar"), _uniqueness_info("TestElectricCar"), attribute]
 
-        result = deduplicator.deduplicate(constraints)
+        result = deduplicator.deduplicate(schema_branch=_schema_branch(), constraints=constraints)
 
         assert _remaining_uniqueness_kinds(result) == {"TestCar"}
         assert attribute in result

--- a/backend/tests/unit/core/validators/test_constraint_merge.py
+++ b/backend/tests/unit/core/validators/test_constraint_merge.py
@@ -46,27 +46,28 @@ class TestConstraintInfoMergerPrecedence:
 
     def test_full_scan_wins_over_node_scoped(self) -> None:
         # a constraint both broadened (schema diff, full scan) and data-changed collapses to a full scan
-        merger = build_constraint_info_merger(schema_branch=_schema_branch())
+        merger = build_constraint_info_merger()
         data_diff = [_uniqueness_info("TestCar", node_uuids=["a", "b"])]
         schema_diff = [_uniqueness_info("TestCar", node_uuids=None)]
 
-        result = merger.merge(data_diff, schema_diff)
+        result = merger.merge(_schema_branch(), data_diff, schema_diff)
 
         assert result == [_uniqueness_info("TestCar", node_uuids=None)]
 
     def test_full_scan_wins_regardless_of_order(self) -> None:
-        merger = build_constraint_info_merger(schema_branch=_schema_branch())
+        merger = build_constraint_info_merger()
         schema_diff = [_uniqueness_info("TestCar", node_uuids=None)]
         data_diff = [_uniqueness_info("TestCar", node_uuids=["a", "b"])]
 
-        result = merger.merge(schema_diff, data_diff)
+        result = merger.merge(_schema_branch(), schema_diff, data_diff)
 
         assert result == [_uniqueness_info("TestCar", node_uuids=None)]
 
     def test_two_node_scoped_entries_union_their_nodes(self) -> None:
-        merger = build_constraint_info_merger(schema_branch=_schema_branch())
+        merger = build_constraint_info_merger()
 
         result = merger.merge(
+            _schema_branch(),
             [_uniqueness_info("TestCar", node_uuids=["a", "b"])],
             [_uniqueness_info("TestCar", node_uuids=["b", "c"])],
         )
@@ -74,9 +75,10 @@ class TestConstraintInfoMergerPrecedence:
         assert result == [_uniqueness_info("TestCar", node_uuids=["a", "b", "c"])]
 
     def test_distinct_constraints_are_preserved(self) -> None:
-        merger = build_constraint_info_merger(schema_branch=_schema_branch())
+        merger = build_constraint_info_merger()
 
         result = merger.merge(
+            _schema_branch(),
             [_uniqueness_info("TestCar", node_uuids=["a"])],
             [_uniqueness_info("TestPerson", node_uuids=["b"])],
         )
@@ -88,14 +90,14 @@ class TestConstraintInfoMerger:
     def test_merges_then_deduplicates(self) -> None:
         # the data diff scopes the generic; the schema diff broadens it to the full population; and
         # the inherited node check must be dropped as covered by the generic
-        merger = build_constraint_info_merger(schema_branch=_schema_branch())
+        merger = build_constraint_info_merger()
         data_diff = [
             _uniqueness_info("TestCar", node_uuids=["e1"]),
             _uniqueness_info("TestElectricCar", node_uuids=["e1"]),
         ]
         schema_diff = [_uniqueness_info("TestCar", node_uuids=None)]
 
-        result = merger.merge(data_diff, schema_diff)
+        result = merger.merge(_schema_branch(), data_diff, schema_diff)
 
         # merge precedence keeps the full-population generic; dedup then removes the covered node
         assert result == [_uniqueness_info("TestCar", node_uuids=None)]


### PR DESCRIPTION
1. refactor `MergeConstraintValidator` to stop building components at runtime and use proper dependency injection. required passing `schema_branch` down through the call chain, but this is the correct way to do it
2. fix some broken assertions on a rebase uniqueness-related test. the assertions were within the exception capture following where the exception was raised, so would never be run
3. new integration test for node-scoped uniqueness constraints.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

