### PR TITLE
feat(agents): add analyzing-ci-flakiness skill

### DIFF
--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -9,6 +9,8 @@ description: >-
   until green → monitoring-pull-requests; diagnosing or fixing one specific failing test → the
   bug-analysis skills.
 argument-hint: "Optional base-branch glob(s) and window, e.g. `release-1.11 14` (default: all bases, last 7 days)"
+allowed-tools:
+  - Bash(python3 .agents/skills/analyzing-ci-flakiness/scripts/collect.py:*)
 compatibility: Requires the gh CLI authenticated against the repo. Python 3 (stdlib only). Writes a cache under ~/ci-cache.
 metadata:
   version: 0.1.0

--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -51,7 +51,9 @@ It prints a JSON report to stdout and writes everything under
 - `runs.jsonl` — every `pull_request` workflow run created in the window
 - `failed_jobs_with_tests.json` — failed jobs of the interesting run-attempts, with extracted
   failing tests, systemic-bucket tags, and a `recovered_same_run` flag
-- `report-data.json` — headline numbers, ranked per-test table, and the ledger's weekly history
+- `report-data.json` — headline numbers, ranked per-test table, per-bucket incident counts
+  (`bucket_incidents`: distinct jobs/runs/PRs per systemic bucket), and the ledger's weekly
+  history
 - `joblogs/<job_id>.log` — raw logs (ANSI intact; strip with `sed 's/\x1b\[[0-9;]*m//g'`)
 
 Notes the script already accounts for — don't re-derive them:
@@ -101,7 +103,8 @@ For each test in the ranked table, classify:
   explicitly; do not bury it in the flake list. Cross-check: does the test fail on any PR that
   does not contain the suspect change?
 - **Systemic bucket** — tests whose only failures carry a bucket tag are casualties, not causes.
-  Report the bucket (with incident count), not the individual tests.
+  Report the bucket (with the incident count from `bucket_incidents` in `report-data.json`), not
+  the individual tests.
 
 Different tests failing on successive attempts of the same run = two independent flakes, not a
 regression.

