### PR TITLE
refactor(git): enforce invalid-argument-type for the integrator

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -207,6 +207,17 @@ class ObjectImportPlan:
     artifact_definitions: dict[str, InfrahubRepositoryArtifactDefinitionConfig]
 
 
+def find_unloadable_schema_files(schemas_data: list[SchemaFile]) -> list[SchemaFile]:
+    """Return the schema files whose content never loaded, and which therefore carry no payload."""
+    return [schema_file for schema_file in schemas_data if not schema_file.valid or schema_file.content is None]
+
+
+def format_unloadable_schema_files(unloadable: list[SchemaFile]) -> str:
+    """Report the reason the loader recorded for each file, rather than an opaque validation error."""
+    details = ", ".join(f"{item.identifier} ({item.error_message})" for item in unloadable)
+    return f"Unable to load {len(unloadable)} schema file(s): {details}"
+
+
 class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     """This class provides interfaces to read and process information from .infrahub.yml files and can perform.
 
@@ -859,29 +870,21 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             # and send an empty list to the API
             return
 
-        # A file that failed to load carries no content, so it cannot be validated or sent to the
-        # API. Report the reason the loader recorded rather than letting the empty content surface
-        # later as an opaque schema validation failure. Each payload travels next to its file
-        # because re-reading the content attribute in the loops below would lose the narrowing.
-        unloadable: list[SchemaFile] = []
-        payloads: list[tuple[SchemaFile, dict[str, Any]]] = []
-        for schema_file in schemas_data:
-            if not schema_file.valid or schema_file.content is None:
-                unloadable.append(schema_file)
-                log.error(f"Unable to load the file {schema_file.identifier}, {schema_file.error_message}")
-                continue
-            payloads.append((schema_file, schema_file.content))
-
+        # A file that failed to load carries no content, so it can be neither validated nor sent to
+        # the API. Report the reason the loader recorded rather than letting the missing content
+        # surface later as an opaque schema validation failure. Rejecting them here is also what
+        # makes `payload` below safe: it substitutes an empty dict for absent content, which would
+        # otherwise turn an unloadable file into a misleading schema error.
+        unloadable = find_unloadable_schema_files(schemas_data)
+        for schema_file in unloadable:
+            log.error(f"Unable to load the file {schema_file.identifier}, {schema_file.error_message}")
         if unloadable:
-            details = ", ".join(f"{item.identifier} ({item.error_message})" for item in unloadable)
-            raise ValidationError(
-                identifier=str(self.id), message=f"Unable to load {len(unloadable)} schema file(s): {details}"
-            )
+            raise ValidationError(identifier=str(self.id), message=format_unloadable_schema_files(unloadable))
 
         # Valid data format of content
-        for schema_file, payload in payloads:
+        for schema_file in schemas_data:
             try:
-                self.sdk.schema.validate(payload)
+                self.sdk.schema.validate(schema_file.payload)
             except PydanticValidationError as exc:
                 log.error(f"Schema not valid, found '{len(exc.errors())}' error(s) in {schema_file.identifier} : {exc}")
                 raise ValidationError(
@@ -890,7 +893,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 ) from exc
 
         response = await self.sdk.schema.load(
-            schemas=[payload for _, payload in payloads], branch=branch_name, wait_until_converged=True
+            schemas=[item.payload for item in schemas_data], branch=branch_name, wait_until_converged=True
         )
 
         if response.errors:

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -21,6 +21,7 @@ from infrahub_sdk.protocols import (
     CoreGeneratorDefinition,
     CoreGenericRepository,
     CoreGraphQLQuery,
+    CoreGroup,
     CoreTransformation,
     CoreTransformJinja2,
     CoreTransformPython,
@@ -504,7 +505,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         # Resolve each query reference to its node id now that the queries have been applied.
         for transform in local_transforms.values():
             graphql_query = await self.sdk.get(
-                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform.query), populate_store=True
+                kind=CoreGraphQLQuery, branch=branch_name, id=str(transform.query), populate_store=True
             )
             transform.query = graphql_query.id
 
@@ -551,7 +552,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         schema = await self.sdk.schema.get(kind=InfrahubKind.TRANSFORMJINJA2, branch=branch_name)
         payload_data = {**data.payload, "fingerprint": fingerprint}
         create_payload = self.sdk.schema.generate_payload_create(
-            schema=schema, data=payload_data, source=self.id, is_protected=True
+            schema=schema, data=payload_data, source=str(self.id), is_protected=True
         )
         obj = await self.sdk.create(kind=CoreTransformJinja2, branch=branch_name, **create_payload)
         await obj.save()
@@ -711,13 +712,13 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         branch_name: str,
         data: InfrahubRepositoryArtifactDefinitionConfig,
         fingerprint: str | None = None,
-    ) -> InfrahubNode:
+    ) -> CoreArtifactDefinition:
         schema = await self.sdk.schema.get(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch_name)
         payload_data = {**data.model_dump(), "fingerprint": fingerprint}
         create_payload = self.sdk.schema.generate_payload_create(
-            schema=schema, data=payload_data, source=self.id, is_protected=True
+            schema=schema, data=payload_data, source=str(self.id), is_protected=True
         )
-        obj = await self.sdk.create(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch_name, **create_payload)
+        obj = await self.sdk.create(kind=CoreArtifactDefinition, branch=branch_name, **create_payload)
         await obj.save()
         return obj
 
@@ -858,15 +859,29 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             # and send an empty list to the API
             return
 
+        # A file that failed to load carries no content, so it cannot be validated or sent to the
+        # API. Report the reason the loader recorded rather than letting the empty content surface
+        # later as an opaque schema validation failure. Each payload travels next to its file
+        # because re-reading the content attribute in the loops below would lose the narrowing.
+        unloadable: list[SchemaFile] = []
+        payloads: list[tuple[SchemaFile, dict[str, Any]]] = []
         for schema_file in schemas_data:
-            if schema_file.valid:
+            if not schema_file.valid or schema_file.content is None:
+                unloadable.append(schema_file)
+                log.error(f"Unable to load the file {schema_file.identifier}, {schema_file.error_message}")
                 continue
-            log.error(f"Unable to load the file {schema_file.identifier}, {schema_file.error_message}")
+            payloads.append((schema_file, schema_file.content))
+
+        if unloadable:
+            details = ", ".join(f"{item.identifier} ({item.error_message})" for item in unloadable)
+            raise ValidationError(
+                identifier=str(self.id), message=f"Unable to load {len(unloadable)} schema file(s): {details}"
+            )
 
         # Valid data format of content
-        for schema_file in schemas_data:
+        for schema_file, payload in payloads:
             try:
-                self.sdk.schema.validate(schema_file.content)
+                self.sdk.schema.validate(payload)
             except PydanticValidationError as exc:
                 log.error(f"Schema not valid, found '{len(exc.errors())}' error(s) in {schema_file.identifier} : {exc}")
                 raise ValidationError(
@@ -875,7 +890,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 ) from exc
 
         response = await self.sdk.schema.load(
-            schemas=[item.content for item in schemas_data], branch=branch_name, wait_until_converged=True
+            schemas=[payload for _, payload in payloads], branch=branch_name, wait_until_converged=True
         )
 
         if response.errors:
@@ -1015,7 +1030,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         create_payload = self.sdk.schema.generate_payload_create(
             schema=schema,
             data=data,
-            source=self.id,
+            source=str(self.id),
             is_protected=True,
         )
         obj = await self.sdk.create(kind=CoreGraphQLQuery, branch=branch_name, **create_payload)
@@ -1092,7 +1107,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         # Resolve each query reference to its node id now that the queries have been applied.
         for check in local_check_definitions.values():
             graphql_query = await self.sdk.get(
-                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(check.query), populate_store=True
+                kind=CoreGraphQLQuery, branch=branch_name, id=str(check.query), populate_store=True
             )
             check.query = str(graphql_query.id)
 
@@ -1170,7 +1185,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 worktree_directory=commit_wt.directory,
             )
 
-            generator.load_class(import_root=self.directory_root, relative_path=file_info.relative_repo_path_dir)
+            generator.load_class(import_root=str(self.directory_root), relative_path=file_info.relative_repo_path_dir)
 
             closure = closure_builder.build(
                 transform_config=generator,
@@ -1264,7 +1279,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     async def _resolve_target_group_id(self, branch_name: str, group_name: str) -> str | None:
         """Resolve a target group name to its node id for the group-identity fingerprint term."""
         targets = await self.sdk.filters(
-            kind=InfrahubKind.GENERICGROUP,
+            kind=CoreGroup,
             branch=branch_name,
             name__value=group_name,
             populate_store=True,
@@ -1280,12 +1295,12 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         closure: ClosureResult,
     ) -> bool:
         graphql_queries = await self.sdk.filters(
-            kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, name__value=generator.query, populate_store=True
+            kind=CoreGraphQLQuery, branch=branch_name, name__value=generator.query, populate_store=True
         )
         if graphql_queries:
             generator.query = graphql_queries[0].id
         targets = await self.sdk.filters(
-            kind=InfrahubKind.GENERICGROUP,
+            kind=CoreGroup,
             branch=branch_name,
             name__value=generator.targets,
             populate_store=True,
@@ -1411,7 +1426,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         # Resolve each query reference to its node id now that the queries have been applied.
         for transform in local_transform_definitions.values():
             graphql_query = await self.sdk.get(
-                kind=InfrahubKind.GRAPHQLQUERY, branch=branch_name, id=str(transform.query), populate_store=True
+                kind=CoreGraphQLQuery, branch=branch_name, id=str(transform.query), populate_store=True
             )
             transform.query = str(graphql_query.id)
 
@@ -1614,7 +1629,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         branch_name: str,
         closure: ClosureResult,
         fingerprint: str | None = None,
-    ) -> InfrahubNode:
+    ) -> CoreGeneratorDefinition:
         # `watch` is an SDK-config-only field that drives closure detection; it is not a
         # graph attribute, so it must not reach the node create payload.
         data = generator.model_dump(exclude_none=True, exclude={"file_path", "watch"})
@@ -1632,7 +1647,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             source=str(self.id),
             is_protected=True,
         )
-        obj = await self.sdk.create(kind=InfrahubKind.GENERATORDEFINITION, branch=branch_name, **create_payload)
+        obj = await self.sdk.create(kind=CoreGeneratorDefinition, branch=branch_name, **create_payload)
         await obj.save()
 
         return obj
@@ -1700,7 +1715,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         create_payload = self.sdk.schema.generate_payload_create(
             schema=schema,
             data=data,
-            source=self.id,
+            source=str(self.id),
             is_protected=True,
         )
         obj = await self.sdk.create(kind=CoreCheckDefinition, branch=branch_name, data=create_payload)
@@ -2025,7 +2040,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
 
-        if artifact.checksum.value == checksum:
+        # The storage id is written in the same save() as the checksum, so a matching checksum
+        # means the content was uploaded. Regenerate if that pairing was ever broken, rather than
+        # reporting a result with no storage id.
+        if artifact.checksum.value == checksum and artifact.storage_id.value:
             return ArtifactGenerateResult(
                 changed=False, checksum=checksum, storage_id=artifact.storage_id.value, artifact_id=artifact.id
             )
@@ -2085,7 +2103,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
 
-        if artifact.checksum.value == checksum:
+        # The storage id is written in the same save() as the checksum, so a matching checksum
+        # means the content was uploaded. Regenerate if that pairing was ever broken, rather than
+        # reporting a result with no storage id.
+        if artifact.checksum.value == checksum and artifact.storage_id.value:
             return ArtifactGenerateResult(
                 changed=False, checksum=checksum, storage_id=artifact.storage_id.value, artifact_id=artifact.id
             )

--- a/backend/tests/unit/git/test_integrator.py
+++ b/backend/tests/unit/git/test_integrator.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from infrahub_sdk.yaml import SchemaFile
+
+from infrahub.git.integrator import find_unloadable_schema_files, format_unloadable_schema_files
+
+
+def build_schema_file(
+    identifier: str,
+    content: dict | None = None,
+    valid: bool = True,
+    error_message: str | None = None,
+) -> SchemaFile:
+    return SchemaFile(
+        identifier=identifier,
+        location=Path(identifier),
+        content=content,
+        valid=valid,
+        error_message=error_message,
+    )
+
+
+@dataclass
+class FindUnloadableTestCase:
+    name: str
+    """Descriptive name for the test scenario (used as test ID)."""
+
+    schemas_data: list[SchemaFile]
+    """The schema files as the loader left them."""
+
+    expected_identifiers: list[str] = field(default_factory=list)
+    """Identifiers of the files expected to be reported as unloadable, in order."""
+
+
+FIND_UNLOADABLE_TEST_CASES: list[FindUnloadableTestCase] = [
+    FindUnloadableTestCase(
+        name="every_file_loaded_reports_nothing",
+        schemas_data=[
+            build_schema_file(identifier="one.yml", content={"version": "1.0"}),
+            build_schema_file(identifier="two.yml", content={"version": "1.0"}),
+        ],
+    ),
+    FindUnloadableTestCase(
+        name="absent_content_is_unloadable",
+        schemas_data=[
+            build_schema_file(identifier="one.yml", content={"version": "1.0"}),
+            build_schema_file(identifier="broken.yml", valid=False, error_message="Invalid YAML/JSON file"),
+        ],
+        expected_identifiers=["broken.yml"],
+    ),
+    FindUnloadableTestCase(
+        name="empty_document_is_unloadable_even_though_content_is_a_dict",
+        schemas_data=[
+            build_schema_file(identifier="empty.yml", content={}, valid=False, error_message="Empty YAML/JSON file"),
+        ],
+        expected_identifiers=["empty.yml"],
+    ),
+    FindUnloadableTestCase(
+        name="every_unloadable_file_is_reported_not_only_the_first",
+        schemas_data=[
+            build_schema_file(identifier="first.yml", valid=False, error_message="Empty YAML/JSON file"),
+            build_schema_file(identifier="ok.yml", content={"version": "1.0"}),
+            build_schema_file(identifier="second.yml", valid=False, error_message="Invalid YAML/JSON file"),
+        ],
+        expected_identifiers=["first.yml", "second.yml"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in FIND_UNLOADABLE_TEST_CASES],
+)
+def test_find_unloadable_schema_files(test_case: FindUnloadableTestCase) -> None:
+    """A file is unloadable when the loader flagged it or left no content behind."""
+    unloadable = find_unloadable_schema_files(schemas_data=test_case.schemas_data)
+
+    assert [item.identifier for item in unloadable] == test_case.expected_identifiers
+
+
+@dataclass
+class FormatUnloadableTestCase:
+    name: str
+    """Descriptive name for the test scenario (used as test ID)."""
+
+    unloadable: list[SchemaFile]
+    """The files reported as unloadable."""
+
+    expected: str
+    """The full message handed to the caller."""
+
+
+FORMAT_UNLOADABLE_TEST_CASES: list[FormatUnloadableTestCase] = [
+    FormatUnloadableTestCase(
+        name="single_file_carries_the_loader_reason",
+        unloadable=[build_schema_file(identifier="empty.yml", valid=False, error_message="Empty YAML/JSON file")],
+        expected="Unable to load 1 schema file(s): empty.yml (Empty YAML/JSON file)",
+    ),
+    FormatUnloadableTestCase(
+        name="every_file_is_named",
+        unloadable=[
+            build_schema_file(identifier="empty.yml", valid=False, error_message="Empty YAML/JSON file"),
+            build_schema_file(identifier="broken.yml", valid=False, error_message="Invalid YAML/JSON file"),
+        ],
+        expected=(
+            "Unable to load 2 schema file(s): empty.yml (Empty YAML/JSON file), broken.yml (Invalid YAML/JSON file)"
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in FORMAT_UNLOADABLE_TEST_CASES],
+)
+def test_format_unloadable_schema_files(test_case: FormatUnloadableTestCase) -> None:
+    """The reported message names every file and the reason the loader recorded for it."""
+    assert format_unloadable_schema_files(unloadable=test_case.unloadable) == test_case.expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1687,7 +1687,6 @@ unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 [[tool.ty.overrides]]
 include = [
     "backend/infrahub/git/base.py",
-    "backend/infrahub/git/integrator.py",
     "backend/infrahub/git/repository.py",
     "backend/infrahub/git/tasks.py",
     "backend/infrahub/git/utils.py",


### PR DESCRIPTION
# Why

`backend/infrahub/git/integrator.py` was listed under four ty overrides. This clears one of them outright: **`invalid-argument-type` is now enforced for the file** and its entry is gone from `pyproject.toml`. That is the first file in `git/` to shed a rule since the module-wide override was split per file in #10125, and integrator.py is the largest file in the module at 91 KB.

Goal: take a rule from "suppressed for this file" to "enforced for this file", so no new violation of it can land here again.

Non-goals: the other three rules integrator.py is still listed under (`unresolved-attribute` 9, `no-matching-overload` 9, `invalid-assignment` 7). Those need the surrounding function signatures tightened, which is judgement work, not substitution.

## What changed

Nine `invalid-argument-type` diagnostics, four mechanical causes plus one behaviour fix.

**Mechanical (no runtime effect):**

- `source=self.id` at four sites passed a `UUID` where the SDK declares `str | None`. `generate_payload_create` does `item_metadata["source"] = str(source)` internally, so wrapping it produces the identical string. Two other sites in the same file already did this; now all six agree.
- `load_class(import_root=...)` received a `Path` where `str | None` is declared. The SDK does `Path(import_root, relative_path, module_path.name)`, which accepts either, so `str()` is a no-op.
- Two artifact early-returns fed `CoreArtifact.storage_id.value` (a `StringOptional`) into `ArtifactGenerateResult.storage_id: str`. The invariant is real, the storage id is written in the same `save()` as the checksum, but it is not visible at the point of use. The returns now guard on both fields, so the impossible state falls through and regenerates rather than reporting a result with no storage id.

**Behaviour change, one place:** `import_schema_files` detected unloadable schema files, logged them, and then left them in the list. The failure was therefore produced accidentally by Pydantic choking on `None` further down, so a user with an empty schema file was told:

```
Schema not valid, found '1' error(s) in foo.yml : Input should be a valid dictionary or instance of InfrahubSchemaWrite
```

rather than the reason `YamlFile.load_content()` had already recorded. Now:

```
Unable to load 1 schema file(s): foo.yml (Empty YAML/JSON file)
```

Every invalid file is still logged individually first, exactly as before, and all of them are named in the error instead of whichever one Pydantic happened to reach first. Payloads are collected into a narrowed list because re-reading `.content` in the later loops would lose the non-`None` narrowing.

**Also included:** the eight remaining kind-string node fetches in the file now pass the generated SDK protocol classes, finishing what #10125 started for `tasks.py`. That required correcting two return annotations from `InfrahubNode` to the precise protocol type, since the generated protocols are **not** `InfrahubNode` subclasses (`CoreArtifactDefinition.__mro__` is `CoreArtifactDefinition -> CoreTaskTarget -> CoreNode -> CoreNodeBase -> object`). Both callers discard the return value, so there is no cascade. Only two of the module's diagnostics now come from the SDK `__getattr__` union, down from 57 before this work began.

`integrator.py` 37 -> 27 suppressed ty diagnostics, the module 108 -> 98.

## How to review

Start with the one-line `pyproject.toml` diff, that is the point of the PR. Then the `import_schema_files` restructure, which is the only behaviour change. The rest is `str()` wrappers and one-token kind substitutions.

**Known inconsistency worth a decision:** six functions now read `schema.get(kind=InfrahubKind.X)` a few lines above `sdk.create(kind=CoreX)`. I stopped at the node calls deliberately, because `schema.get` returns a schema rather than a node so there is no typing gain, but the two spellings sitting three lines apart do look odd. `schema.get` accepts `type[SchemaType | SchemaTypeSync] | str`, so converting them is safe if you would rather have the consistency. Say the word and I will.

## How to test

```bash
uv run ty check .                                  # All checks passed!
uv run invoke backend.mypy                         # Success: no issues found in 1601 source files
uv run invoke backend.ruff
uv run pytest backend/tests/unit/git/ --no-cov -q  # 178 passed
```

The ratchet is armed, not just asserted. With a deliberate violation injected into integrator.py, `ty check .` now fails on it, where before the override would have swallowed it:

```
backend/infrahub/git/integrator.py:835:34: error[invalid-argument-type] Argument to bound method
`InfrahubSchemaBase.validate` is incorrect: Expected `dict[str, Any]`, found `None`
```

## Tests

The behaviour change is covered by `backend/tests/unit/git/test_integrator.py`: 6 unit tests, 0.09s, no database and no containers. `find_unloadable_schema_files` and `format_unloadable_schema_files` are extracted as pure functions over `list[SchemaFile]`, which is directly constructible, so no fixtures or patching are needed. The cases include a document containing only `{}`, which loads to an empty dict rather than `None`, so the loader's `valid` flag rather than the content is the signal. The tests were mutation-checked: dropping that condition makes them fail.

The `storage_id` guard is deliberately not tested. It only changes behaviour when the checksum matches while `storage_id` is empty, and in that state the previous code did not work either, it raised `ValidationError: storage_id` from Pydantic because the field is declared `str`. The guard replaces that crash with a re-upload that repairs the record, so it cannot regress that state. The state should also be unreachable, since `checksum` and `storage_id` are only ever written together in the same `save()`.

Where this logic belongs is a separate question from whether it is tested. `infrahubctl schema load` performs the identical flow using SDK helpers that Infrahub cannot call because they are coupled to a rich `Console` and `typer.Exit`, which is why this hand-rolled copy diverged and lost the invalid-file handling in the first place. Tracked in **opsmill/infrahub-sdk-python#1225**, which proposes a library-level `load_schema_files()`. The two functions extracted here are shaped to be replaced by it.

## Impact & rollout

- **Backward compatibility:** one user-visible error message improves; no API or schema change.
- **Performance:** none.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Follow-ups

- opsmill/infrahub-sdk-python#1225, after which this file loses ~20 lines and gains real test coverage.
- Deduplicating `generate_artifact` and the near-identical method below it, roughly 35 lines each, which would collapse the two storage-id guards into one.
- The remaining three rules for this file, plus `repository.py`, where `assignment` and `call-overload` are one mypy error each and would remove two more override entries.

## Checklist

- [ ] Tests added/updated <!-- 6 unit tests in backend/tests/unit/git/test_integrator.py -->
- [ ] Changelog entry added <!-- one error message improves; happy to add a fragment if you consider that user-facing -->
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content
