### PR TITLE
chore(deps): unpin pytest-xdist

### DIFF
--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -159,6 +159,28 @@ def neo4j(request, load_settings_before_session) -> dict[int, int] | None:
     }
 ```
 
+### Parallel execution and database isolation
+
+Component, core, functional and integration tests run under pytest-xdist (`-n <workers>`, see
+`tasks/backend.py`); unit tests do not. Each xdist worker is a separate process running its own
+pytest session, so the session-scoped container fixtures above execute **once per worker** — four
+workers means four Neo4j containers, each with its own graph.
+
+That per-worker isolation is what makes the destructive fixtures safe. `empty_database` runs
+`delete_all_nodes`, which is a bare `MATCH (n) DETACH DELETE n` over the entire graph, and several
+tests assert on global counts rather than on nodes they can identify as their own. Both are only
+correct while a worker owns its database outright.
+
+Two consequences worth remembering:
+
+- Do not introduce cross-worker container sharing (for example testcontainers' `reuse` support, or
+  keying a container off `PYTEST_XDIST_WORKER`) without first removing the whole-graph wipes.
+  Sharing one database between workers makes every `empty_database` test hostile to whatever else
+  is running.
+- Test ordering under `--dist loadscope` (set in `addopts`) is not stable across pytest-xdist
+  releases — scopes are sorted largest-first, so which modules run concurrently can change on an
+  upgrade. Tests must not depend on what else is or is not running.
+
 ### Base Test Classes
 
 Located in `backend/tests/helpers/test_app.py`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "pytest-asyncio>=1.3,<1.4",
     "pytest-clarity>=1.0,<1.1",
     "pytest-cov==7.1.0",
-    "pytest-xdist>=3.4,<3.5",
+    "pytest-xdist>=3.8,<3.9",
     "types-python-slugify>=8.0.0.3,<9",
     "types-ujson",
     "types-pyyaml",

--- a/uv.lock
+++ b/uv.lock
@@ -1600,7 +1600,7 @@ dev = [
     { name = "pytest-httpx", specifier = ">=0.33" },
     { name = "pytest-playwright-asyncio", specifier = ">=0.8.0" },
     { name = "pytest-timeout", specifier = "==2.3.1" },
-    { name = "pytest-xdist", specifier = ">=3.4,<3.5" },
+    { name = "pytest-xdist", specifier = ">=3.8,<3.9" },
     { name = "ruamel-yaml", specifier = "==0.18.6" },
     { name = "ruff", specifier = "==0.15.0" },
     { name = "semver", specifier = ">=3.0.2,<4" },
@@ -3463,15 +3463,15 @@ wheels = [
 
 [[package]]
 name = "pytest-xdist"
-version = "3.4.0"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/61/3eb25e71d2368d59ce4ecdfb7197d7767772f81e00a57fe95280defcdf6d/pytest-xdist-3.4.0.tar.gz", hash = "sha256:3a94a931dd9e268e0b871a877d09fe2efb6175c2c23d60d56a6001359002b832", size = 78703, upload-time = "2023-11-11T16:10:20.912Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/94/71d5bdffe6efc8f224154323bb3e026c5e961bd56bd2a5a20f23917377d4/pytest_xdist-3.4.0-py3-none-any.whl", hash = "sha256:e513118bf787677a427e025606f55e95937565e06dfaac8d87f55301e57ae607", size = 41925, upload-time = "2023-11-11T16:10:18.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

`pytest-xdist` has been pinned to `<3.5` since December 2023 as a workaround: 3.5.0 made
`test_database_transaction` fail in CI while passing locally. The pin was never revisited, so the
test suite has been sitting on a November 2023 release for two and a half years.

Goal: retire the pin with the cause actually understood, not guessed at.

Non-goals: no change to the test itself, to `--dist loadscope`, or to any other dependency.

Closes #1643

## What changed

- `pytest-xdist` goes from `>=3.4,<3.5` to `>=3.8,<3.9` (3.4.0 → 3.8.0), plus the `uv.lock` update.
- `dev/knowledge/backend/testing.md` gains a section on parallel execution and database isolation.

### Root cause

pytest-xdist 3.5.0's changelog has exactly one entry:

> `#632`: `--dist=loadscope` now sorts scopes by number of tests to assign largest scopes early

This repo has run `--dist loadscope` since July 2023 (`5793d5d05`). `test_database.py` holds a
single test, so it is the smallest possible scope, and 3.5.0 sorted it to the end of the queue. The
test did not change; the modules running alongside it did.

That mattered only because of a second condition, which held then and does not now: every worker in
a CI job shared one Neo4j instance from the job's compose stack. `test_database_transaction`
asserts on global graph state (`MATCH (b:Book)`) and its `empty_database` fixture runs a bare
`MATCH (n) DETACH DELETE n`, so two such tests on one database are mutually destructive. `:Book`
appears nowhere else in the tree, which is why this only ever reproduced in the parallel CI job.

### Why it is safe to unpin now

Workers no longer share a database. The `neo4j` fixture is session-scoped with no reuse
(`backend/tests/conftest.py:353`) and each xdist worker is a separate process, so every worker
starts its own container — confirmed by watching `docker ps` during a 4-worker run: four Neo4j
containers, four graphs. The test has also moved to `backend/tests/component/`, and
`backend.test-unit` no longer passes `-n` at all.

The releases in between help rather than hurt. 3.6.0's `main_thread_only` execmodel keeps worker
tests on the main thread, which matters for this session-scoped-event-loop asyncio suite, and 3.8.0
adds `--loadscope-reorder` / `--no-loadscope-reorder` — an explicit escape hatch that restores
pre-3.5.0 ordering if anything ever does resurface.

No test is added. A regression test for a scheduler-ordering race would be inherently flaky; the
verification is that the suite passes under the new xdist with more than one worker.

## How to review

The dependency change is mechanical. The part worth scrutiny is the claim now written into
`dev/knowledge/backend/testing.md`: that per-worker containers are what make the whole-graph wipes
in `empty_database` and the global-count assertions safe. If that ever stops being true — someone
adopting testcontainers' `reuse`, say — this test is the canary.

## How to test

```bash
uv run pytest backend/tests/component/test_database.py
```

Single-worker runs prove nothing about this issue, though — the failure mode was cross-worker. What
matters is a run with enough module groups for `loadscope` to reorder, which schedules the
one-test `test_database.py` last:

```bash
uv run invoke backend.test-component --shard other
```

Locally verified on 3.8.0 with `-n 4`: 94 passed across 9 component modules, then 119 passed across
12. Both included `test_database.py`.

## Impact & rollout

- **Backward compatibility:** none. `pytest-xdist` is a dev dependency; no runtime or API surface is touched.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy — affects local and CI test runs only.

## Checklist

- [ ] Tests added/updated — deliberately not; see above.
- [ ] Changelog entry — not applicable, dev-only dependency with no user-facing effect (`ci/skip-changelog`). Matches precedent for dependency bumps such as `0b44b14fd`.
- [ ] External docs updated — not applicable.
- [x] Internal .md docs updated — `dev/knowledge/backend/testing.md`.
- [x] I have reviewed AI generated content.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

