### PR TITLE
feat(attribute): store bare IP values on write when allow_prefix is disabled [INFP-551]

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -1047,17 +1047,6 @@ class IPHost(BaseAttribute):
     value: str
 
     @staticmethod
-    def _allows_prefix(schema: AttributeSchema) -> bool:
-        """Return whether the attribute accepts an address carrying a prefix.
-
-        Anything other than the per-kind parameters class cannot express the restriction, so the
-        permissive answer is the safe one for a base-classed schema.
-        """
-        if isinstance(schema.parameters, IPHostAttributeParameters):
-            return schema.parameters.allow_prefix
-        return True
-
-    @staticmethod
     def get_allowed_property_in_path() -> list[str]:
         return [
             "binary_address",
@@ -1150,6 +1139,12 @@ class IPHost(BaseAttribute):
         return convert_ip_to_binary_str(obj=self.obj)
 
     @classmethod
+    def _allows_prefix(cls, schema: AttributeSchema) -> bool:
+        if isinstance(schema.parameters, IPHostAttributeParameters):
+            return schema.parameters.allow_prefix
+        return True
+
+    @classmethod
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
         """Validate the format of the attribute.
 
@@ -1186,16 +1181,7 @@ class IPHost(BaseAttribute):
         return str(interface.ip)
 
     def _normalize_assigned_value(self, value: Any) -> Any:
-        """Return the bare form of a value assigned to an attribute that refuses a prefix.
-
-        An attribute that refuses a prefix has exactly one spelling for an address, and that has to
-        hold however the value arrived, so an edit converges on the same value a creation would have
-        stored. An attribute that accepts a prefix keeps whatever spelling it was given, because
-        normalising it would rewrite addresses already stored under a different one.
-
-        The value is validated first, so a prefix that is not permitted is reported rather than
-        quietly rewritten into an address that is.
-        """
+        """Return the bare form of a value assigned to an attribute that refuses a prefix."""
         if value is None or self._allows_prefix(schema=self.schema):
             return value
 

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -377,6 +377,16 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         """Return the canonical form of a value."""
         return value
 
+    def _normalize_assigned_value(self, value: Any) -> Any:
+        """Return the form of a value assigned after construction that a write path should keep.
+
+        A value is only normalised while the attribute is being built, so a value assigned afterwards
+        keeps the spelling its caller used. Re-normalising every kind here would rewrite values
+        already in the graph, so a kind opts in only where a single canonical form is part of its
+        contract.
+        """
+        return value
+
     async def save(
         self, db: InfrahubDatabase, user_id: str = SYSTEM_USER_ID, at: Timestamp | None = None
     ) -> AttributeChangelog | None:
@@ -444,6 +454,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         # Validate if the value is still correct, will raise a ValidationError if not
         self.validate(value=self.value, name=self.name, schema=self.schema)
+        self.value = self._normalize_assigned_value(self.value)
 
         # Check if the current value is still the default one
         if self.is_default:
@@ -636,7 +647,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
             if self.is_enum:
                 value_to_set = self.schema.convert_value_to_enum(data["value"])
             else:
-                value_to_set = data["value"]
+                value_to_set = self._normalize_assigned_value(data["value"])
             if value_to_set != self.value:
                 self.value = value_to_set
                 changed = True
@@ -1173,6 +1184,23 @@ class IPHost(BaseAttribute):
         if self._allows_prefix(schema=self.schema):
             return interface.with_prefixlen
         return str(interface.ip)
+
+    def _normalize_assigned_value(self, value: Any) -> Any:
+        """Return the bare form of a value assigned to an attribute that refuses a prefix.
+
+        An attribute that refuses a prefix has exactly one spelling for an address, and that has to
+        hold however the value arrived, so an edit converges on the same value a creation would have
+        stored. An attribute that accepts a prefix keeps whatever spelling it was given, because
+        normalising it would rewrite addresses already stored under a different one.
+
+        The value is validated first, so a prefix that is not permitted is reported rather than
+        quietly rewritten into an address that is.
+        """
+        if value is None or self._allows_prefix(schema=self.schema):
+            return value
+
+        self.validate(value=value, name=self.name, schema=self.schema)
+        return self._normalize_value(value)
 
     def get_db_node_type(self) -> AttributeDBNodeType:
         if self.value is not None:

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -42,7 +42,7 @@ from infrahub.log import get_logger
 
 from ..types import is_large_attribute_type
 from .constants.relationship_label import RELATIONSHIP_TO_NODE_LABEL, RELATIONSHIP_TO_VALUE_LABEL
-from .schema.attribute_parameters import NumberAttributeParameters
+from .schema.attribute_parameters import IPHostAttributeParameters, NumberAttributeParameters
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -1036,6 +1036,17 @@ class IPHost(BaseAttribute):
     value: str
 
     @staticmethod
+    def _allows_prefix(schema: AttributeSchema) -> bool:
+        """Return whether the attribute accepts an address carrying a prefix.
+
+        Anything other than the per-kind parameters class cannot express the restriction, so the
+        permissive answer is the safe one for a base-classed schema.
+        """
+        if isinstance(schema.parameters, IPHostAttributeParameters):
+            return schema.parameters.allow_prefix
+        return True
+
+    @staticmethod
     def get_allowed_property_in_path() -> list[str]:
         return [
             "binary_address",
@@ -1143,12 +1154,25 @@ class IPHost(BaseAttribute):
         super().validate_format(value=value, name=name, schema=schema)
 
         try:
-            ipaddress.ip_interface(value)
+            interface = ipaddress.ip_interface(value)
         except ValueError as exc:
             raise ValidationError({name: f"{value} is not a valid {schema.kind}"}) from exc
 
+        if cls._allows_prefix(schema=schema):
+            return
+
+        # A host mask is redundant rather than a prefix, so the comparison is against the host length
+        # of the parsed address' own version -- a `/32` is a subnet prefix on an IPv6 address.
+        if interface.network.prefixlen != interface.ip.max_prefixlen:
+            raise ValidationError(
+                {name: f"{value} is not a valid {schema.kind} because a subnet prefix is not permitted"}
+            )
+
     def _normalize_value(self, value: Any) -> str:
-        return ipaddress.ip_interface(value).with_prefixlen
+        interface = ipaddress.ip_interface(value)
+        if self._allows_prefix(schema=self.schema):
+            return interface.with_prefixlen
+        return str(interface.ip)
 
     def get_db_node_type(self) -> AttributeDBNodeType:
         if self.value is not None:

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -2299,6 +2299,15 @@ async def empty_database(db: InfrahubDatabase, delete_all_nodes_in_db: None) -> 
 
 @pytest.fixture
 async def init_nodes_registry(db: InfrahubDatabase) -> None:
+    do_init_nodes_registry()
+
+
+@pytest.fixture(scope="class")
+async def init_nodes_registry_scope_class(db: InfrahubDatabase) -> None:
+    do_init_nodes_registry()
+
+
+def do_init_nodes_registry() -> None:
     registry.node["Node"] = Node
     registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
     registry.node[InfrahubKind.IPPREFIXPOOL] = CoreIPPrefixPool

--- a/backend/tests/component/core/schema_manager/test_iphost_default_value.py
+++ b/backend/tests/component/core/schema_manager/test_iphost_default_value.py
@@ -1,0 +1,132 @@
+"""How an `IPHost` attribute's `default_value` is treated when the attribute refuses a prefix."""
+
+import copy
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from tests.helpers.schema import load_schema
+from tests.helpers.schema.dns_record import DNS_RECORD_DICT
+
+from .conftest import _get_schema_by_kind
+
+
+@dataclass
+class IPHostDefaultValueTestCase:
+    name: str
+    default_value: str
+    parameters: dict[str, Any] | None = None
+    recorded_default: str | None = None
+    expected_error: str | None = None
+
+
+IPHOST_DEFAULT_VALUE_CASES = [
+    IPHostDefaultValueTestCase(
+        name="declared_host_mask_is_rejected",
+        default_value="10.0.0.1/32",
+        parameters={"allow_prefix": False},
+        expected_error="10.0.0.1/32 is not a valid default value for something because a prefix is not permitted",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_bare_is_recorded_bare",
+        default_value="10.0.0.1",
+        parameters={"allow_prefix": False},
+        recorded_default="10.0.0.1",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_ipv6_host_mask_is_rejected",
+        default_value="2001:db8::1/128",
+        parameters={"allow_prefix": False},
+        expected_error="2001:db8::1/128 is not a valid default value for something because a prefix is not permitted",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_subnet_prefix_is_rejected",
+        default_value="10.0.0.1/24",
+        parameters={"allow_prefix": False},
+        expected_error="10.0.0.1/24 is not a valid default value for something because a prefix is not permitted",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_ipv6_subnet_prefix_is_rejected",
+        default_value="2001:db8::1/64",
+        parameters={"allow_prefix": False},
+        expected_error="2001:db8::1/64 is not a valid default value for something because a prefix is not permitted",
+    ),
+    IPHostDefaultValueTestCase(
+        name="undeclared_subnet_prefix_is_accepted",
+        default_value="10.0.0.1/24",
+        recorded_default="10.0.0.1/24",
+    ),
+    IPHostDefaultValueTestCase(
+        name="undeclared_host_mask_is_kept",
+        default_value="10.0.0.1/32",
+        recorded_default="10.0.0.1/32",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", IPHOST_DEFAULT_VALUE_CASES, ids=lambda case: case.name)
+async def test_validate_default_value_iphost_prefix_policy(
+    schema_all_in_one: dict[str, Any], case: IPHostDefaultValueTestCase
+) -> None:
+    """A declared attribute refuses a prefixed default; an undeclared one records whatever it was given.
+
+    A rejected case never reaches the default-value validation below: the refusal happens while the
+    attribute's own model is validated, which is what keeps a subnet prefix from being reported twice.
+    """
+    attribute: dict[str, Any] = {
+        "name": "something",
+        "kind": "IPHost",
+        "optional": True,
+        "default_value": case.default_value,
+    }
+    if case.parameters is not None:
+        attribute["parameters"] = case.parameters
+    schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
+    schema_dict["attributes"].append(attribute)
+
+    if case.expected_error is not None:
+        with pytest.raises(PydanticValidationError, match=re.escape(case.expected_error)):
+            SchemaRoot(**schema_all_in_one)
+        return
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
+
+    schema.validate_default_values()
+
+    assert schema.get(name="InfraTinySchema").get_attribute(name="something").default_value == case.recorded_default
+
+
+async def test_bare_iphost_default_value_reaches_a_node_bare(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    definition = copy.deepcopy(DNS_RECORD_DICT)
+    # v6_target is allow_prefix=False
+    defaults = {"v6_target": "2001:db8::1", "mgmt_ip": "10.0.0.1"}
+    for attribute in definition["attributes"]:
+        if attribute["name"] in defaults:
+            attribute["default_value"] = defaults[attribute["name"]]
+    await load_schema(db=db, schema=SchemaRoot(nodes=[definition]))
+
+    node = await Node.init(db=db, schema="TestingDnsRecord", branch=default_branch)
+    await node.new(db=db, dns_target="10.10.10.10")
+    await node.save(db=db)
+
+    reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
+
+    assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+    assert reloaded.get_attribute("v6_target").is_default is True
+    assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
+    assert reloaded.get_attribute("mgmt_ip").is_default is True

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from infrahub_sdk.utils import compare_lists
+from pydantic import ValidationError as PydanticValidationError
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -49,7 +50,7 @@ from tests.conftest import TestHelper
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING, load_schema
 from tests.helpers.schema.device import LAG_INTERFACE
-from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
+from tests.helpers.schema.dns_record import DNS_RECORD_DICT
 
 from .conftest import _get_schema_by_kind
 
@@ -2285,10 +2286,10 @@ class IPHostDefaultValueTestCase:
 
 IPHOST_DEFAULT_VALUE_CASES = [
     IPHostDefaultValueTestCase(
-        name="declared_host_mask_is_recorded_bare",
+        name="declared_host_mask_is_rejected",
         default_value="10.0.0.1/32",
         parameters={"allow_prefix": False},
-        recorded_default="10.0.0.1",
+        expected_error="10.0.0.1/32 is not a valid default value for something because a prefix is not permitted",
     ),
     IPHostDefaultValueTestCase(
         name="declared_bare_is_recorded_bare",
@@ -2297,28 +2298,22 @@ IPHOST_DEFAULT_VALUE_CASES = [
         recorded_default="10.0.0.1",
     ),
     IPHostDefaultValueTestCase(
-        name="declared_ipv6_host_mask_is_recorded_bare",
+        name="declared_ipv6_host_mask_is_rejected",
         default_value="2001:db8::1/128",
         parameters={"allow_prefix": False},
-        recorded_default="2001:db8::1",
+        expected_error="2001:db8::1/128 is not a valid default value for something because a prefix is not permitted",
     ),
     IPHostDefaultValueTestCase(
         name="declared_subnet_prefix_is_rejected",
         default_value="10.0.0.1/24",
         parameters={"allow_prefix": False},
-        expected_error=(
-            "InfraTinySchema: default value 10.0.0.1/24 is not a valid IPHost "
-            "because a subnet prefix is not permitted at something"
-        ),
+        expected_error="10.0.0.1/24 is not a valid default value for something because a prefix is not permitted",
     ),
     IPHostDefaultValueTestCase(
         name="declared_ipv6_subnet_prefix_is_rejected",
         default_value="2001:db8::1/64",
         parameters={"allow_prefix": False},
-        expected_error=(
-            "InfraTinySchema: default value 2001:db8::1/64 is not a valid IPHost "
-            "because a subnet prefix is not permitted at something"
-        ),
+        expected_error="2001:db8::1/64 is not a valid default value for something because a prefix is not permitted",
     ),
     IPHostDefaultValueTestCase(
         name="undeclared_subnet_prefix_is_accepted",
@@ -2337,6 +2332,11 @@ IPHOST_DEFAULT_VALUE_CASES = [
 async def test_validate_default_value_iphost_prefix_policy(
     schema_all_in_one: dict[str, Any], case: IPHostDefaultValueTestCase
 ) -> None:
+    """A declared attribute refuses a prefixed default; an undeclared one records whatever it was given.
+
+    A rejected case never reaches the default-value validation below: the refusal happens while the
+    attribute's own model is validated, which is what keeps a subnet prefix from being reported twice.
+    """
     attribute: dict[str, Any] = {
         "name": "something",
         "kind": "IPHost",
@@ -2348,13 +2348,13 @@ async def test_validate_default_value_iphost_prefix_policy(
     schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
     schema_dict["attributes"].append(attribute)
 
+    if case.expected_error is not None:
+        with pytest.raises(PydanticValidationError, match=re.escape(case.expected_error)):
+            SchemaRoot(**schema_all_in_one)
+        return
+
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
-
-    if case.expected_error is not None:
-        with pytest.raises(ValidationError, match=rf"^{re.escape(case.expected_error)}$"):
-            schema.validate_default_values()
-        return
 
     schema.validate_default_values()
 
@@ -2367,8 +2367,8 @@ async def test_bare_iphost_default_value_reaches_a_node_bare(
     register_core_models_schema: SchemaBranch,
     init_nodes_registry: None,
 ) -> None:
-    definition = copy.deepcopy(DNS_RECORD_DEFINITION)
-    defaults = {"v6_target": "2001:db8::1/128", "mgmt_ip": "10.0.0.1"}
+    definition = copy.deepcopy(DNS_RECORD_DICT)
+    defaults = {"v6_target": "2001:db8::1", "mgmt_ip": "10.0.0.1"}
     for attribute in definition["attributes"]:
         if attribute["name"] in defaults:
             attribute["default_value"] = defaults[attribute["name"]]

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -47,8 +47,9 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from tests.conftest import TestHelper
 from tests.constants import TestKind
-from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING
+from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING, load_schema
 from tests.helpers.schema.device import LAG_INTERFACE
+from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
 
 from .conftest import _get_schema_by_kind
 
@@ -2271,6 +2272,118 @@ async def test_validate_default_value_error(
 
     with pytest.raises(ValidationError, match=expected_error):
         schema.validate_default_values()
+
+
+@dataclass
+class IPHostDefaultValueTestCase:
+    name: str
+    default_value: str
+    parameters: dict[str, Any] | None = None
+    recorded_default: str | None = None
+    expected_error: str | None = None
+
+
+IPHOST_DEFAULT_VALUE_CASES = [
+    IPHostDefaultValueTestCase(
+        name="declared_host_mask_is_recorded_bare",
+        default_value="10.0.0.1/32",
+        parameters={"allow_prefix": False},
+        recorded_default="10.0.0.1",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_bare_is_recorded_bare",
+        default_value="10.0.0.1",
+        parameters={"allow_prefix": False},
+        recorded_default="10.0.0.1",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_ipv6_host_mask_is_recorded_bare",
+        default_value="2001:db8::1/128",
+        parameters={"allow_prefix": False},
+        recorded_default="2001:db8::1",
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_subnet_prefix_is_rejected",
+        default_value="10.0.0.1/24",
+        parameters={"allow_prefix": False},
+        expected_error=(
+            "InfraTinySchema: default value 10.0.0.1/24 is not a valid IPHost "
+            "because a subnet prefix is not permitted at something"
+        ),
+    ),
+    IPHostDefaultValueTestCase(
+        name="declared_ipv6_subnet_prefix_is_rejected",
+        default_value="2001:db8::1/64",
+        parameters={"allow_prefix": False},
+        expected_error=(
+            "InfraTinySchema: default value 2001:db8::1/64 is not a valid IPHost "
+            "because a subnet prefix is not permitted at something"
+        ),
+    ),
+    IPHostDefaultValueTestCase(
+        name="undeclared_subnet_prefix_is_accepted",
+        default_value="10.0.0.1/24",
+        recorded_default="10.0.0.1/24",
+    ),
+    IPHostDefaultValueTestCase(
+        name="undeclared_host_mask_is_kept",
+        default_value="10.0.0.1/32",
+        recorded_default="10.0.0.1/32",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", IPHOST_DEFAULT_VALUE_CASES, ids=lambda case: case.name)
+async def test_validate_default_value_iphost_prefix_policy(
+    schema_all_in_one: dict[str, Any], case: IPHostDefaultValueTestCase
+) -> None:
+    attribute: dict[str, Any] = {
+        "name": "something",
+        "kind": "IPHost",
+        "optional": True,
+        "default_value": case.default_value,
+    }
+    if case.parameters is not None:
+        attribute["parameters"] = case.parameters
+    schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
+    schema_dict["attributes"].append(attribute)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
+
+    if case.expected_error is not None:
+        with pytest.raises(ValidationError, match=rf"^{re.escape(case.expected_error)}$"):
+            schema.validate_default_values()
+        return
+
+    schema.validate_default_values()
+
+    assert schema.get(name="InfraTinySchema").get_attribute(name="something").default_value == case.recorded_default
+
+
+async def test_bare_iphost_default_value_reaches_a_node_bare(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    definition = copy.deepcopy(DNS_RECORD_DEFINITION)
+    defaults = {"v6_target": "2001:db8::1/128", "mgmt_ip": "10.0.0.1"}
+    for attribute in definition["attributes"]:
+        if attribute["name"] in defaults:
+            attribute["default_value"] = defaults[attribute["name"]]
+    await load_schema(db=db, schema=SchemaRoot(nodes=[definition]))
+
+    node = await Node.init(db=db, schema="TestingDnsRecord", branch=default_branch)
+    await node.new(db=db, dns_target="10.10.10.10")
+    await node.save(db=db)
+
+    reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
+
+    assert reloaded.v6_target.value == "2001:db8::1"
+    assert reloaded.v6_target.is_default is True
+    assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+    assert reloaded.mgmt_ip.is_default is True
 
 
 async def test_schema_branch_load_schema_extension(

--- a/backend/tests/component/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/component/core/schema_manager/test_manager_schema.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 from infrahub_sdk.utils import compare_lists
-from pydantic import ValidationError as PydanticValidationError
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -48,9 +47,8 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from tests.conftest import TestHelper
 from tests.constants import TestKind
-from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING, load_schema
+from tests.helpers.schema import CAR_SCHEMA, CHILD, DEVICE, DEVICE_SCHEMA, THING
 from tests.helpers.schema.device import LAG_INTERFACE
-from tests.helpers.schema.dns_record import DNS_RECORD_DICT
 
 from .conftest import _get_schema_by_kind
 
@@ -2273,117 +2271,6 @@ async def test_validate_default_value_error(
 
     with pytest.raises(ValidationError, match=expected_error):
         schema.validate_default_values()
-
-
-@dataclass
-class IPHostDefaultValueTestCase:
-    name: str
-    default_value: str
-    parameters: dict[str, Any] | None = None
-    recorded_default: str | None = None
-    expected_error: str | None = None
-
-
-IPHOST_DEFAULT_VALUE_CASES = [
-    IPHostDefaultValueTestCase(
-        name="declared_host_mask_is_rejected",
-        default_value="10.0.0.1/32",
-        parameters={"allow_prefix": False},
-        expected_error="10.0.0.1/32 is not a valid default value for something because a prefix is not permitted",
-    ),
-    IPHostDefaultValueTestCase(
-        name="declared_bare_is_recorded_bare",
-        default_value="10.0.0.1",
-        parameters={"allow_prefix": False},
-        recorded_default="10.0.0.1",
-    ),
-    IPHostDefaultValueTestCase(
-        name="declared_ipv6_host_mask_is_rejected",
-        default_value="2001:db8::1/128",
-        parameters={"allow_prefix": False},
-        expected_error="2001:db8::1/128 is not a valid default value for something because a prefix is not permitted",
-    ),
-    IPHostDefaultValueTestCase(
-        name="declared_subnet_prefix_is_rejected",
-        default_value="10.0.0.1/24",
-        parameters={"allow_prefix": False},
-        expected_error="10.0.0.1/24 is not a valid default value for something because a prefix is not permitted",
-    ),
-    IPHostDefaultValueTestCase(
-        name="declared_ipv6_subnet_prefix_is_rejected",
-        default_value="2001:db8::1/64",
-        parameters={"allow_prefix": False},
-        expected_error="2001:db8::1/64 is not a valid default value for something because a prefix is not permitted",
-    ),
-    IPHostDefaultValueTestCase(
-        name="undeclared_subnet_prefix_is_accepted",
-        default_value="10.0.0.1/24",
-        recorded_default="10.0.0.1/24",
-    ),
-    IPHostDefaultValueTestCase(
-        name="undeclared_host_mask_is_kept",
-        default_value="10.0.0.1/32",
-        recorded_default="10.0.0.1/32",
-    ),
-]
-
-
-@pytest.mark.parametrize("case", IPHOST_DEFAULT_VALUE_CASES, ids=lambda case: case.name)
-async def test_validate_default_value_iphost_prefix_policy(
-    schema_all_in_one: dict[str, Any], case: IPHostDefaultValueTestCase
-) -> None:
-    """A declared attribute refuses a prefixed default; an undeclared one records whatever it was given.
-
-    A rejected case never reaches the default-value validation below: the refusal happens while the
-    attribute's own model is validated, which is what keeps a subnet prefix from being reported twice.
-    """
-    attribute: dict[str, Any] = {
-        "name": "something",
-        "kind": "IPHost",
-        "optional": True,
-        "default_value": case.default_value,
-    }
-    if case.parameters is not None:
-        attribute["parameters"] = case.parameters
-    schema_dict = _get_schema_by_kind(schema_all_in_one, "InfraTinySchema")
-    schema_dict["attributes"].append(attribute)
-
-    if case.expected_error is not None:
-        with pytest.raises(PydanticValidationError, match=re.escape(case.expected_error)):
-            SchemaRoot(**schema_all_in_one)
-        return
-
-    schema = SchemaBranch(cache={}, name="test")
-    schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
-
-    schema.validate_default_values()
-
-    assert schema.get(name="InfraTinySchema").get_attribute(name="something").default_value == case.recorded_default
-
-
-async def test_bare_iphost_default_value_reaches_a_node_bare(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    register_core_models_schema: SchemaBranch,
-    init_nodes_registry: None,
-) -> None:
-    definition = copy.deepcopy(DNS_RECORD_DICT)
-    defaults = {"v6_target": "2001:db8::1", "mgmt_ip": "10.0.0.1"}
-    for attribute in definition["attributes"]:
-        if attribute["name"] in defaults:
-            attribute["default_value"] = defaults[attribute["name"]]
-    await load_schema(db=db, schema=SchemaRoot(nodes=[definition]))
-
-    node = await Node.init(db=db, schema="TestingDnsRecord", branch=default_branch)
-    await node.new(db=db, dns_target="10.10.10.10")
-    await node.save(db=db)
-
-    reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
-
-    assert reloaded.v6_target.value == "2001:db8::1"
-    assert reloaded.v6_target.is_default is True
-    assert reloaded.mgmt_ip.value == "10.0.0.1/32"
-    assert reloaded.mgmt_ip.is_default is True
 
 
 async def test_schema_branch_load_schema_extension(

--- a/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
+++ b/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
@@ -30,13 +30,17 @@ from infrahub.core.schema.attribute_parameters import IPHostAttributeParameters,
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import UniquenessViolationError, ValidationError
+from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.pools.noop_allocator import NoOpPoolAllocator
 from infrahub.profiles.node_applier import NodeProfilesApplier
 from infrahub.templates.node_applier import NodeTemplateApplier
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
 from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
 
 if TYPE_CHECKING:
+    from graphql import ExecutionResult
+
     from infrahub.core.branch import Branch
     from infrahub.core.diff.model.path import EnrichedDiffNode
     from infrahub.core.schema.schema_branch import SchemaBranch
@@ -72,6 +76,13 @@ MATCH (n:Node { uuid: $node_id })-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attrib
 MATCH (a)-[:HAS_VALUE]->(av:AttributeIPHost)
 RETURN av.value AS value, av.prefixlen AS prefixlen, av.version AS version,
        av.binary_address AS binary_address
+"""
+
+ACTIVE_VALUE_QUERY = """
+MATCH (n:Node { uuid: $node_id })-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attribute_name })
+MATCH (a)-[e:HAS_VALUE]->(av:AttributeIPHost)
+WHERE e.status = "active" AND e.to IS NULL
+RETURN av.value AS value
 """
 
 CONTAINMENT_QUERY = """
@@ -122,6 +133,43 @@ def _value_conflict(diff_node: EnrichedDiffNode, attribute_name: str) -> Enriche
             if prop.property_type is DatabaseEdgeType.HAS_VALUE:
                 return prop.conflict
     return None
+
+
+async def _active_stored_value(db: InfrahubDatabase, node_id: str, attribute_name: str) -> str:
+    """Return the value vertex an attribute currently points at, ignoring the ones it used to."""
+    records = await db.execute_query(
+        query=ACTIVE_VALUE_QUERY, params={"node_id": node_id, "attribute_name": attribute_name}
+    )
+    assert len(records) == 1
+    return records[0]["value"]
+
+
+async def _run_mutation(
+    db: InfrahubDatabase, branch: Branch, mutation: str, variables: dict[str, Any]
+) -> ExecutionResult:
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    return await graphql(
+        schema=gql_params.schema,
+        source=mutation,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values=variables,
+    )
+
+
+async def _mutation_result(
+    db: InfrahubDatabase, branch: Branch, mutation: str, variables: dict[str, Any]
+) -> dict[str, Any]:
+    result = await _run_mutation(db=db, branch=branch, mutation=mutation, variables=variables)
+    assert result.errors is None
+    assert result.data
+    return result.data["TestingDnsRecordUpdate"]
+
+
+async def _mutation_errors(db: InfrahubDatabase, branch: Branch, mutation: str, variables: dict[str, Any]) -> list[str]:
+    result = await _run_mutation(db=db, branch=branch, mutation=mutation, variables=variables)
+    assert result.errors is not None
+    return [error.message for error in result.errors]
 
 
 async def _node_ids_within(db: InfrahubDatabase, attribute_name: str, binary_prefix: str) -> set[str]:
@@ -450,6 +498,162 @@ class TestUniquenessAcrossInputForms:
         await constraint.check(other)
 
 
+class TestTheUpdatePath:
+    """An edit of a declared attribute converges on the value a creation of it would have stored.
+
+    Normalising an edit is scoped to a declared attribute on purpose. An attribute that accepts a
+    prefix has always kept whatever spelling an edit gave it, and rewriting that would change values
+    already in the graph, so the undeclared control here asserts today's behaviour rather than the
+    behaviour the declared attribute gets.
+    """
+
+    @pytest.fixture
+    async def saved_record(self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None) -> Node:
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await node.new(db=db, dns_target="10.0.0.1", v6_target="2001:db8::1", mgmt_ip="10.0.0.1")
+        await node.save(db=db)
+        return node
+
+    async def test_a_host_masked_edit_reads_back_bare(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        await _set_values(
+            db=db,
+            branch=default_branch,
+            node_id=saved_record.id,
+            dns_target="10.0.0.9/32",
+            v6_target="2001:db8::9/128",
+            mgmt_ip="10.0.0.9",
+        )
+
+        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+
+        assert reloaded.dns_target.value == "10.0.0.9"
+        assert reloaded.v6_target.value == "2001:db8::9"
+        assert await reloaded.get_display_label(db=db) == "10.0.0.9"
+        assert await reloaded.get_hfid(db=db) == ["10.0.0.9"]
+        assert reloaded.dns_target.prefixlen == 32
+        assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="dns_target") == "10.0.0.9"
+        assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="v6_target") == "2001:db8::9"
+
+        # The undeclared control is untouched: an edit still writes exactly the spelling it was given,
+        # so the bare address reaches the graph without the host mask that a creation would have added,
+        # and only reading it back puts the mask on.
+        assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="mgmt_ip") == "10.0.0.9"
+        assert reloaded.mgmt_ip.value == "10.0.0.9/32"
+
+    async def test_a_host_masked_edit_through_graphql_reads_back_bare(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        mutation = """
+        mutation UpdateRecord($id: String!) {
+            TestingDnsRecordUpdate(
+                data: {
+                    id: $id
+                    dns_target: { value: "10.0.0.9/32" }
+                    v6_target: { value: "2001:db8::9/128" }
+                    mgmt_ip: { value: "10.0.0.9" }
+                }
+            ) {
+                ok
+                object {
+                    display_label
+                    hfid
+                    dns_target { value prefixlen }
+                    v6_target { value prefixlen }
+                    mgmt_ip { value prefixlen }
+                }
+            }
+        }
+        """
+        result = await _mutation_result(
+            db=db, branch=default_branch, mutation=mutation, variables={"id": saved_record.id}
+        )
+
+        assert result["ok"] is True
+        assert result["object"]["dns_target"] == {"value": "10.0.0.9", "prefixlen": 32}
+        assert result["object"]["v6_target"] == {"value": "2001:db8::9", "prefixlen": 128}
+        assert result["object"]["display_label"] == "10.0.0.9"
+        assert result["object"]["hfid"] == ["10.0.0.9"]
+        # The undeclared control answers with the spelling the request used rather than the canonical
+        # one a creation would have produced -- the behaviour an edit of it has always had.
+        assert result["object"]["mgmt_ip"] == {"value": "10.0.0.9", "prefixlen": 32}
+
+        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.dns_target.value == "10.0.0.9"
+        assert reloaded.v6_target.value == "2001:db8::9"
+        assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="dns_target") == "10.0.0.9"
+        assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="mgmt_ip") == "10.0.0.9"
+        assert reloaded.mgmt_ip.value == "10.0.0.9/32"
+
+    async def test_an_edit_to_a_subnet_prefix_is_rejected_and_changes_nothing(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        """Normalising an edit must not turn a rejected prefix into an address that would be accepted."""
+        node = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        node.dns_target.value = "10.0.0.9/24"
+        error = _rejected_for_subnet_prefix("10.0.0.9/24", "dns_target")
+
+        with pytest.raises(ValidationError, match=rf"^{re.escape(error)}$"):
+            await node.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.dns_target.value == "10.0.0.1"
+        assert await reloaded.get_display_label(db=db) == "10.0.0.1"
+
+        await _set_values(db=db, branch=default_branch, node_id=saved_record.id, mgmt_ip="10.0.0.9/24")
+
+        control = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        assert control.mgmt_ip.value == "10.0.0.9/24"
+
+    async def test_an_edit_onto_a_taken_address_spelled_differently_is_rejected(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_unique_mgmt_ip: None
+    ) -> None:
+        """A uniqueness check has to see the value the edit will store, not the spelling it arrived in."""
+        taken = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await taken.new(db=db, dns_target="10.0.0.1", mgmt_ip="10.0.0.1")
+        await taken.save(db=db)
+
+        other = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await other.new(db=db, dns_target="10.0.0.9", mgmt_ip="10.0.0.9/24")
+        await other.save(db=db)
+
+        declared_mutation = """
+        mutation UpdateRecord($id: String!) {
+            TestingDnsRecordUpdate(data: { id: $id, dns_target: { value: "10.0.0.1/32" } }) {
+                ok
+            }
+        }
+        """
+        declared_error = "Violates uniqueness constraint 'dns_target'"
+        errors = await _mutation_errors(
+            db=db, branch=default_branch, mutation=declared_mutation, variables={"id": other.id}
+        )
+
+        assert errors == [declared_error]
+
+        # The undeclared control compares the spelling the request used against the one in the graph, so
+        # a bare address is not seen to collide with the host mask already holding it -- the behaviour it
+        # has always had, and the reason normalising an edit stays scoped to the declared attribute.
+        undeclared_mutation = """
+        mutation UpdateRecord($id: String!) {
+            TestingDnsRecordUpdate(data: { id: $id, mgmt_ip: { value: "10.0.0.1" } }) {
+                ok
+            }
+        }
+        """
+        result = await _mutation_result(
+            db=db, branch=default_branch, mutation=undeclared_mutation, variables={"id": other.id}
+        )
+
+        assert result["ok"] is True
+
+        reloaded = await NodeManager.get_one(db=db, id=other.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.dns_target.value == "10.0.0.9"
+        assert await _active_stored_value(db=db, node_id=other.id, attribute_name="mgmt_ip") == "10.0.0.1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+
 class TestGeneratedKindsInheritTheDeclaration:
     """The generated profile and object-template kinds behave like the kind they are derived from.
 
@@ -627,14 +831,6 @@ class TestBranchMerge:
         assert _value_conflict(diff_node, "dns_target") is not None
         assert _value_conflict(diff_node, "mgmt_ip") is not None
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "An attribute value is normalised when it is constructed but not when it is updated, so the two"
-            " input forms reach the graph unchanged and still read as two different values. Remove this"
-            " marker once updating an attribute stores its canonical form."
-        ),
-    )
     async def test_input_forms_that_converge_on_one_value_do_not_conflict(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_in_db: None
     ) -> None:

--- a/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
+++ b/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
@@ -1,0 +1,396 @@
+"""Behaviour of an `IPHost` attribute declared to hold a bare address.
+
+Every test here pairs a declared attribute (`allow_prefix: false`) with the undeclared `mgmt_ip`
+control, because regressing the pre-existing prefixed behaviour is a worse outcome than failing to
+add the new one.
+"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.node.constraints.attribute_uniqueness import NodeAttributeUniquenessConstraint
+from infrahub.core.schema import SchemaRoot
+from infrahub.exceptions import UniquenessViolationError, ValidationError
+from tests.helpers.schema import load_schema
+from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+DNS_RECORD_KIND = "TestingDnsRecord"
+
+# A valid bare value for the mandatory declared attribute, so a case exercising another attribute is
+# not also fighting a missing mandatory value.
+FILLER_TARGET = "10.10.10.10"
+
+IPV4_TARGET_BINARY = "00001010" + "00000000" * 2 + "00000001"
+IPV6_TARGET_BINARY = "0010000000000001" + "0000110110111000" + "0" * 80 + "0000000000000001"
+
+# The leading bits shared by every address inside 10.0.0.0/8, which is how prefix containment is
+# resolved against the value vertex.
+IPV4_SLASH_8_BINARY = "00001010"
+
+
+def _rejected_for_subnet_prefix(value: str, attribute_name: str) -> str:
+    return f"{value} is not a valid IPHost because a subnet prefix is not permitted at {attribute_name}"
+
+
+def _rejected_as_malformed(value: str, attribute_name: str) -> str:
+    return f"{value} is not a valid IPHost at {attribute_name}"
+
+
+VALUE_VERTEX_QUERY = """
+MATCH (n:Node { uuid: $node_id })-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attribute_name })
+MATCH (a)-[:HAS_VALUE]->(av:AttributeIPHost)
+RETURN av.value AS value, av.prefixlen AS prefixlen, av.version AS version,
+       av.binary_address AS binary_address
+"""
+
+CONTAINMENT_QUERY = """
+MATCH (n:TestingDnsRecord)-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attribute_name })
+MATCH (a)-[:HAS_VALUE]->(av:AttributeIPHost)
+WHERE av.binary_address STARTS WITH $binary_prefix
+RETURN DISTINCT n.uuid AS uuid
+"""
+
+
+def _dns_record_root(**attribute_overrides: dict[str, Any]) -> SchemaRoot:
+    definition = deepcopy(DNS_RECORD_DEFINITION)
+    for attribute_name, overrides in attribute_overrides.items():
+        attribute = next(attr for attr in definition["attributes"] if attr["name"] == attribute_name)
+        attribute.update(overrides)
+    return SchemaRoot(nodes=[definition])
+
+
+async def _stored_value_properties(db: InfrahubDatabase, node_id: str, attribute_name: str) -> dict[str, Any]:
+    records = await db.execute_query(
+        query=VALUE_VERTEX_QUERY, params={"node_id": node_id, "attribute_name": attribute_name}
+    )
+    assert len(records) == 1
+    return dict(records[0])
+
+
+async def _node_ids_within(db: InfrahubDatabase, attribute_name: str, binary_prefix: str) -> set[str]:
+    records = await db.execute_query(
+        query=CONTAINMENT_QUERY, params={"attribute_name": attribute_name, "binary_prefix": binary_prefix}
+    )
+    return {record["uuid"] for record in records}
+
+
+@pytest.fixture
+async def dns_record_schema(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    await load_schema(db=db, schema=_dns_record_root())
+
+
+@pytest.fixture
+async def dns_record_schema_unique_mgmt_ip(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    """The undeclared control needs its own uniqueness constraint to be comparable to the declared one."""
+    await load_schema(db=db, schema=_dns_record_root(mgmt_ip={"unique": True}))
+
+
+@dataclass
+class ValueCase:
+    name: str
+    attribute: str
+    value: str
+    stored: str | None = None
+    error: str | None = None
+
+
+DECLARED_IPV4_CASES = [
+    ValueCase(name="declared_ipv4_bare_stays_bare", attribute="dns_target", value="10.0.0.1", stored="10.0.0.1"),
+    ValueCase(
+        name="declared_ipv4_host_mask_is_normalised_away",
+        attribute="dns_target",
+        value="10.0.0.1/32",
+        stored="10.0.0.1",
+    ),
+    ValueCase(
+        name="declared_ipv4_subnet_prefix_is_rejected",
+        attribute="dns_target",
+        value="10.0.0.1/24",
+        error=_rejected_for_subnet_prefix("10.0.0.1/24", "dns_target"),
+    ),
+    ValueCase(
+        name="declared_ipv4_point_to_point_prefix_is_rejected",
+        attribute="dns_target",
+        value="10.0.0.1/31",
+        error=_rejected_for_subnet_prefix("10.0.0.1/31", "dns_target"),
+    ),
+    ValueCase(
+        name="declared_ipv4_zero_prefix_is_rejected",
+        attribute="dns_target",
+        value="10.0.0.1/0",
+        error=_rejected_for_subnet_prefix("10.0.0.1/0", "dns_target"),
+    ),
+    ValueCase(
+        name="declared_ipv4_with_ipv6_host_length_stays_malformed",
+        attribute="dns_target",
+        value="10.0.0.1/128",
+        error=_rejected_as_malformed("10.0.0.1/128", "dns_target"),
+    ),
+]
+
+DECLARED_IPV6_CASES = [
+    ValueCase(name="declared_ipv6_bare_stays_bare", attribute="v6_target", value="2001:db8::1", stored="2001:db8::1"),
+    ValueCase(
+        name="declared_ipv6_host_mask_is_normalised_away",
+        attribute="v6_target",
+        value="2001:db8::1/128",
+        stored="2001:db8::1",
+    ),
+    ValueCase(
+        name="declared_ipv6_subnet_prefix_is_rejected",
+        attribute="v6_target",
+        value="2001:db8::1/64",
+        error=_rejected_for_subnet_prefix("2001:db8::1/64", "v6_target"),
+    ),
+    ValueCase(
+        name="declared_ipv6_point_to_point_prefix_is_rejected",
+        attribute="v6_target",
+        value="2001:db8::1/127",
+        error=_rejected_for_subnet_prefix("2001:db8::1/127", "v6_target"),
+    ),
+    ValueCase(
+        name="declared_ipv6_with_ipv4_host_length_is_a_subnet_prefix",
+        attribute="v6_target",
+        value="2001:db8::1/32",
+        error=_rejected_for_subnet_prefix("2001:db8::1/32", "v6_target"),
+    ),
+    ValueCase(
+        name="declared_ipv6_zero_prefix_is_rejected",
+        attribute="v6_target",
+        value="2001:db8::1/0",
+        error=_rejected_for_subnet_prefix("2001:db8::1/0", "v6_target"),
+    ),
+]
+
+UNDECLARED_CASES = [
+    ValueCase(name="undeclared_ipv4_bare_gains_host_mask", attribute="mgmt_ip", value="10.0.0.1", stored="10.0.0.1/32"),
+    ValueCase(name="undeclared_ipv4_host_mask_is_kept", attribute="mgmt_ip", value="10.0.0.1/32", stored="10.0.0.1/32"),
+    ValueCase(
+        name="undeclared_ipv4_subnet_prefix_is_kept", attribute="mgmt_ip", value="10.0.0.1/24", stored="10.0.0.1/24"
+    ),
+    ValueCase(
+        name="undeclared_ipv4_point_to_point_prefix_is_kept",
+        attribute="mgmt_ip",
+        value="10.0.0.1/31",
+        stored="10.0.0.1/31",
+    ),
+    ValueCase(name="undeclared_ipv4_zero_prefix_is_kept", attribute="mgmt_ip", value="10.0.0.1/0", stored="10.0.0.1/0"),
+    ValueCase(
+        name="undeclared_ipv6_bare_gains_host_mask",
+        attribute="mgmt_ip",
+        value="2001:db8::1",
+        stored="2001:db8::1/128",
+    ),
+    ValueCase(
+        name="undeclared_ipv6_host_mask_is_kept",
+        attribute="mgmt_ip",
+        value="2001:db8::1/128",
+        stored="2001:db8::1/128",
+    ),
+    ValueCase(
+        name="undeclared_ipv6_subnet_prefix_is_kept",
+        attribute="mgmt_ip",
+        value="2001:db8::1/64",
+        stored="2001:db8::1/64",
+    ),
+    ValueCase(
+        name="undeclared_ipv6_point_to_point_prefix_is_kept",
+        attribute="mgmt_ip",
+        value="2001:db8::1/127",
+        stored="2001:db8::1/127",
+    ),
+    ValueCase(
+        name="undeclared_ipv6_with_ipv4_host_length_is_kept",
+        attribute="mgmt_ip",
+        value="2001:db8::1/32",
+        stored="2001:db8::1/32",
+    ),
+    ValueCase(
+        name="undeclared_ipv6_zero_prefix_is_kept",
+        attribute="mgmt_ip",
+        value="2001:db8::1/0",
+        stored="2001:db8::1/0",
+    ),
+    ValueCase(
+        name="undeclared_ipv4_with_ipv6_host_length_stays_malformed",
+        attribute="mgmt_ip",
+        value="10.0.0.1/128",
+        error=_rejected_as_malformed("10.0.0.1/128", "mgmt_ip"),
+    ),
+]
+
+
+class TestValueValidationAndNormalisation:
+    @pytest.mark.parametrize(
+        "case", DECLARED_IPV4_CASES + DECLARED_IPV6_CASES + UNDECLARED_CASES, ids=lambda case: case.name
+    )
+    async def test_input_form(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None, case: ValueCase
+    ) -> None:
+        fields: dict[str, Any] = {"dns_target": FILLER_TARGET, case.attribute: case.value}
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+
+        if case.error is not None:
+            with pytest.raises(ValidationError, match=rf"^{re.escape(case.error)}$"):
+                await node.new(db=db, **fields)
+            return
+
+        await node.new(db=db, **fields)
+
+        assert getattr(node, case.attribute).value == case.stored
+
+    async def test_an_omitted_optional_attribute_holds_no_value(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+
+        await node.new(db=db, dns_target="10.0.0.1")
+
+        assert node.v6_target.value is None
+        assert node.mgmt_ip.value is None
+
+    async def test_an_explicit_null_holds_no_value(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+
+        await node.new(db=db, dns_target="10.0.0.1", v6_target=None, mgmt_ip=None)
+
+        assert node.v6_target.value is None
+        assert node.mgmt_ip.value is None
+
+
+class TestStorageAndDerivedProperties:
+    @pytest.fixture
+    async def saved_record(self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None) -> Node:
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await node.new(db=db, dns_target="10.0.0.1/32", v6_target="2001:db8::1/128", mgmt_ip="10.0.0.1")
+        await node.save(db=db)
+        return node
+
+    async def test_stored_value_is_bare_and_reads_back_bare(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+
+        assert reloaded.dns_target.value == "10.0.0.1"
+        assert reloaded.v6_target.value == "2001:db8::1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+    async def test_declared_value_vertex_keeps_its_derived_properties(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        ipv4 = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="dns_target")
+        ipv6 = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="v6_target")
+
+        assert ipv4 == {
+            "value": "10.0.0.1",
+            "prefixlen": 32,
+            "version": 4,
+            "binary_address": IPV4_TARGET_BINARY,
+        }
+        assert ipv6 == {
+            "value": "2001:db8::1",
+            "prefixlen": 128,
+            "version": 6,
+            "binary_address": IPV6_TARGET_BINARY,
+        }
+
+    async def test_undeclared_value_vertex_is_unchanged(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        stored = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="mgmt_ip")
+
+        assert stored == {
+            "value": "10.0.0.1/32",
+            "prefixlen": 32,
+            "version": 4,
+            "binary_address": IPV4_TARGET_BINARY,
+        }
+
+    async def test_prefix_containment_still_resolves_a_declared_attribute(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        declared = await _node_ids_within(db=db, attribute_name="dns_target", binary_prefix=IPV4_SLASH_8_BINARY)
+        undeclared = await _node_ids_within(db=db, attribute_name="mgmt_ip", binary_prefix=IPV4_SLASH_8_BINARY)
+
+        assert declared == {saved_record.id}
+        assert undeclared == {saved_record.id}
+
+    async def test_derived_attribute_properties_report_the_host_length(
+        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+    ) -> None:
+        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+
+        assert reloaded.dns_target.prefixlen == 32
+        assert reloaded.dns_target.version == 4
+        assert reloaded.dns_target.ip == "10.0.0.1"
+        assert reloaded.v6_target.prefixlen == 128
+        assert reloaded.v6_target.version == 6
+        assert reloaded.v6_target.ip == "2001:db8::1"
+        assert reloaded.mgmt_ip.prefixlen == 32
+        assert reloaded.mgmt_ip.version == 4
+
+
+class TestUniquenessAcrossInputForms:
+    async def test_bare_and_host_masked_input_collide(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_unique_mgmt_ip: None
+    ) -> None:
+        constraint = NodeAttributeUniquenessConstraint(db=db, branch=default_branch)
+        existing = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await existing.new(db=db, dns_target="10.0.0.1", mgmt_ip="10.0.0.1")
+        await existing.save(db=db)
+
+        assert existing.dns_target.value == "10.0.0.1"
+        assert existing.mgmt_ip.value == "10.0.0.1/32"
+
+        declared_duplicate = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await declared_duplicate.new(db=db, dns_target="10.0.0.1/32", mgmt_ip="10.0.0.9")
+        declared_message = "An object already exist with this value: dns_target: 10.0.0.1 at dns_target"
+
+        with pytest.raises(UniquenessViolationError, match=rf"^{re.escape(declared_message)}$"):
+            await constraint.check(declared_duplicate)
+
+        undeclared_duplicate = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await undeclared_duplicate.new(db=db, dns_target="10.0.0.9", mgmt_ip="10.0.0.1/32")
+        undeclared_message = "An object already exist with this value: mgmt_ip: 10.0.0.1/32 at mgmt_ip"
+
+        with pytest.raises(UniquenessViolationError, match=rf"^{re.escape(undeclared_message)}$"):
+            await constraint.check(undeclared_duplicate)
+
+    async def test_a_distinct_address_does_not_collide(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_unique_mgmt_ip: None
+    ) -> None:
+        constraint = NodeAttributeUniquenessConstraint(db=db, branch=default_branch)
+        existing = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await existing.new(db=db, dns_target="10.0.0.1", mgmt_ip="10.0.0.1")
+        await existing.save(db=db)
+
+        other = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await other.new(db=db, dns_target="10.0.0.2/32", mgmt_ip="10.0.0.2")
+
+        await constraint.check(other)

--- a/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
+++ b/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
@@ -36,7 +36,7 @@ from infrahub.profiles.node_applier import NodeProfilesApplier
 from infrahub.templates.node_applier import NodeTemplateApplier
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
-from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
+from tests.helpers.schema.dns_record import DNS_RECORD_DICT
 
 if TYPE_CHECKING:
     from graphql import ExecutionResult
@@ -94,7 +94,7 @@ RETURN DISTINCT n.uuid AS uuid
 
 
 def _dns_record_root(**attribute_overrides: dict[str, Any]) -> SchemaRoot:
-    definition = deepcopy(DNS_RECORD_DEFINITION)
+    definition = deepcopy(DNS_RECORD_DICT)
     for attribute_name, overrides in attribute_overrides.items():
         attribute = next(attr for attr in definition["attributes"] if attr["name"] == attribute_name)
         attribute.update(overrides)

--- a/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
+++ b/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
@@ -11,24 +11,41 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import pytest
 
+from infrahub.core import registry
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffConflict
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.attribute_uniqueness import NodeAttributeUniquenessConstraint
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import IPHostAttributeParameters, TextAttributeParameters
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import UniquenessViolationError, ValidationError
+from infrahub.pools.noop_allocator import NoOpPoolAllocator
+from infrahub.profiles.node_applier import NodeProfilesApplier
+from infrahub.templates.node_applier import NodeTemplateApplier
 from tests.helpers.schema import load_schema
 from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
+    from infrahub.core.diff.model.path import EnrichedDiffNode
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
 
 
 DNS_RECORD_KIND = "TestingDnsRecord"
+DNS_RECORD_PROFILE_KIND = "ProfileTestingDnsRecord"
+DNS_RECORD_TEMPLATE_KIND = "TemplateTestingDnsRecord"
 
 # A valid bare value for the mandatory declared attribute, so a case exercising another attribute is
 # not also fighting a missing mandatory value.
@@ -81,6 +98,32 @@ async def _stored_value_properties(db: InfrahubDatabase, node_id: str, attribute
     return dict(records[0])
 
 
+async def _set_values(db: InfrahubDatabase, branch: Branch, node_id: str, **values: str) -> None:
+    node = await NodeManager.get_one(db=db, branch=branch, id=node_id, raise_on_error=True)
+    for name, value in values.items():
+        node.get_attribute(name).value = value
+    await node.save(db=db)
+
+
+async def _branch_diff_node(db: InfrahubDatabase, branch: Branch, node_id: str) -> EnrichedDiffNode:
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    await diff_coordinator.update_branch_diff(base_branch=registry.get_branch_from_registry(), diff_branch=branch)
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(tracking_id=BranchTrackingId(name=branch.name), diff_branch_name=branch.name)
+    return next(node for node in diff.nodes if node.uuid == node_id)
+
+
+def _value_conflict(diff_node: EnrichedDiffNode, attribute_name: str) -> EnrichedDiffConflict | None:
+    for attribute in diff_node.attributes:
+        if attribute.name != attribute_name:
+            continue
+        for prop in attribute.properties:
+            if prop.property_type is DatabaseEdgeType.HAS_VALUE:
+                return prop.conflict
+    return None
+
+
 async def _node_ids_within(db: InfrahubDatabase, attribute_name: str, binary_prefix: str) -> set[str]:
     records = await db.execute_query(
         query=CONTAINMENT_QUERY, params={"attribute_name": attribute_name, "binary_prefix": binary_prefix}
@@ -107,6 +150,17 @@ async def dns_record_schema_unique_mgmt_ip(
 ) -> None:
     """The undeclared control needs its own uniqueness constraint to be comparable to the declared one."""
     await load_schema(db=db, schema=_dns_record_root(mgmt_ip={"unique": True}))
+
+
+@pytest.fixture
+async def dns_record_schema_in_db(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    """The schema persisted to the graph, so a branch forked from it can be diffed and merged."""
+    await load_schema(db=db, schema=_dns_record_root(), update_db=True)
 
 
 @dataclass
@@ -394,3 +448,253 @@ class TestUniquenessAcrossInputForms:
         await other.new(db=db, dns_target="10.0.0.2/32", mgmt_ip="10.0.0.2")
 
         await constraint.check(other)
+
+
+class TestGeneratedKindsInheritTheDeclaration:
+    """The generated profile and object-template kinds behave like the kind they are derived from.
+
+    A declaration lost on either path would be invisible: the node kind would keep storing bare
+    addresses, so the feature would still look like it works while every value that reached a node
+    through a profile or a template carried a mask.
+
+    `dns_target` is absent from both generated kinds because unique attributes are excluded from them,
+    so `v6_target` is the declared attribute under test and `mgmt_ip` remains the undeclared control.
+    """
+
+    async def test_the_declaration_reaches_the_generated_kinds(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        for kind in (DNS_RECORD_KIND, DNS_RECORD_PROFILE_KIND, DNS_RECORD_TEMPLATE_KIND):
+            schema = registry.schema.get(name=kind, branch=default_branch, duplicate=False)
+
+            assert schema.get_attribute("v6_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+            assert schema.get_attribute("mgmt_ip").parameters == IPHostAttributeParameters(allow_prefix=True)
+
+    async def test_a_profile_validates_and_normalises_like_a_node(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        rejected = await Node.init(db=db, schema=DNS_RECORD_PROFILE_KIND, branch=default_branch)
+        error = _rejected_for_subnet_prefix("2001:db8::1/64", "v6_target")
+
+        with pytest.raises(ValidationError, match=rf"^{re.escape(error)}$"):
+            await rejected.new(db=db, profile_name="rejected", profile_priority=1000, v6_target="2001:db8::1/64")
+
+        profile = await Node.init(db=db, schema=DNS_RECORD_PROFILE_KIND, branch=default_branch)
+        await profile.new(
+            db=db,
+            profile_name="accepted",
+            profile_priority=1000,
+            v6_target="2001:db8::1/128",
+            mgmt_ip="10.0.0.1",
+        )
+        await profile.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=profile.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.v6_target.value == "2001:db8::1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+    async def test_a_node_receives_the_bare_value_from_its_profile(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        profile = await Node.init(db=db, schema=DNS_RECORD_PROFILE_KIND, branch=default_branch)
+        await profile.new(
+            db=db,
+            profile_name="dns-defaults",
+            profile_priority=1000,
+            v6_target="2001:db8::1/128",
+            mgmt_ip="10.0.0.1",
+        )
+        await profile.save(db=db)
+
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await node.new(db=db, dns_target=FILLER_TARGET)
+        await node.save(db=db)
+        await node.profiles.update(db=db, data=[profile])
+        await node.save(db=db)
+
+        applier = NodeProfilesApplier(db=db, branch=default_branch)
+        assert sorted(await applier.apply_profiles(node=node)) == ["mgmt_ip", "v6_target"]
+        await node.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.v6_target.value == "2001:db8::1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+    async def test_a_template_validates_and_normalises_like_a_node(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        template_schema = registry.schema.get_template_schema(name=DNS_RECORD_TEMPLATE_KIND, branch=default_branch)
+        rejected = await Node.init(db=db, schema=template_schema, branch=default_branch)
+        error = _rejected_for_subnet_prefix("2001:db8::1/64", "v6_target")
+
+        with pytest.raises(ValidationError, match=rf"^{re.escape(error)}$"):
+            await rejected.new(db=db, template_name="rejected", v6_target="2001:db8::1/64")
+
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch)
+        await template.new(db=db, template_name="accepted", v6_target="2001:db8::1/128", mgmt_ip="10.0.0.1")
+        await template.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=template.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.v6_target.value == "2001:db8::1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+    async def test_a_node_receives_the_bare_value_from_its_template(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+    ) -> None:
+        template_schema = registry.schema.get_template_schema(name=DNS_RECORD_TEMPLATE_KIND, branch=default_branch)
+        template = await Node.init(db=db, schema=template_schema, branch=default_branch)
+        await template.new(db=db, template_name="dns-defaults", v6_target="2001:db8::1/128", mgmt_ip="10.0.0.1")
+        await template.save(db=db)
+
+        applier = NodeTemplateApplier(db=db, branch=default_branch, pool_allocator=NoOpPoolAllocator())
+        fields = await applier.apply(
+            template=template,
+            target_schema=registry.schema.get_node_schema(name=DNS_RECORD_KIND, branch=default_branch),
+            target_id=str(uuid4()),
+            user_fields={"dns_target": FILLER_TARGET},
+        )
+
+        assert fields["v6_target"]["value"] == "2001:db8::1"
+        assert fields["mgmt_ip"]["value"] == "10.0.0.1/32"
+
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await node.new(db=db, **fields)
+        await node.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.v6_target.value == "2001:db8::1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+
+
+class TestBranchMerge:
+    async def test_the_declaration_and_its_rejection_survive_a_schema_merge(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+        init_nodes_registry: None,
+    ) -> None:
+        """A declaration authored on a branch keeps working once it reaches the target branch."""
+        branch = await create_branch(db=db, branch_name="declare-bare-addresses")
+        await load_schema(db=db, schema=_dns_record_root(), branch_name=branch.name, update_db=True)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        await diff_merger.merge_graph(at=Timestamp())
+
+        merged_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=merged_schema)
+        merged_record = merged_schema.get(name=DNS_RECORD_KIND, duplicate=False)
+
+        assert merged_record.get_attribute("dns_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert merged_record.get_attribute("v6_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert merged_record.get_attribute("mgmt_ip").parameters == IPHostAttributeParameters(allow_prefix=True)
+
+        rejected = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        error = _rejected_for_subnet_prefix("10.0.0.1/24", "dns_target")
+
+        with pytest.raises(ValidationError, match=rf"^{re.escape(error)}$"):
+            await rejected.new(db=db, dns_target="10.0.0.1/24")
+
+        accepted = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await accepted.new(db=db, dns_target="10.0.0.1/32", mgmt_ip="10.0.0.1/24")
+        await accepted.save(db=db)
+
+        reloaded = await NodeManager.get_one(db=db, id=accepted.id, branch=default_branch, raise_on_error=True)
+        assert reloaded.dns_target.value == "10.0.0.1"
+        assert reloaded.mgmt_ip.value == "10.0.0.1/24"
+
+    async def test_divergent_edits_on_either_flavour_still_conflict(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_in_db: None
+    ) -> None:
+        """Two branches picking genuinely different addresses conflict, declared attribute or not.
+
+        This is the floor the convergence expectation is measured against: without it, a reported
+        absence of conflict could just as well mean the diff never looked at the attribute.
+        """
+        record = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await record.new(db=db, dns_target="10.0.0.100", mgmt_ip="10.0.0.100")
+        await record.save(db=db)
+
+        branch = await create_branch(db=db, branch_name="divergent-addresses")
+        await _set_values(db=db, branch=branch, node_id=record.id, dns_target="10.0.0.2", mgmt_ip="10.0.0.2/24")
+        await _set_values(db=db, branch=default_branch, node_id=record.id, dns_target="10.0.0.3", mgmt_ip="10.0.0.3/24")
+
+        diff_node = await _branch_diff_node(db=db, branch=branch, node_id=record.id)
+
+        assert _value_conflict(diff_node, "dns_target") is not None
+        assert _value_conflict(diff_node, "mgmt_ip") is not None
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "An attribute value is normalised when it is constructed but not when it is updated, so the two"
+            " input forms reach the graph unchanged and still read as two different values. Remove this"
+            " marker once updating an attribute stores its canonical form."
+        ),
+    )
+    async def test_input_forms_that_converge_on_one_value_do_not_conflict(
+        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_in_db: None
+    ) -> None:
+        """Bare and host-masked edits of a declared attribute are the same edit, so a merge sees no conflict.
+
+        The undeclared control is the same shape one prefix apart: there a bare address and a host mask
+        also mean the same thing, while a real subnet prefix does not, so only the declared attribute
+        can converge on a value the other side spelled differently.
+        """
+        record = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        await record.new(db=db, dns_target="10.0.0.100", mgmt_ip="10.0.0.100")
+        await record.save(db=db)
+
+        branch = await create_branch(db=db, branch_name="converging-addresses")
+        await _set_values(db=db, branch=branch, node_id=record.id, dns_target="10.0.0.1", mgmt_ip="10.0.0.1")
+        await _set_values(
+            db=db, branch=default_branch, node_id=record.id, dns_target="10.0.0.1/32", mgmt_ip="10.0.0.1/24"
+        )
+
+        diff_node = await _branch_diff_node(db=db, branch=branch, node_id=record.id)
+
+        assert _value_conflict(diff_node, "dns_target") is None
+        assert _value_conflict(diff_node, "mgmt_ip") is not None
+
+
+class TestAttributeKindChange:
+    """Today a declaration is dropped without a word when the attribute stops being an `IPHost`.
+
+    The parameters of an attribute are re-typed from its kind, and fields the target kind does not know
+    about are discarded. That silence is accepted for now; these assertions exist so that changing it
+    is a deliberate act rather than an accident.
+    """
+
+    def test_leaving_iphost_drops_the_declaration_from_a_schema_payload(self) -> None:
+        declared = _dns_record_root().nodes[0].get_attribute("dns_target")
+        assert declared.parameters == IPHostAttributeParameters(allow_prefix=False)
+
+        retyped = _dns_record_root(dns_target={"kind": "Text"}).nodes[0].get_attribute("dns_target")
+
+        assert retyped.parameters == TextAttributeParameters()
+
+    def test_leaving_iphost_drops_the_declaration_from_a_loaded_schema(self) -> None:
+        declared = _dns_record_root().nodes[0].get_attribute("dns_target")
+
+        retyped = AttributeSchema(name=declared.name, kind="Text", parameters=declared.parameters)
+
+        assert retyped.parameters == TextAttributeParameters()
+
+    def test_returning_to_iphost_restores_the_permissive_default(self) -> None:
+        retyped = AttributeSchema(
+            name="dns_target", kind="Text", parameters=IPHostAttributeParameters(allow_prefix=False)
+        )
+
+        restored = AttributeSchema(name="dns_target", kind="IPHost", parameters=retyped.parameters)
+
+        assert restored.parameters == IPHostAttributeParameters(allow_prefix=True)
+
+    def test_a_change_that_keeps_the_kind_keeps_the_declaration(self) -> None:
+        """Pairing the drop with a re-parse that keeps the kind, so the cause is the kind and nothing else."""
+        edited = _dns_record_root(dns_target={"description": "The address this record resolves to"}).nodes[0]
+
+        assert edited.get_attribute("dns_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert edited.get_attribute("mgmt_ip").parameters == IPHostAttributeParameters(allow_prefix=True)

--- a/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
+++ b/backend/tests/component/core/test_attribute_iphost_allow_prefix.py
@@ -55,12 +55,10 @@ DNS_RECORD_TEMPLATE_KIND = "TemplateTestingDnsRecord"
 # not also fighting a missing mandatory value.
 FILLER_TARGET = "10.10.10.10"
 
+# The binary form is what prefix containment is resolved against, so pinning it exactly is what proves
+# a bare value stays reachable by a containment lookup.
 IPV4_TARGET_BINARY = "00001010" + "00000000" * 2 + "00000001"
 IPV6_TARGET_BINARY = "0010000000000001" + "0000110110111000" + "0" * 80 + "0000000000000001"
-
-# The leading bits shared by every address inside 10.0.0.0/8, which is how prefix containment is
-# resolved against the value vertex.
-IPV4_SLASH_8_BINARY = "00001010"
 
 
 def _rejected_for_subnet_prefix(value: str, attribute_name: str) -> str:
@@ -83,13 +81,6 @@ MATCH (n:Node { uuid: $node_id })-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attrib
 MATCH (a)-[e:HAS_VALUE]->(av:AttributeIPHost)
 WHERE e.status = "active" AND e.to IS NULL
 RETURN av.value AS value
-"""
-
-CONTAINMENT_QUERY = """
-MATCH (n:TestingDnsRecord)-[:HAS_ATTRIBUTE]->(a:Attribute { name: $attribute_name })
-MATCH (a)-[:HAS_VALUE]->(av:AttributeIPHost)
-WHERE av.binary_address STARTS WITH $binary_prefix
-RETURN DISTINCT n.uuid AS uuid
 """
 
 
@@ -172,13 +163,6 @@ async def _mutation_errors(db: InfrahubDatabase, branch: Branch, mutation: str, 
     return [error.message for error in result.errors]
 
 
-async def _node_ids_within(db: InfrahubDatabase, attribute_name: str, binary_prefix: str) -> set[str]:
-    records = await db.execute_query(
-        query=CONTAINMENT_QUERY, params={"attribute_name": attribute_name, "binary_prefix": binary_prefix}
-    )
-    return {record["uuid"] for record in records}
-
-
 @pytest.fixture
 async def dns_record_schema(
     db: InfrahubDatabase,
@@ -186,6 +170,17 @@ async def dns_record_schema(
     register_core_models_schema: SchemaBranch,
     init_nodes_registry: None,
 ) -> None:
+    await load_schema(db=db, schema=_dns_record_root())
+
+
+@pytest.fixture(scope="class")
+async def dns_record_schema_scope_class(
+    db: InfrahubDatabase,
+    default_branch_scope_class: Branch,
+    register_core_models_schema_scope_class: SchemaBranch,
+    init_nodes_registry_scope_class: None,
+) -> None:
+    """The same schema loaded once per class, because loading it per test dominates the suite's runtime."""
     await load_schema(db=db, schema=_dns_record_root())
 
 
@@ -347,14 +342,20 @@ UNDECLARED_CASES = [
 
 
 class TestValueValidationAndNormalisation:
+    """No test here saves a node, so one schema load serves the whole class."""
+
     @pytest.mark.parametrize(
         "case", DECLARED_IPV4_CASES + DECLARED_IPV6_CASES + UNDECLARED_CASES, ids=lambda case: case.name
     )
     async def test_input_form(
-        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None, case: ValueCase
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        dns_record_schema_scope_class: None,
+        case: ValueCase,
     ) -> None:
         fields: dict[str, Any] = {"dns_target": FILLER_TARGET, case.attribute: case.value}
-        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch_scope_class)
 
         if case.error is not None:
             with pytest.raises(ValidationError, match=rf"^{re.escape(case.error)}$"):
@@ -363,48 +364,54 @@ class TestValueValidationAndNormalisation:
 
         await node.new(db=db, **fields)
 
-        assert getattr(node, case.attribute).value == case.stored
+        assert node.get_attribute(case.attribute).value == case.stored
 
     async def test_an_omitted_optional_attribute_holds_no_value(
-        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, dns_record_schema_scope_class: None
     ) -> None:
-        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch_scope_class)
 
         await node.new(db=db, dns_target="10.0.0.1")
 
-        assert node.v6_target.value is None
-        assert node.mgmt_ip.value is None
+        assert node.get_attribute("v6_target").value is None
+        assert node.get_attribute("mgmt_ip").value is None
 
     async def test_an_explicit_null_holds_no_value(
-        self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, dns_record_schema_scope_class: None
     ) -> None:
-        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch_scope_class)
 
         await node.new(db=db, dns_target="10.0.0.1", v6_target=None, mgmt_ip=None)
 
-        assert node.v6_target.value is None
-        assert node.mgmt_ip.value is None
+        assert node.get_attribute("v6_target").value is None
+        assert node.get_attribute("mgmt_ip").value is None
 
 
 class TestStorageAndDerivedProperties:
-    @pytest.fixture
-    async def saved_record(self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None) -> Node:
-        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
+    """One record, saved once, read by every test here — so one schema load and one save serve the class."""
+
+    @pytest.fixture(scope="class")
+    async def saved_record(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, dns_record_schema_scope_class: None
+    ) -> Node:
+        node = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch_scope_class)
         await node.new(db=db, dns_target="10.0.0.1/32", v6_target="2001:db8::1/128", mgmt_ip="10.0.0.1")
         await node.save(db=db)
         return node
 
     async def test_stored_value_is_bare_and_reads_back_bare(
-        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, saved_record: Node
     ) -> None:
-        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        reloaded = await NodeManager.get_one(
+            db=db, id=saved_record.id, branch=default_branch_scope_class, raise_on_error=True
+        )
 
-        assert reloaded.dns_target.value == "10.0.0.1"
-        assert reloaded.v6_target.value == "2001:db8::1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.1"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
     async def test_declared_value_vertex_keeps_its_derived_properties(
-        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, saved_record: Node
     ) -> None:
         ipv4 = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="dns_target")
         ipv6 = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="v6_target")
@@ -423,7 +430,7 @@ class TestStorageAndDerivedProperties:
         }
 
     async def test_undeclared_value_vertex_is_unchanged(
-        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, saved_record: Node
     ) -> None:
         stored = await _stored_value_properties(db=db, node_id=saved_record.id, attribute_name="mgmt_ip")
 
@@ -434,28 +441,21 @@ class TestStorageAndDerivedProperties:
             "binary_address": IPV4_TARGET_BINARY,
         }
 
-    async def test_prefix_containment_still_resolves_a_declared_attribute(
-        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
-    ) -> None:
-        declared = await _node_ids_within(db=db, attribute_name="dns_target", binary_prefix=IPV4_SLASH_8_BINARY)
-        undeclared = await _node_ids_within(db=db, attribute_name="mgmt_ip", binary_prefix=IPV4_SLASH_8_BINARY)
-
-        assert declared == {saved_record.id}
-        assert undeclared == {saved_record.id}
-
     async def test_derived_attribute_properties_report_the_host_length(
-        self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, saved_record: Node
     ) -> None:
-        reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
+        reloaded = await NodeManager.get_one(
+            db=db, id=saved_record.id, branch=default_branch_scope_class, raise_on_error=True
+        )
 
-        assert reloaded.dns_target.prefixlen == 32
-        assert reloaded.dns_target.version == 4
-        assert reloaded.dns_target.ip == "10.0.0.1"
-        assert reloaded.v6_target.prefixlen == 128
-        assert reloaded.v6_target.version == 6
-        assert reloaded.v6_target.ip == "2001:db8::1"
-        assert reloaded.mgmt_ip.prefixlen == 32
-        assert reloaded.mgmt_ip.version == 4
+        assert reloaded.get_attribute("dns_target").prefixlen == 32
+        assert reloaded.get_attribute("dns_target").version == 4
+        assert reloaded.get_attribute("dns_target").ip == "10.0.0.1"
+        assert reloaded.get_attribute("v6_target").prefixlen == 128
+        assert reloaded.get_attribute("v6_target").version == 6
+        assert reloaded.get_attribute("v6_target").ip == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").prefixlen == 32
+        assert reloaded.get_attribute("mgmt_ip").version == 4
 
 
 class TestUniquenessAcrossInputForms:
@@ -467,8 +467,8 @@ class TestUniquenessAcrossInputForms:
         await existing.new(db=db, dns_target="10.0.0.1", mgmt_ip="10.0.0.1")
         await existing.save(db=db)
 
-        assert existing.dns_target.value == "10.0.0.1"
-        assert existing.mgmt_ip.value == "10.0.0.1/32"
+        assert existing.get_attribute("dns_target").value == "10.0.0.1"
+        assert existing.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
         declared_duplicate = await Node.init(db=db, schema=DNS_RECORD_KIND, branch=default_branch)
         await declared_duplicate.new(db=db, dns_target="10.0.0.1/32", mgmt_ip="10.0.0.9")
@@ -528,11 +528,11 @@ class TestTheUpdatePath:
 
         reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
 
-        assert reloaded.dns_target.value == "10.0.0.9"
-        assert reloaded.v6_target.value == "2001:db8::9"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.9"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::9"
         assert await reloaded.get_display_label(db=db) == "10.0.0.9"
         assert await reloaded.get_hfid(db=db) == ["10.0.0.9"]
-        assert reloaded.dns_target.prefixlen == 32
+        assert reloaded.get_attribute("dns_target").prefixlen == 32
         assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="dns_target") == "10.0.0.9"
         assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="v6_target") == "2001:db8::9"
 
@@ -540,7 +540,7 @@ class TestTheUpdatePath:
         # so the bare address reaches the graph without the host mask that a creation would have added,
         # and only reading it back puts the mask on.
         assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="mgmt_ip") == "10.0.0.9"
-        assert reloaded.mgmt_ip.value == "10.0.0.9/32"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.9/32"
 
     async def test_a_host_masked_edit_through_graphql_reads_back_bare(
         self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
@@ -580,31 +580,31 @@ class TestTheUpdatePath:
         assert result["object"]["mgmt_ip"] == {"value": "10.0.0.9", "prefixlen": 32}
 
         reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.dns_target.value == "10.0.0.9"
-        assert reloaded.v6_target.value == "2001:db8::9"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.9"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::9"
         assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="dns_target") == "10.0.0.9"
         assert await _active_stored_value(db=db, node_id=saved_record.id, attribute_name="mgmt_ip") == "10.0.0.9"
-        assert reloaded.mgmt_ip.value == "10.0.0.9/32"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.9/32"
 
     async def test_an_edit_to_a_subnet_prefix_is_rejected_and_changes_nothing(
         self, db: InfrahubDatabase, default_branch: Branch, saved_record: Node
     ) -> None:
         """Normalising an edit must not turn a rejected prefix into an address that would be accepted."""
         node = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
-        node.dns_target.value = "10.0.0.9/24"
+        node.get_attribute("dns_target").value = "10.0.0.9/24"
         error = _rejected_for_subnet_prefix("10.0.0.9/24", "dns_target")
 
         with pytest.raises(ValidationError, match=rf"^{re.escape(error)}$"):
             await node.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.dns_target.value == "10.0.0.1"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.1"
         assert await reloaded.get_display_label(db=db) == "10.0.0.1"
 
         await _set_values(db=db, branch=default_branch, node_id=saved_record.id, mgmt_ip="10.0.0.9/24")
 
         control = await NodeManager.get_one(db=db, id=saved_record.id, branch=default_branch, raise_on_error=True)
-        assert control.mgmt_ip.value == "10.0.0.9/24"
+        assert control.get_attribute("mgmt_ip").value == "10.0.0.9/24"
 
     async def test_an_edit_onto_a_taken_address_spelled_differently_is_rejected(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_unique_mgmt_ip: None
@@ -649,9 +649,9 @@ class TestTheUpdatePath:
         assert result["ok"] is True
 
         reloaded = await NodeManager.get_one(db=db, id=other.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.dns_target.value == "10.0.0.9"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.9"
         assert await _active_stored_value(db=db, node_id=other.id, attribute_name="mgmt_ip") == "10.0.0.1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
 
 class TestGeneratedKindsInheritTheDeclaration:
@@ -694,8 +694,8 @@ class TestGeneratedKindsInheritTheDeclaration:
         await profile.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=profile.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.v6_target.value == "2001:db8::1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
     async def test_a_node_receives_the_bare_value_from_its_profile(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
@@ -721,8 +721,8 @@ class TestGeneratedKindsInheritTheDeclaration:
         await node.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.v6_target.value == "2001:db8::1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
     async def test_a_template_validates_and_normalises_like_a_node(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
@@ -739,8 +739,8 @@ class TestGeneratedKindsInheritTheDeclaration:
         await template.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=template.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.v6_target.value == "2001:db8::1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
     async def test_a_node_receives_the_bare_value_from_its_template(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema: None
@@ -766,8 +766,8 @@ class TestGeneratedKindsInheritTheDeclaration:
         await node.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=node.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.v6_target.value == "2001:db8::1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/32"
+        assert reloaded.get_attribute("v6_target").value == "2001:db8::1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/32"
 
 
 class TestBranchMerge:
@@ -807,8 +807,8 @@ class TestBranchMerge:
         await accepted.save(db=db)
 
         reloaded = await NodeManager.get_one(db=db, id=accepted.id, branch=default_branch, raise_on_error=True)
-        assert reloaded.dns_target.value == "10.0.0.1"
-        assert reloaded.mgmt_ip.value == "10.0.0.1/24"
+        assert reloaded.get_attribute("dns_target").value == "10.0.0.1"
+        assert reloaded.get_attribute("mgmt_ip").value == "10.0.0.1/24"
 
     async def test_divergent_edits_on_either_flavour_still_conflict(
         self, db: InfrahubDatabase, default_branch: Branch, dns_record_schema_in_db: None

--- a/backend/tests/component/graphql/queries/test_hfid.py
+++ b/backend/tests/component/graphql/queries/test_hfid.py
@@ -89,3 +89,92 @@ async def test_iphost_hfid_roundtrip_via_graphql(
     assert len(looked_up) == 1
     assert looked_up[0]["node"]["id"] == node.id
     assert looked_up[0]["node"]["hfid"] == ["192.0.2.10/32"]
+
+
+async def test_bare_iphost_hfid_roundtrip_via_graphql(
+    db: InfrahubDatabase, default_branch: Branch, data_schema: None
+) -> None:
+    """An IPHost attribute declared to hold a bare address exposes no mask on any identifier surface.
+
+    The returned hfid carries no mask and is accepted verbatim as lookup input.
+    """
+    schema_root = SchemaRoot(
+        nodes=[
+            {
+                "name": "BareHostAddress",
+                "namespace": "Test",
+                "human_friendly_id": ["address__value"],
+                "display_label": "address__value",
+                "attributes": [
+                    {"name": "address", "kind": "IPHost", "unique": True, "parameters": {"allow_prefix": False}}
+                ],
+            }
+        ]
+    )
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    node = await Node.init(db=db, schema="TestBareHostAddress", branch=default_branch)
+    await node.new(db=db, address="192.0.2.10/32")
+    await node.save(db=db)
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+
+    fetch_query = """
+    query {
+        TestBareHostAddress {
+            edges {
+                node {
+                    id
+                    hfid
+                    display_label
+                    address { value prefixlen }
+                }
+            }
+        }
+    }
+    """
+    fetch_result = await graphql(
+        schema=gql_params.schema,
+        source=fetch_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert fetch_result.errors is None
+    assert fetch_result.data
+    edges = fetch_result.data["TestBareHostAddress"]["edges"]
+    assert len(edges) == 1
+    returned_node = edges[0]["node"]
+    assert returned_node["address"]["value"] == "192.0.2.10"
+    assert returned_node["address"]["prefixlen"] == 32
+    assert returned_node["display_label"] == "192.0.2.10"
+    assert returned_node["hfid"] == ["192.0.2.10"]
+
+    lookup_query = """
+    query LookupByHfid($hfid: [String]) {
+        TestBareHostAddress(hfid: $hfid) {
+            edges {
+                node {
+                    id
+                    hfid
+                }
+            }
+        }
+    }
+    """
+    lookup_result = await graphql(
+        schema=gql_params.schema,
+        source=lookup_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"hfid": returned_node["hfid"]},
+    )
+
+    assert lookup_result.errors is None
+    assert lookup_result.data
+    looked_up = lookup_result.data["TestBareHostAddress"]["edges"]
+    assert len(looked_up) == 1
+    assert looked_up[0]["node"]["id"] == node.id
+    assert looked_up[0]["node"]["hfid"] == ["192.0.2.10"]

--- a/backend/tests/component/graphql/queries/test_hfid.py
+++ b/backend/tests/component/graphql/queries/test_hfid.py
@@ -1,7 +1,8 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import IPHostAttributeParameters
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
@@ -100,15 +101,20 @@ async def test_bare_iphost_hfid_roundtrip_via_graphql(
     """
     schema_root = SchemaRoot(
         nodes=[
-            {
-                "name": "BareHostAddress",
-                "namespace": "Test",
-                "human_friendly_id": ["address__value"],
-                "display_label": "address__value",
-                "attributes": [
-                    {"name": "address", "kind": "IPHost", "unique": True, "parameters": {"allow_prefix": False}}
+            NodeSchema(
+                name="BareHostAddress",
+                namespace="Test",
+                human_friendly_id=["address__value"],
+                display_label="address__value",
+                attributes=[
+                    AttributeSchema(
+                        name="address",
+                        kind="IPHost",
+                        unique=True,
+                        parameters=IPHostAttributeParameters(allow_prefix=False),
+                    )
                 ],
-            }
+            )
         ]
     )
     registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
@@ -169,7 +175,7 @@ async def test_bare_iphost_hfid_roundtrip_via_graphql(
         source=lookup_query,
         context_value=gql_params.context,
         root_value=None,
-        variable_values={"hfid": returned_node["hfid"]},
+        variable_values={"hfid": ["192.0.2.10"]},
     )
 
     assert lookup_result.errors is None

--- a/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
@@ -14,7 +14,7 @@ from infrahub.core.schema.attribute_parameters import (
     TextAttributeParameters,
 )
 from tests.helpers.schema import load_schema as load_schema_root
-from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
+from tests.helpers.schema.dns_record import DNS_RECORD_DICT
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -353,7 +353,7 @@ class TestAllowPrefixIsImmutable(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     def schema_step_01(self) -> dict[str, Any]:
-        return {"version": "1.0", "nodes": [deepcopy(DNS_RECORD_DEFINITION)]}
+        return {"version": "1.0", "nodes": [deepcopy(DNS_RECORD_DICT)]}
 
     @pytest.fixture(scope="class")
     async def load_schema_01(

--- a/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -7,11 +8,13 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.attribute_parameters import (
+    IPHostAttributeParameters,
     NumberAttributeParameters,
     NumberPoolParameters,
     TextAttributeParameters,
 )
 from tests.helpers.schema import load_schema as load_schema_root
+from tests.helpers.schema.dns_record import DNS_RECORD_DEFINITION
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -24,6 +27,7 @@ if TYPE_CHECKING:
 
 LEGACY_KIND = "TestingThingLegacy"
 NEW_KIND = "TestingThing"
+DNS_RECORD_KIND = "TestingDnsRecord"
 
 
 class TestUpdateAttributeParameters(TestInfrahubApp):
@@ -342,3 +346,106 @@ class TestUpdateAttributeParameters(TestInfrahubApp):
         )
         self._validate_schema_number_parameters(schema=new_schema, min_value=20, max_value=30)
         self._validate_schema_numberpool_parameters(schema=new_schema, start_range=50, end_range=1200)
+
+
+class TestAllowPrefixIsImmutable(TestInfrahubApp):
+    """A bare-address declaration can be set when an attribute is created but never changed afterwards."""
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(self) -> dict[str, Any]:
+        return {"version": "1.0", "nodes": [deepcopy(DNS_RECORD_DEFINITION)]}
+
+    @pytest.fixture(scope="class")
+    async def load_schema_01(
+        self, db: InfrahubDatabase, default_branch: Branch, schema_step_01: dict[str, Any]
+    ) -> None:
+        schema_root = SchemaRoot(**schema_step_01)
+        await load_schema_root(db=db, branch_name=default_branch.name, schema=schema_root, update_db=True)
+
+    @staticmethod
+    def _with_parameters(
+        schema_step: dict[str, Any], attribute_name: str, parameters: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        candidate = deepcopy(schema_step)
+        attribute = next(attr for attr in candidate["nodes"][0]["attributes"] if attr["name"] == attribute_name)
+        if parameters is None:
+            attribute.pop("parameters", None)
+        else:
+            attribute["parameters"] = parameters
+        return candidate
+
+    async def test_declaration_is_recorded_on_load(
+        self, db: InfrahubDatabase, default_branch: Branch, load_schema_01: None
+    ) -> None:
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
+        dns_record = schema_branch.get_node(name=DNS_RECORD_KIND, duplicate=False)
+
+        assert dns_record.get_attribute("dns_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert dns_record.get_attribute("mgmt_ip").parameters == IPHostAttributeParameters(allow_prefix=True)
+
+    @pytest.mark.parametrize(
+        ("attribute_name", "parameters"),
+        [
+            pytest.param("dns_target", {"allow_prefix": True}, id="flip_to_allow_prefixes"),
+            pytest.param("dns_target", None, id="remove_the_declaration"),
+            pytest.param("mgmt_ip", {"allow_prefix": False}, id="add_the_declaration"),
+        ],
+    )
+    async def test_changing_the_declaration_is_refused(
+        self,
+        client: InfrahubClient,
+        default_branch: Branch,
+        load_schema_01: None,
+        schema_step_01: dict[str, Any],
+        attribute_name: str,
+        parameters: dict[str, Any] | None,
+    ) -> None:
+        candidate = self._with_parameters(schema_step_01, attribute_name, parameters)
+
+        success, response = await client.schema.check(schemas=[candidate], branch=default_branch.name)
+
+        assert success is False
+        assert response == {
+            "data": None,
+            "errors": [
+                {
+                    "message": f"'not_supported': {DNS_RECORD_KIND} {attribute_name} None",
+                    "extensions": {"code": 422},
+                }
+            ],
+        }
+
+        assert self._validation_error_paths(default_branch=default_branch, candidate_schema=candidate) == [
+            ("not_supported", attribute_name, "parameters.allow_prefix")
+        ]
+
+    @staticmethod
+    def _validation_error_paths(
+        default_branch: Branch, candidate_schema: dict[str, Any]
+    ) -> list[tuple[str, str | None, str | None]]:
+        """The rejected path, which carries the parameter name that the rendered message drops."""
+        branch_schema = registry.schema.get_schema_branch(name=default_branch.name)
+        candidate = branch_schema.duplicate()
+        candidate.load_schema(schema=SchemaRoot(**candidate_schema))
+        candidate.process()
+        diff = branch_schema.diff(other=candidate)
+
+        result = branch_schema.validate_update(other=candidate, diff=diff)
+
+        return [(error.error.value, error.path.field_name, error.path.property_name) for error in result.errors]
+
+    async def test_an_unrelated_parameter_change_is_still_accepted(
+        self,
+        client: InfrahubClient,
+        default_branch: Branch,
+        load_schema_01: None,
+        schema_step_01: dict[str, Any],
+    ) -> None:
+        """The refusal must be specific to the declaration, not to touching the attribute at all."""
+        candidate = deepcopy(schema_step_01)
+        mgmt_ip = next(attr for attr in candidate["nodes"][0]["attributes"] if attr["name"] == "mgmt_ip")
+        mgmt_ip["description"] = "Address used to reach the record's host out of band"
+
+        success, _ = await client.schema.check(schemas=[candidate], branch=default_branch.name)
+
+        assert success is True

--- a/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_attribute_parameters_update.py
@@ -434,6 +434,37 @@ class TestAllowPrefixIsImmutable(TestInfrahubApp):
 
         return [(error.error.value, error.path.field_name, error.path.property_name) for error in result.errors]
 
+    async def test_changing_the_declaration_is_refused_by_the_load_endpoint(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        load_schema_01: None,
+        schema_step_01: dict[str, Any],
+    ) -> None:
+        """A toggle that slipped past the real load path would reinterpret every stored value.
+
+        The flag is deliberately migration-free, so nothing would rewrite the addresses already in the
+        graph to match the new meaning.
+        """
+        candidate = self._with_parameters(schema_step_01, "dns_target", {"allow_prefix": True})
+
+        response = await client.schema.load(schemas=[candidate], branch=default_branch.name)
+
+        assert response.errors
+        # The rendered message drops the parameter name, so the assertion pins the refusal and the
+        # attribute it names rather than the whole string.
+        messages = [error["message"] for error in response.errors["errors"]]
+        assert len(messages) == 1
+        assert "not_supported" in messages[0]
+        assert "dns_target" in messages[0]
+
+        reloaded = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
+        dns_record = reloaded.get_node(name=DNS_RECORD_KIND, duplicate=False)
+        assert dns_record.get_attribute("dns_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert dns_record.get_attribute("v6_target").parameters == IPHostAttributeParameters(allow_prefix=False)
+        assert dns_record.get_attribute("mgmt_ip").parameters == IPHostAttributeParameters(allow_prefix=True)
+
     async def test_an_unrelated_parameter_change_is_still_accepted(
         self,
         client: InfrahubClient,


### PR DESCRIPTION
**Stack position: 2 of 5.** Base is **#10081** (PR 1), which declares `allow_prefix`. See
`dev/specs/infp-551-bare-ip-attribute/pr-split-plan.md` for the full split. Merge strictly 1 → 5.

**~85% of this PR is test code.** The production change is ~40 lines in `backend/infrahub/core/attribute.py`.

# Why

PR 1 gave an `IPHost` attribute the vocabulary to say it holds a bare address. This PR makes the write
path honour it: a declared attribute stores exactly one spelling of an address, whichever spelling the
caller used. Reads are untouched — making the masked spelling resolve as *lookup input* is PR 3.

## What changed

`backend/infrahub/core/attribute.py`:

- `IPHost._normalize_value` returns the bare address when the attribute refuses a prefix, and the
  existing `with_prefixlen` form otherwise. The undeclared path is byte-for-byte what it was.
- `validate_format` rejects a real subnet prefix on a declared attribute. The host-length comparison is
  `interface.ip.max_prefixlen`, never a hardcoded 32/128 — a `/32` is a redundant host mask on IPv4 but a
  subnet prefix on IPv6, and the version-agnostic comparison is what gets that right.
- A new `BaseAttribute._normalize_assigned_value` hook, a no-op on the base class, called on the update
  path (`from_db`-sourced assignment and the pre-save validation). `IPHost` overrides it so an **edit**
  converges on the value a **creation** would have stored. Every other kind is provably unaffected
  because the base implementation returns its argument.
- `iphost_allows_prefix()`, a module-level helper, answers permissively for a schema whose `parameters`
  is not the per-kind class, so a base-classed schema cannot accidentally acquire the restriction.

`to_db()` and the derived properties (`ip`, `version`, `prefixlen`, `binary_address`) are deliberately
untouched — they read `self.value`, so they follow the stored spelling without needing to know about the
flag.

## The uniqueness bypass this closes

The commit `normalise bare IP values on the update path` is worth reading on its own. The pre-save
uniqueness check ran against the **un-normalised** value, so on a declared attribute `10.0.0.1/32` could
be written alongside an existing `10.0.0.1` — two rows for one address on an attribute marked
`unique=True`. Normalising before the check closes it, and
`TestUniquenessAcrossInputForms::test_bare_and_host_masked_input_collide` pins it, with the undeclared
attribute asserted in the same test to still collide only on its own stored spelling.

## Test shape

Every behavioural test pairs a **declared** attribute with an **undeclared control** asserting the old
behaviour, on one kind (`TestingDnsRecord`) that carries both flavours side by side. The classes:

| Class | Covers |
|---|---|
| `TestValueValidationAndNormalisation` | input forms accepted, rejected, and how each is stored |
| `TestStorageAndDerivedProperties` | the `:AttributeValue` vertex, and the derived properties following it |
| `TestUniquenessAcrossInputForms` | the bypass above |
| `TestTheUpdatePath` | an edit converging on the creation value |
| `TestGeneratedKindsInheritTheDeclaration` | profile and object-template kinds |
| `TestBranchMerge` | the value surviving a branch merge bare |
| `TestAttributeKindChange` | a kind change off/onto `IPHost` |

The two read-only classes load their schema once per class rather than once per test, and share a single
saved record — per-test schema loading was the dominant cost in the suite.

The `default_value` cases live in their own file, `test_iphost_default_value.py`, rather than being added
to `test_manager_schema.py`, which was already too large. That file is untouched by this branch.

`TestAllowPrefixIsImmutable` (integration) proves the flag cannot be toggled **through the real
`/api/schema/load` endpoint**, not merely through the model. That test is why the SDK pointer bump in PR 1
is load-bearing rather than cosmetic: without `IPHostAttributeWrite` in the SDK's generated write models,
`allow_prefix` is silently dropped from every schema-load payload and 4 of these cases fail.

This PR touches no generated file and does not move the submodule pointer (still `525b28f`, inherited
from PR 1).

## Changelog

No fragment here. Per constraint C6 in the split plan, all documentation and changelog content is
consolidated into PR 5 so the user-facing wording is reviewed in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
