### PR TITLE
refactor(core/query): type forwarded query constructor kwargs

### DIFF
--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Generator, Iterator, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterator, TypedDict, TypeVar
 
 import ujson
 from neo4j.graph import Node as Neo4jNode
@@ -387,6 +387,18 @@ class QueryStat:
     def from_metadata(cls, data: dict[str, Any]) -> Self:
         data = {key.replace("-", "_"): value for key, value in data.items()}
         return cls(**data)
+
+
+class QueryInitKwargs(TypedDict, total=False):
+    """Keyword arguments every query constructor accepts and forwards to its base."""
+
+    branch: Branch | None
+    at: Timestamp | str | None
+    limit: int | None
+    offset: int | None
+    order_by: list[str] | None
+    branch_agnostic: bool
+    user_id: str
 
 
 class Query:

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any, Generator, Unpack
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipStatus
-from infrahub.core.query import Query, QueryResult, QueryType
+from infrahub.core.query import Query, QueryInitKwargs, QueryResult, QueryType
 
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreNumberPool
@@ -79,14 +79,14 @@ class IPAddressPoolGetIdentifiers(Query):
         self,
         pool_id: str,
         allocated: list[str],
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.addresses = allocated
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["addresses"] = self.addresses
 
@@ -115,14 +115,14 @@ class IPAddressPoolGetReserved(Query):
         self,
         pool_id: str,
         identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["identifier"] = self.identifier
 
@@ -143,15 +143,15 @@ class IPAddressPoolSetReserved(Query):
         pool_id: str,
         address_id: str,
         identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.address_id = address_id
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["address_id"] = self.address_id
         self.params["identifier"] = self.identifier
