### PR TITLE
perf(diff): batch node field summary retrieval over paged queries

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -121,6 +121,20 @@ class NodeDiffFieldSummary:
         """Record that `node_uuid` is a node of this kind whose relationship `name` changed."""
         self.relationship_node_uuids.setdefault(name, set()).add(node_uuid)
 
+    def merge(self, other: NodeDiffFieldSummary) -> None:
+        """Fold another summary of the same kind into this one.
+
+        Raises:
+            ValueError: If the other summary is for a different kind.
+
+        """
+        if other.kind != self.kind:
+            raise ValueError(f"Cannot merge summary for kind {other.kind} into summary for kind {self.kind}")
+        for name, node_uuids in other.attribute_node_uuids.items():
+            self.attribute_node_uuids.setdefault(name, set()).update(node_uuids)
+        for name, node_uuids in other.relationship_node_uuids.items():
+            self.relationship_node_uuids.setdefault(name, set()).update(node_uuids)
+
     @property
     def attribute_names(self) -> set[str]:
         return set(self.attribute_node_uuids)

--- a/backend/infrahub/core/diff/query/field_summary.py
+++ b/backend/infrahub/core/diff/query/field_summary.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from collections.abc import Generator
 from typing import Any
 
 from infrahub.core.constants import DiffAction
@@ -8,16 +8,13 @@ from infrahub.database import InfrahubDatabase
 from ..model.path import NodeDiffFieldSummary, TrackingId
 
 
-@dataclass
-class FieldNodeUuidsRow:
-    """One changed field of a kind and the uuids of the nodes that changed it, as projected by the query."""
-
-    name: str
-    node_uuids: list[str]
-
-
 class EnrichedDiffNodeFieldSummaryQuery(Query):
-    """Get node kind and names of all altered attributes and relationships for each kind."""
+    """Get the names of all altered attributes and relationships for one page of changed nodes.
+
+    Pagination is over the changed nodes, strictly ordered, with each row carrying every altered
+    field name of one node; aggregating the fields of every node in one transaction does not scale
+    with large diffs.
+    """
 
     name = "enriched_diff_node_field_summary"
     type = QueryType.READ
@@ -25,12 +22,16 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
     def __init__(
         self,
         diff_branch_name: str,
+        node_offset: int,
+        node_limit: int,
         tracking_id: TrackingId | None = None,
         diff_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.diff_branch_name = diff_branch_name
+        self.node_offset = node_offset
+        self.node_limit = node_limit
         self.tracking_id = tracking_id
         self.diff_id = diff_id
 
@@ -42,6 +43,8 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
             "diff_branch": self.diff_branch_name,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "diff_id": self.diff_id,
+            "node_offset": self.node_offset,
+            "node_limit": self.node_limit,
         }
         query = """
         MATCH (diff_root:DiffRoot)
@@ -51,48 +54,40 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
         AND (diff_root.uuid = $diff_id OR $diff_id IS NULL)
         OPTIONAL MATCH (diff_root)-[:DIFF_HAS_NODE]->(n:DiffNode)
         WHERE n.action <> $unchanged_str
-        WITH DISTINCT diff_root, n.kind AS kind
-        CALL (diff_root, kind) {
-            OPTIONAL MATCH (diff_root)-[:DIFF_HAS_NODE]->(n:DiffNode {kind: kind})-[:DIFF_HAS_ATTRIBUTE]->(a:DiffAttribute)
-            WHERE n.action <> $unchanged_str
-            AND a.action <> $unchanged_str
-            WITH a.name AS attr_name, collect(DISTINCT n.uuid) AS attr_node_uuids
-            WHERE attr_name IS NOT NULL
-            RETURN collect({name: attr_name, node_uuids: attr_node_uuids}) AS attr_name_uuids
+        WITH n
+        ORDER BY n.uuid, elementId(n)
+        SKIP $node_offset
+        LIMIT $node_limit
+        CALL (n) {
+            OPTIONAL MATCH (n)-[:DIFF_HAS_ATTRIBUTE]->(a:DiffAttribute)
+            WHERE a.action <> $unchanged_str
+            RETURN collect(DISTINCT a.name) AS attr_names
         }
-        WITH diff_root, kind, attr_name_uuids
-        CALL (diff_root, kind) {
-            OPTIONAL MATCH (diff_root)-[:DIFF_HAS_NODE]->(n:DiffNode {kind: kind})-[:DIFF_HAS_RELATIONSHIP]->(r:DiffRelationship)
-            WHERE n.action <> $unchanged_str
-            AND r.action <> $unchanged_str
-            WITH r.name AS rel_name, collect(DISTINCT n.uuid) AS rel_node_uuids
-            WHERE rel_name IS NOT NULL
-            RETURN collect({name: rel_name, node_uuids: rel_node_uuids}) AS rel_name_uuids
+        CALL (n) {
+            OPTIONAL MATCH (n)-[:DIFF_HAS_RELATIONSHIP]->(r:DiffRelationship)
+            WHERE r.action <> $unchanged_str
+            RETURN collect(DISTINCT r.name) AS rel_names
         }
         """
         self.add_to_query(query=query)
