### PR TITLE
chore(labels): add state/verified-2026-08

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -167,6 +167,10 @@
   description: "This issue is part of the backlog"
   color: "eeeeee"
 
+- name: "state/verified-2026-08"
+  description: "Checked against current code during the 2026-08 backlog triage, confirmed still valid"
+  color: "0e8a16"
+
 - name: "state/planned"
   description: "This issue is planned to be worked on in an upcoming release."
   color: "eeeeee"


### PR DESCRIPTION
# Why

We are sweeping the open `type/bug` backlog to close what is already fixed and prioritise what survives. Issues that have been checked against current code and confirmed still valid need a marker, so a later pass does not re-verify the same ones.

The label has to be declared here: the sync workflow runs `crazy-max/ghaction-github-labeler` with `skip-delete: false`, so a label created only over the API is deleted on the next sync and stripped from every issue carrying it.

## What changed

One label:

| Label | Meaning |
|---|---|
| `state/verified-2026-08` | Checked against current code during the 2026-08 backlog triage, confirmed still valid |

The date is ISO 8601 (`YYYY-MM`) and records when the check happened rather than implying a monthly cadence. It will go on the 28 open pre-2025 bugs, which are the ones verified so far.

No behavioural change to Infrahub.

## How to test

```bash
uv run python -c "import yaml; d=yaml.safe_load(open('.github/labels.yml')); n=[x['name'] for x in d]; print(len(d),'labels, dupes:', [x for x in set(n) if n.count(x)>1] or 'none')"
```

After merge the `github` workflow runs and the label should appear in `gh label list`.

## Checklist

- [ ] Tests added/updated — n/a, label configuration
- [ ] Changelog entry added — n/a, not user-facing (`ci/skip-changelog`)
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