@@ -182,13 +182,13 @@ class NumberPoolGetAllocated(Query):
     def __init__(
         self,
         pool: CoreNumberPool,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool = pool
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["node_attribute"] = self.pool.node_attribute.value
         self.params["start_range"] = self.pool.start_range.value
         self.params["end_range"] = self.pool.end_range.value
@@ -262,14 +262,14 @@ class NumberPoolGetReserved(Query):
         self,
         pool_id: str,
         identifier: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["identifier"] = self.identifier
 
@@ -348,14 +348,14 @@ class PoolChangeReserved(Query):
         self,
         existing_identifier: str,
         new_identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.existing_identifier = existing_identifier
         self.new_identifier = new_identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["new_identifier"] = self.new_identifier
         self.params["existing_identifier"] = self.existing_identifier
         self.params["at"] = self.at.to_string()
@@ -404,13 +404,13 @@ class NumberPoolGetUsed(Query):
     def __init__(
         self,
         pool: CoreNumberPool,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool = pool
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool.get_id()
         self.params["start_range"] = self.pool.start_range.value
         self.params["end_range"] = self.pool.end_range.value
@@ -472,15 +472,15 @@ class NumberPoolGetFree(Query):
         pool: CoreNumberPool,
         min_value: int | None = None,
         max_value: int | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool = pool
         self.min_value = min_value
         self.max_value = max_value
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool.get_id()
         # Use min_value/max_value if provided, otherwise use pool's start_range/end_range
         self.params["start_range"] = self.min_value if self.min_value is not None else self.pool.start_range.value
@@ -569,15 +569,15 @@ class NumberPoolSetReserved(Query):
         pool_id: str,
         reserved: int,
         identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.reserved = reserved
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["reserved"] = self.reserved
         self.params["identifier"] = self.identifier
@@ -611,14 +611,14 @@ class PrefixPoolGetIdentifiers(Query):
         self,
         pool_id: str,
         allocated: list[str],
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.prefixes = allocated
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["prefixes"] = self.prefixes
 
@@ -647,14 +647,14 @@ class PrefixPoolGetReserved(Query):
         self,
         pool_id: str,
         identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["identifier"] = self.identifier
 
@@ -675,15 +675,15 @@ class PrefixPoolSetReserved(Query):
         pool_id: str,
         prefix_id: str,
         identifier: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Unpack[QueryInitKwargs],
     ) -> None:
         self.pool_id = pool_id
         self.prefix_id = prefix_id
         self.identifier = identifier
 
-        super().__init__(**kwargs)  # type: ignore[arg-type]
+        super().__init__(**kwargs)
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["pool_id"] = self.pool_id
         self.params["prefix_id"] = self.prefix_id
         self.params["identifier"] = self.identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disable_error_code = [
 module = "infrahub.core.query"
 disable_error_code = [
     "arg-type",
-    "attr-defined",
     "return-value",
 ]
 
@@ -278,14 +277,12 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "infrahub.core.query.ipam"
 disable_error_code = [
-    "attr-defined",
     "no-untyped-def",
 ]
 
 [[tool.mypy.overrides]]
 module = "infrahub.core.query.node"
 disable_error_code = [
-    "annotation-unchecked",
     "arg-type",
     "assignment",
     "no-untyped-def",
@@ -297,13 +294,9 @@ module = "infrahub.core.query.relationship"
 disable_error_code = [
     "arg-type",
     "assignment",
-    "call-overload",
-    "index",
-    "misc",
     "no-untyped-def",
     "union-attr",
     "valid-type",
-    "var-annotated",
 ]
 
 [[tool.mypy.overrides]]
@@ -1389,7 +1382,11 @@ include = [
     "backend/infrahub/core/merge/**",
     "backend/infrahub/core/migrations/**",
     "backend/infrahub/core/node/**",
-    "backend/infrahub/core/query/**",
+    "backend/infrahub/core/query/__init__.py",
+    "backend/infrahub/core/query/diff.py",
+    "backend/infrahub/core/query/node.py",
+    "backend/infrahub/core/query/relationship.py",
+    "backend/infrahub/core/query/subquery.py",
     "backend/infrahub/core/relationship/**",
     "backend/infrahub/core/schema/**",
     "backend/infrahub/core/validators/**",


### PR DESCRIPTION
Note, the end goal would be to remove Query.query_init instead, this is just improvements along the way to reduce typing ignores.

# Why

`**kwargs: dict[str, Any]` does not mean "kwargs is an arbitrary mapping". It declares that every keyword *value* is itself a `dict[str, Any]`. The twelve query constructors in `core/query/resource_manager.py` that forward to the base query constructor therefore looked like they were passing a dict to each of its typed parameters (`branch`, `at`, `limit`, `offset`, `order_by`, `branch_agnostic`, `user_id`).

The consequences were a `# type: ignore[arg-type]` on every single forwarding call, and 84 suppressed ty `invalid-argument-type` diagnostics in that one file (one per base parameter per call site). That is 20% of all suppressed ty debt in `backend/infrahub/core/`, from one bad idiom in one file. It also meant callers of those query classes were entirely unchecked.

Goal: correct the annotation so the forwarded kwargs are verified, and permanently enforce `invalid-argument-type` for the rest of `core/query/`.

Non-goals: the same idiom appears at ~150 further sites (`query_init` overrides, graphene `__init_subclass_with_meta__`, migration `init`). None of those produce diagnostics today, and they are a separate mechanical sweep.

## What changed

- Added a `QueryInitKwargs` TypedDict next to the base query constructor and declared the twelve forwarding constructors as `**kwargs: Unpack[QueryInitKwargs]`.
- Deleted the twelve now-unnecessary `# type: ignore[arg-type]` comments.
- Aligned the `query_init` overrides in the same file with the base signature (`**kwargs: Any`); they were drifted copies of a base that was already correct.
- Narrowed the ty `invalid-argument-type` override from the coarse `backend/infrahub/core/query/**` glob to the five files that still trip it (`__init__.py`, `diff.py`, `node.py`, `relationship.py`, `subquery.py`). Every other file in the package, including `resource_manager.py`, is now permanently enforced for that rule.
- Dropped seven stale mypy `disable_error_code` entries for `infrahub.core.query*` that no longer match any reported error: `attr-defined` (on `query` and `query.ipam`), `annotation-unchecked` (`query.node`), and `call-overload` / `index` / `misc` / `var-annotated` (`query.relationship`). These were already stale before this change; measuring the modules with all their overrides stripped surfaced them.

**What stayed the same:** no runtime behaviour. Every top-level definition in `resource_manager.py` is byte-identical after stripping annotations; the only other edits to that file are two added imports. `**kwargs` annotations are never evaluated at runtime here (`from __future__ import annotations`), and removing a `# type: ignore` comment has no runtime effect.

This is not a suppression swap. The kwargs are genuinely checked now, where before anything was accepted:

```
$ uv run mypy <probe with a deliberately wrong call>
error: Argument "limit" to "IPAddressPoolGetIdentifiers" has incompatible type "str"; expected "int | None"  [arg-type]
error: Unexpected keyword argument "bogus" for "IPAddressPoolGetIdentifiers"  [call-arg]
```

### On ty versions

ty 0.0.32 (pinned here) accepts `Unpack[TypedDict]` on `**kwargs` and stops emitting the 84 diagnostics, but does not yet enforce the TypedDict contents, so today's enforcement comes from mypy. ty 0.0.66 does enforce it, so a later ty upgrade tightens this change rather than breaking it. No upgrade is required for this PR.

## How to review

Start with `backend/infrahub/core/query/__init__.py` (the new TypedDict, 12 lines), then the `pyproject.toml` diff (both the ty glob narrowing and the stale mypy entries). `resource_manager.py` is 36 mechanical, uniform edits: 12 `**kwargs` annotations, 12 removed type-ignores, 12 `query_init` signatures.

The `QueryInitKwargs` fields must stay in sync with the base constructor's signature by hand. That is the one thing worth a careful look, and the reason it lives directly above `class Query`.

## How to test

```bash
uv run invoke backend.mypy      # Success: no issues found in 1601 source files
uv run ty check .               # All checks passed!
uv run invoke backend.ruff
uv run invoke backend.test-unit # 2166 passed
```

Note: 4 tests in `backend/tests/unit/services/adapters/workflow/test_local_stamping.py` fail locally without a Prefect API on `localhost:4200`. They fail identically on a clean tree and are unrelated to this change. The touched code is covered by component and functional tests, which need the testcontainers stack, so CI is the gate for those.

Measured effect on suppressed debt in `backend/infrahub/core/`, checking with the debt overrides stripped: **423 -> 339** ty diagnostics, and `resource_manager.py` goes from 84 to 0.

## Impact & rollout

- **Backward compatibility:** no API or behaviour change; annotations only.
- **Performance:** none.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Follow-ups found while doing this

- `QueryResult.__init__` annotates `data` as `list[Neo4jNode | Neo4jRelationship | list[Neo4jNode]]`, but is passed a neo4j `Record` (`query/__init__.py:660`). No runtime bug, since a `Record` accepts string keys, but the wrong annotation is why `relationship.py:1546` still carries a bare `# type: ignore` for `row.data["uuid"]`. Correcting it on a class used throughout the query layer looks like the next root-cause fix.
- The remaining ~150 `**kwargs: dict[str, Any]` sites, none of which produce diagnostics today.

## Checklist

- [ ] Tests added/updated <!-- annotation-only change with no runtime effect; the type checkers are the test -->
- [ ] Changelog entry added <!-- not applicable: internal typing only, no user-facing change -->
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