-        self.order_by = ["kind"]
-        self.return_labels = ["kind", "attr_name_uuids", "rel_name_uuids"]
+        self.return_labels = ["n.kind AS kind", "n.uuid AS node_uuid", "attr_names", "rel_names"]
 
-    async def get_field_summaries(self) -> list[NodeDiffFieldSummary]:
-        field_summaries = []
+    def get_node_field_rows(self) -> Generator[NodeDiffFieldSummary, None, None]:
+        """Yield a single-node field summary for each changed node in this page.
+
+        A node whose fields are all unchanged still yields a summary (with empty field maps) so the
+        caller can count the nodes consumed from this page. A diff root with no changed nodes at all
+        produces one node-less row instead; it is skipped here, which is safe for the caller's
+        consumed-node count because null nodes sort after every real node.
+        """
         for result in self.get_results():
-            kind = result.get_as_type(label="kind", return_type=str)
-            attribute_node_uuids = self._to_field_uuids(
-                result.get_as_list_of_type(label="attr_name_uuids", return_type=FieldNodeUuidsRow)
-            )
-            relationship_node_uuids = self._to_field_uuids(
-                result.get_as_list_of_type(label="rel_name_uuids", return_type=FieldNodeUuidsRow)
-            )
-            if attribute_node_uuids or relationship_node_uuids:
-                field_summaries.append(
-                    NodeDiffFieldSummary(
-                        kind=kind,
-                        attribute_node_uuids=attribute_node_uuids,
-                        relationship_node_uuids=relationship_node_uuids,
-                    )
-                )
-        return field_summaries
-
-    def _to_field_uuids(self, rows: list[FieldNodeUuidsRow]) -> dict[str, set[str]]:
-        return {row.name: set(row.node_uuids) for row in rows}
+            kind = result.get_as_str("kind")
+            node_uuid = result.get_as_str("node_uuid")
+            if not kind or not node_uuid:
+                continue
+            summary = NodeDiffFieldSummary(kind=kind)
+            for attr_name in result.get_as_type(label="attr_names", return_type=list[str]):
+                summary.add_attribute_node_uuid(name=attr_name, node_uuid=node_uuid)
+            for rel_name in result.get_as_type(label="rel_names", return_type=list[str]):
+                summary.add_relationship_node_uuid(name=rel_name, node_uuid=node_uuid)
+            yield summary

--- a/backend/infrahub/core/diff/query/field_summary.py
+++ b/backend/infrahub/core/diff/query/field_summary.py
@@ -18,20 +18,19 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
 
     name = "enriched_diff_node_field_summary"
     type = QueryType.READ
