### PR TITLE
fix(ci): label every testcontainers service with the GHA run id and job

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
@@ -20,6 +20,12 @@ x-neo4j-config-common: &neo4j-config-common
   NEO4J_server_memory_pagecache_size: ${INFRAHUB_TESTING_DB_PAGECACHE_SIZE}
 
 
+# Identifies which CI run and job owns a container, for leftover-container triage on the runners.
+# JOB_NAME is the workflow-provided override, GITHUB_JOB the value GitHub sets in every job.
+x-ci-labels: &ci-labels
+  com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+  com.github.job: "${JOB_NAME:-${GITHUB_JOB:-unknown}}"
+
 services:
   message-queue:
     image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:4.2.1-management}
@@ -34,6 +40,8 @@ services:
       retries: 50
     ports:
       - ${INFRAHUB_TESTING_MESSAGE_QUEUE_PORT:-0}:15692
+    labels:
+      <<: *ci-labels
 
   cache:
     image: ${CACHE_DOCKER_IMAGE:-redis:8.4.0}
@@ -43,6 +51,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 15
+    labels:
+      <<: *ci-labels
 
   infrahub-server-lb:
     image: haproxy:3.1-alpine
@@ -58,6 +68,8 @@ services:
       retries: 100
     ports:
       - ${INFRAHUB_TESTING_SERVER_PORT:-0}:8000
+    labels:
+      <<: *ci-labels
 
   database:
     deploy:
@@ -89,6 +101,8 @@ services:
       - ${INFRAHUB_TESTING_DATABASE_PORT:-0}:6362
       - ${INFRAHUB_TESTING_DATABASE_BOLT_PORT:-0}:7687
       - ${INFRAHUB_TESTING_DATABASE_UI_PORT:-0}:7474
+    labels:
+      <<: *ci-labels
 
   database-core2:
     deploy:
@@ -116,9 +130,8 @@ services:
       timeout: 1s
       retries: 40
     labels:
+      <<: *ci-labels
       infrahub_role: "database"
-      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
-      com.github.job: "${JOB_NAME:-unknown}"
     ports:
       - "${INFRAHUB_TESTING_DATABASE_PORT:-0}:6363"
       - ${INFRAHUB_TESTING_DATABASE_BOLT_PORT:-0}:7687
@@ -149,9 +162,8 @@ services:
       timeout: 1s
       retries: 40
     labels:
+      <<: *ci-labels
       infrahub_role: "database"
-      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
-      com.github.job: "${JOB_NAME:-unknown}"
     ports:
       - "${INFRAHUB_TESTING_DATABASE_PORT:-0}:6364"
       - ${INFRAHUB_TESTING_DATABASE_BOLT_PORT:-0}:7687
@@ -191,6 +203,8 @@ services:
       retries: 100
     ports:
       - ${INFRAHUB_TESTING_TASK_MANAGER_PORT:-0}:4200
+    labels:
+      <<: *ci-labels
 
   task-manager-background-svc:
     deploy:
@@ -234,6 +248,8 @@ services:
       PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_FLUSH_INTERVAL: ${INFRAHUB_TESTING_TASKMGR_TASK_RUN_RECORDER_FLUSH_INTERVAL:-5}
 
       PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE: ${INFRAHUB_TESTING_TASKMGR_TRIGGERS_READ_BATCH_SIZE:-1}
+    labels:
+      <<: *ci-labels
 
   task-manager-db:
     image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
@@ -250,6 +266,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 50
+    labels:
+      <<: *ci-labels
 
   infrahub-server:
     deploy:
@@ -298,6 +316,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 100
+    labels:
+      <<: *ci-labels
 
   task-worker:
     deploy:
@@ -334,6 +354,8 @@ services:
     volumes:
       - "./${INFRAHUB_TESTING_LOCAL_REMOTE_GIT_DIRECTORY}:${INFRAHUB_TESTING_INTERNAL_REMOTE_GIT_DIRECTORY}"
     tty: true
+    labels:
+      <<: *ci-labels
 
   cadvisor:
     image: "${CADVISOR_DOCKER_IMAGE:-ghcr.io/google/cadvisor:v0.60.5}"
@@ -351,6 +373,8 @@ services:
       - /dev/disk/:/dev/disk:ro
     ports:
       - "${INFRAHUB_TESTING_CADVISOR_PORT:-0}:8080"
+    labels:
+      <<: *ci-labels
 
   scraper:
     image: "${SCRAPER_DOCKER_IMAGE:-victoriametrics/victoria-metrics:v1.110.0}"
@@ -366,6 +390,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 50
+    labels:
+      <<: *ci-labels
 
 volumes:
   database_data:

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -3,6 +3,12 @@
 # The following environment variables are part of the Infrahub configuration options.
 # For detailed information on these configuration options, please refer to the Infrahub documentation:
 # https://docs.infrahub.app/reference/configuration
+# Identifies which CI run and job owns a container, for leftover-container triage on the runners.
+# JOB_NAME is the workflow-provided override, GITHUB_JOB the value GitHub sets in every job.
+x-ci-labels: &ci-labels
+  com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+  com.github.job: "${JOB_NAME:-${GITHUB_JOB:-unknown}}"
+
 services:
   message-queue:
     image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:4.2.1-management}
