### PR TITLE
fix(backend): retry transient database errors in schema and graph migrations

### DIFF
--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator, Sequence
 
+from neo4j.exceptions import TransientError
 from pydantic import BaseModel, ConfigDict, Field
 from rich.console import Console
 from typing_extensions import Self
@@ -15,6 +16,7 @@ from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema, SchemaRoot, internal_schema
 from infrahub.core.timestamp import Timestamp
+from infrahub.database import retry_db_transaction
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -154,12 +156,18 @@ class SchemaMigration(BaseModel):
                 )
                 await query.execute(db=migration_input.db)
                 result.nbr_migrations_executed += query.get_nbr_migrations_executed()
+            except TransientError:
+                # A transient error aborts the enclosing transaction server-side: recording it here
+                # would leave the commit to fail with a non-retryable TransactionError, so it must
+                # propagate to the transaction owner to be replayed on a fresh transaction.
+                raise
             except Exception as exc:
                 result.errors.append(str(exc))
                 return result
 
         return result
 
+    @retry_db_transaction(name="schema_migration")
     async def execute(
         self,
         migration_input: MigrationInput,
@@ -231,6 +239,7 @@ class GraphMigration(BaseMigration):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     queries: Sequence[type[Query]] = Field(..., description="List of queries to execute for this migration")
 
+    @retry_db_transaction(name="graph_migration")
     async def execute(self, migration_input: MigrationInput) -> MigrationResult:
         async with migration_input.db.start_transaction() as ts:
             txn_migration_input = MigrationInput(db=ts, at=migration_input.at, console=migration_input.console)
@@ -242,6 +251,9 @@ class GraphMigration(BaseMigration):
             try:
                 query = await migration_query.init(db=migration_input.db, at=migration_input.at)
                 await query.execute(db=migration_input.db)
+            except TransientError:
+                # Must reach the transaction owner to be replayed on a fresh transaction.
+                raise
             except Exception as exc:
                 result.errors.append(str(exc))
                 return result

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator, Sequence
 
-from neo4j.exceptions import TransientError
 from pydantic import BaseModel, ConfigDict, Field
 from rich.console import Console
 from typing_extensions import Self
@@ -16,7 +15,7 @@ from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema, SchemaRoot, internal_schema
 from infrahub.core.timestamp import Timestamp
-from infrahub.database import retry_db_transaction
+from infrahub.database import is_retriable_db_error, retry_db_transaction
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -111,6 +110,16 @@ class MigrationInput:
     console: Console = field(default_factory=get_migration_console)
 
 
+def _should_propagate(db: InfrahubDatabase, exc: BaseException) -> bool:
+    """Whether a query error must bubble out to be retried rather than recorded as a failure.
+
+    A replayable error inside a transaction must reach the transaction owner: recording it would
+    leave the commit to fail with a non-retryable TransactionError and the replay would never happen.
+    Outside a transaction there is no owner, so the error is recorded as a migration failure instead.
+    """
+    return db.is_transaction and is_retriable_db_error(exc)
+
+
 class SchemaMigration(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str = Field(..., description="Name of the migration")
@@ -156,17 +165,9 @@ class SchemaMigration(BaseModel):
                 )
                 await query.execute(db=migration_input.db)
                 result.nbr_migrations_executed += query.get_nbr_migrations_executed()
-            except TransientError as exc:
-                if migration_input.db.is_transaction:
-                    # A transient error aborts the enclosing transaction server-side: recording it here
-                    # would leave the commit to fail with a non-retryable TransactionError, so it must
-                    # propagate to the transaction owner to be replayed on a fresh transaction.
-                    raise
-                # Running outside a transaction there is nothing to abort and no owner to replay it,
-                # so keep the failed-result contract instead of surfacing an unhandled error.
-                result.errors.append(str(exc))
-                return result
             except Exception as exc:
+                if _should_propagate(db=migration_input.db, exc=exc):
+                    raise
                 result.errors.append(str(exc))
                 return result
 
@@ -256,15 +257,9 @@ class GraphMigration(BaseMigration):
             try:
                 query = await migration_query.init(db=migration_input.db, at=migration_input.at)
                 await query.execute(db=migration_input.db)
-            except TransientError as exc:
-                if migration_input.db.is_transaction:
-                    # Must reach the transaction owner to be replayed on a fresh transaction.
-                    raise
-                # Running outside a transaction there is no owner to replay the error, so keep the
-                # failed-result contract instead of surfacing an unhandled error.
-                result.errors.append(str(exc))
-                return result
             except Exception as exc:
+                if _should_propagate(db=migration_input.db, exc=exc):
+                    raise
                 result.errors.append(str(exc))
                 return result
 

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -156,11 +156,16 @@ class SchemaMigration(BaseModel):
                 )
                 await query.execute(db=migration_input.db)
                 result.nbr_migrations_executed += query.get_nbr_migrations_executed()