+    insert_limit = False
 
     def __init__(
         self,
         diff_branch_name: str,
-        node_offset: int,
-        node_limit: int,
+        limit: int,
         tracking_id: TrackingId | None = None,
         diff_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.diff_branch_name = diff_branch_name
-        self.node_offset = node_offset
-        self.node_limit = node_limit
+        self.limit = limit
         self.tracking_id = tracking_id
         self.diff_id = diff_id
 
@@ -43,8 +42,8 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
             "diff_branch": self.diff_branch_name,
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
             "diff_id": self.diff_id,
-            "node_offset": self.node_offset,
-            "node_limit": self.node_limit,
+            "node_offset": self.offset or 0,
+            "node_limit": self.limit,
         }
         query = """
         MATCH (diff_root:DiffRoot)
@@ -86,8 +85,8 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
             if not kind or not node_uuid:
                 continue
             summary = NodeDiffFieldSummary(kind=kind)
-            for attr_name in result.get_as_type(label="attr_names", return_type=list[str]):
+            for attr_name in result.get_as_list_of_type(label="attr_names", return_type=str):
                 summary.add_attribute_node_uuid(name=attr_name, node_uuid=node_uuid)
-            for rel_name in result.get_as_type(label="rel_names", return_type=list[str]):
+            for rel_name in result.get_as_list_of_type(label="rel_names", return_type=str):
                 summary.add_relationship_node_uuid(name=rel_name, node_uuid=node_uuid)
             yield summary

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -597,8 +597,8 @@ class DiffRepository:
                 diff_branch_name=diff_branch_name,
                 tracking_id=tracking_id,
                 diff_id=diff_id,
-                node_offset=node_offset,
-                node_limit=node_limit,
+                offset=node_offset,
+                limit=node_limit,
             )
             await query.execute(db=self.db)
             num_nodes = 0

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -588,11 +588,32 @@ class DiffRepository:
     async def get_node_field_summaries(
         self, diff_branch_name: str, tracking_id: TrackingId | None = None, diff_id: str | None = None
     ) -> list[NodeDiffFieldSummary]:
-        query = await EnrichedDiffNodeFieldSummaryQuery.init(
-            db=self.db, diff_branch_name=diff_branch_name, tracking_id=tracking_id, diff_id=diff_id
-        )
-        await query.execute(db=self.db)
-        return await query.get_field_summaries()
+        node_limit = config.SETTINGS.database.query_size_limit
+        node_offset = 0
+        summaries_by_kind: dict[str, NodeDiffFieldSummary] = {}
+        while True:
+            query = await EnrichedDiffNodeFieldSummaryQuery.init(
+                db=self.db,
+                diff_branch_name=diff_branch_name,
+                tracking_id=tracking_id,
+                diff_id=diff_id,
+                node_offset=node_offset,
+                node_limit=node_limit,
+            )
+            await query.execute(db=self.db)
+            num_nodes = 0
+            for node_summary in query.get_node_field_rows():
+                num_nodes += 1
+                if not node_summary.attribute_node_uuids and not node_summary.relationship_node_uuids:
+                    continue
+                kind_summary = summaries_by_kind.setdefault(
+                    node_summary.kind, NodeDiffFieldSummary(kind=node_summary.kind)
+                )
+                kind_summary.merge(node_summary)
+            if num_nodes < node_limit:
+                break
+            node_offset += node_limit
+        return list(summaries_by_kind.values())
 
     async def mark_tracking_ids_merged(self, tracking_ids: list[TrackingId]) -> None:
         query = await EnrichedDiffMergedTrackingIdQuery.init(db=self.db, tracking_ids=tracking_ids)

--- a/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
+++ b/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
@@ -12,10 +12,12 @@ from infrahub.core.diff.model.path import (
     NodeDiffFieldSummary,
 )
 from infrahub.core.diff.parent_node_adder import DiffParentNodeAdder
+from infrahub.core.diff.query.field_summary import EnrichedDiffNodeFieldSummaryQuery
 from infrahub.core.diff.repository.deserializer import EnrichedDiffDeserializer
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from tests.helpers.db_query_counter import CountingInfrahubDatabase
 from tests.helpers.diff_factories import (
     EnrichedAttributeFactory,
     EnrichedNodeFactory,
@@ -30,12 +32,17 @@ from .base import DiffRepositoryTestBase
 class PageSizeCase:
     name: str
     query_size_limit: int
+    expected_query_count: int
 
 
+NUM_CHANGED_NODES = 10
+
+# One query per page, where the last page is the first to come back shorter than the page size. A
+# node count that is an exact multiple of the page size therefore needs one extra, empty page.
 PAGE_SIZE_CASES = [
-    PageSizeCase(name="partial_last_page", query_size_limit=4),
-    PageSizeCase(name="node_count_exact_multiple_of_page", query_size_limit=5),
-    PageSizeCase(name="single_page", query_size_limit=50),
+    PageSizeCase(name="partial_last_page", query_size_limit=4, expected_query_count=3),
+    PageSizeCase(name="node_count_exact_multiple_of_page", query_size_limit=5, expected_query_count=3),
+    PageSizeCase(name="single_page", query_size_limit=50, expected_query_count=1),
 ]
 
 
@@ -46,17 +53,32 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
     diff_to_time = Timestamp("2024-06-15T18:49:40Z")
 
     @pytest.fixture
-    def diff_repository(self, db: InfrahubDatabase) -> Generator[DiffRepository, None, None]:
+    def database_settings(self) -> Generator[None, None, None]:
         original_depth = config.SETTINGS.database.max_depth_search_hierarchy
         original_size = config.SETTINGS.database.query_size_limit
         config.SETTINGS.database.max_depth_search_hierarchy = 10
         config.SETTINGS.database.query_size_limit = 50
-        diff_repository = DiffRepository(
-            db=db, deserializer=EnrichedDiffDeserializer(DiffParentNodeAdder()), max_save_batch_size=30
-        )
-        yield diff_repository
+        yield
         config.SETTINGS.database.max_depth_search_hierarchy = original_depth
         config.SETTINGS.database.query_size_limit = original_size
+
+    @pytest.fixture
+    def diff_repository(self, db: InfrahubDatabase, database_settings: None) -> DiffRepository:
+        return DiffRepository(
+            db=db, deserializer=EnrichedDiffDeserializer(DiffParentNodeAdder()), max_save_batch_size=30
+        )
+
+    @pytest.fixture
+    def counting_db(self, db: InfrahubDatabase) -> CountingInfrahubDatabase:
+        return CountingInfrahubDatabase.from_db(db=db)
+
+    @pytest.fixture
+    def counting_diff_repository(
+        self, counting_db: CountingInfrahubDatabase, database_settings: None
+    ) -> DiffRepository:
+        return DiffRepository(
+            db=counting_db, deserializer=EnrichedDiffDeserializer(DiffParentNodeAdder()), max_save_batch_size=30
+        )
 
     def _build_named_field_node(
         self,
@@ -215,19 +237,26 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
 
     @pytest.mark.parametrize("case", PAGE_SIZE_CASES, ids=lambda c: c.name)
     async def test_get_node_field_summaries_batched(
-        self, diff_repository: DiffRepository, reset_database: None, case: PageSizeCase
+        self,
+        counting_diff_repository: DiffRepository,
+        counting_db: CountingInfrahubDatabase,
+        reset_database: None,
+        case: PageSizeCase,
     ) -> None:
-        """Per-kind summaries are complete when the changed nodes span multiple retrieval pages.
+        """Per-kind summaries are complete, and cost one query per page, when nodes span pages.
 
         Ten changed nodes of two kinds are saved, so each page size below ten forces every kind
         across a page boundary; one node has only unchanged fields, so it fills a page slot without
         contributing a summary.
+
+        The query count pins the retrieval cost. Improperly configured Query subclasses can cause
+        duplicate queries to run.
         """
         tracking_id = BranchTrackingId(name=self.diff_branch_name)
         kinds = ["TestingKindAlpha", "TestingKindBravo"]
         nodes: set[EnrichedDiffNode] = set()
         expected_by_kind: dict[str, NodeDiffFieldSummary] = {}