--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: analyzing-ci-flakiness
+description: >-
+  Analyzes recent CI failures on pull requests to identify flaky tests, using retry outcomes
+  (failed attempt → green re-run) and cross-PR recurrence as evidence, and maintains a local
+  longitudinal ledger so flakiness can be tracked over time. TRIGGER when: the user wants to find
+  flaky tests, correlate recent CI failures, check which tests fail across PRs or recover on
+  retry, or refresh the flakiness trend report. DO NOT TRIGGER when: babysitting a single PR's CI
+  until green → monitoring-pull-requests; diagnosing or fixing one specific failing test → the
+  bug-analysis skills.
+argument-hint: "Optional base-branch glob(s) and window, e.g. `release-1.11 14` (default: all bases, last 7 days)"
+compatibility: Requires the gh CLI authenticated against the repo. Python 3 (stdlib only). Writes a cache under ~/ci-cache.
+metadata:
+  version: 0.1.0
+  author: OpsMill
+---
+
+# CI Flakiness Analyzer
+
+## Introduction
+
+A test is *flaky* when its failure does not reproduce on the same code: the run was retried and
+went green, or the same test fails on unrelated PRs. This skill mines both signals from GitHub
+Actions history, downloads the failed job logs once into a local cache, and appends every
+observation to a ledger (`~/ci-cache/<owner>-<name>/ledger.jsonl`) so repeated invocations —
+weekly, or ad hoc — accumulate trend data instead of starting from scratch.
+
+The mechanical part (fetching, caching, test-name extraction, known-signature classification) is
+done by the bundled script. Your job is the judgment part: separating flakes from real
+regressions, spotting new systemic signatures, and writing the report.
+
+## Step 1 — Parse arguments
+
+- Base-branch filter: any arguments that look like branch names or globs (`release-1.11`,
+  `release-*`, `stable`). Default: no filter (all PR bases), which is usually what "how flaky is
+  CI" means. Filter when the user names a branch.
+- Window: a bare integer is a number of days (default 7). An ISO date means "since that date".
+
+## Step 2 — Collect
+
+Run the bundled collector (repo-root relative):
+
+```bash
+python3 .agents/skills/analyzing-ci-flakiness/scripts/collect.py \
+  [--base <glob> ...] [--days N | --since YYYY-MM-DD] [--repo owner/name]
+```
+
+It prints a JSON report to stdout and writes everything under
+`~/ci-cache/<owner>-<name>/windows/<since>_<until>/`:
+
+- `runs.jsonl` — every `pull_request` workflow run created in the window
+- `failed_jobs_with_tests.json` — failed jobs of the interesting run-attempts, with extracted
+  failing tests, systemic-bucket tags, and a `recovered_same_run` flag
+- `report-data.json` — headline numbers, ranked per-test table, and the ledger's weekly history
+- `joblogs/<job_id>.log` — raw logs (ANSI intact; strip with `sed 's/\x1b\[[0-9;]*m//g'`)
+
+Notes the script already accounts for — don't re-derive them:
+
+- The runs API's `pull_requests` field is empty for many runs; the script joins runs to PRs
+  through every PR head commit SHA as well. Don't trust the field alone.
+- "Interesting attempts" = every earlier attempt of a retried run (that's what the retry fixed)
+  plus final attempts that failed. Runs cancelled on attempt 1 are concurrency noise and skipped.
+- Logs already on disk are never re-downloaded; the ledger is deduplicated by (job, test). Old
+  logs expire on GitHub's side (~90 days) — an empty `joblogs/*.log` means expired, not passing.
+
+## Step 3 — Investigate what the script could not name
+
+For failed jobs with an empty `tests` list and no bucket tag, read the log yourself (grep for
+`##[error]`, `FAILED`, `Error:`, `Timeout`). Two outcomes:
+
+- It matches a *new* systemic signature (infra failure that cascades over many tests). Add a
+  regex for it to `BUCKETS` in `collect.py` and to the table below, so future runs classify it.
+- It's a genuine test failure the extraction regexes missed — note the test manually and
+  consider extending `extract_tests`.
+
+### Known systemic signatures (as of 2026-08 — keep in sync with `BUCKETS` in collect.py)
+
+| Bucket | Signature | Meaning |
+|---|---|---|
+| `stack-readiness` | `ServerNotResponsiveError … /api/schema/load` | Seeded testcontainers stack not ready; the whole pytest-playwright shard errors. One incident, not N flaky tests. |
+| `vitest-mock-corruption` | `TypeError: vi.mocked(...).mockX is not a function` | vitest browser-mode module-mocking race; hits a different test file each time. |
+| `prefect-setup-triggers-timeout` | `Setup triggers` task `ReadTimeout` | Prefect hang at session setup; downstream tests hit their own timeouts. |
+| `neo4j-deadlock` | `Neo.TransientError.Transaction.DeadlockDetected` | Concurrent-write deadlock, usually integration suites under xdist. |
+| `compose-boot-failure` | `docker compose … up --wait` non-zero exit | Stack never booted; job-level infra failure. |
+| `sqlite-locked` | `sqlite3.OperationalError: database is locked` | Prefect's sqlite under contention. |
+
+## Step 4 — Judge: flake vs regression
+
+For each test in the ranked table, classify:
+
+- **Flaky (strong)** — fails on ≥2 unrelated PRs, or `recovered_on_retry > 0`. The more distinct
+  PRs, the stronger.
+- **Flaky (weak)** — single occurrence with an infra-flavored error (locator timeout, transient
+  branch not found) and the PR later went green. List, but rank low.
+- **Suspect regression, not a flake** — the same test fails on *every* attempt of the same
+  commit and the PR is still red, or the failures started only after a specific merge. Say so
+  explicitly; do not bury it in the flake list. Cross-check: does the test fail on any PR that
+  does not contain the suspect change?
+- **Systemic bucket** — tests whose only failures carry a bucket tag are casualties, not causes.
+  Report the bucket (with incident count), not the individual tests.
+
+Different tests failing on successive attempts of the same run = two independent flakes, not a
+regression.
+
+## Step 5 — Report
+
+Write `ANALYSIS.md` into the window directory, then give the user a summary. Lead with the
+ranked flake candidates. Include:
+
+1. Headline numbers: PRs in scope, runs matched, retried runs, retried-and-recovered runs
+   (pure-flake evidence), hard failures.
+2. Ranked flake candidates — test id, distinct PRs/runs, recovered-on-retry count, one-line
+   error cause. Group systemic buckets as single entries.
+3. Suspected real regressions, clearly separated.
+4. Trend — from `weekly_history` in `report-data.json`: which offenders are new this window,
+   which recur week over week, which disappeared (likely fixed). This section is the reason the
+   ledger exists; don't skip it once ≥2 windows of data exist.
+
+Do not propose fixes unless asked; the deliverable is the evidence-ranked candidate list.

--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -83,6 +83,10 @@ For failed jobs with an empty `tests` list and no bucket tag, read the log yours
 | `neo4j-deadlock` | `Neo.TransientError.Transaction.DeadlockDetected` | Concurrent-write deadlock, usually integration suites under xdist. |
 | `compose-boot-failure` | `docker compose … up --wait` non-zero exit | Stack never booted; job-level infra failure. |
 | `sqlite-locked` | `sqlite3.OperationalError: database is locked` | Prefect's sqlite under contention. |
+| `runner-oom` | `Process completed with exit code 137` | Runner OOM/SIGKILL; the mass test failures in the same job are casualties, not flakes. |
+| `docker-network-pool-exhausted` | `all predefined address pools have been fully subnetted` | Leaked compose networks exhausted the docker address pools on a self-hosted runner. |
+| `actions-download-429` | `Failed to download action … 429` | GitHub rate-limited its own action download; pure platform flake. |
+| `pytest-green-exit-1` | green pytest summary directly followed by exit 1 | Session-teardown/plugin abort after all tests passed (e.g. testcontainers result reporting). |
 
 ## Step 4 — Judge: flake vs regression
 

--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -82,7 +82,7 @@ For failed jobs with an empty `tests` list and no bucket tag, read the log yours
 | `prefect-setup-triggers-timeout` | `Setup triggers` task `ReadTimeout` | Prefect hang at session setup; downstream tests hit their own timeouts. |
 | `neo4j-deadlock` | `Neo.TransientError.Transaction.DeadlockDetected` | Concurrent-write deadlock, usually integration suites under xdist. |
 | `compose-boot-failure` | `docker compose … up --wait` non-zero exit | Stack never booted; job-level infra failure. |
-| `sqlite-locked` | `sqlite3.OperationalError: database is locked` | Prefect's sqlite under contention. |
+| `sqlite-locked` | `(sqlite3.OperationalError) database is locked` (also matches the raw `sqlite3.OperationalError:` form) | Prefect's sqlite under contention. |
 | `runner-oom` | `Process completed with exit code 137` | Runner OOM/SIGKILL; the mass test failures in the same job are casualties, not flakes. |
 | `docker-network-pool-exhausted` | `all predefined address pools have been fully subnetted` | Leaked compose networks exhausted the docker address pools on a self-hosted runner. |
 | `actions-download-429` | `Failed to download action … 429` | GitHub rate-limited its own action download; pure platform flake. |

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Collect CI failure data for flakiness analysis, incrementally, into a local cache.
+
+Fetches GitHub Actions runs for pull requests, matches them to PRs (via the
+runs' ``pull_requests`` field *and* a head-SHA join, since the field is often
+empty), identifies retried runs and failed attempts, downloads the failed job
+logs, extracts failing test identifiers, classifies known systemic failure
+signatures, and appends everything to a longitudinal ledger so successive
+invocations build trend data.
+
+Only stdlib + the ``gh`` CLI (must be authenticated). Safe to re-run: the runs
+listing is refreshed each time, but job logs already on disk are never
+re-downloaded and the ledger is deduplicated.
+
+Usage:
+  collect.py [--repo OWNER/NAME] [--base GLOB ...] [--days N | --since YYYY-MM-DD]
+             [--cache DIR]
+
+Outputs (under <cache>/<owner>-<name>/):
+  ledger.jsonl                     one record per (job, test) ever observed
+  windows/<since>_<until>/         this invocation's window
+    runs.jsonl                     all pull_request runs created in the window
+    failed_jobs_with_tests.json    failed jobs of interesting attempts + tests
+    report-data.json               ranked frequency table + headline numbers
+    joblogs/<job_id>.log           raw logs of failed jobs (ANSI codes intact)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# Known systemic failure signatures. When one matches a job log, the job is
+# tagged with the bucket so per-test counts don't mistake an infra cascade for
+# N independent flaky tests. Keep in sync with the table in SKILL.md.
+BUCKETS: list[tuple[str, str]] = [
+    ("stack-readiness", r"ServerNotResponsiveError: Unable to read from '[^']*/api/schema/load"),
+    ("vitest-mock-corruption", r"TypeError: (?:vi\.mocked\(\.\.\.\)|\w+)\.mock\w+ is not a function"),
+    ("prefect-setup-triggers-timeout", r"'Setup triggers'.*ReadTimeout|Task run encountered an exception ReadTimeout"),
+    ("neo4j-deadlock", r"Neo\.TransientError\.Transaction\.DeadlockDetected"),
+    ("compose-boot-failure", r"'docker', 'compose'.*'up', '--wait'.*non-zero exit status"),
+    ("sqlite-locked", r"sqlite3\.OperationalError\) database is locked"),
+]
+
+
+def gh(args: list[str], *, check: bool = True) -> str:
+    res = subprocess.run(["gh", *args], capture_output=True, text=True, errors="replace", check=False)  # noqa: S603, S607
+    if res.returncode != 0 and check:
+        raise RuntimeError(f"gh {' '.join(args[:3])}... failed: {res.stderr.strip()[:300]}")
+    return res.stdout
+
+
+def gh_json_lines(args: list[str]) -> list[dict]:
+    out = gh(args)
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def list_prs(repo: str, since: dt.date, base_globs: list[str]) -> list[dict]:
+    # Look back further than the run window: a re-run in the window can belong
+    # to a PR whose updatedAt predates it.
+    pr_since = since - dt.timedelta(days=21)
+    prs = json.loads(
+        gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--limit",
+                "500",
+                "--search",
+                f"updated:>={pr_since.isoformat()}",
+                "--json",
+                "number,title,state,baseRefName,headRefName,updatedAt",
+            ]
+        )
+    )
+    if base_globs:
+        prs = [p for p in prs if any(fnmatch.fnmatch(p["baseRefName"], g) for g in base_globs)]
+    return prs
+
+
+def pr_head_shas(repo: str, numbers: list[int]) -> dict[str, set[int]]:
+    sha2pr: dict[str, set[int]] = defaultdict(set)
+    for n in numbers:
+        out = gh(["api", f"repos/{repo}/pulls/{n}/commits?per_page=100", "--paginate", "--jq", ".[].sha"], check=False)
+        for sha in out.split():
+            sha2pr[sha].add(n)
+    return sha2pr
+
+
+def list_runs(repo: str, since: dt.date) -> list[dict]:
+    jq = (
+        ".workflow_runs[] | {id, name, head_branch, head_sha, run_attempt, "
+        "conclusion, status, created_at, prs: [.pull_requests[] | "
+        "{number, base: .base.ref}]}"
+    )
+    return gh_json_lines(
+        [
+            "api",
+            f"repos/{repo}/actions/runs?event=pull_request&created=%3E%3D{since.isoformat()}&per_page=100",
+            "--paginate",
+            "--jq",
+            jq,
+        ]
+    )
+
+
+def failed_jobs_for_attempt(repo: str, run_id: int, attempt: int) -> list[dict]:
+    return gh_json_lines(
+        [
+            "api",
+            f"repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100",
+            "--paginate",
+            "--jq",
+            '.jobs[] | select(.conclusion=="failure") | {id, name}',
+        ]
+    )
+
+
+def extract_tests(job_name: str, text: str) -> list[str]:
+    """Pull failing test identifiers out of a cleaned (ANSI-stripped) job log."""
+    fails: set[str] = set()
+    # pytest — backend suites and the pytest-playwright e2e suite
+    for m in re.finditer(r"(?:FAILED|ERROR) ((?:backend/)?tests/\S+::\S+)", text):
+        fails.add(m.group(1).split(" - ")[0].rstrip(","))
+    # legacy TS Playwright — numbered entries of the failure report
+    if "E2E-testing-playwright" in job_name:
+        for m in re.finditer(r"\d+\)\s+\[\w+\]\s+›\s+(tests/e2e/[^\n›]+)›([^\n]+)", text):
+            spec = m.group(1).strip().split(":")[0]
+            title = re.sub(r"\s+", " ", m.group(2)).strip()[:120]
+            fails.add(f"PW {spec} › {title}")
+    # vitest browser mode
+    if job_name == "frontend-tests":
+        for m in re.finditer(r"FAIL\s+\|?\s*\w*\s*\|?\s+(src/\S+\.test\.\w+)", text):
+            fails.add(f"VITEST {m.group(1)}")
+    return sorted(fails)
+
+
+def classify(text: str) -> list[str]:
+    return [name for name, pat in BUCKETS if re.search(pat, text)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default="opsmill/infrahub")
+    ap.add_argument(
+        "--base",
+        action="append",
+        default=[],
+        help="base-branch glob(s) to keep, e.g. release-1.11 or 'release-*' (default: all)",
+    )
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--since", type=lambda s: dt.date.fromisoformat(s))
+    ap.add_argument("--cache", type=Path, default=Path.home() / "ci-cache")
+    args = ap.parse_args()
+
+    today = dt.datetime.now(tz=dt.timezone.utc).date()
+    since = args.since or today - dt.timedelta(days=args.days)
+    repo_dir = args.cache / args.repo.replace("/", "-")
+    win_dir = repo_dir / "windows" / f"{since.isoformat()}_{today.isoformat()}"
+    (win_dir / "joblogs").mkdir(parents=True, exist_ok=True)
+    ledger_path = repo_dir / "ledger.jsonl"
+
+    prs = list_prs(args.repo, since, args.base)
+    pr_by_num = {p["number"]: p for p in prs}
+    print(f"[collect] {len(prs)} PRs in scope (bases: {args.base or 'all'})", file=sys.stderr)
+
+    runs = list_runs(args.repo, since)
+    (win_dir / "runs.jsonl").write_text("".join(json.dumps(r) + "\n" for r in runs))
+    print(f"[collect] {len(runs)} pull_request runs since {since}", file=sys.stderr)
+
+    sha2pr = pr_head_shas(args.repo, list(pr_by_num))
+
+    matched = []
+    for r in runs:
+        nums = {p["number"] for p in r["prs"] if p["number"] in pr_by_num}
+        nums |= sha2pr.get(r["head_sha"], set())
+        nums = {n for n in nums if n in pr_by_num}
+        if nums:
+            r["pr_nums"] = sorted(nums)
+            matched.append(r)
+
+    # Attempts worth reading: every earlier attempt of a retried run (those
+    # failures are what the retry "fixed"), plus the final attempt when it
+    # failed outright. Runs cancelled on attempt 1 are concurrency noise.
+    targets: list[tuple[dict, int]] = [
+        (r, a) for r in matched for a in range(1, r["run_attempt"] + (r["conclusion"] == "failure"))
+    ]
+
+    print(f"[collect] {len(matched)} runs matched to PRs, {len(targets)} run-attempts to inspect", file=sys.stderr)
+
+    seen_ledger: set[str] = set()
+    if ledger_path.exists():
+        for line in ledger_path.open():
+            rec = json.loads(line)
+            seen_ledger.add(rec["dedup_key"])
+
+    jobs_out, ledger_new = [], []
+    for r, attempt in targets:
+        try:
+            jobs = failed_jobs_for_attempt(args.repo, r["id"], attempt)
+        except RuntimeError as exc:
+            print(f"[collect] WARN jobs {r['id']}/{attempt}: {exc}", file=sys.stderr)
+            continue
+        for job in jobs:
+            log_path = win_dir / "joblogs" / f"{job['id']}.log"
+            if not log_path.exists() or log_path.stat().st_size == 0:
+                text = gh(["api", f"repos/{args.repo}/actions/jobs/{job['id']}/logs"], check=False)
+                log_path.write_text(text)  # empty file = log expired/unavailable
+            text = ANSI.sub("", log_path.read_text(errors="replace"))
+            tests = extract_tests(job["name"], text)
+            buckets = classify(text)
+            recovered = attempt < r["run_attempt"] and r["conclusion"] == "success"
+            entry = {
+                "run": r["id"],
+                "attempt": attempt,
+                "final_attempt": r["run_attempt"],
+                "final_conclusion": r["conclusion"],
+                "recovered_same_run": recovered,
+                "run_created": r["created_at"],
+                "workflow": r["name"],
+                "prs": [{"number": n, "base": pr_by_num[n]["baseRefName"]} for n in r["pr_nums"]],
+                "job_id": job["id"],
+                "job": job["name"],
+                "tests": tests,
+                "buckets": buckets,
+                "log_ok": bool(text.strip()),
+            }
+            jobs_out.append(entry)
+            week = dt.datetime.fromisoformat(r["created_at"]).strftime("%G-W%V")
+            for test in tests or [""]:
+                key = f"{job['id']}:{test}"
+                if key in seen_ledger:
+                    continue
+                seen_ledger.add(key)
+                ledger_new.append(
+                    {
+                        "dedup_key": key,
+                        "fetched_at": today.isoformat(),
+                        "week": week,
+                        "repo": args.repo,
+                        "test": test,
+                        **{
+                            k: entry[k]
+                            for k in (
+                                "run",
+                                "attempt",
+                                "final_conclusion",
+                                "recovered_same_run",
+                                "run_created",
+                                "workflow",
+                                "job_id",
+                                "job",
+                                "prs",
+                                "buckets",
+                            )
+                        },
+                    }
+                )
+
+    (win_dir / "failed_jobs_with_tests.json").write_text(json.dumps(jobs_out, indent=1))
+    with ledger_path.open("a") as fh:
+        for rec in ledger_new:
+            fh.write(json.dumps(rec) + "\n")
+
+    # Frequency table for this window + trend across ledger weeks
+    freq: dict[str, list[dict]] = defaultdict(list)
+    for e in jobs_out:
+        for t in e["tests"]:
+            freq[t].append(e)
+    table = []
+    for test, entries in freq.items():
+        table.append(
+            {
+                "test": test,
+                "distinct_runs": len({e["run"] for e in entries}),
+                "distinct_prs": len({p["number"] for e in entries for p in e["prs"]}),
+                "attempts": len(entries),
+                "recovered_on_retry": sum(e["recovered_same_run"] for e in entries),
+                "buckets": sorted({b for e in entries for b in e["buckets"]}),
+                "prs": sorted({p["number"] for e in entries for p in e["prs"]}),
+            }
+        )
+    table.sort(key=lambda x: (-x["distinct_prs"], -x["distinct_runs"], x["test"]))
+
+    weeks_hist: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    if ledger_path.exists():
+        for line in ledger_path.open():
+            rec = json.loads(line)
+            if rec["test"]:
+                weeks_hist[rec["test"]][rec["week"]] += 1
+
+    report = {
+        "window": {"since": since.isoformat(), "until": today.isoformat()},
+        "base_filter": args.base or "all",
+        "prs_in_scope": len(prs),
+        "runs_matched": len(matched),
+        "runs_retried": sum(1 for r in matched if r["run_attempt"] > 1),
+        "runs_recovered_on_retry": sum(1 for r in matched if r["run_attempt"] > 1 and r["conclusion"] == "success"),
+        "runs_failed_final": sum(1 for r in matched if r["conclusion"] == "failure"),
+        "failed_jobs": len(jobs_out),
+        "ranked_tests": table,
+        "weekly_history": {t: dict(sorted(w.items())) for t, w in sorted(weeks_hist.items())},
+        "new_ledger_records": len(ledger_new),
+    }
+    (win_dir / "report-data.json").write_text(json.dumps(report, indent=1))
+    print(json.dumps(report, indent=1))
+    print(f"[collect] window dir: {win_dir}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -32,12 +32,15 @@ import datetime as dt
 import fnmatch
 import json
 import re
-import subprocess
+import subprocess  # noqa: S404
 import sys
 from collections import defaultdict
 from pathlib import Path
 
 ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# Playwright's breadcrumb separator (U+203A) as it appears in job logs.
+PW_SEP = "\u203a"
 
 # Known systemic failure signatures. When one matches a job log, the job is
 # tagged with the bucket so per-test counts don't mistake an infra cascade for
@@ -50,6 +53,19 @@ BUCKETS: list[tuple[str, str]] = [
     ("compose-boot-failure", r"'docker', 'compose'.*'up', '--wait'.*non-zero exit status"),
     ("sqlite-locked", r"sqlite3\.OperationalError\) database is locked"),
 ]
+
+LEDGER_FIELDS = (
+    "run",
+    "attempt",
+    "final_conclusion",
+    "recovered_same_run",
+    "run_created",
+    "workflow",
+    "job_id",
+    "job",
+    "prs",
+    "buckets",
+)
 
 
 def gh(args: list[str], *, check: bool = True) -> str:
@@ -133,23 +149,132 @@ def extract_tests(job_name: str, text: str) -> list[str]:
     """Pull failing test identifiers out of a cleaned (ANSI-stripped) job log."""
     fails: set[str] = set()
     # pytest — backend suites and the pytest-playwright e2e suite
-    for m in re.finditer(r"(?:FAILED|ERROR) ((?:backend/)?tests/\S+::\S+)", text):
-        fails.add(m.group(1).split(" - ")[0].rstrip(","))
+    fails.update(
+        m.group(1).split(" - ")[0].rstrip(",")
+        for m in re.finditer(r"(?:FAILED|ERROR) ((?:backend/)?tests/\S+::\S+)", text)
+    )
     # legacy TS Playwright — numbered entries of the failure report
     if "E2E-testing-playwright" in job_name:
-        for m in re.finditer(r"\d+\)\s+\[\w+\]\s+›\s+(tests/e2e/[^\n›]+)›([^\n]+)", text):
+        for m in re.finditer(rf"\d+\)\s+\[\w+\]\s+{PW_SEP}\s+(tests/e2e/[^\n{PW_SEP}]+){PW_SEP}([^\n]+)", text):
             spec = m.group(1).strip().split(":")[0]
             title = re.sub(r"\s+", " ", m.group(2)).strip()[:120]
-            fails.add(f"PW {spec} › {title}")
+            fails.add(f"PW {spec} {PW_SEP} {title}")
     # vitest browser mode
     if job_name == "frontend-tests":
-        for m in re.finditer(r"FAIL\s+\|?\s*\w*\s*\|?\s+(src/\S+\.test\.\w+)", text):
-            fails.add(f"VITEST {m.group(1)}")
+        fails.update(
+            f"VITEST {m.group(1)}" for m in re.finditer(r"FAIL\s+\|?\s*\w*\s*\|?\s+(src/\S+\.test\.\w+)", text)
+        )
     return sorted(fails)
 
 
 def classify(text: str) -> list[str]:
     return [name for name, pat in BUCKETS if re.search(pat, text)]
+
+
+def match_runs_to_prs(runs: list[dict], pr_by_num: dict[int, dict], sha2pr: dict[str, set[int]]) -> list[dict]:
+    matched = []
+    for r in runs:
+        nums = {p["number"] for p in r["prs"] if p["number"] in pr_by_num}
+        nums |= {n for n in sha2pr.get(r["head_sha"], set()) if n in pr_by_num}
+        if nums:
+            r["pr_nums"] = sorted(nums)
+            matched.append(r)
+    return matched
+
+
+def collect_failed_jobs(
+    repo: str, targets: list[tuple[dict, int]], pr_by_num: dict[int, dict], win_dir: Path
+) -> list[dict]:
+    """Fetch failed jobs and their logs for each (run, attempt); build job entries."""
+    jobs_out = []
+    for r, attempt in targets:
+        try:
+            jobs = failed_jobs_for_attempt(repo, r["id"], attempt)
+        except RuntimeError as exc:
+            print(f"[collect] WARN jobs {r['id']}/{attempt}: {exc}", file=sys.stderr)
+            continue
+        for job in jobs:
+            log_path = win_dir / "joblogs" / f"{job['id']}.log"
+            if not log_path.exists() or log_path.stat().st_size == 0:
+                # empty file = log expired/unavailable on GitHub's side
+                log_path.write_text(gh(["api", f"repos/{repo}/actions/jobs/{job['id']}/logs"], check=False))
+            text = ANSI.sub("", log_path.read_text(errors="replace"))
+            jobs_out.append(
+                {
+                    "run": r["id"],
+                    "attempt": attempt,
+                    "final_attempt": r["run_attempt"],
+                    "final_conclusion": r["conclusion"],
+                    "recovered_same_run": attempt < r["run_attempt"] and r["conclusion"] == "success",
+                    "run_created": r["created_at"],
+                    "workflow": r["name"],
+                    "prs": [{"number": n, "base": pr_by_num[n]["baseRefName"]} for n in r["pr_nums"]],
+                    "job_id": job["id"],
+                    "job": job["name"],
+                    "tests": extract_tests(job["name"], text),
+                    "buckets": classify(text),
+                    "log_ok": bool(text.strip()),
+                }
+            )
+    return jobs_out
+
+
+def append_ledger(ledger_path: Path, jobs_out: list[dict], repo: str, today: dt.date) -> int:
+    seen: set[str] = set()
+    if ledger_path.exists():
+        seen = {json.loads(line)["dedup_key"] for line in ledger_path.open(encoding="utf-8")}
+    added = 0
+    with ledger_path.open("a", encoding="utf-8") as fh:
+        for entry in jobs_out:
+            week = dt.datetime.fromisoformat(entry["run_created"]).strftime("%G-W%V")
+            for test in entry["tests"] or [""]:
+                key = f"{entry['job_id']}:{test}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                record = {
+                    "dedup_key": key,
+                    "fetched_at": today.isoformat(),
+                    "week": week,
+                    "repo": repo,
+                    "test": test,
+                    **{k: entry[k] for k in LEDGER_FIELDS},
+                }
+                fh.write(json.dumps(record) + "\n")
+                added += 1
+    return added
+
+
+def ranked_tests(jobs_out: list[dict]) -> list[dict]:
+    freq: dict[str, list[dict]] = defaultdict(list)
+    for e in jobs_out:
+        for t in e["tests"]:
+            freq[t].append(e)
+    table = [
+        {
+            "test": test,
+            "distinct_runs": len({e["run"] for e in entries}),
+            "distinct_prs": len({p["number"] for e in entries for p in e["prs"]}),
+            "attempts": len(entries),
+            "recovered_on_retry": sum(e["recovered_same_run"] for e in entries),
+            "buckets": sorted({b for e in entries for b in e["buckets"]}),
+            "prs": sorted({p["number"] for e in entries for p in e["prs"]}),
+        }
+        for test, entries in freq.items()
+    ]
+    table.sort(key=lambda x: (-x["distinct_prs"], -x["distinct_runs"], x["test"]))
+    return table
+
+
+def weekly_history(ledger_path: Path) -> dict[str, dict[str, int]]:
+    hist: dict[str, dict[str, int]] = {}
+    if ledger_path.exists():
+        for line in ledger_path.open(encoding="utf-8"):
+            rec = json.loads(line)
+            if rec["test"]:
+                weeks = hist.setdefault(rec["test"], {})
+                weeks[rec["week"]] = weeks.get(rec["week"], 0) + 1
+    return {t: dict(sorted(w.items())) for t, w in sorted(hist.items())}
 
 
 def main() -> int:
@@ -162,158 +287,47 @@ def main() -> int:
         help="base-branch glob(s) to keep, e.g. release-1.11 or 'release-*' (default: all)",
     )
     ap.add_argument("--days", type=int, default=7)
-    ap.add_argument("--since", type=lambda s: dt.date.fromisoformat(s))
+    ap.add_argument("--since", type=dt.date.fromisoformat)
     ap.add_argument("--cache", type=Path, default=Path.home() / "ci-cache")
     args = ap.parse_args()
 
-    today = dt.datetime.now(tz=dt.timezone.utc).date()
+    today = dt.datetime.now(tz=dt.UTC).date()
     since = args.since or today - dt.timedelta(days=args.days)
     repo_dir = args.cache / args.repo.replace("/", "-")
     win_dir = repo_dir / "windows" / f"{since.isoformat()}_{today.isoformat()}"
     (win_dir / "joblogs").mkdir(parents=True, exist_ok=True)
-    ledger_path = repo_dir / "ledger.jsonl"
 
-    prs = list_prs(args.repo, since, args.base)
-    pr_by_num = {p["number"]: p for p in prs}
-    print(f"[collect] {len(prs)} PRs in scope (bases: {args.base or 'all'})", file=sys.stderr)
+    pr_by_num = {p["number"]: p for p in list_prs(args.repo, since, args.base)}
+    print(f"[collect] {len(pr_by_num)} PRs in scope (bases: {args.base or 'all'})", file=sys.stderr)
 
     runs = list_runs(args.repo, since)
     (win_dir / "runs.jsonl").write_text("".join(json.dumps(r) + "\n" for r in runs))
     print(f"[collect] {len(runs)} pull_request runs since {since}", file=sys.stderr)
 
