### PR TITLE
Add ruff exception for broad exception

### DIFF
--- a/backend/infrahub/telemetry/utils.py
+++ b/backend/infrahub/telemetry/utils.py
@@ -26,7 +26,8 @@ async def safe_metric[T](coro: Awaitable[T]) -> T | None:
     """
     try:
         return await coro
-    except Exception as exc:
+    # Degradation boundary: any collection failure must null out one field, never fail the whole telemetry run
+    except Exception as exc:  # noqa: BLE001
         log.warning("Telemetry metric collection failed; reporting null for this field: %s", exc)
         return None
 


### PR DESCRIPTION
# Why

The pipeline for `develop` is currently failing as two a PR that introduced a linting violation was merged as we also updated the linting rules

## What changed

* Add an ignore statement. At some point we should go back and investigate how we can limit these for specific exceptions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