-        for index in range(9):
+        for index in range(NUM_CHANGED_NODES - 1):
             kind = kinds[index % len(kinds)]
             node = self._build_named_field_node(
                 kind=kind,
@@ -261,13 +290,15 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
             tracking_id=tracking_id,
         )
         await self._save_single_diff(
-            diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+            diff_repository=counting_diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
         )
 
         config.SETTINGS.database.query_size_limit = case.query_size_limit
-        retrieved = await diff_repository.get_node_field_summaries(
+        counting_db.reset_counts()
+        retrieved = await counting_diff_repository.get_node_field_summaries(
             diff_branch_name=self.diff_branch_name, tracking_id=tracking_id
         )
 
         assert len(retrieved) == len(expected_by_kind)
         assert {summary.kind: summary for summary in retrieved} == expected_by_kind
+        assert counting_db.count_for(EnrichedDiffNodeFieldSummaryQuery.name) == case.expected_query_count

--- a/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
+++ b/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
@@ -214,9 +214,17 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
         assert retrieved_by_diff_id == expected_summaries
 
     async def test_get_node_field_summaries_empty_diff(
-        self, diff_repository: DiffRepository, reset_database: None
+        self,
+        counting_diff_repository: DiffRepository,
+        counting_db: CountingInfrahubDatabase,
+        reset_database: None,
     ) -> None:
-        """A diff root with no diff nodes at all yields no summaries."""
+        """A diff root with no diff nodes at all yields no summaries, and costs a single query.
+
+        Such a root still produces one node-less row, which occupies a page slot without being a node.
+        Counting that row as a consumed node would keep pagination going past the only page, so the
+        page size here is one: it is the only size at which that miscount changes the query count.
+        """
         tracking_id = BranchTrackingId(name=self.diff_branch_name)
         enriched_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
@@ -227,13 +235,16 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
             tracking_id=tracking_id,
         )
         await self._save_single_diff(
-            diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+            diff_repository=counting_diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
         )
 
