### PR TITLE
test(scale): remove broken branch.diff_data call

### DIFF
--- a/backend/tests/scale/common/users.py
+++ b/backend/tests/scale/common/users.py
@@ -89,7 +89,7 @@ class InfrahubClientUser(User):
                 delete_this_node.delete()
 
             if "diff" in self.custom_options["stager"]:
-                self.client.branch.diff_data("DiffTestBranch")
+                self.client.get_diff_tree(branch="DiffTestBranch")
 
         # End with a branch merge
         if "diff" in self.custom_options["stager"]:

--- a/backend/tests/scale/common/users.py
+++ b/backend/tests/scale/common/users.py
@@ -88,9 +88,6 @@ class InfrahubClientUser(User):
 
                 delete_this_node.delete()
 
-            if "diff" in self.custom_options["stager"]:
-                self.client.get_diff_tree(branch="DiffTestBranch")
-
         # End with a branch merge
         if "diff" in self.custom_options["stager"]:
             self.client.branch.merge("DiffTestBranch")


### PR DESCRIPTION
# Why

The scale test's diff stager loop calls `client.branch.diff_data("DiffTestBranch")`, but that SDK method targets `GET /api/diff/data`, an endpoint removed in #4865, so every call has been silently returning a 404 instead of exercising the diff feature.

This is part of the rework of #8594 as suggested by @ogenstad: the broken `diff_data()` method is deleted from the SDK without a replacement, nobody can have been using it (opsmill/infrahub-sdk-python#1229).

## What changed

- `backend/tests/scale/common/users.py`: the diff fetch is removed from the stager loop. It never measured anything (404 since the endpoint was removed), and with `diff_data()` gone from the SDK there is nothing to call. The closing `branch.merge("DiffTestBranch")` stays, so the diff stager still exercises the server-side diff/merge path at scale.

No changelog entry, test-infrastructure only.

## How to review

The stager loop in the scale test loses its dead diff call, nothing else changes.

## Impact & rollout

- Test infrastructure only, scale tests are not part of regular CI
- No ordering dependency on the SDK PR, the removed call is gone either way
