### PR TITLE
chore(labels): add state/need-decision

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -147,6 +147,10 @@
   description: "This issue needs more information"
   color: "cccccc"
 
+- name: "state/need-decision"
+  description: "Behaviour is intentional but contested, needs a human judgement call"
+  color: "fbca04"
+
 - name: "state/need-testing"
   description: "This issue is ready and needs to be tested."
   color: "cccccc"
@@ -162,6 +166,10 @@
 - name: "state/backlog"
   description: "This issue is part of the backlog"
   color: "eeeeee"
+
+- name: "state/verified-2026-08"
+  description: "Checked against current code during the 2026-08 backlog triage, confirmed still valid"
+  color: "0e8a16"
 
 - name: "state/planned"
   description: "This issue is planned to be worked on in an upcoming release."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -167,10 +167,6 @@
   description: "This issue is part of the backlog"
   color: "eeeeee"
 
-- name: "state/verified-2026-08"
-  description: "Checked against current code during the 2026-08 backlog triage, confirmed still valid"
-  color: "0e8a16"
-
 - name: "state/planned"
   description: "This issue is planned to be worked on in an upcoming release."
   color: "eeeeee"


### PR DESCRIPTION
# Why

We are sweeping the open `type/bug` backlog (164 issues, oldest from 2023) to deduplicate it, close what is already fixed, and prioritise what survives.

Several old issues turn out to describe behaviour that is deliberate but was never ruled on. #1946 is the example that prompted this: it asks for inherited generic attributes to keep the generic's `branch` setting, while `process_branch_support` deliberately does the opposite, and the concrete example in the description is void because `CoreRepository` is branch-agnostic today. That is not an engineering task, it is a judgement call, and the existing labels can't say so — `state/need-triage` blends it into 47 other issues.

Discussed with @ogenstad.

## What changed

One label added to `.github/labels.yml`:

| Label | Meaning |
|---|---|
| `state/need-decision` | Behaviour is intentional but contested, needs a human judgement call |

It is registered here rather than created only over the API because the sync workflow runs `crazy-max/ghaction-github-labeler` with `skip-delete: false` — any label absent from `labels.yml` is deleted on the next sync, so an API-only label would survive exactly until the next push to this file.

No behavioural change to Infrahub. Nothing outside `.github/labels.yml` is touched.

An earlier revision of this PR also added `state/verified-2026-08` to mark bugs re-checked during the sweep. Dropped in the second commit: the sweep's real output is a priority label on every surviving bug, and `priority/*` already separates a triaged bug from an untouched one. Verification evidence goes in a comment on the issue instead, where it records *what* was found rather than just that someone looked.

## Heads-up, separate from this PR

Six labels currently exist on the repo but are **not** in `labels.yml`, so merging this will trigger the sync and delete them:

```
state/ai-pipeline-ready    <- used by the bug-agent pipeline
agentic-workflows
review/release-1.11
dependencies               <- Dependabot recreates
javascript                 <- Dependabot recreates
python:uv                  <- Dependabot recreates
```

Reproduce with:

```bash
gh label list --repo opsmill/infrahub --limit 200 --json name -q '.[].name' | sort > /tmp/repo.txt
grep -E '^- name:' .github/labels.yml | sed 's/^- name: "//; s/"$//' | sort > /tmp/yml.txt
comm -23 /tmp/repo.txt /tmp/yml.txt
```

`state/ai-pipeline-ready` looks load-bearing. Worth deciding whether to add these to `labels.yml` or flip the workflow to `skip-delete: true` **before** merging this. Happy to fold that fix in here if preferred.

## How to test

```bash
uv run python -c "import yaml; d=yaml.safe_load(open('.github/labels.yml')); print(len(d), 'labels, no dupes:', len({x['name'] for x in d})==len(d))"
```

After merge the `github` workflow runs and `state/need-decision` should appear in `gh label list`.

## Impact & rollout

- **Backward compatibility:** no breaking changes
- **Config/env changes:** none beyond the one label definition
- **Deployment notes:** safe to deploy, but read the heads-up above first — the sync prunes

## Checklist

- [ ] Tests added/updated — n/a, label configuration
- [ ] Changelog entry added — n/a, not user-facing (`ci/skip-changelog`)
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