-        retrieved = await diff_repository.get_node_field_summaries(
+        config.SETTINGS.database.query_size_limit = 1
+        counting_db.reset_counts()
+        retrieved = await counting_diff_repository.get_node_field_summaries(
             diff_branch_name=self.diff_branch_name, tracking_id=tracking_id
         )
         assert retrieved == []
+        assert counting_db.count_for(EnrichedDiffNodeFieldSummaryQuery.name) == 1
 
     @pytest.mark.parametrize("case", PAGE_SIZE_CASES, ids=lambda c: c.name)
     async def test_get_node_field_summaries_batched(

--- a/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
+++ b/backend/tests/component/core/diff/repository/test_diff_field_summaries.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Generator
 
 import pytest
@@ -23,6 +24,19 @@ from tests.helpers.diff_factories import (
 )
 
 from .base import DiffRepositoryTestBase
+
+
+@dataclass
+class PageSizeCase:
+    name: str
+    query_size_limit: int
+
+
+PAGE_SIZE_CASES = [
+    PageSizeCase(name="partial_last_page", query_size_limit=4),
+    PageSizeCase(name="node_count_exact_multiple_of_page", query_size_limit=5),
+    PageSizeCase(name="single_page", query_size_limit=50),
+]
 
 
 class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
@@ -176,3 +190,84 @@ class TestDiffNodeFieldSummaries(DiffRepositoryTestBase):
             diff_branch_name=requested_branch_name, diff_id=requested_diff.uuid
         )
         assert retrieved_by_diff_id == expected_summaries
+
+    async def test_get_node_field_summaries_empty_diff(
+        self, diff_repository: DiffRepository, reset_database: None
+    ) -> None:
+        """A diff root with no diff nodes at all yields no summaries."""
+        tracking_id = BranchTrackingId(name=self.diff_branch_name)
+        enriched_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=set(),
+            tracking_id=tracking_id,
+        )
+        await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+        )
+
+        retrieved = await diff_repository.get_node_field_summaries(
+            diff_branch_name=self.diff_branch_name, tracking_id=tracking_id
+        )
+        assert retrieved == []
+
+    @pytest.mark.parametrize("case", PAGE_SIZE_CASES, ids=lambda c: c.name)
+    async def test_get_node_field_summaries_batched(
+        self, diff_repository: DiffRepository, reset_database: None, case: PageSizeCase
+    ) -> None:
+        """Per-kind summaries are complete when the changed nodes span multiple retrieval pages.
+
+        Ten changed nodes of two kinds are saved, so each page size below ten forces every kind
+        across a page boundary; one node has only unchanged fields, so it fills a page slot without
+        contributing a summary.
+        """
+        tracking_id = BranchTrackingId(name=self.diff_branch_name)
+        kinds = ["TestingKindAlpha", "TestingKindBravo"]
+        nodes: set[EnrichedDiffNode] = set()
+        expected_by_kind: dict[str, NodeDiffFieldSummary] = {}
+        for index in range(9):
+            kind = kinds[index % len(kinds)]
+            node = self._build_named_field_node(
+                kind=kind,
+                node_action=DiffAction.UPDATED,
+                attribute_actions={
+                    "shared_attr": DiffAction.UPDATED,
+                    f"attr_{index}": DiffAction.ADDED,
+                    "quiet_attr": DiffAction.UNCHANGED,
+                },
+                relationship_actions={"shared_rel": DiffAction.UPDATED},
+            )
+            nodes.add(node)
+            expected = expected_by_kind.setdefault(kind, NodeDiffFieldSummary(kind=kind))
+            expected.add_attribute_node_uuid(name="shared_attr", node_uuid=node.uuid)
+            expected.add_attribute_node_uuid(name=f"attr_{index}", node_uuid=node.uuid)
+            expected.add_relationship_node_uuid(name="shared_rel", node_uuid=node.uuid)
+        nodes.add(
+            self._build_named_field_node(
+                kind=kinds[0],
+                node_action=DiffAction.UPDATED,
+                attribute_actions={"quiet_attr": DiffAction.UNCHANGED},
+                relationship_actions={"quiet_rel": DiffAction.UNCHANGED},
+            )
+        )
+        enriched_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=self.diff_from_time,
+            to_time=self.diff_to_time,
+            nodes=nodes,
+            tracking_id=tracking_id,
+        )
+        await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+        )
+
+        config.SETTINGS.database.query_size_limit = case.query_size_limit
+        retrieved = await diff_repository.get_node_field_summaries(
+            diff_branch_name=self.diff_branch_name, tracking_id=tracking_id
+        )
+
+        assert len(retrieved) == len(expected_by_kind)
+        assert {summary.kind: summary for summary in retrieved} == expected_by_kind

