### PR TITLE
fix(frontend): keep the current branch when opening tasks from the header

### DIFF
--- a/changelog/+task-status-branch-link.fixed.md
+++ b/changelog/+task-status-branch-link.fixed.md
@@ -1,0 +1,1 @@
+Fixed the task status button in the header sending you to the tasks page on the default branch instead of the branch you were working on.

--- a/frontend/app/src/entities/tasks/ui/task-status.test.tsx
+++ b/frontend/app/src/entities/tasks/ui/task-status.test.tsx
@@ -67,6 +67,44 @@ describe("TaskStatus", () => {
     expect(component.getByTestId("pulse").query()).toBeNull();
   });
 
+  test("links to the tasks page with the current branch, not the branch in the URL", async () => {
+    // GIVEN
+    useCurrentBranchMock.mockReturnValue({
+      currentBranch: generateBranch({ name: "branch1", is_default: false }),
+      setCurrentBranch: () => {},
+    });
+    getBranchTaskStatusFromApiMock.mockResolvedValue({
+      data: { InfrahubTaskBranchStatus: { count: 0 } },
+    } as Awaited<ReturnType<typeof getBranchTaskStatusFromApi>>);
+
+    // WHEN
+    const component = await render(<TaskStatus />);
+
+    // THEN
+    await expect
+      .element(component.getByRole("link", { name: "View branch tasks" }))
+      .toHaveAttribute("href", expect.stringContaining("branch=branch1"));
+  });
+
+  test("omits the branch query param when the current branch is the default one", async () => {
+    // GIVEN
+    useCurrentBranchMock.mockReturnValue({
+      currentBranch: generateBranch({ name: "main", is_default: true }),
+      setCurrentBranch: () => {},
+    });
+    getBranchTaskStatusFromApiMock.mockResolvedValue({
+      data: { InfrahubTaskBranchStatus: { count: 0 } },
+    } as Awaited<ReturnType<typeof getBranchTaskStatusFromApi>>);
+
+    // WHEN
+    const component = await render(<TaskStatus />);
+
+    // THEN
+    await expect
+      .element(component.getByRole("link", { name: "View branch tasks" }))
+      .toHaveAttribute("href", expect.not.stringContaining("branch="));
+  });
+
   test("renders error icon with tooltip when query fails", async () => {
     // GIVEN
     useCurrentBranchMock.mockReturnValue({

--- a/frontend/app/src/entities/tasks/ui/task-status.tsx
+++ b/frontend/app/src/entities/tasks/ui/task-status.tsx
@@ -29,8 +29,8 @@ export function TaskStatus() {
     value: currentBranch.name,
   };
 
-  // constructPath reads window.location, which nuqs updates one render later than the branch
-  // context, so the branch has to come from currentBranch to avoid linking to the previous one.
+  // The branch must come from the context, not the URL: nuqs writes it one render later, so a
+  // param inherited from the URL would still point at the previous branch.
   const branchParam: overrideQueryParams = currentBranch.is_default
     ? { name: QSP.BRANCH, exclude: true }
     : { name: QSP.BRANCH, value: currentBranch.name };

--- a/frontend/app/src/entities/tasks/ui/task-status.tsx
+++ b/frontend/app/src/entities/tasks/ui/task-status.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import TasksStatusIcon from "@/assets/icons/tasks-status.svg?react";
 
-import { constructPath } from "@/shared/api/rest/fetch";
+import { constructPath, type overrideQueryParams } from "@/shared/api/rest/fetch";
 import { Tooltip } from "@/shared/components/aria/tooltip";
 import { Pulse } from "@/shared/components/ui/pulse";
 import { QSP } from "@/shared/config/qsp";
@@ -29,11 +29,20 @@ export function TaskStatus() {
     value: currentBranch.name,
   };
 
+  // constructPath reads window.location, which nuqs updates one render later than the branch
+  // context, so the branch has to come from currentBranch to avoid linking to the previous one.
+  const branchParam: overrideQueryParams = currentBranch.is_default
+    ? { name: QSP.BRANCH, exclude: true }
+    : { name: QSP.BRANCH, value: currentBranch.name };
+
   const commonButtonProps: LinkButtonProps = {
     shape: "square",
     variant: "outline",
     size: "sm",
-    href: constructPath("/tasks", [{ name: QSP.FILTER, value: JSON.stringify([filter]) }]),
+    href: constructPath("/tasks", [
+      branchParam,
+      { name: QSP.FILTER, value: JSON.stringify([filter]) },
+    ]),
   };
 
   if (error) {


### PR DESCRIPTION
# Why

Clicking the task-status button in the header while working on a non-default branch took you to the tasks page but silently reset the branch selector to `main`, so you lost your working branch just by checking on tasks.

The link built its `branch` query param from `window.location`, which nuqs updates one render *after* the branch context — so the href always lagged one branch switch behind (empty on the first switch), while its `filters` param carried the correct branch:

```
after picking platform-conflict:     href = /tasks?filters=[…"platform-conflict"]                ← no branch at all
after picking jfk1-update-edge-ips:  href = /tasks?branch=platform-conflict&filters=[…"jfk1-…"]  ← previous branch
after picking atl1-delete-upstream:  href = /tasks?branch=jfk1-update-edge-ips&filters=[…"atl1-…"]
```

## What changed

- The header task-status link now keeps you on your current branch, and correctly drops the `branch` param when you are on the default branch.
- `TaskStatus` derives the param from `currentBranch` — which it already holds — instead of inheriting it from the ambient URL.
- Non-goal: `constructPath` still reads `window.location` during render, so the same staleness can affect any link rendered outside a `useLocation` subscriber. Left for a follow-up.

## How to review

Single behavioural change in `frontend/app/src/entities/tasks/ui/task-status.tsx`. The `is_default` branchpoint exists because `constructPath` ignores a `null` value and needs `exclude: true` to remove a param.

## How to test

```bash
cd frontend/app && pnpm vitest run src/entities/tasks/ui/task-status.test.tsx
```

Two new tests: the branch must come from the context (fails before this change), and the param must be absent on the default branch. Manually: switch to a non-default branch, click the task-status button, confirm the selector still shows your branch.

## Impact & rollout

- **Backward compatibility:** none — URL shape unchanged, only correctly populated.
- **Deployment notes:** safe to deploy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

