### PR TITLE
fix(testcontainers): stop a cancelled performance run from leaking its compose stack

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -25,6 +25,10 @@ from .models import (
     MeasurementDefinition,
 )
 
+# Bounded so that a stalled endpoint cannot hold the session open indefinitely, while still
+# allowing for a payload that grows with the length of the run.
+RESULTS_UPLOAD_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
 
 class InfrahubPerformanceTest:
     context: dict[str, InfrahubResultContext]
@@ -165,19 +169,32 @@ class InfrahubPerformanceTest:
             "test_info": self.test_info,
         }
 
+    def _serialize_request(self) -> bytes:
+        """Encode the request body, hashing the encoded payload instead of re-encoding it.
+
+        The payload embeds every metric series scraped over the run, which makes it the most
+        expensive thing on the session-finish path. Encoding it once and wrapping the envelope
+        around those bytes halves that cost, and leaves the checksum covering exactly the bytes
+        that go on the wire.
+        """
+        data = json.dumps(self._get_payload(), separators=(",", ":")).encode()
+        envelope = json.dumps(
+            {
+                "kind": PERFORMANCE_TEST_KIND,
+                "payload_format": PERFORMANCE_TEST_VERSION,
+                "checksum": hashlib.sha256(data).hexdigest(),
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        return envelope.removesuffix(b"}") + b',"data":' + data + b"}"
+
     def send_results(self) -> None:
-        data = self._get_payload()
+        body = self._serialize_request()
 
-        payload = {
-            "kind": PERFORMANCE_TEST_KIND,
-            "payload_format": PERFORMANCE_TEST_VERSION,
-            "data": data,
-            "checksum": hashlib.sha256(json.dumps(data, separators=(",", ":")).encode()).hexdigest(),
-        }
-
-        with httpx.Client() as client:
+        with httpx.Client(timeout=RESULTS_UPLOAD_TIMEOUT) as client:
             try:
-                response = client.post(self.results_url, json=payload)
+                response = client.post(self.results_url, content=body, headers={"Content-Type": "application/json"})
                 response.raise_for_status()
             except Exception as exc:
                 print(exc)

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -62,10 +62,18 @@ class InfrahubPerformanceTest:
         self.initialized = True
 
     def finalize(self, session: pytest.Session) -> None:
-        if self.initialized:
+        if not self.initialized:
+            return
+
+        try:
             self.end_time = datetime.now(timezone.utc)
             self.extract_test_session_information(session)
             self.send_results()
+        except BaseException as exc:
+            # Anything escaping here aborts the pytest session, skipping the remaining
+            # teardown that stops the compose stack. That includes KeyboardInterrupt:
+            # a cancelled CI job signals the process again while this is still running.
+            print(f"Failed to report performance results: {exc!r}")
 
     def extract_compose_information(self, compose: InfrahubDockerCompose) -> None:
         self.env_vars = compose.env_vars

--- a/python_testcontainers/infrahub_testcontainers/plugin.py
+++ b/python_testcontainers/infrahub_testcontainers/plugin.py
@@ -97,8 +97,15 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     )
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
-    """whole test run finishes."""
+    """whole test run finishes.
+
+    Runs last so that reporting stays behind the fixture teardown that stops the compose
+    stack. On an interrupted session that teardown happens from pytest's own
+    pytest_sessionfinish, and a CI runner allows only a few seconds between the cancel
+    signal and the kill: anything ahead of the teardown can cost the stack its shutdown.
+    """
     if not session.config.getoption("infrahub_performance_report"):
         return
 

--- a/python_testcontainers/infrahub_testcontainers/plugin.py
+++ b/python_testcontainers/infrahub_testcontainers/plugin.py
@@ -98,7 +98,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
 
 @pytest.hookimpl(trylast=True)
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """whole test run finishes.
 
     Runs last so that reporting stays behind the fixture teardown that stops the compose
@@ -107,6 +107,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # n
     signal and the kill: anything ahead of the teardown can cost the stack its shutdown.
     """
     if not session.config.getoption("infrahub_performance_report"):
+        return
+
+    if exitstatus == pytest.ExitCode.INTERRUPTED:
+        # An interrupted run measured only part of the suite, and the seconds left before
+        # the runner kills the process are better spent shutting the stack down.
         return
 
     session.infrahub_performance_test.finalize(session=session)

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -82,6 +82,12 @@ ignore = [
     "TRY003",   # Avoid specifying long messages outside the exception class
 ]
 
+"tests/**.py" = [
+    # Test doubles override base methods, so the signature is dictated by the superclass
+    "ARG002",   # Unused method argument
+    "PLR6301",  # Method could be a function, class method, or static method
+]
+
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/python_testcontainers/tests/test_performance_payload.py
+++ b/python_testcontainers/tests/test_performance_payload.py
@@ -1,0 +1,24 @@
+import hashlib
+import json
+
+from infrahub_testcontainers.constants import PERFORMANCE_TEST_KIND, PERFORMANCE_TEST_VERSION
+from infrahub_testcontainers.measurements import BRANCH_MERGE_TIME
+from infrahub_testcontainers.models import ContextUnit
+from infrahub_testcontainers.performance_test import InfrahubPerformanceTest
+
+
+def test_request_checksum_covers_the_payload_on_the_wire() -> None:
+    """Reproduce the receiver's verification: re-encode the payload and compare checksums."""
+    performance_test = InfrahubPerformanceTest(results_url="http://localhost")
+    performance_test.initialize(name="test_request_checksum_covers_the_payload_on_the_wire")
+    performance_test.add_context("sites", 2, ContextUnit.COUNT)
+    performance_test.add_measurement(BRANCH_MERGE_TIME, value=100)
+
+    request = json.loads(performance_test._serialize_request())  # noqa: SLF001
+
+    assert request["kind"] == PERFORMANCE_TEST_KIND
+    assert request["payload_format"] == PERFORMANCE_TEST_VERSION
+    assert request["data"] == performance_test._get_payload()  # noqa: SLF001
+    assert (
+        request["checksum"] == hashlib.sha256(json.dumps(request["data"], separators=(",", ":")).encode()).hexdigest()
+    )

--- a/python_testcontainers/tests/test_plugin_shutdown.py
+++ b/python_testcontainers/tests/test_plugin_shutdown.py
@@ -1,0 +1,16 @@
+import pytest
+
+PLUGIN_NAME = "pytest-infrahub-performance-test"
+
+
+def test_reporting_runs_after_the_stack_teardown(pytestconfig: pytest.Config) -> None:
+    """Result reporting must not sit in front of the compose stack teardown.
+
+    Class and session fixtures of an interrupted run are torn down by pytest's own
+    pytest_sessionfinish, so a plugin that reports before it holds the stack hostage to
+    however long reporting takes.
+    """
+    impls = pytestconfig.pluginmanager.hook.pytest_sessionfinish.get_hookimpls()
+    execution_order = [impl.plugin_name for impl in reversed(impls)]
+
+    assert execution_order.index("runner") < execution_order.index(PLUGIN_NAME)

--- a/python_testcontainers/tests/test_plugin_shutdown.py
+++ b/python_testcontainers/tests/test_plugin_shutdown.py
@@ -1,6 +1,26 @@
 import pytest
 
+from infrahub_testcontainers.performance_test import InfrahubPerformanceTest
+from infrahub_testcontainers.plugin import pytest_sessionfinish
+
 PLUGIN_NAME = "pytest-infrahub-performance-test"
+
+
+class InterruptedPerformanceTest(InfrahubPerformanceTest):
+    """Stands in for a report upload that a cancelled CI job signals mid-flight."""
+
+    def send_results(self) -> None:
+        raise KeyboardInterrupt
+
+
+class RecordingPerformanceTest(InfrahubPerformanceTest):
+    finalized: bool = False
+
+    def finalize(self, session: pytest.Session) -> None:
+        self.finalized = True
+
+    def fetch_metrics(self) -> None:
+        return
 
 
 def test_reporting_runs_after_the_stack_teardown(pytestconfig: pytest.Config) -> None:
@@ -14,3 +34,22 @@ def test_reporting_runs_after_the_stack_teardown(pytestconfig: pytest.Config) ->
     execution_order = [impl.plugin_name for impl in reversed(impls)]
 
     assert execution_order.index("runner") < execution_order.index(PLUGIN_NAME)
+
+
+def test_finalize_swallows_an_interrupt(request: pytest.FixtureRequest) -> None:
+    performance_test = InterruptedPerformanceTest(results_url="http://localhost")
+    performance_test.initialize(name="test_finalize_swallows_an_interrupt")
+
+    performance_test.finalize(session=request.session)
+
+
+def test_interrupted_session_is_not_reported(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    performance_test = RecordingPerformanceTest(results_url="http://localhost")
+    monkeypatch.setattr(request.config.option, "infrahub_performance_report", True)
+    monkeypatch.setattr(request.session, "infrahub_performance_test", performance_test)
+
+    pytest_sessionfinish(session=request.session, exitstatus=pytest.ExitCode.INTERRUPTED)
+    assert not performance_test.finalized
+
+    pytest_sessionfinish(session=request.session, exitstatus=pytest.ExitCode.OK)
+    assert performance_test.finalized


### PR DESCRIPTION
# Why

A cancelled performance run leaves its Docker Compose stack running on the CI
runner. [This run](https://github.com/opsmill/infrahub-private-tests/actions/runs/31086406302/job/92566782607)
is the case that prompted the fix: the cancel signal arrived, `send_results()`
was still serializing the report when the follow-up signal landed, pytest died
mid-upload, and `infrahub-test-b52f4d8e` was never torn down.

The mechanism is a hook-ordering problem. On an interrupted session pytest does
**not** tear fixtures down from the test loop — class and session fixtures are
finalized by `_pytest.runner`'s `pytest_sessionfinish`. Pluggy runs entry-point
plugins *before* core ones, so result reporting was sitting in front of the
fixture that stops the stack, and a GitHub runner gives a cancelled step only
about 7.5s between signals.

Goal: a cancel can no longer cost the stack its shutdown.

Non-goals: the workflow-side `if: always()` sweep of leftover `infrahub-test-*`
projects, which belongs in `infrahub-private-tests`. That is the only cleanup
that survives SIGKILL and is still worth adding — these commits shrink the
window, they do not remove the need for a backstop.

## What changed

Three commits, each independently reviewable.

**`fix: report performance results after the stack teardown`** — marks
`pytest_sessionfinish` `trylast` so reporting runs behind the teardown.

**`fix: keep result reporting from aborting the session`** — `finalize()`
guarded only the HTTP call, and only against `Exception`; the serialization
ahead of it was unguarded, so a `KeyboardInterrupt` there escaped
`wrap_session`'s `finally` and took the process down before pytest finished
unwinding. Now the whole reporting path is guarded against `BaseException`, and
an interrupted session is not reported at all — those numbers cover part of the
suite, and the remaining seconds belong to the teardown.

**`perf: encode the performance payload once per upload`** — the payload embeds
every metric series scraped over the run, so it grows with run length and
dominates the session-finish path. It was encoded twice (once for the checksum,
again by httpx for the body). Now encoded once, with the envelope assembled
around those bytes, plus an explicit upload timeout instead of httpx's 5s
default.

What stayed the same: the checksum contract. It still covers a compact encoding
of the payload value, so a receiver that re-encodes the parsed payload verifies
exactly as before — the difference is that those bytes are now also the bytes on
the wire. Envelope key order changes (`data` moves last); no other API change.

## How to review

Start with `plugin.py` — the `trylast` marker and the `INTERRUPTED` early return
are the whole behavioral fix. `_serialize_request()` in `performance_test.py` is
the part worth extra scrutiny: it splices pre-encoded bytes into the envelope
rather than handing httpx a dict, and `test_request_checksum_covers_the_payload_on_the_wire`
reproduces the receiver's verification to pin that down.

`test_reporting_runs_after_the_stack_teardown` asserts the hook order directly,
so a future plugin change that reintroduces the bug fails a test rather than a
production run.

## How to test

```bash
cd python_testcontainers && uv sync --all-groups
uv run pytest --rootdir=. -c pyproject.toml -q tests
```

The cancellation itself was reproduced out of tree by driving a real pytest
session with a class-scoped fixture and a slow `send_results`, sending SIGINT
and then a second SIGINT 3s later:

| | exit | teardown ran? |
|---|---|---|
| before | `-2` (killed mid-upload) | **no** — stack leaks |
| after | `2` (clean `INTERRUPTED`) | **yes** |

## Impact & rollout

- **Backward compatibility:** checksum verification unchanged; envelope key
  order changes. No change to any collected metric.
- **Performance:** halves payload encoding on the session-finish path.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy; `infrahub-testcontainers` only, no
  server-side code touched.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry — not applicable, `python_testcontainers`-only changes
      carry no fragment by existing convention
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