--- a/backend/tests/helpers/db_query_counter.py
+++ b/backend/tests/helpers/db_query_counter.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode
+
+if TYPE_CHECKING:
+    from neo4j import Record
+
+    from infrahub.core.query import QueryType
+
+
+class CountingInfrahubDatabase(InfrahubDatabase):
+    """Database that records how many queries were executed, keyed by query name."""
+
+    def __init__(self, query_counts: Counter[str] | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        # shared by reference so counts recorded by derived session/transaction instances land here
+        self.query_counts: Counter[str] = query_counts if query_counts is not None else Counter()
+
+    @classmethod
+    def from_db(cls, db: InfrahubDatabase) -> CountingInfrahubDatabase:
+        """Build a counting database on the driver of an existing one."""
+        return cls(
+            mode=InfrahubDatabaseMode.DRIVER,
+            driver=db._driver,
+            db_type=db.db_type,
+            default_neo4j_runtime=db.default_neo4j_runtime,
+            queries_names_to_config=db.queries_names_to_config,
+        )
+
+    def get_context(self) -> dict[str, Any]:
+        ctx = super().get_context()
+        ctx["query_counts"] = self.query_counts
+        return ctx
+
+    def count_for(self, name: str) -> int:
+        return self.query_counts[name]
+
+    def reset_counts(self) -> None:
+        self.query_counts.clear()
+
+    async def execute_query_with_metadata(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        name: str = "undefined",
+        context: dict[str, str] | None = None,
+        type: QueryType | None = None,
+        timeout_seconds: float | None = None,
+    ) -> tuple[list[Record], dict[str, Any]]:
+        self.query_counts[name] += 1
+        return await super().execute_query_with_metadata(
+            query=query, params=params, name=name, context=context, type=type, timeout_seconds=timeout_seconds
+        )

--- a/dev/knowledge/backend/query-pattern.md
+++ b/dev/knowledge/backend/query-pattern.md
@@ -146,6 +146,52 @@ class MyQuery(Query):
         self.add_to_query("RETURN n.uuid AS uuid, n.name AS name LIMIT 100")  # Manual pagination
 ```
 
+#### Paginating a query that expands each row
+
+The automatic clause is appended *after* the `RETURN`, so it bounds the rows a query returns, not the work it does to produce them. When a query expands each matched row — a per-row `CALL` subquery, a `collect()` over a traversal — that expansion has already run for every match by the time the automatic `LIMIT` applies, and an `ORDER BY` there forces every expanded row to be materialized before sorting. A query that must bound *that* work takes its page in the body, before the expansion:
+
+```python
+class PagedNodeFieldsQuery(Query):
+    name = "paged_node_fields"
+    type = QueryType.READ
+    insert_limit = False
+
+    def __init__(self, limit: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.limit = limit
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {"page_offset": self.offset or 0, "page_limit": self.limit}
+        self.add_to_query("""
+        MATCH (n:Node)
+        WITH n
+        ORDER BY n.uuid, elementId(n)
+        SKIP $page_offset
+        LIMIT $page_limit
+        CALL (n) {
+            OPTIONAL MATCH (n)-[:HAS_ATTRIBUTE]->(a:Attribute)
+            RETURN collect(DISTINCT a.name) AS attr_names
+        }
+        """)
+        self.return_labels = ["n.uuid AS node_uuid", "attr_names"]
+```
+
+Three details make this correct:
+
+- Type the page size as `limit: int`, not `int | None`: a query that pages itself has no meaningful unpaged mode, and a required constructor parameter says so at the call site instead of failing later.
+- Read the bounds from the base class's `self.limit` and `self.offset` rather than adding parallel attributes, and bind them as query parameters. Reusing the base fields keeps one source of truth for the page size and is what `execute()` inspects (see below); parameters rather than interpolated literals let every page reuse one compiled plan.
+- Order strictly. `SKIP`/`LIMIT` over an unordered match can return one row on two pages and another on none; `elementId(n)` breaks ties when the sort property is not unique.
+
+`GetPathDetailsBranchQuery` in `backend/infrahub/core/migrations/query/path_details.py` is the reference implementation, driven by the caller loop in `backend/infrahub/core/migrations/helpers/attribute_recompute.py`.
+
+#### Always set self.limit on a self-paging read
+
+`Query.execute()` treats a READ with neither `limit` nor `offset` as unpaginated and routes it through `query_with_size_limit()`, which re-runs the query once per `database.query_size_limit` rows with a growing `SKIP` appended after the `RETURN`. Wrapped around a query that already pages itself, that costs one extra execution of the whole query per full page; the extra run's rows are all discarded by the outer `SKIP`, so results stay correct and only the cost shows up.
+
+With `insert_limit = False` it is worse than wasteful. The wrapper cannot append its `SKIP`/`LIMIT`, so every iteration re-sends identical text, and the loop ends only because a batch came back shorter than `query_size_limit`. A query whose own bound is greater than or equal to `query_size_limit` never produces a short batch, so the loop never terminates and keeps appending the same rows.
+
+Because the wasted execution changes no returned value, assertions on query results cannot detect it. `CountingInfrahubDatabase` in `backend/tests/helpers/db_query_counter.py` counts executions by query name, so a test can assert how many queries a paged read issues.
+
 ### Branch-Aware Edge Resolution
 
 Every edge in the graph has branch/temporal properties (`branch`, `branch_level`, `from`, `to`, `status`). When traversing multiple edges in a single query, filter each edge independently to resolve the correct active version:


### PR DESCRIPTION
Encountered an issue with the query to retrieve diff summaries of nodes when running merge performance testing locally on a very large branch. Could be that it was just too much data for my machine to handle, but better safe than sorry and this batching will cost us very little.

# Why

Retrieving the node field summaries for a diff currently runs one query that aggregates the changed field names and node UUIDs of every changed node per kind in a single transaction. On large diffs (tens of thousands of changed nodes) that aggregation does not scale and can exhaust the Neo4j heap (`Java heap space` errors during merge/rebase validation).

This PR pages the retrieval over the changed nodes so memory use per query is bounded by `database.query_size_limit`, regardless of diff size.

Non-goals: no change to what the summaries contain or how consumers (schema-constraint validation) use them.

## What changed

Behavioral changes:

- `DiffRepository.get_node_field_summaries()` now issues one query per page of changed nodes instead of a single aggregate query. Results are identical; only the retrieval strategy changed.

Implementation notes:

- `EnrichedDiffNodeFieldSummaryQuery` now selects one page of changed nodes (`SKIP`/`LIMIT` over a strict `ORDER BY n.uuid, elementId(n)`) and collects each node's altered attribute/relationship names per row, rather than aggregating across the whole diff per kind.
- `get_node_field_rows()` yields one single-node `NodeDiffFieldSummary` per row; the repository folds them into per-kind summaries via the new `NodeDiffFieldSummary.merge()`.
- The `DIFF_HAS_NODE` match stays `OPTIONAL` so a diff root with no changed nodes still produces a (node-less) row. Those rows are skipped when yielding summaries; this cannot terminate pagination early because nulls sort after every real node in the `ORDER BY`.
- Pagination stops when a page yields fewer nodes than the limit.

What stayed the same: the shape of `NodeDiffFieldSummary` (per-field node-UUID maps and derived views) and the repository's public API are unchanged.

## How to review

The part deserving the most scrutiny is the pagination-termination logic: the loop breaks when a page yields fewer rows than `query_size_limit`, and the node-less rows from the `OPTIONAL MATCH` occupy page slots without being counted. This is safe only because nulls sort last in the query's `ORDER BY` — see the `get_node_field_rows()` docstring.

## Impact & rollout

- **Backward compatibility:** none — no API, schema, or data changes.
- **Performance:** bounds per-query memory on large diffs; adds one extra round trip per `query_size_limit` changed nodes.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

