### PR TITLE
run pnpm codegen:graphql

### DIFF
--- a/frontend/app/src/shared/api/graphql/generated/graphql-cache.d.ts
+++ b/frontend/app/src/shared/api/graphql/generated/graphql-cache.d.ts
@@ -1,6 +1,26 @@
 /* eslint-disable */
 /* prettier-ignore */
 import type { TadaDocumentNode, $tada } from 'gql.tada';
+import {
+  type AnyVariables,
+  Client,
+  type CombinedError,
+  type DocumentInput,
+  fetchExchange,
+  formatDocument,
+  makeOperation,
+  mapExchange,
+} from "@urql/core";
+import { authExchange } from "@urql/exchange-auth";
+import { ERROR_CODES } from "@/shared/api/errors";
+import { handleGraphQLErrors, hasCatalogueCode } from "@/shared/api/graphql/error-handling";
+import type { GraphQLRequestContext, GraphQLResult } from "@/shared/api/graphql/types";
+import { DEFAULT_PRIORITY, PRIORITY_HEADER } from "@/shared/api/priority";
+import { queryClient } from "@/shared/api/rest/client";
+import { CONFIG } from "@/shared/config/config";
+import { getAccessToken } from "@/entities/authentication/api/token-storage";
+import { redirectToLogin } from "@/entities/authentication/domain/use-cases/redirect-to-login";
+import { refreshAccessTokenQueryOptions } from "@/entities/authentication/ui/queries/refresh-access-token.query";
 
 declare module 'gql.tada' {
  interface setupCache {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Regenerated GraphQL cache typings to align `gql.tada` with our URQL client stack, adding imports from `@urql/core`, `@urql/exchange-auth`, and internal auth/error/priority helpers to ensure operations and exchanges are correctly typed.

<sup>Written for commit 458137038c644452da62e37619a083c64b648a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