-    sha2pr = pr_head_shas(args.repo, list(pr_by_num))
-
-    matched = []
-    for r in runs:
-        nums = {p["number"] for p in r["prs"] if p["number"] in pr_by_num}
-        nums |= sha2pr.get(r["head_sha"], set())
-        nums = {n for n in nums if n in pr_by_num}
-        if nums:
-            r["pr_nums"] = sorted(nums)
-            matched.append(r)
+    matched = match_runs_to_prs(runs, pr_by_num, pr_head_shas(args.repo, list(pr_by_num)))
 
     # Attempts worth reading: every earlier attempt of a retried run (those
     # failures are what the retry "fixed"), plus the final attempt when it
     # failed outright. Runs cancelled on attempt 1 are concurrency noise.
-    targets: list[tuple[dict, int]] = [
-        (r, a) for r in matched for a in range(1, r["run_attempt"] + (r["conclusion"] == "failure"))
-    ]
-
+    targets = [(r, a) for r in matched for a in range(1, r["run_attempt"] + (r["conclusion"] == "failure"))]
     print(f"[collect] {len(matched)} runs matched to PRs, {len(targets)} run-attempts to inspect", file=sys.stderr)
 
-    seen_ledger: set[str] = set()
-    if ledger_path.exists():
-        for line in ledger_path.open():
-            rec = json.loads(line)
-            seen_ledger.add(rec["dedup_key"])
-
-    jobs_out, ledger_new = [], []
-    for r, attempt in targets:
-        try:
-            jobs = failed_jobs_for_attempt(args.repo, r["id"], attempt)
-        except RuntimeError as exc:
-            print(f"[collect] WARN jobs {r['id']}/{attempt}: {exc}", file=sys.stderr)
-            continue
-        for job in jobs:
-            log_path = win_dir / "joblogs" / f"{job['id']}.log"
-            if not log_path.exists() or log_path.stat().st_size == 0:
-                text = gh(["api", f"repos/{args.repo}/actions/jobs/{job['id']}/logs"], check=False)
-                log_path.write_text(text)  # empty file = log expired/unavailable
-            text = ANSI.sub("", log_path.read_text(errors="replace"))
-            tests = extract_tests(job["name"], text)
-            buckets = classify(text)
-            recovered = attempt < r["run_attempt"] and r["conclusion"] == "success"
-            entry = {
-                "run": r["id"],
-                "attempt": attempt,
-                "final_attempt": r["run_attempt"],
-                "final_conclusion": r["conclusion"],
-                "recovered_same_run": recovered,
-                "run_created": r["created_at"],
-                "workflow": r["name"],
-                "prs": [{"number": n, "base": pr_by_num[n]["baseRefName"]} for n in r["pr_nums"]],
-                "job_id": job["id"],
-                "job": job["name"],
-                "tests": tests,
-                "buckets": buckets,
-                "log_ok": bool(text.strip()),
-            }
-            jobs_out.append(entry)
-            week = dt.datetime.fromisoformat(r["created_at"]).strftime("%G-W%V")
-            for test in tests or [""]:
-                key = f"{job['id']}:{test}"
-                if key in seen_ledger:
-                    continue
-                seen_ledger.add(key)
-                ledger_new.append(
-                    {
-                        "dedup_key": key,
-                        "fetched_at": today.isoformat(),
-                        "week": week,
-                        "repo": args.repo,
-                        "test": test,
-                        **{
-                            k: entry[k]
-                            for k in (
-                                "run",
-                                "attempt",
-                                "final_conclusion",
-                                "recovered_same_run",
-                                "run_created",
-                                "workflow",
-                                "job_id",
-                                "job",
-                                "prs",
-                                "buckets",
-                            )
-                        },
-                    }
-                )
-
+    jobs_out = collect_failed_jobs(args.repo, targets, pr_by_num, win_dir)
     (win_dir / "failed_jobs_with_tests.json").write_text(json.dumps(jobs_out, indent=1))
