### PR TITLE
chore(labels): restore six labels deleted by the sync, add state/verified-2026-08

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -163,9 +163,17 @@
   description: "The bug agent pipeline could not write a test for this issue automatically"
   color: "e34918"
 
+- name: "state/ai-pipeline-ready"
+  description: "Issue is approved for the automated bug-agent pipeline to act on"
+  color: "1d76db"
+
 - name: "state/backlog"
   description: "This issue is part of the backlog"
   color: "eeeeee"
+
+- name: "state/verified-2026-08"
+  description: "Checked against current code during the 2026-08 backlog triage, confirmed still valid"
+  color: "0e8a16"
 
 - name: "state/planned"
   description: "This issue is planned to be worked on in an upcoming release."
@@ -202,3 +210,28 @@
 - name: "stale"
   description: "Marks stale issues and pull requests"
   color: "ffffff"
+
+- name: "agentic-workflows"
+  description: "Related to the agentic workflows under .github/workflows"
+  color: "5319e7"
+
+- name: "review/release-1.11"
+  description: "Reviewed as part of the 1.11 release"
+  color: "c9510c"
+
+# ----------------------------------
+# DEPENDABOT
+# Applied automatically by Dependabot. They must be declared here or the label
+# sync deletes them on its next run.
+# ----------------------------------
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0366d6"
+
+- name: "javascript"
+  description: "Pull requests that update JavaScript code"
+  color: "f1e05a"
+
+- name: "python:uv"
+  description: "Pull requests that update Python dependencies managed by uv"
+  color: "3572a5"


### PR DESCRIPTION
# Why

Merging #10151 triggered the label sync workflow, which runs `crazy-max/ghaction-github-labeler` with `skip-delete: false`. Any label present on the repo but absent from `.github/labels.yml` is deleted by that run. Six were:

```
🔫 Deleting 'agentic-workflows'
🔫 Deleting 'dependencies'
🔫 Deleting 'javascript'
🔫 Deleting 'python:uv'
🔫 Deleting 'review/release-1.11'
🔫 Deleting 'state/ai-pipeline-ready'
```

([run 31166887193](https://github.com/opsmill/infrahub/actions/runs/31166887193))

Deleting a label also strips it from every issue and PR carrying it.

**`state/ai-pipeline-ready` is load-bearing.** It is the approval gate for four bug-agent workflows — `bug-agent-fix`, `bug-agent-test`, `bug-agent-analyst` and `bug-agent-review` all list it under `approval-labels`. With the label gone, that gate could not be satisfied.

This was flagged in #10151's description before merge, but the merge is what fired the sync, so it landed anyway.

## What changed

All six labels are declared in `.github/labels.yml`, and have already been recreated over the API so function is restored now rather than at merge time.

One label added: `state/verified-2026-08`, marking a bug checked against current code during the 2026-08 backlog triage and confirmed still valid, so a later sweep does not re-verify the same issues. Currently applied to the 28 open pre-2025 bugs. The date is ISO 8601 (`YYYY-MM`) and records when the check happened rather than implying a monthly cadence.

After this, the repo's label set matches this file exactly, so the next sync prunes nothing.

## Caveats

- **Colors and descriptions for the six are reconstructed, not recovered.** The originals went with the labels. Please correct any that are wrong — `review/release-1.11` in particular is a guess at intent.
- **Which issues carried `state/ai-pipeline-ready` before the deletion is not recoverable.** If the bug-agent pipeline had queued work gated on it, that queue needs rebuilding by hand.

## How to test

```bash
uv run python -c "import yaml; d=yaml.safe_load(open('.github/labels.yml')); n=[x['name'] for x in d]; print(len(d),'labels, dupes:', [x for x in set(n) if n.count(x)>1] or 'none')"
```

Confirm nothing will be pruned:

```bash
gh label list --repo opsmill/infrahub --limit 200 --json name -q '.[].name' | sort > /tmp/r.txt
grep -E '^- name:' .github/labels.yml | sed 's/^- name: "//; s/"$//' | sort > /tmp/y.txt
comm -23 /tmp/r.txt /tmp/y.txt   # empty means nothing gets deleted
```

## Worth considering separately

`skip-delete: false` means every future label created through the UI or API — by a person, by Dependabot, by any action — is silently deleted the next time this file changes. If that is not the intent, `skip-delete: true` in `.github/workflows/labels.yml` makes the file additive instead of authoritative.

## Checklist

- [ ] Tests added/updated — n/a, label configuration
- [ ] Changelog entry added — n/a, not user-facing (`ci/skip-changelog`)
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

