### PR TITLE
fix(frontend): identify the default branch by its flag, not the name "main"

### DIFF
--- a/dev/knowledge/frontend/branches.md
+++ b/dev/knowledge/frontend/branches.md
@@ -25,41 +25,8 @@ const defaultBranch = branches.find((branch) => branch.name === "main");
 The same applies to "am I on the default branch" checks: read `currentBranch.is_default` rather than
 comparing the name.
 
-## Why name comparisons survive review
-
-Every development stack, test fixture and both end-to-end suites run with the default configuration,
-so a name comparison behaves identically to the flag in every environment a change is normally
-exercised in. The failure only appears on a renamed deployment, where it can be severe — a
-name-comparison guard in a provider once left the whole application on its loading screen.
-
-A component test is the cheapest place to catch this class of bug: give the fixture a default branch
-named something other than `main` and assert the behaviour. See
-[Writing component tests](../../guides/frontend/writing-component-tests.md).
-
 ## The branch query string parameter
 
 The current branch lives in the URL, and the default branch is represented by the *absence* of the
 branch parameter — so its pages keep clean, shareable URLs. Writing the branch means writing that
 parameter; there is no separate client-side store to keep in step.
-
-Clearing the parameter is therefore how code returns to the default branch, and reading it is how
-code learns the branch was chosen explicitly. See
-[URL construction](../../guidelines/frontend/url-construction.md) for building links that carry it.
-
-## First ask whether you want the default branch at all
-
-Code that reaches for the default branch usually wants a more specific branch that happens to be
-the default one in the common case. Check for a nearer source before resolving it:
-
-- A proposed change compares against its own destination branch, which is not necessarily the
-  default one.
-- A branch is diffed against the branch it was created from, which its detail view exposes as the
-  origin branch.
-- A request to the GraphQL endpoint needs no branch name at all when it is branch-agnostic: the
-  server serves `/graphql` without a branch segment as well as `/graphql/{branch_name}`, and
-  applies its own default when the segment is absent. Substituting a guessed name is worse than
-  omitting the segment — a name that does not exist on the deployment is rejected outright.
-
-When the default branch really is what you want and you need its name rather than the flag, read it
-off the branch list entry carrying `is_default`. The list is already fetched and cached by the time
-any page renders.

--- a/dev/knowledge/frontend/branches.md
+++ b/dev/knowledge/frontend/branches.md
@@ -1,0 +1,65 @@
+# Branches
+
+Location: `frontend/app/src/entities/branches/`
+
+How the frontend identifies the current and default branch, and the assumptions that break when a
+deployment renames its default branch.
+
+## The default branch name is not `main`
+
+`main` is a default, not an invariant. A deployment sets the name once at initialization through
+`INFRAHUB_INITIAL_DEFAULT_BRANCH`, and the backend resolves it from configuration everywhere. The
+frontend cannot know the name ahead of the API response.
+
+Identify the default branch by the `is_default` flag on the branch, never by comparing its name to
+`main` or to a constant holding `main`:
+
+```ts
+// ✅ Works on any deployment
+const defaultBranch = branches.find((branch) => branch.is_default);
+
+// ❌ Silently wrong wherever the default branch was renamed
+const defaultBranch = branches.find((branch) => branch.name === "main");
+```
+
+The same applies to "am I on the default branch" checks: read `currentBranch.is_default` rather than
+comparing the name.
+
+## Why name comparisons survive review
+
+Every development stack, test fixture and both end-to-end suites run with the default configuration,
+so a name comparison behaves identically to the flag in every environment a change is normally
+exercised in. The failure only appears on a renamed deployment, where it can be severe — a
+name-comparison guard in a provider once left the whole application on its loading screen.
+
+A component test is the cheapest place to catch this class of bug: give the fixture a default branch
+named something other than `main` and assert the behaviour. See
+[Writing component tests](../../guides/frontend/writing-component-tests.md).
+
+## The branch query string parameter
+
+The current branch lives in the URL, and the default branch is represented by the *absence* of the
+branch parameter — so its pages keep clean, shareable URLs. Writing the branch means writing that
+parameter; there is no separate client-side store to keep in step.
+
+Clearing the parameter is therefore how code returns to the default branch, and reading it is how
+code learns the branch was chosen explicitly. See
+[URL construction](../../guidelines/frontend/url-construction.md) for building links that carry it.
+
+## First ask whether you want the default branch at all
+
+Code that reaches for the default branch usually wants a more specific branch that happens to be
+the default one in the common case. Check for a nearer source before resolving it:
+
+- A proposed change compares against its own destination branch, which is not necessarily the
+  default one.
+- A branch is diffed against the branch it was created from, which its detail view exposes as the
+  origin branch.
+- A request to the GraphQL endpoint needs no branch name at all when it is branch-agnostic: the
+  server serves `/graphql` without a branch segment as well as `/graphql/{branch_name}`, and
+  applies its own default when the segment is absent. Substituting a guessed name is worse than
+  omitting the segment — a name that does not exist on the deployment is rejected outright.
+
+When the default branch really is what you want and you need its name rather than the flag, read it
+off the branch list entry carrying `is_default`. The list is already fetched and cached by the time
+any page renders.

