### PR TITLE
test(frontend): pin metadata date filter time precision

### DIFF
--- a/changelog/+date-filter-time-precision-tests.housekeeping.md
+++ b/changelog/+date-filter-time-precision-tests.housekeeping.md
@@ -1,0 +1,1 @@
+Added regression tests pinning minute precision of the metadata date filters

--- a/changelog/+date-filter-time-precision-tests.housekeeping.md
+++ b/changelog/+date-filter-time-precision-tests.housekeeping.md
@@ -1,1 +1,0 @@
-Added regression tests pinning minute precision of the metadata date filters

--- a/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.test.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.test.tsx
@@ -1,0 +1,74 @@
+import { format } from "date-fns";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { QSP } from "@/shared/config/qsp";
+
+import { METADATA_UPDATED_AT } from "@/entities/nodes/object/domain/metadata-filter-definitions";
+
+import { render } from "../../../../../../tests/components/render";
+import { DateMetadataFilterForm } from "./date-metadata-filter-form";
+
+// The HH:MM selected in the date picker must be carried into the applied filter
+// value, not silently truncated to the date portion.
+
+function getFilterValue(filterName: string): string {
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get(QSP.FILTER);
+  expect(raw, `expected ${QSP.FILTER} query param to be set`).toBeTruthy();
+  const filters: Array<{ name: string; value: unknown }> = JSON.parse(raw as string);
+  const filter = filters.find((f) => f.name === filterName);
+  expect(filter, `expected filter ${filterName} in ${raw}`).toBeDefined();
+  return filter?.value as string;
+}
+
+function seedFilters(filters: Array<{ name: string; value: string }>) {
+  window.history.replaceState(
+    null,
+    "",
+    `/?${QSP.FILTER}=${encodeURIComponent(JSON.stringify(filters))}`
+  );
+}
+
+describe("DateMetadataFilterForm", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  test("keeps the selected time in the applied 'after' filter", async () => {
+    // GIVEN
+    const component = await render(<DateMetadataFilterForm definition={METADATA_UPDATED_AT} />);
+    const dayInCurrentMonth = new Date();
+    dayInCurrentMonth.setDate(15);
+
+    // WHEN
+    await component.getByLabelText(`Choose ${format(dayInCurrentMonth, "PPPP")}`).click();
+    await component.getByText("9:35 PM", { exact: true }).click();
+    await component.getByRole("button", { name: "Apply" }).click();
+
+    // THEN
+    const value = getFilterValue("node_metadata__updated_at__after");
+    const applied = new Date(value);
+    expect(applied.getHours()).toBe(21);
+    expect(applied.getMinutes()).toBe(35);
+    expect(applied.getDate()).toBe(15);
+  });
+
+  test("changing only the time of an existing 'before' filter updates the applied value", async () => {
+    // GIVEN an applied "before <today> 00:00" filter, as in the issue's reproduction steps
+    const midnight = new Date();
+    midnight.setHours(0, 0, 0, 0);
+    seedFilters([{ name: "node_metadata__updated_at__before", value: midnight.toISOString() }]);
+    const component = await render(<DateMetadataFilterForm definition={METADATA_UPDATED_AT} />);
+
+    // WHEN only the time is changed to 23:59
+    await component.getByText("11:59 PM", { exact: true }).click();
+    await component.getByRole("button", { name: "Apply" }).click();
+
+    // THEN
+    const value = getFilterValue("node_metadata__updated_at__before");
+    const applied = new Date(value);
+    expect(applied.getHours()).toBe(23);
+    expect(applied.getMinutes()).toBe(59);
+    expect(applied.getDate()).toBe(midnight.getDate());
+  });
+});

--- a/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.test.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/date-metadata-filter-form.test.tsx
@@ -8,20 +8,12 @@ import { METADATA_UPDATED_AT } from "@/entities/nodes/object/domain/metadata-fil
 import { render } from "../../../../../../tests/components/render";
 import { DateMetadataFilterForm } from "./date-metadata-filter-form";
 
