### PR TITLE
refactor(git): use SDK protocol classes for node kinds in tasks

### DIFF
--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -6,8 +6,13 @@ from infrahub_sdk.protocols import (
     CoreArtifact,
     CoreArtifactDefinition,
     CoreCheckDefinition,
+    CoreFileCheck,
+    CoreGenericRepository,
+    CoreProposedChange,
+    CoreReadOnlyRepository,
     CoreRepository,
     CoreRepositoryValidator,
+    CoreStandardCheck,
     CoreUserValidator,
 )
 from infrahub_sdk.uuidt import UUIDT
@@ -586,9 +591,7 @@ async def generate_request_artifact_definition(
     repository = transformation_repository.peer
     branch = await client.branch.get(branch_name=model.branch)
     if branch.sync_with_git:
-        repository = await client.get(
-            kind=InfrahubKind.GENERICREPOSITORY, id=repository.id, branch=model.branch, fragment=True
-        )
+        repository = await client.get(kind=CoreGenericRepository, id=repository.id, branch=model.branch, fragment=True)
     transform_location = ""
 
     convert_query_response = False
@@ -737,10 +740,8 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         and model.repository_kind == InfrahubKind.REPOSITORY
     ):
         log.info(f"Merging {model.repository_kind}")
-        repo_source = await client.get(
-            kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id, branch=model.source_branch
-        )
-        repo_main = await client.get(kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id)
+        repo_source = await client.get(kind=CoreGenericRepository, id=model.repository_id, branch=model.source_branch)
+        repo_main = await client.get(kind=CoreGenericRepository, id=model.repository_id)
         repo_main.internal_status.value = RepositoryInternalStatus.ACTIVE.value
         repo_main.sync_status.value = repo_source.sync_status.value
 
@@ -751,11 +752,9 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         log.info(f"Finished merging {model.repository_kind}")
 
     elif model.repository_kind == InfrahubKind.READONLYREPOSITORY:
-        repo_source = await client.get(
-            kind=InfrahubKind.READONLYREPOSITORY, id=model.repository_id, branch=model.source_branch
-        )
+        repo_source = await client.get(kind=CoreReadOnlyRepository, id=model.repository_id, branch=model.source_branch)
         repo_destination = await client.get(
-            kind=InfrahubKind.READONLYREPOSITORY, id=model.repository_id, branch=model.destination_branch
+            kind=CoreReadOnlyRepository, id=model.repository_id, branch=model.destination_branch
         )
 
         if (
@@ -873,7 +872,7 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
     client.request_context = context.to_request_context()
 
     definition = await client.get(kind=CoreCheckDefinition, id=model.check_definition_id, branch=model.branch_name)
-    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    proposed_change = await client.get(kind=CoreProposedChange, id=model.proposed_change)
     validator_execution_id = str(UUIDT())
     check_execution_ids: list[str] = []
     await proposed_change.validations.fetch()
@@ -989,7 +988,7 @@ async def trigger_user_checks(model: TriggerRepositoryUserChecks, context: Infra
     client.request_context = context.to_request_context()
 
     repository = await client.get(
-        kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id, branch=model.source_branch, fragment=True
+        kind=CoreGenericRepository, id=model.repository_id, branch=model.source_branch, fragment=True
     )
     await repository.checks.fetch()
 
@@ -1027,8 +1026,8 @@ async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, contex
     client = get_client()
     client.request_context = context.to_request_context()
 
-    repository = await client.get(kind=InfrahubKind.GENERICREPOSITORY, id=model.repository, branch=model.source_branch)
-    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    repository = await client.get(kind=CoreGenericRepository, id=model.repository, branch=model.source_branch)
+    proposed_change = await client.get(kind=CoreProposedChange, id=model.proposed_change)
 
     validator_execution_id = str(UUIDT())
     check_execution_ids: list[str] = []
@@ -1101,7 +1100,7 @@ async def run_check_merge_conflicts(model: CheckRepositoryMergeConflicts) -> Val
     client = get_client()
 
     success_condition = "-"
-    validator = await client.get(kind=InfrahubKind.REPOSITORYVALIDATOR, id=model.validator_id)
+    validator = await client.get(kind=CoreRepositoryValidator, id=model.validator_id)
     await validator.checks.fetch()
 
     repo = await get_initialized_repo(
@@ -1133,7 +1132,7 @@ async def run_check_merge_conflicts(model: CheckRepositoryMergeConflicts) -> Val
                 existing_checks.pop(conflict_key)
             else:
                 check = await client.create(
-                    kind=InfrahubKind.FILECHECK,
+                    kind=CoreFileCheck,
                     data={
                         "name": conflict,
                         "origin": "ConflictCheck",
@@ -1156,7 +1155,7 @@ async def run_check_merge_conflicts(model: CheckRepositoryMergeConflicts) -> Val
     else:
         validator_conclusion = ValidatorConclusion.SUCCESS
         check = await client.create(
-            kind=InfrahubKind.FILECHECK,
+            kind=CoreFileCheck,
             data={
                 "name": "Merge Conflict Check",
                 "origin": "ConflictCheck",
@@ -1183,7 +1182,7 @@ async def run_user_check(model: UserCheckData) -> ValidatorConclusion:
     log = get_run_logger()
     client = get_client()
 
-    validator = await client.get(kind=InfrahubKind.USERVALIDATOR, id=model.validator_id)
+    validator = await client.get(kind=CoreUserValidator, id=model.validator_id)
     await validator.checks.fetch()
 
     repo = await get_initialized_repo(
@@ -1236,7 +1235,7 @@ async def run_user_check(model: UserCheckData) -> ValidatorConclusion:
         await check.save()
     else:
         check = await client.create(
-            kind=InfrahubKind.STANDARDCHECK,
+            kind=CoreStandardCheck,
             data={
                 "name": model.name,
                 "origin": model.repository_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,8 +363,6 @@ disable_error_code = [
 module = "infrahub.git.base"
 disable_error_code = [
     "arg-type",
-    "attr-defined",
-    "index",
     "return-value",
 ]
 
@@ -374,7 +372,6 @@ disable_error_code = [
     "arg-type",
     "assignment",
     "call-overload",
-    "return-value",
 ]
 
 [[tool.mypy.overrides]]
@@ -1680,18 +1677,64 @@ invalid-context-manager = "ignore"
 include = ["backend/infrahub/git/**"]
 
 [tool.ty.overrides.rules]
-##################################################################################################
-# The ignored rules below should be removed once the code has been updated, they are included    #
-# like this so that we can reactivate them one by one.                                           #
-##################################################################################################
-invalid-argument-type = "ignore"
-invalid-assignment = "ignore"
-invalid-await = "ignore"
-invalid-return-type = "ignore"
-no-matching-overload = "ignore"
-possibly-missing-attribute = "ignore"
-unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
+
+##################################################################################################
+# backend/infrahub/git/** type-check debt, scoped per file instead of module-wide.               #
+#                                                                                                #
+# Each override's `include` list IS the remaining to-do list for that rule: fix a file, remove   #
+# it from the list, and that file starts being enforced. When a list is empty, delete the rule.  #
+# Every path in git/ not listed below is fully enforced for these rules.                         #
+##################################################################################################
+
+[[tool.ty.overrides]]
+include = [
+    "backend/infrahub/git/base.py",
+    "backend/infrahub/git/integrator.py",
+    "backend/infrahub/git/repository.py",
+    "backend/infrahub/git/tasks.py",
+    "backend/infrahub/git/utils.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "backend/infrahub/git/integrator.py",
+    "backend/infrahub/git/tasks.py",
+    "backend/infrahub/git/utils.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-assignment = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "backend/infrahub/git/integrator.py",
+    "backend/infrahub/git/tasks.py",
+    "backend/infrahub/git/utils.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "backend/infrahub/git/base.py",
+    "backend/infrahub/git/integrator.py",
+    "backend/infrahub/git/repository.py",
+    "backend/infrahub/git/tasks.py",
+]
+
+[tool.ty.overrides.rules]
+no-matching-overload = "ignore"
+
+[[tool.ty.overrides]]
+include = ["backend/infrahub/git/base.py"]
+
+[tool.ty.overrides.rules]
+invalid-return-type = "ignore"
 
 [[tool.ty.overrides]]
 include = ["backend/infrahub/database/**"]


### PR DESCRIPTION
Note: The below text covers the reasoning around this, but a review of the actual code changes might be quicker :)

* Swap out text strings for kinds -> protocols
* Remove resolved typing violations (mypy & ty)
* Split apart remaining ty rules for infrahub.git so that it's easier to solve specific violations in the future

# Why

Fetching a node with a kind *string* makes the SDK return a bare `InfrahubNode`, so every attribute access on it goes through `InfrahubNode.__getattr__` and resolves to `Attribute | RelationshipManager[InfrahubNode] | RelatedNode[InfrahubNode]`. Nothing useful can be narrowed from that union, which is why `backend/infrahub/git/` suppresses `unresolved-attribute` and `invalid-assignment` for the whole module. 57 of the module's 133 suppressed ty diagnostics come from that one union, 29 of them on `.value`.

The module already knows the answer: it imports `infrahub_sdk.protocols` in three files and 16 call sites already pass a protocol class. This PR finishes that migration for `tasks.py`.

Goal: convert the remaining kind-string node fetches in `tasks.py`, and restructure the module's ty override so progress is visible per file instead of hidden behind one module-wide glob.

Non-goals: `integrator.py`'s 16 equivalent sites (same edit, separate PR), and the remaining union errors that come from `InfrahubNode`-annotated parameters rather than from the kind argument.

## What changed

- **14 call sites in `tasks.py`** now pass the generated protocol class instead of `InfrahubKind.*`: `CoreGenericRepository` (5), `CoreProposedChange` (2), `CoreReadOnlyRepository` (2), `CoreFileCheck` (2), `CoreRepositoryValidator`, `CoreUserValidator`, `CoreStandardCheck`. `tasks.py` drops from **73 to 48** suppressed ty diagnostics; the module from **133 to 108**.
- **The `backend/infrahub/git/**` ty override is split per rule, per file**, matching the convention already used for `core/**` and `graphql/**`. Only `unused-type-ignore-comment` stays module-wide, since that is a genuine mypy/ty clash rather than debt.

  | rule | files still listed |
  |---|---|
  | `invalid-argument-type` | base, integrator, repository, tasks, utils |
  | `invalid-assignment` | integrator, tasks, utils |
  | `unresolved-attribute` | integrator, tasks, utils |
  | `no-matching-overload` | base, integrator, repository, tasks |
  | `invalid-return-type` | base |

  `invalid-await` and `possibly-missing-attribute` are deleted outright: neither reports anything in the module. The split immediately enforces all five rules for `sync.py`, `models.py`, `directory.py`, `worktree.py`, `graphql_queries.py`, `constants.py`, `__init__.py` and the `closure_builder/` and `fingerprint/` subpackages, so no new violation can slip into any of them.
- **Three stale mypy `disable_error_code` entries removed**: `attr-defined` and `index` on `infrahub.git.base`, `return-value` on `infrahub.git.repository`. These no longer match any reported error and were already stale before this change. `infrahub.git_credential.askpass` was measured too and genuinely needs all three of its entries, so it is untouched.

**What stayed the same:** behaviour. `get`, `filters` and `create` all declare `kind: str | type[SchemaType]`, and a class is resolved through `_get_schema_name` (`python_sdk/infrahub_sdk/schema/__init__.py:263`), which returns `__name__`. Every converted constant's value is exactly the class name that replaced it, e.g. `InfrahubKind.FILECHECK == "CoreFileCheck"`, so the identical string reaches the schema lookup as before. The typing gain comes purely from overload selection: `kind: type[SchemaType]` returns `SchemaType`, and the overload used when `raise_when_missing` is omitted returns a non-`Optional` node, so no new narrowing is introduced.

## How to review

`pyproject.toml` is the part worth reading carefully; the `tasks.py` diff is 14 one-token substitutions plus 5 added imports, and formatting collapsed a few calls that now fit on one line.

## How to test

```bash
uv run ty check .                                  # All checks passed!
uv run invoke backend.mypy                         # Success: no issues found in 1601 source files
uv run invoke backend.ruff
uv run pytest backend/tests/unit/git/ --no-cov -q  # 178 passed
```

Integration coverage for these code paths lives in `backend/tests/integration/git/` and needs the testcontainers stack, so CI is the gate there.

## Impact & rollout

- **Backward compatibility:** none affected; the same kind string reaches the SDK.
- **Performance:** none.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Follow-ups

- `integrator.py`: the same conversion at 16 sites (`CoreTransformJinja2`, `CoreGraphQLQuery`, `CoreArtifactDefinition`, `CoreGroup`, `CoreGeneratorDefinition`, `CoreCheckDefinition`, `CoreTransformPython`).
- After that, 28 of `tasks.py`'s remaining 48 diagnostics are still the same SDK union, but sourced from parameters annotated `InfrahubNode` and from `.peer` traversals. Those need the surrounding signatures tightened, which is judgement work rather than substitution.
- The 10 `client.schema.get(kind=...)` sites can also take a protocol class, but there is no typing payoff since they return a schema rather than a node.

## Checklist

- [ ] Tests added/updated <!-- no behaviour change; the type checkers plus the existing git unit tests are the coverage -->
- [ ] Changelog entry added <!-- not applicable: internal typing only -->
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