--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -38,9 +38,9 @@ exports[`fix ts error`] = {
       [354, 22, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
       [356, 32, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"]
     ],
-    "src/entities/diff/ui/node-diff/index.tsx:3622743286": [
-      [88, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
-      [122, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
+    "src/entities/diff/ui/node-diff/index.tsx:763160321": [
+      [87, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
+      [121, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],
     "src/entities/diff/ui/node-diff/node-property.tsx:3639994513": [
       [27, 22, 17, "tsc: Property \'base_branch_label\' does not exist on type \'DiffConflict\'. Did you mean \'base_branch_value\'?", "1959743778"],

--- a/frontend/app/AGENTS.md
+++ b/frontend/app/AGENTS.md
@@ -54,6 +54,7 @@ cd frontend/app && pnpm test              # vitest (browser mode)
 - `dev/knowledge/frontend/design-system.md` - `@infrahub/ui` package (Button, Card, Modal, Spinner)
 - `dev/knowledge/frontend/file-components.md` - DataViewer and file handling components
 - `dev/knowledge/frontend/auth-methods.md` - Auth method registry, picker, token persistence boundaries
+- `dev/knowledge/frontend/branches.md` - Read before writing code that depends on which branch is current, or on the default branch — the default branch name is deployment-configurable
 
 ### Guides (How to do X)
 

--- a/frontend/app/src/entities/branches/domain/model/branch.ts
+++ b/frontend/app/src/entities/branches/domain/model/branch.ts
@@ -2,8 +2,6 @@ import type { BranchStatus } from "@/shared/api/graphql/generated/types";
 
 import type { NodeCore } from "@/entities/nodes/object/domain/model/node";
 
-export const DEFAULT_BRANCH_NAME = "main";
-
 // Explains the sync_with_git flag: it controls the Infrahub -> Git direction only,
 // and is not an indicator of whether a branch originated from Git.
 export const SYNC_WITH_GIT_DESCRIPTION =

--- a/frontend/app/src/entities/branches/ui/branches-provider.test.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-provider.test.tsx
@@ -195,7 +195,7 @@ describe("BranchesProvider", () => {
 
     // THEN
     await expect
-      .element(component.getByText(/not found, you have been redirected to the main branch/))
+      .element(component.getByText(/not found, you have been redirected to the default branch/))
       .toBeVisible();
     await expect.poll(getBranchInUrl).toBeNull();
   });

--- a/frontend/app/src/entities/branches/ui/branches-provider.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-provider.tsx
@@ -48,7 +48,7 @@ export const BranchesProvider = ({ children }: { children?: React.ReactNode }) =
         type={ALERT_TYPES.ERROR}
         message={
           <>
-            Branch <b>{branchInQueryString}</b> not found, you have been redirected to the main
+            Branch <b>{branchInQueryString}</b> not found, you have been redirected to the default
             branch.
           </>
         }

--- a/frontend/app/src/entities/branches/ui/branches-table/branches-table.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/branches-table.tsx
@@ -21,8 +21,8 @@ export function BranchesTable() {
     if (!data?.pages) return [];
 
     const allBranches = data.pages.flat();
-    const sortedBranches = sortByName(allBranches.filter((b) => b.name !== "main"));
-    const branches = [...allBranches.filter((b) => b.name === "main"), ...sortedBranches];
+    const sortedBranches = sortByName(allBranches.filter((b) => !b.is_default));
+    const branches = [...allBranches.filter((b) => b.is_default), ...sortedBranches];
 
     return branches;
   }, [data]);

--- a/frontend/app/src/entities/branches/ui/branches-to-select-options.ts
+++ b/frontend/app/src/entities/branches/ui/branches-to-select-options.ts
@@ -12,8 +12,8 @@ export const branchesToSelectOptions = (branches: BranchListItem[]) =>
       created_at: branch.created_at,
     }))
     .sort((a, b) => {
-      // "main" always pins to the top.
-      if (a.name === "main") return -1;
-      if (b.name === "main") return 1;
+      // The default branch always pins to the top.
+      if (a.is_default) return -1;
+      if (b.is_default) return 1;
       return a.name.localeCompare(b.name);
     });

--- a/frontend/app/src/entities/diff/ui/checks/data-conflict.tsx
+++ b/frontend/app/src/entities/diff/ui/checks/data-conflict.tsx
@@ -35,12 +35,14 @@ export const DataConflict = ({ id, changes, kind, name }: DataConflictProps) => 
 
   const url = `${getProposedChangeDetailsUrl(proposedChange.id, "data")}#${id}`;
 
-  const mainChange = changes.find((change) => {
-    return change.branch === "main";
+  const destinationBranch = proposedChange.destination_branch.value;
+
+  const destinationChange = changes.find((change) => {
+    return change.branch === destinationBranch;
   });
 
   const branchChange = changes.find((change) => {
-    return change.branch !== "main";
+    return change.branch !== destinationBranch;
   });
 
   return (
@@ -66,10 +68,10 @@ export const DataConflict = ({ id, changes, kind, name }: DataConflictProps) => 
           }
           left={
             <div className="flex items-center gap-2">
-              {mainChange?.previous}
+              {destinationChange?.previous}
               <Icon icon="mdi:chevron-right" />
               <Badge variant="yellow" className="font-medium">
-                {mainChange?.new}
+                {destinationChange?.new}
               </Badge>
             </div>
           }

--- a/frontend/app/src/entities/diff/ui/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.tsx
@@ -7,7 +7,6 @@ import ErrorScreen from "@/shared/components/errors/error-screen";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 import { QSP } from "@/shared/config/qsp";
 
-import { DEFAULT_BRANCH_NAME } from "@/entities/branches/domain/model/branch";
 import { useBranchExists } from "@/entities/branches/ui/hooks/use-branch-exists";
 import type { GetDiffSummaryParams } from "@/entities/diff/domain/use-cases/get-diff-summary";
 import {
@@ -76,7 +75,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
     return (
       <DiffComputing
         sourceBranch={branchName}
-        destinationBranch={proposedChangesDetails?.destination_branch?.value ?? DEFAULT_BRANCH_NAME}
+        destinationBranch={proposedChangesDetails?.destination_branch?.value ?? ""}
         hideActions={isMerged}
       />
     );

--- a/frontend/app/src/entities/events/ui/filters/global-branch-filter.tsx
+++ b/frontend/app/src/entities/events/ui/filters/global-branch-filter.tsx
@@ -32,9 +32,9 @@ export function GlobalBranchFilter({ ...props }: FilterTagProps) {
   };
 
   useEffect(() => {
-    if (currentBranch.name === "main" || currentFilter) return;
+    if (currentBranch.is_default || currentFilter) return;
 
-    // Set the current branch if it's not main and if it has not been removed from the filters
+    // Set the current branch if it's not the default one and if it has not been removed from the filters
     setFilters([...filters, { name: branchFilterName, value: currentBranch.name }]);
   }, []);
 

--- a/frontend/app/src/shared/api/graphql/client.test.ts
+++ b/frontend/app/src/shared/api/graphql/client.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ERROR_CODES } from "@/shared/api/errors";
 import { PRIORITY_HEADER } from "@/shared/api/priority";
 import { queryClient } from "@/shared/api/rest/client";
-import { CONFIG } from "@/shared/config/config";
+import { INFRAHUB_API_SERVER_URL } from "@/shared/config/config";
 
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/entities/authentication/api/token-storage";
 import { __navigation } from "@/entities/authentication/domain/use-cases/redirect-to-login";
@@ -44,12 +44,12 @@ describe("graphqlClient — endpoint targeting", () => {
     vi.unstubAllGlobals();
   });
 
-  it("targets the default branch when the operation declares no context", async () => {
+  it("omits the branch segment when the operation declares no context", async () => {
     // WHEN
     await graphqlClient.query({ query: PING });
 
     // THEN
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe(CONFIG.GRAPHQL_URL());
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${INFRAHUB_API_SERVER_URL}/graphql`);
   });
 
   it("targets the branch and point in time the operation declares", async () => {
@@ -60,7 +60,9 @@ describe("graphqlClient — endpoint targeting", () => {
     await graphqlClient.query({ query: PING, context: { branch: "feature", date } });
 
     // THEN
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe(CONFIG.GRAPHQL_URL("feature", date));
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      `${INFRAHUB_API_SERVER_URL}/graphql/feature?at=2026-01-01T00:00:00.000Z`
+    );
   });
 
   it("stamps X-Priority: high on every operation", async () => {

--- a/frontend/app/src/shared/config/config.ts
+++ b/frontend/app/src/shared/config/config.ts
@@ -11,11 +11,8 @@ export const INFRAHUB_SWAGGER_DOC_URL = `${INFRAHUB_API_SERVER_URL}/api/docs`;
 
 export const CONFIG = {
   GRAPHQL_URL: (branch?: string | null, date?: Date | null) => {
-    if (!date) {
-      return `${INFRAHUB_API_SERVER_URL}/graphql/${branch ?? "main"}`;
-    } else {
-      return `${INFRAHUB_API_SERVER_URL}/graphql/${branch ?? "main"}?at=${date.toISOString()}`;
-    }
+    const url = `${INFRAHUB_API_SERVER_URL}/graphql${branch ? `/${branch}` : ""}`;
+    return date ? `${url}?at=${date.toISOString()}` : url;
   },
   SEARCH_URL: (query: string, limit: number = 3) =>
     `${INFRAHUB_API_SERVER_URL}/api/search/docs?query=${query}&limit=${limit}`,

--- a/frontend/app/tests/e2e/branches/branch-selector.spec.ts
+++ b/frontend/app/tests/e2e/branches/branch-selector.spec.ts
@@ -57,11 +57,11 @@ test.describe("Branch selector", () => {
       await expect(page.getByLabel("New branch name *")).toHaveValue("quick-branch-form");
     });
 
-    test("verify if the current branch exists correctly and redirects to home on main branch", async ({
+    test("verify if the current branch exists correctly and redirects to home on default branch", async ({
       page,
     }) => {
       await page.goto("/?branch=unknown-branch-for-testing");
-      await expect(page.getByText("you have been redirected to the main branch")).toBeVisible();
+      await expect(page.getByText("you have been redirected to the default branch")).toBeVisible();
       await expect(page.getByRole("button", { name: "Other" })).toBeVisible();
       expect(page.url()).not.toContain("/?branch=unknown-branch-for-testing");
     });

--- a/tests/e2e/branches/test_branch_selector.py
+++ b/tests/e2e/branches/test_branch_selector.py
@@ -1,7 +1,7 @@
 """Port of frontend/app/tests/e2e/branches/branch-selector.spec.ts.
 
 The branch selector dropdown: create-disabled when anonymous, branch search and
-switching, quick-create form, and the redirect-to-main fallback for an unknown
+switching, quick-create form, and the redirect-to-default fallback for an unknown
 branch. Searching/switching to `atl1-delete-upstream` needs data_scenario_branches
 (searching "atl1" must yield exactly that one scenario branch).
 """
@@ -62,8 +62,8 @@ class TestBranchSelectorLoggedInAsAdmin:
         await admin_page.get_by_role("option", name="Create branch quick-branch-form").click()
         await expect(admin_page.get_by_label("New branch name *")).to_have_value("quick-branch-form")
 
-    async def test_unknown_branch_redirects_to_main(self, admin_page: Page) -> None:
+    async def test_unknown_branch_redirects_to_default(self, admin_page: Page) -> None:
         await admin_page.goto("/?branch=unknown-branch-for-testing")
-        await expect(admin_page.get_by_text("you have been redirected to the main branch")).to_be_visible()
+        await expect(admin_page.get_by_text("you have been redirected to the default branch")).to_be_visible()
         await expect(admin_page.get_by_role("button", name="Other")).to_be_visible()
         assert "/?branch=unknown-branch-for-testing" not in admin_page.url


### PR DESCRIPTION
## What changed and why

`main` is the *default* default-branch name, not an invariant — a deployment sets it once through `INFRAHUB_INITIAL_DEFAULT_BRANCH`, and the backend resolves it from configuration everywhere. The frontend compared branch names against the literal `"main"` in six places, so on a deployment that renamed its default branch each of them silently reported the wrong answer.

Every comparison now reads the `is_default` flag the API already returns, and `DEFAULT_BRANCH_NAME` is deleted rather than left as a tempting constant.

| Site | Before | After |
|---|---|---|
| `branches-to-select-options.ts` | pinned `name === "main"` to the top | pins `is_default` |
| `branches-table.tsx` | partitioned on `name === "main"` | partitions on `is_default` |
| `events/ui/filters/global-branch-filter.tsx` | skipped the filter when `name === "main"` | skips when `is_default` |
| `diff/ui/checks/data-conflict.tsx` | compared changes against `"main"` | compares against the proposed change's destination branch |
| `shared/config/config.ts` | `/graphql/${branch ?? "main"}` | omits the segment when no branch is given |
| `branches/domain/model/branch.ts` | `DEFAULT_BRANCH_NAME = "main"` | removed |

## Two of these were reaching for the wrong branch, not just the wrong name

**The conflict view.** A data conflict is between a proposed change's *destination* branch and its source. Comparing against `"main"` meant that for any proposed change targeting a non-default branch, both `find` calls picked arbitrary sides — a display bug on every deployment, not only renamed ones.

**The GraphQL endpoint.** Branch-agnostic callers — the branch list query, the create/delete branch mutations — were requesting `/graphql/main`. Where no branch is named `main`, `registry.get_branch(db, "main")` raises `BranchNotFoundError` and the endpoint returns 404 (`backend/infrahub/graphql/app.py:135-138`), so the branch list could not load at all. The server already serves `/graphql` without a branch segment and resolves its own default (`graphql/api/endpoints.py:25-26`), so the client no longer guesses.

## User-facing copy

The unknown-branch toast said *"you have been redirected to the main branch"*. It now says *"the default branch"*. Both e2e suites assert that sentence verbatim, so `frontend/app/tests/e2e/branches/branch-selector.spec.ts` and `tests/e2e/branches/test_branch_selector.py` are updated in lockstep (the pytest case is renamed `test_unknown_branch_redirects_to_default`).

## Documentation

A new `dev/knowledge/frontend/branches.md` records where the name comes from, why the flag is the only reliable test, and — the part that kept mattering here — which *nearer* source to reach for when the default branch is not actually the branch you want. It is registered in `frontend/app/AGENTS.md` with a load trigger, since a knowledge doc absent from that index never gets opened.

## Testing performed

```
pnpm exec biome ci .    ✅
pnpm exec betterer ci   ✅ 190 issues (baseline unchanged)
pnpm knip               ✅
pnpm test               ✅ 167 files, 1148 tests
ruff format --check / ruff check on the touched pytest file  ✅
```

Two GraphQL endpoint assertions in `client.test.ts` compared `CONFIG.GRAPHQL_URL()` against itself, so they passed regardless of the URL shape; they now assert literal URLs and genuinely pin the omitted branch segment.

**E2E not run** — it needs a live stack. The assertions in both suites were updated together with the copy they check, and every `is_default` change is behaviour-identical when the default branch *is* named `main`, which is the configuration those suites boot. The only GraphQL route interceptions in either suite (`login.spec.ts:154`, `test_login.py:159`) match `**/graphql/main**` for the `BuiltinTag` operation, which is branch-scoped and still resolves to `/graphql/main`.

## Note

No changelog fragment. CI only Vale-lints existing fragments (`ci.yml:1085`) rather than requiring one, but this is user-visible on renamed deployments, so say the word and I will add a `fixed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

