### PR TITLE
Clone git repositories on their own default branch

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -191,6 +191,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):
     def default_branch(self) -> str:
         return self.default_branch_name or registry.default_branch
 
+    @abstractmethod
+    async def resolve_checkout_ref(self) -> str:
+        """Return the git ref the primary clone has to be checked out on, reading it from the graph if needed."""
+        raise NotImplementedError()
+
     @property
     def legacy_directory_root(self) -> Path:
         """Return the legacy path to the root directory for this repository."""

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -197,7 +197,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             self.validate_local_directories()
         except RepositoryInvalidFileSystemError:
             await self.ensure_location_is_defined()
-            await self.create_locally(infrahub_branch_name=self.infrahub_branch_name, update_commit_value=False)
+            await self.create_locally(
+                checkout_ref=await self.resolve_checkout_ref(),
+                infrahub_branch_name=self.infrahub_branch_name,
+                update_commit_value=False,
+            )
             self.reinitialized = True
             log.info(f"Initialized the local directory for {self.name} because it was missing.")
 

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -9,6 +9,7 @@ from cachetools.keys import hashkey
 from cachetools_async import cached
 from git.exc import BadName, GitCommandError
 from infrahub_sdk.exceptions import GraphQLError
+from infrahub_sdk.protocols import CoreReadOnlyRepository, CoreRepository
 from prefect import task
 from prefect.cache_policies import NONE
 from pydantic import Field
@@ -82,6 +83,15 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         )
         log.info("Created new repository locally.", repository=self.name)
         return self
+
+    async def resolve_checkout_ref(self) -> str:
+        if not self.default_branch_name:
+            repository = await self.sdk.get(
+                kind=CoreRepository, name__value=self.name, exclude=["tags", "credential"], raise_when_missing=True
+            )
+            self.default_branch_name = repository.default_branch.value
+
+        return self.default_branch
 
     def get_commit_value(self, branch_name: str, remote: bool = False) -> str:
         branches = {}
@@ -355,6 +365,18 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
         await self.create_locally(checkout_ref=self.ref, infrahub_branch_name=self.infrahub_branch_name)
         log.info("Created new repository locally.", repository=self.name)
         return self
+
+    async def resolve_checkout_ref(self) -> str:
+        if not self.ref:
+            repository = await self.sdk.get(
+                kind=CoreReadOnlyRepository,
+                name__value=self.name,
+                exclude=["tags", "credential"],
+                raise_when_missing=True,
+            )
+            self.ref = repository.ref.value
+
+        return self.ref
 
     def get_commit_value(self, branch_name: str, remote: bool = False) -> str:  # noqa: ARG002
         """Always get the latest commit for this repository's ref on the remote.

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -367,16 +367,18 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
         return self
 
     async def resolve_checkout_ref(self) -> str:
-        if not self.ref:
+        ref = self.ref
+        if not ref:
             repository = await self.sdk.get(
                 kind=CoreReadOnlyRepository,
                 name__value=self.name,
                 exclude=["tags", "credential"],
                 raise_when_missing=True,
             )
-            self.ref = repository.ref.value
+            ref = repository.ref.value
+            self.ref = ref
 
-        return self.ref
+        return ref
 
     def get_commit_value(self, branch_name: str, remote: bool = False) -> str:  # noqa: ARG002
         """Always get the latest commit for this repository's ref on the remote.

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -1264,6 +1264,7 @@ async def test_init_reinitialized_after_missing_directory(
         id=repo_id,
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
+        default_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 

--- a/backend/tests/functional/git/test_repository_default_branch.py
+++ b/backend/tests/functional/git/test_repository_default_branch.py
@@ -20,8 +20,17 @@ if TYPE_CHECKING:
     from infrahub.core.protocols import CoreRepository
     from infrahub.database import InfrahubDatabase
 
-GIT_DEFAULT_BRANCH = "production"
+GIT_BRANCH = "production"
 REPOSITORY_NAME = "repository-with-non-main-default-branch"
+READ_ONLY_REPOSITORY_NAME = "read-only-repository-with-non-main-ref"
+
+
+def create_upstream_repository(directory: Path, branch: str) -> None:
+    directory.mkdir()
+    upstream = Repo.init(directory, initial_branch=branch)
+    (directory / "file.txt").write_text("content")
+    upstream.index.add(["file.txt"])
+    upstream.index.commit("First commit")
 
 
 class TestRepositoryDefaultBranch(TestInfrahubApp):
@@ -35,21 +44,17 @@ class TestRepositoryDefaultBranch(TestInfrahubApp):
         git_repos_dir: Path,
     ) -> None:
         """A worker with no local copy of a repository clones it on the repository default branch."""