-    with ledger_path.open("a") as fh:
-        for rec in ledger_new:
-            fh.write(json.dumps(rec) + "\n")
-
-    # Frequency table for this window + trend across ledger weeks
-    freq: dict[str, list[dict]] = defaultdict(list)
-    for e in jobs_out:
-        for t in e["tests"]:
-            freq[t].append(e)
-    table = []
-    for test, entries in freq.items():
-        table.append(
-            {
-                "test": test,
-                "distinct_runs": len({e["run"] for e in entries}),
-                "distinct_prs": len({p["number"] for e in entries for p in e["prs"]}),
-                "attempts": len(entries),
-                "recovered_on_retry": sum(e["recovered_same_run"] for e in entries),
-                "buckets": sorted({b for e in entries for b in e["buckets"]}),
-                "prs": sorted({p["number"] for e in entries for p in e["prs"]}),
-            }
-        )
-    table.sort(key=lambda x: (-x["distinct_prs"], -x["distinct_runs"], x["test"]))
-
-    weeks_hist: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
-    if ledger_path.exists():
-        for line in ledger_path.open():
-            rec = json.loads(line)
-            if rec["test"]:
-                weeks_hist[rec["test"]][rec["week"]] += 1
+    new_records = append_ledger(repo_dir / "ledger.jsonl", jobs_out, args.repo, today)
 
     report = {
         "window": {"since": since.isoformat(), "until": today.isoformat()},
         "base_filter": args.base or "all",
-        "prs_in_scope": len(prs),
+        "prs_in_scope": len(pr_by_num),
         "runs_matched": len(matched),
         "runs_retried": sum(1 for r in matched if r["run_attempt"] > 1),
         "runs_recovered_on_retry": sum(1 for r in matched if r["run_attempt"] > 1 and r["conclusion"] == "success"),
         "runs_failed_final": sum(1 for r in matched if r["conclusion"] == "failure"),
         "failed_jobs": len(jobs_out),
-        "ranked_tests": table,
-        "weekly_history": {t: dict(sorted(w.items())) for t, w in sorted(weeks_hist.items())},
-        "new_ledger_records": len(ledger_new),
+        "ranked_tests": ranked_tests(jobs_out),
+        "weekly_history": weekly_history(repo_dir / "ledger.jsonl"),
+        "new_ledger_records": new_records,
     }
     (win_dir / "report-data.json").write_text(json.dumps(report, indent=1))
     print(json.dumps(report, indent=1))

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -22,7 +22,7 @@ Outputs (under <cache>/<owner>-<name>/):
     runs.jsonl                     all pull_request runs created in the window
     failed_jobs_with_tests.json    failed jobs of interesting attempts + tests
     report-data.json               ranked frequency table + headline numbers
