### PR TITLE
fix(pytest-plugin): run repository smoke tests first (#10170)

### DIFF
--- a/backend/infrahub/pytest_plugin.py
+++ b/backend/infrahub/pytest_plugin.py
@@ -77,7 +77,7 @@ class InfrahubBackendPlugin:
             item_cost = 99
             for marker_name, priority in ORDER_ITEM_MAP.items():
                 if item.get_closest_marker(marker_name):
-                    type_cost = priority
+                    item_cost = priority
                     break
 
             return type_cost, item_cost

--- a/backend/tests/unit/test_pytest_plugin.py
+++ b/backend/tests/unit/test_pytest_plugin.py
@@ -1,0 +1,74 @@
+import pytest
+from infrahub_sdk.client import Config as InfrahubClientConfig
+
+from infrahub.pytest_plugin import InfrahubBackendPlugin
+
+
+class OrderingItem(pytest.Item):
+    def runtest(self) -> None:
+        raise NotImplementedError
+
+
+def build_item(session: pytest.Session, name: str, markers: list[str]) -> pytest.Item:
+    item = OrderingItem.from_parent(session, name=name)
+    for marker in markers:
+        item.add_marker(getattr(pytest.mark, marker))
+    return item
+
+
+@pytest.fixture
+def plugin() -> InfrahubBackendPlugin:
+    return InfrahubBackendPlugin(
+        config=InfrahubClientConfig(address="http://localhost:8000", api_token="token"),
+        repository_id="11111111-1111-1111-1111-111111111111",
+        proposed_change_id="22222222-2222-2222-2222-222222222222",
+    )
+
+
+def test_items_are_ordered_by_type_then_by_resource(
+    request: pytest.FixtureRequest, plugin: InfrahubBackendPlugin
+) -> None:
+    items = [
+        build_item(request.session, name, ["infrahub", *markers])
+        for name, markers in (
+            ("integration_check", ["infrahub_integration", "infrahub_check"]),
+            ("unit_python_transform", ["infrahub_unit", "infrahub_python_transform"]),
+            ("smoke_python_transform", ["infrahub_smoke", "infrahub_python_transform"]),
+            ("smoke_check", ["infrahub_smoke", "infrahub_check"]),
+        )
+    ]
+
+    plugin.pytest_collection_modifyitems(session=request.session, config=request.config, items=items)
+
+    assert [item.name for item in items] == [
+        "smoke_check",
+        "smoke_python_transform",
+        "unit_python_transform",
+        "integration_check",
+    ]
+
+
+def test_items_without_the_infrahub_marker_are_discarded(
+    request: pytest.FixtureRequest, plugin: InfrahubBackendPlugin
+) -> None:
+    items = [
+        build_item(request.session, "unrelated", []),
+        build_item(request.session, "smoke_check", ["infrahub", "infrahub_smoke", "infrahub_check"]),
+    ]
+
+    plugin.pytest_collection_modifyitems(session=request.session, config=request.config, items=items)
+
+    assert [item.name for item in items] == ["smoke_check"]
+
+
+def test_items_without_a_known_marker_are_ordered_last(
+    request: pytest.FixtureRequest, plugin: InfrahubBackendPlugin
+) -> None:
+    items = [
+        build_item(request.session, "unknown", ["infrahub"]),
+        build_item(request.session, "integration_check", ["infrahub", "infrahub_integration", "infrahub_check"]),
+    ]
+
+    plugin.pytest_collection_modifyitems(session=request.session, config=request.config, items=items)
+
+    assert [item.name for item in items] == ["integration_check", "unknown"]

--- a/changelog/10170.fixed.md
+++ b/changelog/10170.fixed.md
@@ -1,0 +1,1 @@
+Fixed the ordering of repository tests in a proposed change. Smoke tests now run before unit tests, and unit tests before integration tests, instead of being ordered by resource kind only.


### PR DESCRIPTION
# Why

`InfrahubBackendPlugin` is supposed to order repository tests so that smoke tests run first, then unit tests, then integration tests. It never did.

In `sort_key`, the resource loop assigned the priority to `type_cost` instead of `item_cost`. Every item carries both a type marker (`infrahub_smoke`, `infrahub_unit`, `infrahub_integration`) and a resource marker (`infrahub_check`, ...), so that loop always ran and always erased the value the first loop had computed. Items were sorted by resource kind only, and an integration test could run before the smoke test of the same resource.

Closes #10170

## What changed

- Repository test checks in a proposed change now appear in the documented order: smoke, then unit, then integration. Resource kind still decides the order inside a type.
- Added unit tests on the collection hook, nothing covered the ordering before.

## How to review

The fix itself is one word in `backend/infrahub/pytest_plugin.py`. The test file is the part worth reading: it builds real pytest items and marks them the same way the SDK loader does.

Side note for whoever runs the tests: the suite prints `PytestUnknownMarkWarning: Unknown pytest.mark.infrahub_integration`. That comes from a typo in the SDK, `plugin.py` registers `infrahub_integraton`. Harmless today, but it would bite with `--strict-markers`. Separate fix, separate repo.

## How to test

```bash
uv run pytest backend/tests/unit/test_pytest_plugin.py
```

The ordering test fails on `stable` and passes with this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