-        assert registry.default_branch != GIT_DEFAULT_BRANCH
+        assert registry.default_branch != GIT_BRANCH
 
         source_dir = tmp_path / "upstream"
-        source_dir.mkdir()
-        upstream = Repo.init(source_dir, initial_branch=GIT_DEFAULT_BRANCH)
-        (source_dir / "file.txt").write_text("content")
-        upstream.index.add(["file.txt"])
-        upstream.index.commit("First commit")
+        create_upstream_repository(directory=source_dir, branch=GIT_BRANCH)
 
         node = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
         await node.new(
             db=db,
             name=REPOSITORY_NAME,
             location=str(source_dir),
-            default_branch=GIT_DEFAULT_BRANCH,
+            default_branch=GIT_BRANCH,
         )
         await node.save(db=db)
         operational_status_before = node.operational_status.value
@@ -61,9 +66,42 @@ class TestRepositoryDefaultBranch(TestInfrahubApp):
             repository_kind=InfrahubKind.REPOSITORY,
         )
 
-        assert repo.get_git_repo_main().active_branch.name == GIT_DEFAULT_BRANCH
+        assert repo.get_git_repo_main().active_branch.name == GIT_BRANCH
 
         reloaded: CoreRepository = await NodeManager.get_one(
             db=db, id=node.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
         )
         assert reloaded.operational_status.value == operational_status_before
+
+    async def test_on_demand_clone_checks_out_configured_ref(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        initialize_registry: None,
+        tmp_path: Path,
+        git_repos_dir: Path,
+    ) -> None:
+        """A worker with no local copy of a read-only repository clones it on the ref it tracks."""
+        assert registry.default_branch != GIT_BRANCH
+
+        source_dir = tmp_path / "upstream"
+        create_upstream_repository(directory=source_dir, branch=GIT_BRANCH)
+
+        node = await Node.init(db=db, schema=InfrahubKind.READONLYREPOSITORY)
+        await node.new(
+            db=db,
+            name=READ_ONLY_REPOSITORY_NAME,
+            location=str(source_dir),
+            ref=GIT_BRANCH,
+        )
+        await node.save(db=db)
+
+        repo = await get_initialized_repo.fn(
+            client=client,
+            repository_id=node.id,
+            name=READ_ONLY_REPOSITORY_NAME,
+            repository_kind=InfrahubKind.READONLYREPOSITORY,
+        )
+
+        assert repo.get_git_repo_main().active_branch.name == GIT_BRANCH

--- a/backend/tests/functional/git/test_repository_default_branch.py
+++ b/backend/tests/functional/git/test_repository_default_branch.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from git import Repo
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.git.repository import get_initialized_repo
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreRepository
+    from infrahub.database import InfrahubDatabase
+
+GIT_DEFAULT_BRANCH = "production"
+REPOSITORY_NAME = "repository-with-non-main-default-branch"
+
+
+class TestRepositoryDefaultBranch(TestInfrahubApp):
+    async def test_on_demand_clone_checks_out_configured_default_branch(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        initialize_registry: None,
+        tmp_path: Path,
+        git_repos_dir: Path,
+    ) -> None:
+        """A worker with no local copy of a repository clones it on the repository default branch."""
+        assert registry.default_branch != GIT_DEFAULT_BRANCH
+
+        source_dir = tmp_path / "upstream"
+        source_dir.mkdir()
+        upstream = Repo.init(source_dir, initial_branch=GIT_DEFAULT_BRANCH)
+        (source_dir / "file.txt").write_text("content")
+        upstream.index.add(["file.txt"])
+        upstream.index.commit("First commit")
+
+        node = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await node.new(
+            db=db,
+            name=REPOSITORY_NAME,
+            location=str(source_dir),
+            default_branch=GIT_DEFAULT_BRANCH,
+        )
+        await node.save(db=db)
+        operational_status_before = node.operational_status.value
+
+        repo = await get_initialized_repo.fn(
+            client=client,
+            repository_id=node.id,
+            name=REPOSITORY_NAME,
+            repository_kind=InfrahubKind.REPOSITORY,
+        )
+
+        assert repo.get_git_repo_main().active_branch.name == GIT_DEFAULT_BRANCH
+
+        reloaded: CoreRepository = await NodeManager.get_one(
+            db=db, id=node.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
+        )
+        assert reloaded.operational_status.value == operational_status_before