@@ -17,6 +23,8 @@ services:
       retries: 50
     ports:
       - ${INFRAHUB_TESTING_MESSAGE_QUEUE_PORT:-0}:15692
+    labels:
+      <<: *ci-labels
 
   cache:
     image: ${CACHE_DOCKER_IMAGE:-redis:8.4.0}
@@ -26,6 +34,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 15
+    labels:
+      <<: *ci-labels
 
   infrahub-server-lb:
     image: haproxy:3.1-alpine
@@ -41,6 +51,8 @@ services:
       retries: 100
     ports:
       - ${INFRAHUB_TESTING_SERVER_PORT:-0}:8000
+    labels:
+      <<: *ci-labels
 
   database:
     deploy:
@@ -71,6 +83,8 @@ services:
       - ${INFRAHUB_TESTING_DATABASE_PORT:-0}:6362
       - ${INFRAHUB_TESTING_DATABASE_BOLT_PORT:-0}:7687
       - ${INFRAHUB_TESTING_DATABASE_UI_PORT:-0}:7474
+    labels:
+      <<: *ci-labels
 
   task-manager:
     image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
@@ -107,6 +121,8 @@ services:
       retries: 100
     ports:
       - ${INFRAHUB_TESTING_TASK_MANAGER_PORT:-0}:4200
+    labels:
+      <<: *ci-labels
 
   task-manager-background-svc:
     deploy:
@@ -150,6 +166,8 @@ services:
       PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_FLUSH_INTERVAL: ${INFRAHUB_TESTING_TASKMGR_TASK_RUN_RECORDER_FLUSH_INTERVAL:-5}
 
       PREFECT_SERVER_SERVICES_TRIGGERS_READ_BATCH_SIZE: ${INFRAHUB_TESTING_TASKMGR_TRIGGERS_READ_BATCH_SIZE:-1}
+    labels:
+      <<: *ci-labels
 
   task-manager-db:
     image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
@@ -166,6 +184,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 50
+    labels:
+      <<: *ci-labels
 
   infrahub-server:
     deploy:
@@ -211,6 +231,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 100
+    labels:
+      <<: *ci-labels
 
   task-worker:
     deploy:
@@ -248,6 +270,8 @@ services:
     volumes:
       - "./${INFRAHUB_TESTING_LOCAL_REMOTE_GIT_DIRECTORY}:${INFRAHUB_TESTING_INTERNAL_REMOTE_GIT_DIRECTORY}"
     tty: true
+    labels:
+      <<: *ci-labels
 
   cadvisor:
     image: "${CADVISOR_DOCKER_IMAGE:-ghcr.io/google/cadvisor:v0.60.5}"
@@ -265,6 +289,8 @@ services:
       - /dev/disk/:/dev/disk:ro
     ports:
       - "${INFRAHUB_TESTING_CADVISOR_PORT:-0}:8080"
+    labels:
+      <<: *ci-labels
 
   scraper:
     image: "${SCRAPER_DOCKER_IMAGE:-victoriametrics/victoria-metrics:v1.110.0}"
@@ -280,6 +306,8 @@ services:
       interval: 1s
       timeout: 1s
       retries: 50
+    labels:
+      <<: *ci-labels
 
 volumes:
   database_data:


### PR DESCRIPTION
## Summary

Containers left behind by a test stack on the self-hosted runners could not be traced back to the CI run that spawned them. The default testcontainers stack carried no `com.github.*` labels at all, and the cluster stack only had them on `database-core2` / `database-core3` — copied in with those services and never extended to the rest.

## Key Changes

- Every service in both testcontainers stacks (11 in the default stack, 13 in the cluster stack) now carries `com.github.run_id` and `com.github.job`, so a stray container can be attributed to a run with `docker ps --filter label=com.github.run_id=…`.
- The pair is defined once per file as an `x-ci-labels` anchor and merged into each service, so adding a service doesn't silently opt out of labelling.
- `com.github.job` falls back to `GITHUB_JOB` when `JOB_NAME` is unset. Only the three E2E jobs export `JOB_NAME`; the integration, functional, docker-integration, benchmark and version-upgrade jobs — which are the ones actually building testcontainers stacks — do not, so the label would otherwise have read `unknown` precisely where it is most useful. `GITHUB_JOB` is the same value those three assign, and GitHub sets it in every job.

## Test Plan

- `docker compose config` on both files, with and without a CI environment: all 11 / 13 services resolve the run id and job, `JOB_NAME` still overrides `GITHUB_JOB`, and both fall back to `unknown` locally.
- `uv run yamllint -s` clean on both files.
- No behavioural change to the stacks — labels only.

**Deliberately not included:** the in-stack cAdvisor whitelist stays as-is (`-whitelisted_container_labels=com.docker.compose.project`) — its metrics are per-stack and filtered by project name, so the run id there would be a constant. No changelog fragment: CI-infra only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

