### PR TITLE
fix(frontend): give every GraphQL call its own request

### DIFF
--- a/frontend/app/src/shared/api/graphql/client.dedup.test.ts
+++ b/frontend/app/src/shared/api/graphql/client.dedup.test.ts
@@ -3,8 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { graphqlClient } from "./client";
 
-// Guards against urql merging concurrent identical operations that target different endpoints.
-describe("concurrent identical query across endpoints", () => {
+describe("request isolation between concurrent operations", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   const SAME_QUERY = gql`
@@ -62,7 +61,7 @@ describe("concurrent identical query across endpoints", () => {
     expect(b.data).toEqual({ __typename: `main@${late.toISOString()}` });
   });
 
-  it("still merges two identical concurrent queries on the same endpoint", async () => {
+  it("fires a distinct request for each identical concurrent query on the same endpoint", async () => {
     // WHEN
     const [a, b] = await Promise.all([
       graphqlClient.query({ query: SAME_QUERY, context: { branch: "branch-a" } }),
@@ -70,7 +69,7 @@ describe("concurrent identical query across endpoints", () => {
     ]);
 
     // THEN
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(a.data).toEqual({ __typename: "branch-a" });
     expect(b.data).toEqual({ __typename: "branch-a" });
   });

--- a/frontend/app/src/shared/api/graphql/client.ts
+++ b/frontend/app/src/shared/api/graphql/client.ts
@@ -54,30 +54,23 @@ const authenticationExchange = authExchange(async (authUtilities) => {
   };
 });
 
-// Grows only with the branch/point-in-time endpoints a session visits, and dies with the page.
-const clientsByEndpoint = new Map<string, Client>();
-
-// urql's Client dedups concurrent operations by hash(query, variables) and ignores the URL.
-// but this app carries the branch/point-in-time in the URL, not in variables.
-// Without this, two concurrent identical query+variables on DIFFERENT branches share one network request
-// and both receive one branch's data.
-function getGraphqlClient(branch?: string | null, date?: Date | null): Client {
-  const url = CONFIG.GRAPHQL_URL(branch, date);
-  let client = clientsByEndpoint.get(url);
-  if (!client) {
-    client = new Client({
-      url,
-      preferGetMethod: false,
-      fetchOptions: {
-        headers: {
-          [PRIORITY_HEADER]: DEFAULT_PRIORITY,
-        },
+// A urql Client merges a query into an identical operation it already has in flight, keyed by
+// hash(query, variables) — which carries neither the endpoint nor the moment the caller asked. Reusing
+// a Client across calls therefore hands a caller a response computed before it asked: a refetch after
+// a write, a poll, or an event-driven refresh can all resolve with pre-change data and nothing
+// refetches again. React Query owns caching and deduplication here, so the transport keeps no state
+// across calls — each call gets its own Client and therefore its own request.
+function createGraphqlClient(branch?: string | null, date?: Date | null): Client {
+  return new Client({
+    url: CONFIG.GRAPHQL_URL(branch, date),
+    preferGetMethod: false,
+    fetchOptions: {
+      headers: {
+        [PRIORITY_HEADER]: DEFAULT_PRIORITY,
       },
-      exchanges: [addTypenameExchange, authenticationExchange, fetchExchange],
-    });
-    clientsByEndpoint.set(url, client);
-  }
-  return client;
+    },
+    exchanges: [addTypenameExchange, authenticationExchange, fetchExchange],
+  });
 }
 
 // Map urql result to the preserved `{ data, errors }` shape and run error routing.
@@ -117,7 +110,7 @@ export const graphqlClient = {
   async query<TData = any, TVars extends AnyVariables = AnyVariables>(
     args: QueryArgs<TData, TVars>
   ): Promise<GraphQLResult<TData>> {
-    const result = await getGraphqlClient(args.context?.branch, args.context?.date)
+    const result = await createGraphqlClient(args.context?.branch, args.context?.date)
       .query<TData, TVars>(args.query, args.variables as TVars)
       .toPromise();
     return toGraphQLResult(result.data, result.error, args.context);
@@ -126,7 +119,7 @@ export const graphqlClient = {
   async mutate<TData = any, TVars extends AnyVariables = AnyVariables>(
     args: MutateArgs<TData, TVars>
   ): Promise<GraphQLResult<TData>> {
-    const result = await getGraphqlClient(args.context?.branch, args.context?.date)
+    const result = await createGraphqlClient(args.context?.branch, args.context?.date)
       .mutation<TData, TVars>(args.mutation, args.variables as TVars)
       .toPromise();
     return toGraphQLResult(result.data, result.error, args.context);


### PR DESCRIPTION
## Why this matters

**For users:** any list in the app could show data that is no longer true — a row you just deleted stays on screen, a value you just edited reverts to the old one, a row you just created never appears. There is no error and no spinner; the page simply looks wrong until you reload it. It happens more often the slower the backend is, which means it hits hardest exactly when the app is under load.

**For us:** `test_group_crud` has failed on *every* CI run of `release-1.11` since 31 July, while passing whenever anyone ran it on its own. A test that fails only in CI gets written off as flaky, and a permanently red shard means nobody can tell a real regression from the usual noise — so every PR on this base has had unreliable signal for a week. It was not flaky. It was catching a real bug, reliably, and the bug was in the app rather than the test.

## What happens

1. A table is loading its rows — the request is still on the wire.
2. You delete a row. The delete really works; the server has removed it.
3. The app asks for the rows again to refresh the table.
4. That second request gets handed the answer to the *first* one, which was calculated before the delete. So the table redraws with the deleted row still in it, and because the app believes it has fresh data, it never asks again.

The window in step 1–3 is what makes this load-dependent: on a fast backend the first request has usually finished before the delete, and nothing goes wrong.

The same collapse applies to any refresh, not just one caused by a delete — a background poll or an event-driven refresh can equally be answered with data from before the change.

<details>
<summary>Root cause in the transport layer</summary>

`@urql/core@6.0.3`, `Client.executeRequestOperation`:

```js
if (operation.kind === 'mutation') return withPromise(makeResultSource(operation));  // always fresh
return withPromise(wonka.lazy(() => {
  var source = active.get(operation.key);   // ← queries JOIN an in-flight request
  if (!source) active.set(operation.key, source = makeResultSource(operation));
```

A query is merged into an identical operation the Client already has in flight. `operation.key` is `hash(document) + hash(variables)` — it carries neither the endpoint nor the moment the caller asked, so a caller can be handed a response computed before it asked. Mutations are exempt, which is why the write itself always lands.

Two dead ends worth recording, since they are the first fixes that come to mind:

- **No exchange can disable the merge.** It happens in `executeRequestOperation` before any exchange sees the operation — which is why omitting `dedupExchange` from the chain, as this code already did, changes nothing.
- **The stale response cannot be detected upstream.** The payload carries no server timestamp, so the cache layer cannot tell a pre-write answer from a post-write one.

</details>

## The fix

Deduplication belongs to the cache layer, which already keys it per query. The transport now keeps no state across calls: each call builds its own client and gets its own request, so an answer always belongs to the caller that asked for it. `clientsByEndpoint` is deleted — it existed only to stop this same merging across branches, which no longer needs guarding.

**One contract is deliberately reversed.** The suite previously pinned merging as desirable:

```ts
it("still merges two identical concurrent queries on the same endpoint", …
  expect(fetchSpy).toHaveBeenCalledTimes(1);
```

That is the behaviour causing this bug, so it now expects a distinct request per call. Little is lost: the cache layer dedupes by query key before the transport sees anything, and in the trace from the failing run two concurrent identical count queries already produced two separate network requests — merging was not collapsing them in practice.

## How it was found

Reproduced locally only by running the whole `branches_repo` shard with `INFRAHUB_TESTING_RESPONSE_DELAY=1`; in isolation it always passes, which is why it looked flaky. The Playwright trace then named the mechanism — every earlier mutation refreshes both the rows and the count, the delete refreshes only the count:

```
GetObjectsCoreAccountGroup + GetObjectsCountCoreAccountGroup   ← create
GetObjectsCoreAccountGroup + GetObjectsCountCoreAccountGroup   ← update
GetObjectsCoreAccountGroup + GetObjectsCountCoreAccountGroup   ← bulk edit
GetObjectsCountCoreAccountGroup ×2 only                        ← DELETE
```

The failure screenshot corroborates it: the header count reads 7 while eight rows are drawn.

Ruled out along the way, each by evidence rather than argument: the Apollo→urql migration itself (its CI run was green), a host-port collision (the test compose binds every port as `:-0`), the injected response delay (reproduced with it on — still passed in isolation), a cross-test name collision, and the `enabled` expression in `useObjects` (it resolves to `undefined`, which the cache layer treats as enabled).

## Testing performed

```
pnpm exec biome ci .    ✅
pnpm exec betterer ci   ✅ 190 issues (baseline unchanged)
pnpm knip               ✅
pnpm test               ✅ 167 files, 1149 tests
```

Two regression tests in `client.dedup.test.ts`, both verified to fail when a client cache is reintroduced:

- `answers a read issued after a write with post-write data` → without the fix: `expected { __typename: 'before' } to deeply equal { __typename: 'after' }` — the user-visible symptom, in 40ms
- `fires a distinct request for each identical concurrent query on the same endpoint` → without the fix: `expected 2 times, but got 1 times`

End-to-end: with an image built from this change, the full `branches_repo` shard was run the way CI runs it. An earlier variant of this fix (ending the merge window at each mutation instead of per call) took the shard from `2 failed, 70 passed` to `72 passed, 4 skipped, 0 failed`, with `test_group_crud` passing at `[48/76]`. The per-call variant in this PR is validated at unit level and its shard run was in progress when this PR was opened — worth confirming green before merge.

## Note

No changelog fragment. CI only Vale-lints existing fragments rather than requiring one, but this is user-visible on every list in the app, so say the word and I will add a `fixed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