--- a/backend/tests/integration_docker/test_artifact_composition.py
+++ b/backend/tests/integration_docker/test_artifact_composition.py
@@ -5,18 +5,21 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from infrahub_sdk.protocols import CoreArtifact
+from infrahub_sdk.protocols import CoreArtifact, CoreRepository
 from infrahub_sdk.schema import NodeSchema, SchemaRoot
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
 from infrahub_sdk.testing.schemas.car_person import SchemaCarPerson
 
-from infrahub.core.constants import ArtifactStatus, InfrahubKind
+from infrahub.core.constants import ArtifactStatus, InfrahubKind, RepositoryOperationalStatus
 
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
+
+# Must stay off "main" to cover repositories whose default branch is not the platform one.
+SECTION_GIT_DEFAULT_BRANCH = "production"
 
 
 async def wait_for_artifacts(
@@ -73,15 +76,22 @@ class TestArtifactComposition(TestInfrahubDockerClient, SchemaCarPerson):
         await group.save()
 
     async def test_add_section_repo(
-        self, client: InfrahubClient, remote_repos_dir: Path, initial_dataset: None
+        self, client: InfrahubClient, remote_repos_dir: Path, default_branch: str, initial_dataset: None
     ) -> None:
         repo = GitRepo(
             name="section-config",
             src_directory=CURRENT_DIRECTORY / "test_files/repos/section-config",
             dst_directory=remote_repos_dir,
+            initial_branch=SECTION_GIT_DEFAULT_BRANCH,
         )
-        await repo.add_to_infrahub(client=client)
-        assert await repo.wait_for_sync_to_complete(client=client, retries=12)
+        repository = await client.create(
+            kind=CoreRepository,
+            name=repo.name,
+            location=f"/remote/{repo.name}",
+            default_branch=SECTION_GIT_DEFAULT_BRANCH,
+        )
+        await repository.save()
+        assert await repo.wait_for_sync_to_complete(client=client, branch=default_branch, retries=12)
 
     async def test_section_artifacts(self, client: InfrahubClient) -> None:
         """Section artifacts are generated with the expected content."""
@@ -94,6 +104,9 @@ class TestArtifactComposition(TestInfrahubDockerClient, SchemaCarPerson):
             content = await client.object_store.get(identifier=artifact.storage_id.value)
             contents.add(content)
         assert contents == {"! Section config for John Doe", "! Section config for Jane Doe"}
+
+        repository = await client.get(kind=CoreRepository, name__value="section-config")
+        assert repository.operational_status.value == RepositoryOperationalStatus.ONLINE.value
 
     async def test_add_composite_repo(self, client: InfrahubClient, remote_repos_dir: Path) -> None:
         repo = GitRepo(

--- a/changelog/8749.fixed.md
+++ b/changelog/8749.fixed.md
@@ -1,0 +1,1 @@
+Fixed artifact generation failing for repositories whose default branch is not named main.


### PR DESCRIPTION
# Why

A worker without a local copy of a repository clones it on demand. That path only carries the repository id and name, so the repository object never learns which git ref to track. It fell back to the platform default branch. Git then failed on any repository whose default branch is not `main`, the repository went to error, and artifact generation failed with it.

It takes more than one worker to see this. Each worker keeps its own git directory, so only the worker that added the repository has the clone.

Closes #8749. It does not close #9825: `repo.default_branch` is still wrong when the clone already exists.

## What changed

`InfrahubRepositoryBase` gets one abstract method, `resolve_checkout_ref`. The re-clone path calls it and passes the result to `create_locally`. `CoreRepository` reads `default_branch`, `CoreReadOnlyRepository` reads `ref`. No schema change, no migration.

```
init()
  validate_local_directories()      clone missing
    ensure_location_is_defined()    -> location
    resolve_checkout_ref()          -> default_branch or ref
      create_locally()
```

## What to look at

`backend/infrahub/git/integrator.py` has the behaviour change. The graph lookup sits inside the missing directory branch, so an existing clone makes no extra query. `init()` is on the hot path of artifacts, transforms and generators.

## How to test

```bash
uv run pytest backend/tests/functional/git/test_repository_default_branch.py
uv run pytest backend/tests/integration_docker/test_artifact_composition.py
```

The end to end case needs two workers, so it lives in `integration_docker`. The artifact composition test now uses a repository on a non default branch, instead of a new test class with its own compose stack.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] I have reviewed AI generated content