-// The HH:MM selected in the date picker must be carried into the applied filter
-// value, not silently truncated to the date portion.
-
-function getFilterValue(filterName: string): string {
-  const params = new URLSearchParams(window.location.search);
-  const raw = params.get(QSP.FILTER);
-  expect(raw, `expected ${QSP.FILTER} query param to be set`).toBeTruthy();
-  const filters: Array<{ name: string; value: unknown }> = JSON.parse(raw as string);
-  const filter = filters.find((f) => f.name === filterName);
-  expect(filter, `expected filter ${filterName} in ${raw}`).toBeDefined();
-  return filter?.value as string;
+interface AppliedFilter {
+  name: string;
+  value: string;
 }
 
-function seedFilters(filters: Array<{ name: string; value: string }>) {
+function seedAppliedFilters(filters: AppliedFilter[]) {
   window.history.replaceState(
     null,
     "",
@@ -29,46 +21,61 @@ function seedFilters(filters: Array<{ name: string; value: string }>) {
   );
 }
 
+function getAppliedFilterValue(filterName: string): string {
+  const raw = new URLSearchParams(window.location.search).get(QSP.FILTER);
+  if (!raw) throw new Error(`expected the ${QSP.FILTER} query param to be set`);
+
+  const filters: AppliedFilter[] = JSON.parse(raw);
+  const filter = filters.find((entry) => entry.name === filterName);
+  if (!filter) throw new Error(`expected a ${filterName} filter in ${raw}`);
+
+  return filter.value;
+}
+
+// The HH:MM picked in the date picker has to survive into the applied filter value:
+// a value truncated to the date portion silently widens the filter by a whole day.
 describe("DateMetadataFilterForm", () => {
   afterEach(() => {
     window.history.replaceState(null, "", "/");
   });
 
-  test("keeps the selected time in the applied 'after' filter", async () => {
+  test("carries the picked time into a new 'after' filter", async () => {
     // GIVEN
-    const component = await render(<DateMetadataFilterForm definition={METADATA_UPDATED_AT} />);
     const dayInCurrentMonth = new Date();
     dayInCurrentMonth.setDate(15);
-
-    // WHEN
-    await component.getByLabelText(`Choose ${format(dayInCurrentMonth, "PPPP")}`).click();
-    await component.getByText("9:35 PM", { exact: true }).click();
-    await component.getByRole("button", { name: "Apply" }).click();
-
-    // THEN
-    const value = getFilterValue("node_metadata__updated_at__after");
-    const applied = new Date(value);
-    expect(applied.getHours()).toBe(21);
-    expect(applied.getMinutes()).toBe(35);
-    expect(applied.getDate()).toBe(15);
-  });
-
-  test("changing only the time of an existing 'before' filter updates the applied value", async () => {
-    // GIVEN an applied "before <today> 00:00" filter, as in the issue's reproduction steps
-    const midnight = new Date();
-    midnight.setHours(0, 0, 0, 0);
-    seedFilters([{ name: "node_metadata__updated_at__before", value: midnight.toISOString() }]);
     const component = await render(<DateMetadataFilterForm definition={METADATA_UPDATED_AT} />);
 
-    // WHEN only the time is changed to 23:59
-    await component.getByText("11:59 PM", { exact: true }).click();
+    // WHEN
+    await component
+      .getByRole("option", { name: `Choose ${format(dayInCurrentMonth, "PPPP")}`, exact: true })
+      .click();
+    await component.getByRole("option", { name: "9:35 PM", exact: true }).click();
     await component.getByRole("button", { name: "Apply" }).click();
 
     // THEN
-    const value = getFilterValue("node_metadata__updated_at__before");
-    const applied = new Date(value);
+    const applied = new Date(getAppliedFilterValue("node_metadata__updated_at__after"));
+    expect(applied.getDate()).toBe(15);
+    expect(applied.getHours()).toBe(21);
+    expect(applied.getMinutes()).toBe(35);
+  });
+
+  test("carries the picked time into an existing 'before' filter when only the time changes", async () => {
+    // GIVEN
+    const midnight = new Date();
+    midnight.setHours(0, 0, 0, 0);
+    seedAppliedFilters([
+      { name: "node_metadata__updated_at__before", value: midnight.toISOString() },
+    ]);
+    const component = await render(<DateMetadataFilterForm definition={METADATA_UPDATED_AT} />);
+
+    // WHEN
+    await component.getByRole("option", { name: "11:59 PM", exact: true }).click();
+    await component.getByRole("button", { name: "Apply" }).click();
+
+    // THEN
+    const applied = new Date(getAppliedFilterValue("node_metadata__updated_at__before"));
+    expect(applied.getDate()).toBe(midnight.getDate());
     expect(applied.getHours()).toBe(23);
     expect(applied.getMinutes()).toBe(59);
-    expect(applied.getDate()).toBe(midnight.getDate());
   });
 });


### PR DESCRIPTION
# Why

Issue #9026 reported that the metadata date filter ignores the picked HH:MM — that `Updated at before <today> 00:00` and `before <today> 23:59` return identical row counts. We investigated this at three levels (static analysis, component tests, and a live dockerized stack driven through the real UI) and the defect does not exist on current code. This PR pins the correct behavior with regression tests so the issue can be closed against committed evidence, and any future regression reproduces the exact reported failure.

Closes #9026

## Why the original report saw what it saw

The report's environment block records image revision `58ee27980` (digest `sha256:8af0c430…`, built 2026-04-22). That revision **cannot have contained the UI being tested**:

- `date-metadata-filter-form.tsx` was introduced by #8793 (`490f758dd`, merged to `develop` 2026-04-10 via #8867).
- `58ee27980` is a `stable`-line commit that is **not** a descendant of `490f758dd`; at that revision the object-list filter panel has no `Updated at` / `Created at` entries at all (only the branches table had metadata date filters).

Anyone can verify this from a checkout:

```bash
git merge-base --is-ancestor 490f758dd 58ee27980 && echo ancestor || echo NOT-ancestor
# → NOT-ancestor

git ls-tree -r --name-only 58ee27980 -- frontend/app/src/entities/nodes/object/ui/filters/
# → no date-metadata-filter-form.tsx in the listing
```

So the observations in the report were made either on a different build than the one recorded, or through a different (older) filter UI. The component itself is byte-identical from its introduction in #8793 through today's `stable` and `develop` (only a label prop from #8969 and import-path renames from #9792 differ) — there was no window in which a "fixed" version existed, and no fix commit: nothing to regress from.

## Could the bug have been real in April and fixed by something else since?

We checked every layer that could have silently cured a real April defect, and none of them changed:

| Layer | Verdict |
|---|---|
| `date-metadata-filter-form.tsx` (picker → form state) | Byte-identical since #8793 (2026-04-09), apart from a label prop (#8969) and import-path renames (#9792) |
| `addFiltersToRequest` / `useFilters` (form state → GraphQL args) | `before`/`after` passthrough unchanged between the report era and today |
| Backend filter machinery (`_build_metadata_filter_requirement`, comparison operators, `_transform_metadata_day_filters`) | Introduced Dec 2025 (#7960/#7949); **zero** behavior commits since 2026-04-22 — the only `git log -S` hits are docs and release-prep schema regenerations |
| GraphQL argument layer (`manager.py` DateTime args) | No metadata-related commits since 2026-04-22 |
| Dependencies (`react-datepicker`, `nuqs`, `json-to-graphql-query`) | Same locked versions in the April lockfile and today: 8.1.0 / 2.8.9 / ^2.3.0 |

In other words: there is no commit or dependency bump anywhere in the window that could have fixed this behavior, so "it was broken then and got fixed since" is not a viable explanation. The recorded image digest is no longer available in the registry (the `develop` tag has moved on), so the revision label is the only provenance anchor — and it points at code that predates this UI.

## Live reproduction attempt (2026-08-06, full stack, real UI)

Setup mirroring the issue's controlled seed: full docker compose stack, 9 `BuiltinTag` objects created across a minute boundary — 7 with `updated_at` in 09:32 UTC (alpha-1…7), 2 in 09:33 UTC (beta-1, beta-2). Host timezone UTC+3 (EEST), so the boundary minute is 12:33 PM in the picker. Filters applied by clicking through the actual filter panel on `/objects/BuiltinTag`:

| Filter applied in UI | Issue's prediction | Expected if HH:MM respected | **Actual** |
|---|---|---|---|
| `Updated at after Aug 6, 12:33 PM` | 0 (time ignored) | 2 | **2** (beta-1, beta-2) |
| `Updated at before Aug 6, 12:33 PM` | 9 (time ignored) | 7 | **7** (alpha-1…7) |
| `Updated at before Aug 6, 12:00 AM` — issue step 4 | same as step 5 | 0 | **0** |
| `Updated at before Aug 6, 11:59 PM` — issue step 5 | same as step 4 | 9 | **9** |

Rows 3–4 are the issue's literal reproduction steps 4–5. They return different counts.

### Screenshots

Seed — 9 tags, no filter:

![Seed: 9 tags unfiltered](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/1-seed-9-tags.png)

The picker re-opened from an existing chip — condition `before`, Aug 6, **12:33 PM highlighted** (minute precision):

![Picker with 12:33 PM selected](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/6-picker-1233pm-selected.png)

`after 12:33 PM` → exactly the 2 betas (issue predicted 0):

![after 12:33 → 2 rows](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/2-after-1233pm-2-rows.png)

`before 12:33 PM` → exactly the 7 alphas (issue predicted 9):

![before 12:33 → 7 rows](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/3-before-1233pm-7-rows.png)

Issue steps 4–5 side by side — `before 12:00 AM` → 0 rows vs `before 11:59 PM` → 9 rows (the issue claimed these return the same count):

![before 12:00 AM → 0 rows](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/4-before-1200am-0-rows.png)

![before 11:59 PM → 9 rows](https://raw.githubusercontent.com/opsmill/infrahub/assets/ifc-9026-evidence/5-before-1159pm-9-rows.png)

### Wire-level evidence

The issue asked to "inspect the outgoing GraphQL variables in browser DevTools on filter apply — that confirms whether a date-only string is being sent". We did exactly that (fetch hook capturing the outgoing documents at apply time):

```graphql
# picker: before Aug 6, 12:00 AM (local UTC+3) → correct UTC instant, previous day
BuiltinTag(node_metadata__updated_at__before: "2026-08-05T21:00:00.000Z") { count }

# picker: before Aug 6, 11:59 PM (local UTC+3)
BuiltinTag(node_metadata__updated_at__before: "2026-08-06T20:59:00.000Z") { count }
```

URL filter state after applying the boundary-minute filters:

```json
[{"name": "node_metadata__updated_at__after",  "value": "2026-08-06T09:33:00.000Z"}]
[{"name": "node_metadata__updated_at__before", "value": "2026-08-06T09:33:00.000Z"}]
```

Three things worth noting:

- A **full ISO-8601 datetime** with the selected HH:MM goes on the wire — never a date-only string, never a value truncated to 00:00/23:59.
- The filter uses the `__before`/`__after` argument forms, so the backend's midnight day-range expansion (`_transform_metadata_day_filters`, which only rewrites the bare `node_metadata__updated_at` argument at exactly 00:00:00) is not on this code path.
- Local→UTC conversion is correct across the day boundary (12:00 AM EEST → 21:00 UTC on the previous day).

The "re-open an existing filter and change only the condition/time" path was exercised too (that's how rows 2–4 were applied) and behaved correctly.

## What changed

- Two vitest browser-mode component tests drive the real `DateMetadataFilterForm` (real `react-datepicker`, real nuqs URL serialization — nothing mocked) and assert the applied filter value carries the selected HH:MM:
  - fresh `after` filter, day + time picked in the UI;
  - re-open an existing `before` filter and change only the time.
- Mutation-checked: artificially truncating the time in the component makes both tests fail with `expected +0 to be 21/23` — i.e. if the reported bug ever appears, these tests reproduce it verbatim.
- No production code changes.

## Test plan

- `cd frontend/app && pnpm test src/entities/nodes/object/ui/filters/date-metadata-filter-form.test.tsx`

## If it still reproduces for you

If you can still see identical counts for different times on a current build, the most useful evidence would be: the exact image digest **and** `/api/info` version of the running server, plus the outgoing GraphQL document from DevTools → Network on filter apply. With those we can bisect where the time portion is lost — everything measured here says it is not lost between the picker and the database query on current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