-    joblogs/<job_id>.log           raw logs of failed jobs (ANSI codes intact)
+    joblogs/<job_id>.log           raw logs of failed jobs (ANSI intact; empty = expired)
 """
 
 from __future__ import annotations
@@ -90,6 +90,29 @@ def gh(args: list[str], *, check: bool = True) -> str:
 def gh_json_lines(args: list[str]) -> list[dict]:
     out = gh(args)
     return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def fetch_job_log(repo: str, job_id: int, log_path: Path) -> None:
+    """Download one job log, distinguishing gone from transiently unavailable.
+
+    On success the log is written to ``log_path``. On HTTP 404/410 (the log
+    expired or was deleted on GitHub's side) an empty file is written as a
+    durable sentinel so the job is never re-fetched. On any other failure
+    (rate limit, network) nothing is written, so the next collection retries.
+    """
+    res = subprocess.run(  # noqa: S603
+        ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        errors="replace",
+        check=False,
+    )
+    if res.returncode == 0:
+        log_path.write_text(res.stdout, encoding="utf-8")
+    elif "HTTP 404" in res.stderr or "HTTP 410" in res.stderr:
+        log_path.write_text("", encoding="utf-8")
+    else:
+        print(f"[collect] WARN log {job_id}: {res.stderr.strip()[:300]}", file=sys.stderr)
 
 
 def list_prs(repo: str, since: dt.date, base_globs: list[str]) -> list[dict]:
@@ -212,10 +235,9 @@ def collect_failed_jobs(
             continue
         for job in jobs:
             log_path = win_dir / "joblogs" / f"{job['id']}.log"
-            if not log_path.exists() or log_path.stat().st_size == 0:
-                # empty file = log expired/unavailable on GitHub's side
-                log_path.write_text(gh(["api", f"repos/{repo}/actions/jobs/{job['id']}/logs"], check=False))
-            text = ANSI.sub("", log_path.read_text(errors="replace"))
+            if not log_path.exists():
+                fetch_job_log(repo, job["id"], log_path)
+            text = ANSI.sub("", log_path.read_text(errors="replace")) if log_path.exists() else ""
             jobs_out.append(
                 {
                     "run": r["id"],

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -21,7 +21,7 @@ Outputs (under <cache>/<owner>-<name>/):
   windows/<since>_<until>/         this invocation's window
     runs.jsonl                     all pull_request runs created in the window
     failed_jobs_with_tests.json    failed jobs of interesting attempts + tests
-    report-data.json               ranked frequency table + headline numbers
+    report-data.json               ranked frequency table, per-bucket incident counts + headline numbers
     joblogs/<job_id>.log           raw logs of failed jobs (ANSI intact; empty = expired)
 """
 
@@ -46,8 +46,11 @@ API_RESULT_CAP = 1000
 PW_SEP = "\u203a"
 
 # Known systemic failure signatures. When one matches a job log, the job is
-# tagged with the bucket so per-test counts don't mistake an infra cascade for
-# N independent flaky tests. Keep in sync with the table in SKILL.md.
+# tagged with the bucket. The tags feed the report's per-bucket incident counts
+# (``bucket_incidents``) and the judgment step (SKILL.md Step 4), which reports
+# a bucketed cascade as one incident rather than N flaky tests; the per-test
+# table still lists every test, annotated with its buckets, so casualties can
+# be discounted. Keep in sync with the table in SKILL.md.
 BUCKETS: list[tuple[str, str]] = [
     ("stack-readiness", r"ServerNotResponsiveError: Unable to read from '[^']*/api/schema/load"),
     ("vitest-mock-corruption", r"TypeError: (?:vi\.mocked\(\.\.\.\)|\w+)\.mock\w+ is not a function"),
@@ -305,6 +308,19 @@ def ranked_tests(jobs_out: list[dict]) -> list[dict]:
     return table
 
 
+def bucket_incidents(jobs_out: list[dict]) -> dict[str, dict[str, int]]:
+    """Count distinct jobs/runs/PRs per systemic bucket, so a cascade reads as one incident."""
+    jobs: dict[str, set[int]] = defaultdict(set)
+    runs: dict[str, set[int]] = defaultdict(set)
+    prs: dict[str, set[int]] = defaultdict(set)
+    for e in jobs_out:
+        for b in e["buckets"]:
+            jobs[b].add(e["job_id"])
+            runs[b].add(e["run"])
+            prs[b].update(p["number"] for p in e["prs"])
+    return {b: {"jobs": len(jobs[b]), "runs": len(runs[b]), "prs": len(prs[b])} for b in sorted(jobs)}
+
+
 def weekly_history(ledger_path: Path) -> dict[str, dict[str, int]]:
     hist: dict[str, dict[str, int]] = {}
     if ledger_path.exists():
@@ -365,6 +381,7 @@ def main() -> int:
         "runs_failed_final": sum(1 for r in matched if r["conclusion"] == "failure"),
         "failed_jobs": len(jobs_out),
         "ranked_tests": ranked_tests(jobs_out),
+        "bucket_incidents": bucket_incidents(jobs_out),
         "weekly_history": weekly_history(repo_dir / "ledger.jsonl"),
         "new_ledger_records": new_records,
     }

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -39,6 +39,9 @@ from pathlib import Path
 
 ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
+# The Actions list-runs API silently returns at most this many results per query.
+API_RESULT_CAP = 1000
+
 # Playwright's breadcrumb separator (U+203A) as it appears in job logs.
 PW_SEP = "\u203a"
 
@@ -52,6 +55,15 @@ BUCKETS: list[tuple[str, str]] = [
     ("neo4j-deadlock", r"Neo\.TransientError\.Transaction\.DeadlockDetected"),
     ("compose-boot-failure", r"'docker', 'compose'.*'up', '--wait'.*non-zero exit status"),
     ("sqlite-locked", r"sqlite3\.OperationalError\) database is locked"),
+    ("runner-oom", r"Process completed with exit code 137|exit code: 137"),
+    ("docker-network-pool-exhausted", r"all predefined address pools have been fully subnetted"),
+    ("actions-download-429", r"Failed to download action .*429"),
+    # pytest summary is green (no "N failed") yet the process exits 1: a
+    # session-teardown/plugin abort, e.g. the testcontainers result reporting.
+    (
+        "pytest-green-exit-1",
+        r"=+ \d+ passed(?:(?!\d+ failed)[^\n])*=+[^\n]*\n(?:[^\n]*\n){0,3}[^\n]*Process completed with exit code 1\.",
+    ),
 ]
 
 LEDGER_FIELDS = (
@@ -116,21 +128,26 @@ def pr_head_shas(repo: str, numbers: list[int]) -> dict[str, set[int]]:
     return sha2pr
 
 
-def list_runs(repo: str, since: dt.date) -> list[dict]:
+def _runs_query(repo: str, created: str) -> str:
+    return f"repos/{repo}/actions/runs?event=pull_request&created={created}&per_page=100"
+
+
+def list_runs(repo: str, since: dt.date, until: dt.date) -> list[dict]:
+    """List runs in [since, until], splitting the date range to stay under the API's 1000-result cap."""
     jq = (
         ".workflow_runs[] | {id, name, head_branch, head_sha, run_attempt, "
         "conclusion, status, created_at, prs: [.pull_requests[] | "
         "{number, base: .base.ref}]}"
     )
-    return gh_json_lines(
-        [
-            "api",
-            f"repos/{repo}/actions/runs?event=pull_request&created=%3E%3D{since.isoformat()}&per_page=100",
-            "--paginate",
-            "--jq",
-            jq,
-        ]
-    )
+    created = f"{since.isoformat()}..{until.isoformat()}"
+    total = int(gh(["api", _runs_query(repo, created).replace("per_page=100", "per_page=1"), "--jq", ".total_count"]))
+    if total > API_RESULT_CAP and since < until:
+        mid = since + (until - since) // 2
+        print(f"[collect] {total} runs in {created} exceeds the API result cap; splitting", file=sys.stderr)
+        return list_runs(repo, since, mid) + list_runs(repo, mid + dt.timedelta(days=1), until)
+    if total > API_RESULT_CAP:
+        print(f"[collect] WARN {total} runs on {since} alone; the API returns only the newest results", file=sys.stderr)
+    return gh_json_lines(["api", _runs_query(repo, created), "--paginate", "--jq", jq])
 
 
 def failed_jobs_for_attempt(repo: str, run_id: int, attempt: int) -> list[dict]:
@@ -155,7 +172,7 @@ def extract_tests(job_name: str, text: str) -> list[str]:
     )
     # legacy TS Playwright — numbered entries of the failure report
     if "E2E-testing-playwright" in job_name:
-        for m in re.finditer(rf"\d+\)\s+\[\w+\]\s+{PW_SEP}\s+(tests/e2e/[^\n{PW_SEP}]+){PW_SEP}([^\n]+)", text):
+        for m in re.finditer(rf"\d+\)\s+\[[\w-]+\]\s+{PW_SEP}\s+(tests/e2e/[^\n{PW_SEP}]+){PW_SEP}([^\n]+)", text):
             spec = m.group(1).strip().split(":")[0]
             title = re.sub(r"\s+", " ", m.group(2)).strip()[:120]
             fails.add(f"PW {spec} {PW_SEP} {title}")
@@ -300,7 +317,7 @@ def main() -> int:
     pr_by_num = {p["number"]: p for p in list_prs(args.repo, since, args.base)}
     print(f"[collect] {len(pr_by_num)} PRs in scope (bases: {args.base or 'all'})", file=sys.stderr)
 
-    runs = list_runs(args.repo, since)
+    runs = list_runs(args.repo, since, today)
     (win_dir / "runs.jsonl").write_text("".join(json.dumps(r) + "\n" for r in runs))
     print(f"[collect] {len(runs)} pull_request runs since {since}", file=sys.stderr)
 

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -101,7 +101,9 @@ def fetch_job_log(repo: str, job_id: int, log_path: Path) -> None:
     On success the log is written to ``log_path``. On HTTP 404/410 (the log
     expired or was deleted on GitHub's side) an empty file is written as a
     durable sentinel so the job is never re-fetched. On any other failure
-    (rate limit, network) nothing is written, so the next collection retries.
+    (rate limit, network) — including a successful call with an empty body,
+    which a real job log never has — nothing is written, so the next
+    collection retries.
     """
     res = subprocess.run(  # noqa: S603
         ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs"],  # noqa: S607
@@ -110,8 +112,10 @@ def fetch_job_log(repo: str, job_id: int, log_path: Path) -> None:
         errors="replace",
         check=False,
     )
-    if res.returncode == 0:
+    if res.returncode == 0 and res.stdout:
         log_path.write_text(res.stdout, encoding="utf-8")
+    elif res.returncode == 0:
+        print(f"[collect] WARN log {job_id}: empty response, leaving unfetched for retry", file=sys.stderr)
     elif "HTTP 404" in res.stderr or "HTTP 410" in res.stderr:
         log_path.write_text("", encoding="utf-8")
     else:

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -54,7 +54,7 @@ BUCKETS: list[tuple[str, str]] = [
     ("prefect-setup-triggers-timeout", r"'Setup triggers'.*ReadTimeout|Task run encountered an exception ReadTimeout"),
     ("neo4j-deadlock", r"Neo\.TransientError\.Transaction\.DeadlockDetected"),
     ("compose-boot-failure", r"'docker', 'compose'.*'up', '--wait'.*non-zero exit status"),
-    ("sqlite-locked", r"sqlite3\.OperationalError\) database is locked"),
+    ("sqlite-locked", r"sqlite3\.OperationalError[):] database is locked"),
     ("runner-oom", r"Process completed with exit code 137|exit code: 137"),
     ("docker-network-pool-exhausted", r"all predefined address pools have been fully subnetted"),
     ("actions-download-429", r"Failed to download action .*429"),


### PR DESCRIPTION
# Why

Flaky-test hunting has been a manual, repeated effort: paging through failed runs, guessing which failures were retried away, and losing the evidence once logs scroll out of the Actions UI. This PR packages the workflow used for this week's release-1.11 flakiness analysis (below) as a reusable skill, so the analysis can be re-run on any base branch and window, and builds trend data over time instead of starting from scratch.

Non-goals: fixing any of the flaky tests found — this only adds the detection/reporting tooling.

## What changed

- New `analyzing-ci-flakiness` skill (`.agents/skills/analyzing-ci-flakiness/`): correlates CI failures across PRs, using retry outcomes (failed attempt → green re-run) and cross-PR recurrence as flakiness evidence, and separates real regressions (same commit fails every attempt) from flakes.
- Bundled `scripts/collect.py` (stdlib + `gh` only) does the mechanical part: fetches `pull_request` workflow runs, matches them to PRs via the `pull_requests` field **and** a head-SHA join (the field is empty for ~half the runs), pulls the failed jobs of every interesting run-attempt, downloads their logs once into a local cache (`~/ci-cache/<owner>-<repo>/`), extracts failing test ids (pytest / TS Playwright / vitest), tags known systemic signatures, and appends deduplicated records to a longitudinal `ledger.jsonl` for week-over-week trends.
- Known systemic failure signatures (stack-readiness cascade, vitest mock corruption, Prefect setup-triggers timeout, Neo4j deadlock, compose boot failure) are classified as single incidents so an infra cascade doesn't read as N flaky tests.

## How to test

```bash
# Full window collection (all PR bases, last 7 days)
python3 .agents/skills/analyzing-ci-flakiness/scripts/collect.py

# Replicate the release-1.11 analysis below
python3 .agents/skills/analyzing-ci-flakiness/scripts/collect.py --base release-1.11 --since 2026-08-01
```

Validated against a week of real data: the collector reproduces the manual analysis below exactly (180 runs matched, 15 retried, 11 recovered on retry, 38 failed jobs), and a second run is a no-op (`new_ledger_records = 0`, no log re-downloads).

## Findings: release-1.11 PRs, 2026-08-01 → 2026-08-08

22 PRs, 180 CI runs. 15 runs were retried; **11 went green on retry** — those recovered attempts plus 11 hard failures yielded 38 failed jobs whose logs back the ranking below.

**Flaky candidates (ranked by evidence):**

1. **vitest browser-mode mock corruption** (`frontend-tests`, 5 failures / 4 PRs, all recovered on retry). Always `TypeError: vi.mocked(...).mockResolvedValue/mockReturnValue/mockClear is not a function`, each time on a *different* test file (user-preferences-card, has-global-permission, get-relationships, retry-task, upsert-user-preferences, refresh-button). One systemic race, not six flaky tests.
2. **Legacy TS Playwright** (15 of 38 failed jobs):
   - `object-dropdown-creation.spec.ts › should not be able to create a new option for dropdown` — 3 unrelated PRs (#10096, #10101, #10153), recovered on retry. Strongest single-test flake.
   - `object-hierarchy-crud.spec.ts › CRUD on hierarchical objects` — 4 attempts / 3 runs (PR #10003).
   - `branch-selector.spec.ts › allow to create a branch with a name that does not exists` — PRs #10003, #10154.
   - `merged-branch-permissions.spec.ts › should disable edit button on the object details view` — PRs #10003, #10136.
   - Recurring background noise in nearly every failing run: task-worker repo-sync flows dying with `CoreGraphQLQueryCreate "Violates uniqueness constraint 'name'" (backbone_service)` and `BranchNotFoundError` on transient e2e branches.
3. **pytest-playwright shards — one infra cascade**, not test flakiness: `ServerNotResponsiveError: /api/schema/load?branch=main (timeout: 120 s)` at session setup fails the whole shard (tutorial, sites_a, sites_b — PRs #10003, #10118/#10160, #10086). Known seeded-stack readiness race. Genuine test-level candidates: `test_repository_objects.py` (failed attempts 1+2, green on 3, PR #10129) and the role-management pair `test_group_crud`/`test_roles_crud` (same "Locator expected not to be visible" assertion, different PRs).
4. **Backend one-offs, infra-flavored:** Prefect `Setup triggers` ReadTimeout (~420 s) sank two component shards (PR #10095, same day); `test_setup_task_manager` timeout >300 s; PR #10167's run failed a *different* test each attempt (diff-summary cache `ResourceNotFoundError`, then Neo4j `DeadlockDetected` in profile_lifecycle); `test_thread_events` missed the `infrahub.proposed_change_thread.created` event once; one `docker compose up --wait` boot failure.

**Possibly NOT flakes (real-regression suspects):**

- `proposed-changes_diff.spec.ts › diff with conflicts › resolve conflict` — failed both attempts of PR #10086's run; PR still red.
- `test_zombie_detection.py::test_wait_that_never_resumes_is_marked_crashed` — failed both attempts on PR #10162 (unrelated change, merged anyway); timing-based assertion, worth watching.

## Impact & rollout

- No product or CI-workflow changes; `.agents/` tooling only. Safe to merge anytime.
- Cache/ledger live outside the repo (`~/ci-cache/`), nothing checked in.

## Checklist

- [x] Tests added/updated — n/a (agent tooling; validated against a week of real CI data, idempotency verified)
- [x] Changelog entry — n/a, `ci/skip-changelog`
- [x] External docs updated — n/a
- [x] Internal .md docs updated — the skill is self-documenting (`SKILL.md`)
- [x] I have reviewed AI generated content



## Findings: release-1.11 PRs, 2026-08-12 → 2026-08-19 (second window, run with this skill)

77 PRs in scope, 281 CI runs matched, 15 retried runs — **all 15 recovered on retry** — plus 23 hard failures; 110 failed jobs analyzed. Dogfooding this window surfaced three collector bugs/gaps, fixed on this branch: the Actions API silently caps run listings at 1000 results (the first pass dropped the oldest 321 of 1321 runs — the collector now splits the date range), Playwright projects with hyphenated names weren't extracted, and four new systemic buckets were added.

**Flaky candidates (ranked):**

1. **`test_proposed_change.py::TestProposedChange::test_run_generators_validate_requested_jobs`** — **12 PRs / 14 runs / 18 attempts, 11 recovered on retry.** Always `ResourceNotFoundError: Diff summary for pipeline <uuid> was not found in the cache`. Was a single occurrence last window; now the dominant CI tax.
2. **`test_render.py::TestWebhookRender::test_branchless_event_triggers_webhook_process`** — 5 unrelated PRs / 5 runs (Aug 13–18), always `webhook-process deployment was not run; server-side parameter render failed`. New this window.
3. **`test_zombie_detection.py::test_wait_that_never_resumes_is_marked_crashed`** — 4 PRs / 4 runs. Last window's "watch closely" suspect is now confirmed flaky across unrelated PRs.
4. **PW `branch-selector.spec.ts › allow to create a branch with a name that does not exists`** — 4 PRs / 3 runs, recurring from last window.
5. **`test_profile_lifecycle.py` steps 15–19** — every failure carries the `neo4j-deadlock` bucket (6 jobs / 4 runs / 5 PRs): a deadlock casualty, not an independent flake.

**Systemic incidents:** an Aug 14 self-hosted-runner incident (PRs #10277/#10281): 17 jobs killed with exit 137 (**runner OOM**) plus 10 jobs failing with `all predefined address pools have been fully subnetted` (**leaked compose networks**, runner `huge05`) — the 100+-test mass failures in those jobs are casualties, and same-commit retries went green. Also: 6 jobs where **pytest ends green but the job exits 1** (testcontainers result-reporting teardown abort — fixed on stable in 966989fac/2cd6fb2af, still occurring on release-1.11 PRs Aug 13–17), 14 compose-boot failures, 5 stack-readiness cascades (persists from last window), and one GitHub 429 on downloading its own checkout action.

**Suspected regressions, not flakes:** `test_multi_migration.py::test_diff_and_merge_with_migrated_node_kind_and_migrated_inheritance` failed with a deterministic assert mismatch on 4 runs across unrelated PRs (Aug 14–17, zero recoveries) → broken on the release-1.11 base in that window; absent from Aug 18 runs, so likely already fixed — verify before chasing. PR #10250's schema_lifecycle failures (4 runs, that PR only) are self-inflicted branch breakage.

**Trend vs first window:** escalated — the diff-summary cache race (1 → 18 attempts). Recurring — branch-selector PW, zombie-detection, profile_lifecycle deadlocks, merged-branch-permissions PW, stack-readiness. Improved — vitest-mock-corruption (5 jobs → 1), `object-dropdown-creation` PW (3 PRs → 1 run), `object-hierarchy-crud` and the tutorial-shard cascades gone. New — webhook render flake, runner-oom + network-pool exhaustion, pytest-green-exit-1.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