-            except TransientError:
-                # A transient error aborts the enclosing transaction server-side: recording it here
-                # would leave the commit to fail with a non-retryable TransactionError, so it must
-                # propagate to the transaction owner to be replayed on a fresh transaction.
-                raise
+            except TransientError as exc:
+                if migration_input.db.is_transaction:
+                    # A transient error aborts the enclosing transaction server-side: recording it here
+                    # would leave the commit to fail with a non-retryable TransactionError, so it must
+                    # propagate to the transaction owner to be replayed on a fresh transaction.
+                    raise
+                # Running outside a transaction there is nothing to abort and no owner to replay it,
+                # so keep the failed-result contract instead of surfacing an unhandled error.
+                result.errors.append(str(exc))
+                return result
             except Exception as exc:
                 result.errors.append(str(exc))
                 return result
@@ -251,9 +256,14 @@ class GraphMigration(BaseMigration):
             try:
                 query = await migration_query.init(db=migration_input.db, at=migration_input.at)
                 await query.execute(db=migration_input.db)
-            except TransientError:
-                # Must reach the transaction owner to be replayed on a fresh transaction.
-                raise
+            except TransientError as exc:
+                if migration_input.db.is_transaction:
+                    # Must reach the transaction owner to be replayed on a fresh transaction.
+                    raise
+                # Running outside a transaction there is no owner to replay the error, so keep the
+                # failed-result contract instead of surfacing an unhandled error.
+                result.errors.append(str(exc))
+                return result
             except Exception as exc:
                 result.errors.append(str(exc))
                 return result

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -568,6 +568,15 @@ async def get_db(retry: int = 0) -> AsyncDriver:
     return driver
 
 
+def is_retriable_db_error(exc: BaseException) -> bool:
+    """Whether a database error can be replayed on a fresh transaction rather than failed."""
+    if isinstance(exc, TransientError):
+        return True
+    if isinstance(exc, ClientError):
+        return exc.code == "Neo.ClientError.Statement.EntityNotFound"
+    return False
+
+
 def retry_db_transaction(
     name: str,
 ) -> Callable[[Callable[..., Coroutine[Any, Any, R]]], Callable[..., Coroutine[Any, Any, R]]]:
