### PR TITLE
fix: release the urql operation when a GraphQL fetch is aborted

### DIFF
--- a/frontend/app/src/entities/nodes/object/api/get-objects-count-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-count-from-api.ts
@@ -30,6 +30,7 @@ const getObjectsCountQuery = ({ objectKind, filters }: getObjectsCountQueryParam
 export interface GetObjectsCountFromApiParams extends ContextParams {
   objectKind: string;
   filters?: Array<Filter>;
+  signal?: AbortSignal;
 }
 
 export const getObjectsCountFromApi = async ({
@@ -37,6 +38,7 @@ export const getObjectsCountFromApi = async ({
   filters,
   branchName,
   atDate,
+  signal,
 }: GetObjectsCountFromApiParams) => {
   return graphqlClient.query({
     query: getObjectsCountQuery({ objectKind, filters }),
@@ -44,6 +46,7 @@ export const getObjectsCountFromApi = async ({
       branch: branchName,
       date: atDate,
       processErrorMessage: () => {},
+      signal,
     },
   });
 };

--- a/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/get-objects-from-api.ts
@@ -65,7 +65,9 @@ const getObjectsQuery = ({
 export interface GetObjectsFromApiParams
   extends ContextParams,
     PaginationParams,
-    GetObjectsQueryParams {}
+    GetObjectsQueryParams {
+  signal?: AbortSignal;
+}
 
 export async function getObjectsFromApi({
   schemaKind,
@@ -79,6 +81,7 @@ export async function getObjectsFromApi({
   sort,
   attributesOptions,
   relationshipsOptions,
+  signal,
 }: GetObjectsFromApiParams) {
   return graphqlClient.query({
     query: getObjectsQuery({
@@ -95,6 +98,7 @@ export async function getObjectsFromApi({
     context: {
       branch: branchName,
       date: atDate,
+      signal,
     },
   });
 }

--- a/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects-count.ts
+++ b/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects-count.ts
@@ -12,12 +12,14 @@ export const getObjectsCount: GetObjectsCount = async ({
   branchName,
   atDate,
   filters = [],
+  signal,
 }) => {
   const { data, errors } = await getObjectsCountFromApi({
     objectKind,
     branchName,
     atDate,
     filters,
+    signal,
   });
 
   if (errors?.[0]?.message) {

--- a/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects.ts
+++ b/frontend/app/src/entities/nodes/object/domain/use-cases/get-objects.ts
@@ -23,6 +23,7 @@ export type GetObjectsParams = ContextParams &
     getRelationshipsVisible?: (relationships: RelationshipSchema[]) => RelationshipSchema[];
     attributesOptions?: AddAttributesToRequestOptions;
     relationshipsOptions?: AddAttributesToRequestOptions;
+    signal?: AbortSignal;
   };
 
 export type GetObjects = (args: GetObjectsParams) => Promise<Array<NodeObject>>;
@@ -39,6 +40,7 @@ export const getObjects: GetObjects = async ({
   getRelationshipsVisible = getRelationshipsVisibleInListView,
   attributesOptions,
   relationshipsOptions,
+  signal,
 }) => {
   const attributesVisible = getAttributesVisible(schema.attributes ?? []);
   const relationshipsVisible = getRelationshipsVisible(schema.relationships ?? []);
@@ -57,6 +59,7 @@ export const getObjects: GetObjects = async ({
     sort,
     attributesOptions,
     relationshipsOptions,
+    signal,
   });
 
   if (errors) {

--- a/frontend/app/src/entities/nodes/object/ui/queries/get-objects-count.query.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/get-objects-count.query.ts
@@ -14,8 +14,8 @@ import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query
 export function getObjectsCountQueryOptions(params: GetObjectsCountParams) {
   return queryOptions({
     queryKey: objectQueryKeys.count(params),
-    queryFn: async () => {
-      return getObjectsCount(params);
+    queryFn: async ({ signal }) => {
+      return getObjectsCount({ ...params, signal });
     },
   });
 }

--- a/frontend/app/src/entities/nodes/object/ui/queries/get-objects.query.ts
+++ b/frontend/app/src/entities/nodes/object/ui/queries/get-objects.query.ts
@@ -25,11 +25,12 @@ export function getObjectsInfiniteQueryOptions(
   return infiniteQueryOptionsWithOptimizedPageSize(
     {
       queryKey: objectQueryKeys.list({ ...params, objectKind: params.schema.kind! }),
-      queryFn: ({ pageParam }) =>
+      queryFn: ({ pageParam, signal }) =>
         getObjects({
           ...params,
           offset: pageParam.offset,
           limit: pageParam.limit,
+          signal,
         }),
     },
     config

--- a/frontend/app/src/shared/api/graphql/client.dedup.test.ts
+++ b/frontend/app/src/shared/api/graphql/client.dedup.test.ts
@@ -75,3 +75,84 @@ describe("concurrent identical query across endpoints", () => {
     expect(b.data).toEqual({ __typename: "branch-a" });
   });
 });
+
+// A refetch raised right after a mutation must reach the server even when the request it
+// supersedes is still open, or the caller redisplays the pre-mutation snapshot.
+describe("aborted operation", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let resolveRequests: Array<(response: Response) => void>;
+
+  const PING = gql`
+    query Ping {
+      __typename
+    }
+  `;
+
+  const respond = (typename: string) =>
+    new Response(JSON.stringify({ data: { __typename: typename } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  beforeEach(() => {
+    resolveRequests = [];
+    fetchSpy = vi.fn(() => new Promise<Response>((resolve) => resolveRequests.push(resolve)));
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects with the abort reason", async () => {
+    // GIVEN
+    const controller = new AbortController();
+    const pending = graphqlClient.query({
+      query: PING,
+      context: { branch: "abort-reject", signal: controller.signal },
+    });
+
+    // WHEN
+    controller.abort(new Error("superseded"));
+
+    // THEN
+    await expect(pending).rejects.toThrow("superseded");
+  });
+
+  it("rejects without issuing a request when the signal is already aborted", async () => {
+    // GIVEN
+    const controller = new AbortController();
+    controller.abort(new Error("superseded"));
+
+    // WHEN
+    const pending = graphqlClient.query({
+      query: PING,
+      context: { branch: "abort-early", signal: controller.signal },
+    });
+
+    // THEN
+    await expect(pending).rejects.toThrow("superseded");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("lets the replacement query reach the server instead of merging into the aborted one", async () => {
+    // GIVEN a request the caller walks away from while it is still open
+    const controller = new AbortController();
+    const abandoned = graphqlClient.query({
+      query: PING,
+      context: { branch: "abort-release", signal: controller.signal },
+    });
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    controller.abort(new Error("superseded"));
+    await expect(abandoned).rejects.toThrow("superseded");
+
+    // WHEN the same query is raised again, the abandoned request still unresolved
+    const replacement = graphqlClient.query({ query: PING, context: { branch: "abort-release" } });
+
+    // THEN
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    resolveRequests.at(-1)?.(respond("fresh"));
+    await expect(replacement).resolves.toEqual({ data: { __typename: "fresh" } });
+  });
+});

--- a/frontend/app/src/shared/api/graphql/client.ts
+++ b/frontend/app/src/shared/api/graphql/client.ts
@@ -7,6 +7,8 @@ import {
   formatDocument,
   makeOperation,
   mapExchange,
+  type OperationResult,
+  type OperationResultSource,
 } from "@urql/core";
 import { authExchange } from "@urql/exchange-auth";
 
@@ -80,6 +82,60 @@ function getGraphqlClient(branch?: string | null, date?: Date | null): Client {
   return client;
 }
 
+// urql keeps an operation alive until its last subscriber leaves, and merges any identical
+// operation raised in the meantime into that one instead of reaching the server. `toPromise()`
+// only leaves once the response lands, so a caller that walks away from a request it no longer
+// wants still holds the operation open, and the caller that replaces it is handed the abandoned
+// request's snapshot. Unsubscribing on abort releases the operation so the replacement is a real
+// round trip.
+function resolveOperation<TResult extends OperationResult>(
+  source: OperationResultSource<TResult>,
+  signal?: AbortSignal
+): Promise<TResult> {
+  if (!signal) {
+    return source.toPromise();
+  }
+
+  return resolveAbortableOperation(source, signal);
+}
+
+function resolveAbortableOperation<TResult extends OperationResult>(
+  source: OperationResultSource<TResult>,
+  signal: AbortSignal
+): Promise<TResult> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+
+  return new Promise<TResult>((resolve, reject) => {
+    let unsubscribe: (() => void) | undefined;
+    let isSettled = false;
+
+    const settle = (): boolean => {
+      if (isSettled) return false;
+      isSettled = true;
+      signal.removeEventListener("abort", onAbort);
+      unsubscribe?.();
+      return true;
+    };
+
+    function onAbort() {
+      if (settle()) reject(signal.reason);
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    // Mirrors `toPromise()`: the first result that is neither stale nor a partial payload.
+    const subscription = source.subscribe((result) => {
+      if (result.stale || result.hasNext) return;
+      if (settle()) resolve(result);
+    });
+
+    unsubscribe = () => subscription.unsubscribe();
+    if (isSettled) unsubscribe();
+  });
+}
+
 // Map urql result to the preserved `{ data, errors }` shape and run error routing.
 function toGraphQLResult<TData>(
   data: TData | undefined,
@@ -117,18 +173,26 @@ export const graphqlClient = {
   async query<TData = any, TVars extends AnyVariables = AnyVariables>(
     args: QueryArgs<TData, TVars>
   ): Promise<GraphQLResult<TData>> {
-    const result = await getGraphqlClient(args.context?.branch, args.context?.date)
-      .query<TData, TVars>(args.query, args.variables as TVars)
-      .toPromise();
+    const result = await resolveOperation(
+      getGraphqlClient(args.context?.branch, args.context?.date).query<TData, TVars>(
+        args.query,
+        args.variables as TVars
+      ),
+      args.context?.signal
+    );
     return toGraphQLResult(result.data, result.error, args.context);
   },
 
   async mutate<TData = any, TVars extends AnyVariables = AnyVariables>(
     args: MutateArgs<TData, TVars>
   ): Promise<GraphQLResult<TData>> {
-    const result = await getGraphqlClient(args.context?.branch, args.context?.date)
-      .mutation<TData, TVars>(args.mutation, args.variables as TVars)
-      .toPromise();
+    const result = await resolveOperation(
+      getGraphqlClient(args.context?.branch, args.context?.date).mutation<TData, TVars>(
+        args.mutation,
+        args.variables as TVars
+      ),
+      args.context?.signal
+    );
     return toGraphQLResult(result.data, result.error, args.context);
   },
 };

--- a/frontend/app/src/shared/api/graphql/types.ts
+++ b/frontend/app/src/shared/api/graphql/types.ts
@@ -4,6 +4,7 @@ export interface GraphQLRequestContext {
   branch?: string | null;
   date?: Date | null;
   processErrorMessage?: (message: string) => void;
+  signal?: AbortSignal;
 }
 
 export interface GraphQLResult<TData> {

--- a/frontend/app/src/shared/libs/react-query/infinite-query-options-with-optimized-page-size.ts
+++ b/frontend/app/src/shared/libs/react-query/infinite-query-options-with-optimized-page-size.ts
@@ -34,7 +34,10 @@ export function infiniteQueryOptionsWithOptimizedPageSize<
 >(
   options: {
     queryKey: TQueryKey;
-    queryFn: (context: { pageParam: OffsetPagination }) => Promise<TQueryFnData>;
+    queryFn: (context: {
+      pageParam: OffsetPagination;
+      signal: AbortSignal;
+    }) => Promise<TQueryFnData>;
     staleTime?: number;
     gcTime?: number;
   },


### PR DESCRIPTION
## What is broken

Deleting an object from a table in the UI leaves the deleted row on screen. The row never goes away, no matter how long you wait. The count badge above the table correctly drops to the new number, so the table shows, for example, "7 counts" above 8 rows.

This is a regression introduced on `release-1.11` by #10059 (Apollo Client to urql migration). It has never shipped: `e0341de9a` is not in `v1.11.0b0` or any earlier tag.

It is also why `E2E-testing-pytest-playwright` looks flaky on the release-1.11 into develop merge PR (#10084). It is not flaky. Both of these fail on **every** run of `release-1.11` since 2026-07-30:

- `tests/e2e/role-management/test_group_management.py::TestGroupCrud::test_group_crud` (branches_repo shard)
- `tests/e2e/role-management/test_roles_management.py::TestRolesCrud::test_roles_crud` (foundation shard)

Both fail on the same assertion, the one that checks the deleted row is gone:

```
await expect(get_data_table_row(admin_page, "test group")).not_to_be_visible()
E   AssertionError: Locator expected not to be visible
E   Actual value: visible
```

`develop` is green for these tests because it is still on Apollo Client. The merge PR is simply the first place the two branches meet.

## Background for anyone who does not work in the frontend

Two libraries are involved, and the important thing is that they do different jobs:

- **urql** is the GraphQL *transport*. It builds the HTTP request and parses the response. As of #10059 it is configured with no cache exchange, so it is deliberately a dumb pipe.
- **TanStack Query** (React Query) is the *cache*. It owns query keys, staleness, and refetching. When a mutation succeeds, the app calls `invalidateQueries(...)`, and React Query refetches whatever is on screen.

The delete flow is meant to be: run the delete mutation, invalidate the `objects` query keys, React Query refetches the list, the deleted row disappears.

## Root cause

urql keeps an "operation" alive as long as something is subscribed to it, and it deduplicates: an identical operation raised while one is already in flight does not produce a second HTTP request. It is merged into the first and receives that first request's result.

The transport resolved every operation with urql's `toPromise()`. That helper stays subscribed until the response lands. Nothing wired React Query's `AbortSignal` into it, so when React Query walked away from a request it no longer wanted, urql never heard about it and the operation stayed open.

React Query's `invalidateQueries` calls `refetchQueries`, which defaults to `cancelRefetch: true`. That cancels a fetch already in flight and immediately starts a replacement. So on a delete:

1. The list query is fetching (a routine refetch already in progress).
2. The delete mutation succeeds and invalidates the `objects` keys.
3. React Query cancels the in-flight list fetch and starts a replacement.
4. urql never saw a teardown, so the replacement is merged into the cancelled request and is handed **the snapshot taken before the delete**.
5. No second HTTP request is made, and React Query stores the pre-delete rows as the fresh result. The table is stuck.

The count query is a different document, so it is not affected by the merge, refetches normally, and reports the correct number. Hence the count badge and the row list disagreeing.

The Playwright trace from the failing CI job shows exactly this, no list request after the delete for the remaining 60 seconds:

```
21:42:15.704  GetObjectsCoreAccountGroup        (list, +1052ms)
21:42:16.210  mutation CoreAccountGroupDelete   (+1040ms, ok:true)
21:42:17.756  GetObjectsCountCoreAccountGroup   x2   <- counts refetch
              ...no GetObjectsCoreAccountGroup ever again
```

Apollo Client did not behave this way, which is why the tests pass on `develop`.

## The fix

Two parts.

**1. The transport honours an abort signal** (`shared/api/graphql/client.ts`)

`graphqlClient.query`/`mutate` no longer use `toPromise()`. They subscribe to the urql result source and unsubscribe if the caller's `AbortSignal` fires. Unsubscribing is what makes urql tear the operation down and release its dedup slot, so the next identical request is a real round trip. An already-aborted signal rejects without issuing a request. With no signal supplied, behaviour is unchanged.

**2. The object list and count pass their signal down**

React Query hands every query function an `AbortSignal`. It was being dropped. It is now threaded from the query function through the use case into the request context:

```ts
queryFn: ({ pageParam, signal }) => getObjects({ ...params, signal, ... })
// -> getObjectsFromApi({ ..., signal })
// -> graphqlClient.query({ ..., context: { branch, date, signal } })
```

`infiniteQueryOptionsWithOptimizedPageSize` had narrowed its query function context type to `{ pageParam }`, which hid the signal from callers, so that type was widened.

## Scope, and what is deliberately not in here

This covers the object list and its count, which is what the failing tests exercise and where the user-visible bug lives.

The same hazard is still latent in roughly 90 other GraphQL modules: any of them can serve a superseded request's result to the refetch that replaced it. The transport is now ready for them, each needs the same three-line pass-through. That sweep is intentionally left out to keep this diff reviewable on a release branch.

## Testing

Three cases added to `client.dedup.test.ts`:

- an aborted operation rejects with the abort reason
- an already-aborted signal rejects without issuing a request
- **a replacement query reaches the server instead of merging into the aborted one**, which is the actual regression

The third test was checked for vacuousness by removing the teardown call and confirming it fails with `expected 2 calls, got 0`.

Full frontend CI gate run locally:

```
pnpm exec biome ci .      Checked 1516 files. No fixes applied.
pnpm exec betterer ci     stayed the same (190 issues)
pnpm knip                 clean
pnpm test                 166 files, 1142 tests passed
```

The Playwright e2e suite has not been run locally, CI on this PR is the check that matters for `test_group_crud` and `test_roles_crud`.

## No changelog fragment

The regression was introduced and fixed inside the same unreleased cycle, so there is no user-facing change to record.

## Note on the other CI failures

Fixing this does not make everything on #10084 green. Two unrelated problems were found while investigating, both genuinely intermittent and neither addressed here:

1. `test_proposed_changes_ordering.py::test_sort_picker_orders_by_update_date` failed once with the browser rendering a raw JSON body:
   `{"data":null,"errors":[{"message":"Server is shedding load; retry later.","extensions":{"code":429}}]}`
   The SPA catch-all route (`backend/infrahub/server.py:267`) sits behind `AdmissionMiddleware`, is not in `EXCLUDED_PATHS`, and a browser navigation carries no `X-Priority` header, so it is classified MEDIUM and is sheddable. CI makes this much likelier because the e2e suite sets `INFRAHUB_TESTING_RESPONSE_DELAY=1`, adding a second to every response *inside* the admission slot, against a CoDel target of 5ms. Worth its own ticket: a shed should probably never put raw JSON in a user's browser.

2. `test_breadcrumb.py::TestIpamBreadcrumb::test_should_display_breadcrumb_on_ipam_page` intermittently times out on `Page.goto`, on both `develop` and `release-1.11`. Plausibly the same pressure as above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

