### PR TITLE
docs: add a performance tuning page for deployment settings

### DIFF
--- a/docs/docs/deploy-manage/install-configure/configure-infrahub.mdx
+++ b/docs/docs/deploy-manage/install-configure/configure-infrahub.mdx
@@ -266,5 +266,6 @@ If you see the expected value in the output, your configuration change has been 
 ## Related resources
 
 - [Configuration reference](../../reference/configuration.mdx) - Complete list of available environment variables
+- [Tune performance](./performance-tuning.mdx) - Which settings to revisit as an instance grows, and what each one costs
 - [Production deployment](./production-deployment/overview.mdx) - Best practices for deploying Infrahub
 - [Installing Infrahub](./install/overview.mdx) - Installation methods for Infrahub

--- a/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
+++ b/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
@@ -1,0 +1,104 @@
+---
+title: Tune performance
+---
+
+Infrahub's defaults target a general-purpose deployment. As an instance grows — more objects in the database, more open branches, more automation — some of those defaults stop matching the workload. The settings below are the ones worth revisiting, each with the symptom it addresses and what you give up in exchange.
+
+Start with the [hardware requirements](./hardware-requirements.mdx): no setting compensates for an undersized machine or slow storage. Then change one setting at a time and measure the result against your own data.
+
+| Symptom | Setting | Default |
+|---|---|---|
+| Merges queue a burst of tasks while several branches are open | `INFRAHUB_DIFF_UPDATE_AFTER_MERGE` | `true` |
+| Queries over a large dataset make many database round trips | `INFRAHUB_DB_QUERY_SIZE_LIMIT` | `5000` |
+| The database is saturated under concurrent load | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES` | `0` (unlimited) |
+| Graph traversal queries are truncated or time out | `INFRAHUB_DB_PATH_TRAVERSAL_QUERY_TIMEOUT`, `INFRAHUB_DB_REACHABLE_NODES_QUERY_TIMEOUT` | `30`, `75` |
+| Hierarchy queries traverse further than your model needs | `INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY` | `5` |
+| The task list is slow on an instance with a long task history | `INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD` | `100000` |
+
+:::note
+
+For how to set an environment variable and apply it, see [Configure Infrahub](./configure-infrahub.mdx). Set these on both the Infrahub server and the task workers — both read the same configuration.
+
+:::
+
+## Diff updates after a merge
+
+Merging a branch changes the branch you merged into, which makes the stored diff of every other open branch out of date. Infrahub queues a diff update for each of them. With a few branches open this is not noticeable. With dozens of long-lived branches, a single merge queues dozens of diff recalculations, and they compete with generators, artifacts, and checks for task workers.
+
+Turn the automatic update off when you routinely keep many branches open at the same time, or when merges into the default branch are frequent:
+
+```bash title=".env"
+INFRAHUB_DIFF_UPDATE_AFTER_MERGE=false
+```
+
+**What you trade.** Stored diffs are no longer refreshed after a merge, so a branch diff you open later reflects the state before that merge until it is recalculated. Refresh it from the diff view, or through the `DiffUpdate` GraphQL mutation. A proposed change recalculates its own diff every time its pipeline runs, so proposed changes under active review are unaffected.
+
+## Query size on large datasets
+
+Queries that can return many records fetch them in pages of `INFRAHUB_DB_QUERY_SIZE_LIMIT` records, repeating with an increasing offset until a page comes back short. Over a large dataset, one logical query becomes many round trips to the database. Diff calculation and diff storage derive their own batch sizes from the same value.
+
+Raise it when the database holds a large number of objects and the server and workers have memory to spare:
+
+```bash title=".env"
+INFRAHUB_DB_QUERY_SIZE_LIMIT=10000
+```
+
+**What you trade.** Each page is held in the process that issued the query, so peak memory per query grows with the value. Raise it in steps, and watch memory on both `infrahub-server` and the task workers before going further.
+
+## Concurrent queries against the database
+
+By default Infrahub issues as many queries as the workload produces. `INFRAHUB_DB_MAX_CONCURRENT_QUERIES` caps them: before running a query, Infrahub compares the number of in-use connections in the driver pool against the limit, and while it is above, waits `INFRAHUB_DB_MAX_CONCURRENT_QUERIES_DELAY` seconds and checks again.
+
+Use it when the database is the bottleneck rather than the application. That is most often the case on Neo4j Community, which runs queries on a single core: [more cores do not increase throughput](./install/overview.mdx), and neither do more queries in parallel.
+
+```bash title=".env"
+INFRAHUB_DB_MAX_CONCURRENT_QUERIES=50
+INFRAHUB_DB_MAX_CONCURRENT_QUERIES_DELAY=0.01
+```
+
+The `infrahub_db_last_connection_pool_usage` Prometheus metric reports the in-use connection count this limit is compared against. Use it to pick a starting value.
+
+**What you trade.** Queries above the limit wait inside the application, so request latency rises under load. A limit set too low starves the pipeline: workers wait instead of running tasks.
+
+## Graph traversal timeouts
+
+Path traversal runs many small queries, one depth at a time. When a single query exceeds `INFRAHUB_DB_PATH_TRAVERSAL_QUERY_TIMEOUT`, the search stops and returns the paths found so far with `truncated_at_depth` set, rather than failing the request. `INFRAHUB_DB_REACHABLE_NODES_QUERY_TIMEOUT` bounds reachable-nodes queries, which abort with an error once it is exceeded.
+
+```bash title=".env"
+INFRAHUB_DB_PATH_TRAVERSAL_QUERY_TIMEOUT=30
+INFRAHUB_DB_REACHABLE_NODES_QUERY_TIMEOUT=75
+```
+
+Lower them to stop exploratory traversals from occupying the database on a large graph. Raise them when legitimate queries are truncated more often than they complete.
+
+**What you trade.** A lower timeout truncates more searches, so broad queries return partial results more often. Before changing the server-side budget, narrow the search itself with the per-query limits — `max_depth`, `max_paths`, `max_results`, and the kind and namespace filters documented in the [graph traversal reference](../../reference/graph-traversal.mdx).
+
+## Hierarchy search depth
+
+`INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY` bounds how far hierarchy queries traverse: the number of levels to search, applied as a maximum relationship path length of twice that value. The default is 5 and the maximum is 20.
+
+```bash title=".env"
+INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY=5
+```
+
+**What you trade.** Every additional level widens the search space for hierarchy queries and for the diff engine, which uses the same bound. Raise it only when your hierarchy is deeper than the default.
+
+## Task list on a long task history
+
+Infrahub counts task runs to paginate the task list. Counts at or above `INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD` are cached for one minute; counts below it are recomputed on every request. On a busy instance the count is expensive to compute, and with the default threshold of `100000` most counts fall below it and are never cached.
+
+Set it to `0` to cache every count:
+
+```bash title=".env"
+INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD=0
+```
+
+**What you trade.** A cached count can be up to a minute old, so the total shown alongside a task list lags behind tasks that started or finished within that window.
+
+## Related resources
+
+- [Configure Infrahub](./configure-infrahub.mdx) — how to set and apply an environment variable
+- [Configuration reference](../../reference/configuration.mdx) — every available setting, with types and defaults
+- [Hardware requirements](./hardware-requirements.mdx) — sizing, cloud machine types, and the benchmark utility
+- [What drives Infrahub performance at scale](../../faq/faq.mdx#what-drives-infrahub-performance-at-scale-and-what-can-i-tune) — query patterns and pipeline bottlenecks beyond configuration
+- [Community vs Enterprise](../../overview/community-vs-enterprise.mdx) — where the scaling limits of each edition sit

--- a/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
+++ b/docs/docs/deploy-manage/install-configure/production-deployment/overview.mdx
@@ -209,4 +209,5 @@ Contact [support@opsmill.com](mailto:support@opsmill.com) for enterprise support
 
 - [Architecture overview](../../../overview/architecture.mdx)
 - [Configuration reference](../../../reference/configuration.mdx)
+- [Tune performance](../performance-tuning.mdx)
 - [High availability](./high-availability.mdx)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -383,6 +383,7 @@ const sidebars: SidebarsConfig = {
             },
             // Configure Infrahub (PR 4)
             { type: 'doc', id: 'deploy-manage/install-configure/configure-infrahub', label: 'Configure Infrahub' },
+            { type: 'doc', id: 'deploy-manage/install-configure/performance-tuning', label: 'Tune performance' },
             // Configuration reference — stays in reference/, cross-linked here (PR 4)
             { type: 'ref', id: 'reference/configuration', label: 'Configuration reference' },
           ],


### PR DESCRIPTION
# Why

The [configuration reference](https://docs.infrahub.app/reference/configuration) lists every setting with a one-line description, but nothing tells an operator *which* ones matter once an instance grows, or what changing one costs. Someone whose merges have become slow because a dozen branches are open, or whose queries round-trip heavily over a large dataset, has no page to land on.

Goal: one page under Deployment & Management naming the settings worth revisiting at scale — the symptom each addresses, and the trade-off for changing it.

Non-goals: no behavior or default changes. Scale-out levers (`WEB_CONCURRENCY`, task-worker replicas, `INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES`) and the DB retry/backoff settings were considered and deliberately left out of this pass.

## What changed

New page `docs/docs/deploy-manage/install-configure/performance-tuning.mdx` — **Tune performance** — in the sidebar under *Install & configure*, between "Configure Infrahub" and the configuration reference link.

It opens with a symptom → setting → default lookup table, then one section per setting, each closing with a **What you trade** paragraph:

| Section | Setting | Default |
|---|---|---|
| Diff updates after a merge | `INFRAHUB_DIFF_UPDATE_AFTER_MERGE` | `true` |
| Query size on large datasets | `INFRAHUB_DB_QUERY_SIZE_LIMIT` | `5000` |
| Concurrent queries against the database | `INFRAHUB_DB_MAX_CONCURRENT_QUERIES`, `_DELAY` | `0` (unlimited), `0.01` |
| Graph traversal timeouts | `INFRAHUB_DB_PATH_TRAVERSAL_QUERY_TIMEOUT`, `INFRAHUB_DB_REACHABLE_NODES_QUERY_TIMEOUT` | `30`, `75` |
| Hierarchy search depth | `INFRAHUB_DB_MAX_DEPTH_SEARCH_HIERARCHY` | `5` |
| Task list on a long task history | `INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD` | `100000` |

Cross-links added from **Configure Infrahub** and **Production deployment** (Related resources sections).

What stayed the same: no code, config, defaults, or generated files touched. Documentation only.

## Review feedback addressed

@ajtmccarty's review round, all resolved in `db443e57a` (branch squashed to a single commit):

- **A `Branch cleanup after a merge` section for `INFRAHUB_DELETE_BRANCH_AFTER_MERGE` was removed.** Its premise — that a merged-but-undeleted branch still costs post-merge diff work — was wrong. `merge_branch` marks the merged branch's diff root `is_merged = TRUE` (`core/diff/query/merge_tracking_id.py:23`) and freezes it, rewriting `tracking_id` from `branch.<name>` to `frozen.<name>` (`core/diff/query/freeze_by_branch.py:38-43`), both at `core/branch/tasks.py:495-496` — before the post-merge flow is submitted. The post-merge loop then skips it three ways over: `get_roots_metadata` defaults to `exclude_merged=True`, the loop requires `not diff_root.is_frozen`, and it requires a `BranchTrackingId` (a `FrozenTrackingId` fails that check). The #8507 fix in 1.8/1.9 already covers this, so the setting is branch lifecycle, not a performance lever, and doesn't belong on this page.
- **The diff-update opener was rewritten** to state the cause rather than the diff-root mechanics: "Merging a branch changes the branch you merged into, which makes the stored diff of every other open branch out of date. Infrahub queues a diff update for each of them."

## How to review

The page is 107 new lines of prose — read it end to end. Every mechanical claim was traced to source at this commit; these are the load-bearing ones if you want to spot-check:

- Post-merge diff updates cover every *other* open branch → `backend/infrahub/core/branch/tasks.py:668-685`, with the merged branch excluded per the evidence in the section above
- Diffs refresh on request rather than automatically → `frontend/app/src/entities/diff/ui/diff-refresh-button.tsx`; a proposed-change pipeline recomputes its own diff → `backend/infrahub/proposed_change/tasks.py:395`, `:1556`
- Offset pagination loop → `backend/infrahub/core/query/__init__.py:609-631`; derived diff batch sizes → `backend/infrahub/core/diff/calculator.py:144-146`, `backend/infrahub/core/diff/repository/repository.py:137,166`
- Connection-pool comparison and wait loop → `backend/infrahub/database/__init__.py:338-344`; metric name → `backend/infrahub/database/metrics.py:20`
- Traversal timeout semantics → `backend/infrahub/config.py:344-362`
- Hierarchy depth applied as double the path length → `backend/infrahub/config.py:321`, `backend/infrahub/core/schema/relationship_schema.py:179`, and the diff engine's use at `backend/infrahub/core/diff/repository/repository.py:136,165`
- Flow-run count cached for one minute at or above the threshold → `backend/infrahub/task_manager/task.py:88`

The example values in the `.env` snippets are illustrative, not measured recommendations — the page says to change one setting at a time and measure. Flag any you'd rather see stated differently.

## How to test

```bash
cd docs && npm run build     # onBrokenLinks / onBrokenAnchors / onBrokenMarkdownLinks are all "throw"
uv run invoke docs.lint      # markdownlint-cli2 + Vale
```

Both pass. Note for anyone reproducing locally: the build was run with Node 22 (Docusaurus requires ≥ 20), and Vale/markdownlint were invoked directly rather than through `invoke` — neither binary is on `PATH` in a fresh worktree.

## Impact & rollout

- **Backward compatibility:** documentation only, nothing to migrate
- **Config/env changes:** none — the page documents settings that already exist
- **Deployment notes:** safe to merge at any time

## Open question for the reviewer

- [ ] **`INFRAHUB_MISC_MAXIMUM_VALIDATOR_EXECUTION_TIME` was left out.** It is defined at `backend/infrahub/config.py:820` and exported to the containers by both compose files, but nothing in this repository reads it. If Infrahub Enterprise consumes it, the page should carry a section for it with an Enterprise badge — please confirm which it is.

## Checklist

- [ ] Tests added/updated — n/a, documentation only
- [ ] Changelog entry — n/a, matching recent docs-only PRs (#10071, #10072, #10073)
- [x] External docs updated
- [ ] Internal `.md` docs updated — n/a
- [x] I have reviewed AI generated content