@@ -579,9 +588,8 @@ def retry_db_transaction(
                 try:
                     return await func(*args, **kwargs)
                 except (TransientError, ClientError) as exc:
-                    if isinstance(exc, ClientError):
-                        if exc.code != "Neo.ClientError.Statement.EntityNotFound":
-                            raise exc
+                    if not is_retriable_db_error(exc):
+                        raise
                     base_delay = config.SETTINGS.database.retry_base_delay
                     max_delay = config.SETTINGS.database.retry_max_delay
                     jitter = random.uniform(0, config.SETTINGS.database.retry_jitter_max)

--- a/backend/tests/unit/core/migrations/test_shared.py
+++ b/backend/tests/unit/core/migrations/test_shared.py
@@ -91,6 +91,21 @@ class DeadlockOnceGraphQuery(Query):
         return await super().execute(db=db, timeout_seconds=timeout_seconds)
 
 
+class AlwaysDeadlockGraphQuery(Query):
+    name = "test_always_deadlock_graph"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+
+    calls: ClassVar[int] = 0
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.add_to_query("RETURN 1 AS num")
+
+    async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
+        type(self).calls += 1
+        raise TransientError("deadlock detected")
+
+
 def _make_schema_migration(queries: Sequence[type[MigrationBaseQuery]]) -> SchemaMigration:
     return SchemaMigration(
         name="test.migration",
@@ -101,8 +116,14 @@ def _make_schema_migration(queries: Sequence[type[MigrationBaseQuery]]) -> Schem
 
 @pytest.mark.usefixtures("_fast_retry")
 class TestMigrationTransientErrorRetry:
-    async def test_schema_migration_retries_transient_error(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+    @pytest.fixture(autouse=True)
+    def _reset_query_call_counts(self) -> None:
         DeadlockOnceMigrationQuery.calls = 0
+        AlwaysDeadlockMigrationQuery.calls = 0
+        DeadlockOnceGraphQuery.calls = 0
+        AlwaysDeadlockGraphQuery.calls = 0
+
+    async def test_schema_migration_retries_transient_error(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         migration = _make_schema_migration(queries=[DeadlockOnceMigrationQuery])
 
         result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
@@ -115,7 +136,6 @@ class TestMigrationTransientErrorRetry:
     async def test_schema_migration_raises_after_retries_exhausted(
         self, db: InfrahubDatabase, default_branch: Branch
     ) -> None:
-        AlwaysDeadlockMigrationQuery.calls = 0
         migration = _make_schema_migration(queries=[AlwaysDeadlockMigrationQuery])
 
         with pytest.raises(TransientError, match=r"deadlock detected"):
@@ -124,7 +144,6 @@ class TestMigrationTransientErrorRetry:
         assert AlwaysDeadlockMigrationQuery.calls == config.SETTINGS.database.retry_limit
 
     async def test_graph_migration_retries_transient_error(self, db: InfrahubDatabase) -> None:
-        DeadlockOnceGraphQuery.calls = 0
         migration = GraphMigration(
             name="test-graph-migration",
             description="Test graph migration retry",
@@ -137,3 +156,17 @@ class TestMigrationTransientErrorRetry:
         assert result.errors == []
         assert result.success
         assert DeadlockOnceGraphQuery.calls == 2
+
+    async def test_graph_migration_outside_transaction_records_transient_error(self, db: InfrahubDatabase) -> None:
+        migration = GraphMigration(
+            name="test-graph-migration",
+            description="Test graph migration outside a transaction",
+            minimum_version=0,
+            queries=[AlwaysDeadlockGraphQuery],
+        )
+
+        result = await migration.do_execute(migration_input=MigrationInput(db=db))
+
+        assert not result.success
+        assert result.errors == ["deadlock detected"]
+        assert AlwaysDeadlockGraphQuery.calls == 1

--- a/backend/tests/unit/core/migrations/test_shared.py
+++ b/backend/tests/unit/core/migrations/test_shared.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
-from neo4j.exceptions import TransientError
+from neo4j.exceptions import ClientError, TransientError
 from typing_extensions import Self
 
 from infrahub import config
@@ -74,6 +74,32 @@ class AlwaysDeadlockMigrationQuery(MigrationQuery):
         raise TransientError("deadlock detected")
 
 
+def _entity_not_found_error() -> ClientError:
+    error = ClientError("entity not found")
+    error._neo4j_code = "Neo.ClientError.Statement.EntityNotFound"
+    return error
+
+
+class EntityNotFoundOnceMigrationQuery(MigrationQuery):
+    name = "test_entity_not_found_once_migration"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+
+    calls: ClassVar[int] = 0
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.add_to_query("RETURN 1 AS num")
+
+    async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
+        type(self).calls += 1
+        if type(self).calls == 1:
+            raise _entity_not_found_error()
+        return await super().execute(db=db, timeout_seconds=timeout_seconds)
+
+    def get_nbr_migrations_executed(self) -> int:
+        return 1
+
+
 class DeadlockOnceGraphQuery(Query):
     name = "test_deadlock_once_graph"
     type: QueryType = QueryType.WRITE
@@ -120,6 +146,7 @@ class TestMigrationTransientErrorRetry:
     def _reset_query_call_counts(self) -> None:
         DeadlockOnceMigrationQuery.calls = 0
         AlwaysDeadlockMigrationQuery.calls = 0
+        EntityNotFoundOnceMigrationQuery.calls = 0
         DeadlockOnceGraphQuery.calls = 0
         AlwaysDeadlockGraphQuery.calls = 0
 
@@ -132,6 +159,18 @@ class TestMigrationTransientErrorRetry:
         assert result.success
         assert result.nbr_migrations_executed == 1
         assert DeadlockOnceMigrationQuery.calls == 2
+
+    async def test_schema_migration_retries_entity_not_found(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        migration = _make_schema_migration(queries=[EntityNotFoundOnceMigrationQuery])
+
+        result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+
+        assert result.errors == []
+        assert result.success
+        assert result.nbr_migrations_executed == 1
+        assert EntityNotFoundOnceMigrationQuery.calls == 2
 
     async def test_schema_migration_raises_after_retries_exhausted(
         self, db: InfrahubDatabase, default_branch: Branch

--- a/backend/tests/unit/core/migrations/test_shared.py
+++ b/backend/tests/unit/core/migrations/test_shared.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import pytest
+from neo4j.exceptions import TransientError
+from typing_extensions import Self
+
+from infrahub import config
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.migrations.query import MigrationQuery
+from infrahub.core.migrations.shared import GraphMigration, MigrationInput, SchemaMigration
+from infrahub.core.path import SchemaPath
+from infrahub.core.query import Query, QueryType
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.migrations.query import MigrationBaseQuery
+    from infrahub.database import InfrahubDatabase
+
+
+@pytest.fixture
+def _fast_retry() -> Generator[None, None, None]:
+    original_retry_limit = config.SETTINGS.database.retry_limit
+    original_base_delay = config.SETTINGS.database.retry_base_delay
+    original_max_delay = config.SETTINGS.database.retry_max_delay
+    original_jitter_max = config.SETTINGS.database.retry_jitter_max
+
+    config.SETTINGS.database.retry_limit = 3
+    config.SETTINGS.database.retry_base_delay = 0.01
+    config.SETTINGS.database.retry_max_delay = 0.1
+    config.SETTINGS.database.retry_jitter_max = 0.0
+    yield
+    config.SETTINGS.database.retry_limit = original_retry_limit
+    config.SETTINGS.database.retry_base_delay = original_base_delay
+    config.SETTINGS.database.retry_max_delay = original_max_delay
+    config.SETTINGS.database.retry_jitter_max = original_jitter_max
+
+
+class DeadlockOnceMigrationQuery(MigrationQuery):
+    name = "test_deadlock_once_migration"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+
+    calls: ClassVar[int] = 0
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.add_to_query("RETURN 1 AS num")
+
+    async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
+        type(self).calls += 1
+        if type(self).calls == 1:
+            raise TransientError("deadlock detected")
+        return await super().execute(db=db, timeout_seconds=timeout_seconds)
+
+    def get_nbr_migrations_executed(self) -> int:
+        return 1
+
+
+class AlwaysDeadlockMigrationQuery(MigrationQuery):
+    name = "test_always_deadlock_migration"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+
+    calls: ClassVar[int] = 0
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.add_to_query("RETURN 1 AS num")
+
+    async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
+        type(self).calls += 1
+        raise TransientError("deadlock detected")
+
+
+class DeadlockOnceGraphQuery(Query):
+    name = "test_deadlock_once_graph"
+    type: QueryType = QueryType.WRITE
+    insert_return = False
+
+    calls: ClassVar[int] = 0
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.add_to_query("RETURN 1 AS num")
+
+    async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
+        type(self).calls += 1
+        if type(self).calls == 1:
+            raise TransientError("deadlock detected")
+        return await super().execute(db=db, timeout_seconds=timeout_seconds)
+
+
+def _make_schema_migration(queries: Sequence[type[MigrationBaseQuery]]) -> SchemaMigration:
+    return SchemaMigration(
+        name="test.migration",
+        queries=queries,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestKind", field_name="name"),
+    )
+
+
+@pytest.mark.usefixtures("_fast_retry")
+class TestMigrationTransientErrorRetry:
+    async def test_schema_migration_retries_transient_error(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        DeadlockOnceMigrationQuery.calls = 0
+        migration = _make_schema_migration(queries=[DeadlockOnceMigrationQuery])
+
+        result = await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+
+        assert result.errors == []
+        assert result.success
+        assert result.nbr_migrations_executed == 1
+        assert DeadlockOnceMigrationQuery.calls == 2
+
+    async def test_schema_migration_raises_after_retries_exhausted(
+        self, db: InfrahubDatabase, default_branch: Branch
+    ) -> None:
+        AlwaysDeadlockMigrationQuery.calls = 0
+        migration = _make_schema_migration(queries=[AlwaysDeadlockMigrationQuery])
+
+        with pytest.raises(TransientError, match=r"deadlock detected"):
+            await migration.execute(migration_input=MigrationInput(db=db), branch=default_branch)
+
+        assert AlwaysDeadlockMigrationQuery.calls == config.SETTINGS.database.retry_limit
+
+    async def test_graph_migration_retries_transient_error(self, db: InfrahubDatabase) -> None:
+        DeadlockOnceGraphQuery.calls = 0
+        migration = GraphMigration(
+            name="test-graph-migration",
+            description="Test graph migration retry",
+            minimum_version=0,
+            queries=[DeadlockOnceGraphQuery],
+        )
+
+        result = await migration.execute(migration_input=MigrationInput(db=db))
+
+        assert result.errors == []
+        assert result.success
+        assert DeadlockOnceGraphQuery.calls == 2

--- a/changelog/+schema-migration-transient-retry.fixed.md
+++ b/changelog/+schema-migration-transient-retry.fixed.md
@@ -1,0 +1,1 @@
+Schema and graph migrations now retry transient database errors (such as deadlocks) on a fresh transaction instead of failing the migration, matching the retry behavior already applied to mutations and resolvers.

--- a/dev/guides/backend/creating-migrations.md
+++ b/dev/guides/backend/creating-migrations.md
@@ -66,6 +66,8 @@ class Migration070(ArbitraryMigration):
 
 Set `minimum_version` to the current `GRAPH_VERSION` (the migration runs when upgrading from that version).
 
+**Transient database errors.** `SchemaMigration` and `GraphMigration` own their transaction and carry `retry_db_transaction`, so a transient error (a deadlock, or an entity a concurrent migration removed) is replayed on a fresh transaction with backoff and jitter instead of failing the migration; their inner query loops let those errors propagate to the transaction owner. This matters when migrations of the same kind run concurrently (schema path migrations execute as a batch). The catch-all `except` shown above belongs to `ArbitraryMigration`/`execute` overrides that run serially during upgrade and record every error as a failed `MigrationResult`; if you override `execute` to own a transaction on a concurrent path, add `retry_db_transaction` and do not catch retriable errors inside the transaction. See [Database Schema — Transaction Retry](../../knowledge/backend/database-schema.md#transaction-retry).
+
 ### Step 2: Bump `GRAPH_VERSION`
 
 Update `backend/infrahub/core/graph/__init__.py`:

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -277,7 +277,7 @@ Work dispatched *after* an operation has already committed — the recompute and
 
 ### Transient database errors are retried at the transaction layer, not by task retry
 
-A Prefect task retry replays the whole flow run with no per-transaction backoff. When concurrent tasks contend for the same nodes (for example a batch of `schema_path_migrate` tasks), replaying the flow re-runs the deadlocking writers in lockstep and they deadlock again. Transient database errors therefore belong to the transaction-layer retry (`retry_db_transaction`), which reopens a fresh transaction after an exponential backoff with jitter so contending writers separate. A transaction-owning write path invoked from a task must carry `retry_db_transaction` and let retriable errors reach that owner. See [Database Schema — Transaction Retry](database-schema.md#transaction-retry).
+A Prefect task retry re-runs the failed task and by default waits no time between attempts. When a batch of concurrent tasks contend for the same nodes, each deadlocking task retries at the same moment and deadlocks again. Transient database errors therefore belong to the transaction-layer retry (`retry_db_transaction`), which reopens a fresh transaction after an exponential backoff with jitter so contending writers separate; the task-level retry remains the outer fallback. A transaction-owning write path invoked from a task must carry `retry_db_transaction` and let retriable errors reach that owner. See [Database Schema — Transaction Retry](database-schema.md#transaction-retry).
 
 ## Key Locations
 

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -275,6 +275,10 @@ A write whose only purpose is observability — persisting a Prefect artifact th
 
 Work dispatched *after* an operation has already committed — the recompute and event-send follow-ups after a merge, for example — must not be able to fail or roll back the committed operation. The contract to follow for such work is log-and-continue: catch per item, log the skipped item at exception level so a partial failure is greppable rather than silent, and carry on with the rest of the batch so one failed dispatch never aborts the others. Guaranteeing eventual consistency after a transient dispatch failure is the job of a separate reconciliation/backfill job, not of the best-effort path — do not bolt retries onto it. (Not every post-commit path enforces this yet — the merge recompute does per-item; verify before assuming a given caller isolates failures.)
 
+### Transient database errors are retried at the transaction layer, not by task retry
+
+A Prefect task retry replays the whole flow run with no per-transaction backoff. When concurrent tasks contend for the same nodes (for example a batch of `schema_path_migrate` tasks), replaying the flow re-runs the deadlocking writers in lockstep and they deadlock again. Transient database errors therefore belong to the transaction-layer retry (`retry_db_transaction`), which reopens a fresh transaction after an exponential backoff with jitter so contending writers separate. A transaction-owning write path invoked from a task must carry `retry_db_transaction` and let retriable errors reach that owner. See [Database Schema — Transaction Retry](database-schema.md#transaction-retry).
+
 ## Key Locations
 
 | Component | Location |

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -372,7 +372,7 @@ Backoff is configured under the `database` settings (`INFRAHUB_DB_RETRY_*` envir
 
 **The retry must run at the transaction owner.** A method decorated with `retry_db_transaction` opens the transaction it retries. Code running *inside* that transaction (a query loop, a nested helper) must let a retriable error propagate to the owner rather than catching it and returning a failed result: a caught error still leaves the transaction poisoned, so the commit fails with a non-retryable `TransactionError` and the replay never happens. Only paths that run outside any transaction (they skip the transaction wrapper and have no owner to replay them) record the error as a failure instead. Gate that choice on `db.is_transaction`.
 
-This transaction-layer retry is distinct from Prefect task retry (see [Async Tasks — Failure handling](async-tasks.md#failure-handling)): task retry replays an entire workflow with no per-transaction backoff, so concurrent writers that deadlock re-run in lockstep. Transient database errors belong to the transaction-layer retry, which spaces replays with jitter.
+This transaction-layer retry is distinct from Prefect task retry (see [Async Tasks — Failure handling](async-tasks.md#failure-handling)): a task retry re-runs the failed task with no delay between attempts, so a batch of concurrent tasks that deadlock on the same nodes retry at the same time and deadlock again. Transient database errors belong to the transaction-layer retry, which spaces replays with backoff and jitter so contending writers separate.
 
 ## See Also
 

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -356,7 +356,26 @@ CALL (peer, rl) {
 - **Order then filter**: Always `ORDER BY ... LIMIT 1` first, then `WHERE status = "active"` to handle the case where the latest edge is a deletion
 - **No `to` timestamp**: `to IS NULL` ensures the edge is currently valid (not expired)
 
+## Transaction Retry
+
+Neo4j rejects some writes with errors that are safe to replay on a fresh transaction (a lock contention deadlock, or an entity that a concurrent transaction removed mid-statement). Infrahub retries these at the transaction layer with the `retry_db_transaction` decorator.
+
+`retry_db_transaction(name=...)` wraps an `async` method that owns its transaction. On a retriable error it re-runs the whole method after an exponential backoff with jitter, up to `retry_limit` attempts; a non-retriable error propagates immediately. The retriable set is defined by `is_retriable_db_error` in `database/__init__.py`:
+
+| Error | Retriable |
+|-------|-----------|
+| `neo4j.exceptions.TransientError` (deadlock, lock timeout) | Yes |
+| `ClientError` with code `Neo.ClientError.Statement.EntityNotFound` | Yes |
+| Any other exception | No |
+
+Backoff is configured under the `database` settings (`INFRAHUB_DB_RETRY_*` environment variables): `retry_limit`, `retry_base_delay`, `retry_max_delay`, `retry_jitter_max`.
+
+**The retry must run at the transaction owner.** A method decorated with `retry_db_transaction` opens the transaction it retries. Code running *inside* that transaction (a query loop, a nested helper) must let a retriable error propagate to the owner rather than catching it and returning a failed result: a caught error still leaves the transaction poisoned, so the commit fails with a non-retryable `TransactionError` and the replay never happens. Only paths that run outside any transaction (they skip the transaction wrapper and have no owner to replay them) record the error as a failure instead. Gate that choice on `db.is_transaction`.
+
+This transaction-layer retry is distinct from Prefect task retry (see [Async Tasks — Failure handling](async-tasks.md#failure-handling)): task retry replays an entire workflow with no per-transaction backoff, so concurrent writers that deadlock re-run in lockstep. Transient database errors belong to the transaction-layer retry, which spaces replays with jitter.
+
 ## See Also
 
 - [Query Pattern](query-pattern.md) - How to write database queries
 - [Architecture](architecture.md) - Backend architecture overview
+- [Creating Graph Migrations](../../guides/backend/creating-migrations.md) - Transaction-owning migrations and retry


### PR DESCRIPTION
# Why

The `backend-tests-integration` job on #10167 failed with a Neo4j `Neo.TransientError.Transaction.DeadlockDetected` during a schema load ([failing job](https://github.com/opsmill/infrahub/actions/runs/31195836546/job/92935850499)): concurrent `schema_path_migrate` tasks from a single `schema_apply_migrations` batch locked the same profile nodes, and the migration path turned that transient deadlock into a hard failure of the whole schema load (`test_profile_lifecycle` step 18 setup error; step 19 is a cascade of the same event).

The migration execution path was the only transaction-owning write path without `retry_db_transaction`.

## What changed

- `SchemaMigration.execute` and `GraphMigration.execute` — the two methods that open and own their transaction — carry `@retry_db_transaction`, so a deadlocked migration is replayed on a fresh transaction with exponential backoff and jitter.
- The inner query loops (`execute_queries`, `do_execute`) re-raise every error the retry decorator can replay — `TransientError` and the retriable `Neo.ClientError.Statement.EntityNotFound` — instead of recording it in `MigrationResult.errors`, so it reaches the transaction owner and triggers a replay. A retriable error aborts the server-side transaction, so swallowing it only left the commit to raise a non-retryable `TransactionError`. The retry policy now lives in a single `is_retriable_db_error` predicate shared by the decorator and the loops, so the two definitions cannot drift.
- The re-raise is gated on running inside a transaction (`db.is_transaction`). A migration that overrides `execute` to skip the transaction wrapper (large deletes such as `m020`, `m035`, `m054`) runs its queries as independent auto-commit statements with no owner to replay them; there the loops keep the existing failed-result contract instead of surfacing an unhandled error. These run serially during upgrades, so the concurrent-deadlock contention this fixes doesn't apply to them.
- Prefect's `retries=3` on `schema_path_migrate` couldn't save the run: each zero-delay replay deadlocked in lockstep until exhaustion, while the decorator's backoff+jitter breaks that lockstep.
- Retry placement follows the convention from #10121: the retry wraps exactly the transaction scope, and code running inside a transaction propagates retriable errors to the owner.

No schema changes, no API contract changes; retry counts and delays come from the existing `database.retry_*` settings.

## How to test

```bash
uv run pytest backend/tests/unit/core/migrations/test_shared.py
```

New tests (real database, no mocks) cover, for both migration types: replay-once-then-succeed on a transient deadlock; replay on a retriable `EntityNotFound`; retry exhaustion propagating the original error rather than a `TransactionError`; and a migration running outside a transaction recording the error instead of propagating it. The full backend unit suite plus `backend/tests/unit/database/test_retry_db_transaction.py` pass locally.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

