### PR TITLE
fix(backend): report a failure when repository tests never run

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -641,6 +641,31 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, contex
         )
 
 
+def _run_repository_tests(
+    test_directory: Path,
+    config_file: str,
+    address: str | None,
+    plugin: InfrahubBackendPlugin,
+) -> int | pytest.ExitCode:
+    exit_code = pytest.main(
+        [
+            str(test_directory),
+            f"--infrahub-repo-config={config_file}",
+            f"--infrahub-address={address}",
+            "-qqqq",
+            "-s",
+            # Infrahub tests are collected from YAML files, so importing the repository's own Python
+            # test files would only expose this session to failures that are not ours to run.
+            "-o",
+            "python_files=__infrahub_no_python_tests__.py",
+        ],
+        plugins=[plugin],
+    )
+    plugin.record_outcome(exit_code)
+
+    return exit_code
+
+
 @flow(name="proposed-changed-user-tests", flow_run_name="Run unit tests in repositories")
 async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
@@ -697,15 +722,11 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) 
             sys.stdout = devnull
             sys.stderr = devnull
 
-            exit_code = pytest.main(
-                [
-                    str(test_directory),
-                    f"--infrahub-repo-config={config_file}",
-                    f"--infrahub-address={config.SETTINGS.main.internal_address}",
-                    "-qqqq",
-                    "-s",
-                ],
-                plugins=[InfrahubBackendPlugin(client.config, repository.repository_id, proposed_change.id)],
+            exit_code = _run_repository_tests(
+                test_directory=test_directory,
+                config_file=config_file,
+                address=config.SETTINGS.main.internal_address,
+                plugin=InfrahubBackendPlugin(client.config, repository.repository_id, proposed_change.id),
             )
 
         # Restore stdout/stderr back to their orignal states

--- a/backend/infrahub/pytest_plugin.py
+++ b/backend/infrahub/pytest_plugin.py
@@ -8,6 +8,29 @@ from infrahub.core.timestamp import Timestamp
 
 OUTCOME_TO_CONCLUSION_MAP = {"passed": "success", "failed": "failure", "skipped": "failure"}
 OUTCOME_TO_SEVERITY_MAP = {"passed": "success", "failed": "error", "skipped": "warning"}
+
+# Exit codes where the test loop ran to completion, so the collected checks describe the outcome.
+# Anything else means the session gave up early and no check reflects that.
+COMPLETED_SESSION_EXIT_CODES: set[int] = {
+    pytest.ExitCode.OK,
+    pytest.ExitCode.TESTS_FAILED,
+    pytest.ExitCode.NO_TESTS_COLLECTED,
+}
+SESSION_CHECK_ORIGIN = "infrahub-test-session"
+SESSION_ERROR_MESSAGES: dict[int, str] = {
+    pytest.ExitCode.INTERRUPTED: (
+        "The test session was interrupted before any test could run, usually because a file under "
+        "tests/ could not be collected. No Infrahub test was executed."
+    ),
+    pytest.ExitCode.USAGE_ERROR: (
+        "The test session could not start, usually because tests/conftest.py could not be imported. "
+        "No Infrahub test was executed."
+    ),
+    pytest.ExitCode.INTERNAL_ERROR: (
+        "The test session stopped on an internal pytest error. No Infrahub test was executed."
+    ),
+}
+DEFAULT_SESSION_ERROR_MESSAGE = "The test session did not complete, so no Infrahub test result is available."
 ORDER_TYPE_MAP = {"infrahub_smoke": 0, "infrahub_unit": 1, "infrahub_integration": 2}
 ORDER_ITEM_MAP = {
     "infrahub_check": 0,
@@ -26,6 +49,9 @@ class InfrahubBackendPlugin:
 
         self.proposed_change: InfrahubNodeSync
         self.validator: InfrahubNodeSync
+        self.validator_loaded = False
+        self.test_loop_reached = False
+        self.outcome_recorded = False
         self.checks: dict[str, InfrahubNodeSync] = {}
 
     def get_repository_validator(self) -> tuple[InfrahubNodeSync, bool]:
@@ -85,12 +111,16 @@ class InfrahubBackendPlugin:
         filtered_items.sort(key=sort_key)
         items[:] = filtered_items
 
-    def pytest_collection_finish(self, session: pytest.Session) -> None:  # noqa: ARG002
-        """This function is called when tests have been collected and modified, meaning they are ready to be run."""
+    def load_validator(self) -> None:
+        """Fetch or create the RepositoryValidator along with the checks recorded by a previous run."""
+        if self.validator_loaded:
+            return
+
         self.proposed_change = self.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=self.proposed_change_id)
         self.proposed_change.validations.fetch()
 
         self.validator, is_new_validator = self.get_repository_validator()
+        self.validator_loaded = True
         # Workaround for https://github.com/opsmill/infrahub/issues/2184
         if not is_new_validator:
             self.validator.checks.fetch()
@@ -98,8 +128,13 @@ class InfrahubBackendPlugin:
                 check = relationship.peer
                 self.checks[check.origin.value] = check
 
+    def pytest_collection_finish(self, session: pytest.Session) -> None:  # noqa: ARG002
+        """This function is called when tests have been collected and modified, meaning they are ready to be run."""
+        self.load_validator()
+
     def pytest_runtestloop(self, session: pytest.Session) -> object | None:  # noqa: ARG002
         """This function is called when the test loop is being run."""
+        self.test_loop_reached = True
         self.validator.conclusion.value = "unknown"
         self.validator.state.value = "in_progress"
         self.validator.started_at.value = Timestamp().to_string()
@@ -147,16 +182,70 @@ class InfrahubBackendPlugin:
         # Workaround for https://github.com/opsmill/infrahub/issues/2184
         check.update(do_full_update=True)
 
-    def pytest_sessionfinish(self, session: pytest.Session) -> None:  # noqa: ARG002
+    def pytest_sessionfinish(self, session: pytest.Session, exitstatus: int | pytest.ExitCode) -> None:  # noqa: ARG002
         """Set the final RepositoryValidator details after completing the test session."""
-        conclusion = "success"
+        self.record_outcome(exitstatus)
 
-        for check in self.checks.values():
-            if check.conclusion.value == "failure":
+    def record_outcome(self, exitstatus: int | pytest.ExitCode) -> None:
+        """Save the final RepositoryValidator details for the session.
+
+        Also called by the runner, because pytest can give up before the session starts and in that
+        case no hook of this plugin ever runs.
+        """
+        if self.outcome_recorded:
+            return
+
+        self.load_validator()
+        # pytest can also stop with a passing exit code before reaching the tests, for instance when
+        # the SDK plugin aborts on an unusable Infrahub address.
+        session_failed = not self.test_loop_reached or exitstatus not in COMPLETED_SESSION_EXIT_CODES
+
+        conclusion = "success"
+        for origin, check in self.checks.items():
+            if origin != SESSION_CHECK_ORIGIN and check.conclusion.value == "failure":
                 conclusion = check.conclusion.value
                 break
+
+        if session_failed:
+            conclusion = "failure"
+        self._record_session_check(exitstatus=exitstatus, failed=session_failed)
 
         self.validator.state.value = "completed"
         self.validator.completed_at.value = Timestamp().to_string()
         self.validator.conclusion.value = conclusion
         self.validator.save()
+        self.outcome_recorded = True
+
+    def _record_session_check(self, exitstatus: int | pytest.ExitCode, failed: bool) -> None:
+        """Report a session that produced no result, which would otherwise only reach the git agent logs."""
+        check = self.checks.get(SESSION_CHECK_ORIGIN)
+        if check is None and not failed:
+            return
+
+        message = SESSION_ERROR_MESSAGES.get(exitstatus, DEFAULT_SESSION_ERROR_MESSAGE) if failed else ""
+        created_at = Timestamp().to_string()
+
+        if check is None:
+            check = self.client.create(
+                kind=InfrahubKind.STANDARDCHECK,
+                data={
+                    "name": "test-session",
+                    "origin": SESSION_CHECK_ORIGIN,
+                    "kind": "TestReport",
+                    "validator": self.validator.id,
+                    "created_at": created_at,
+                    "message": message,
+                    "severity": "error",
+                    "conclusion": "failure",
+                },
+            )
+            self.checks[SESSION_CHECK_ORIGIN] = check
+            check.save()
+            return
+
+        # A check left over from an earlier run has to be cleared, or it outlives the problem it reported.
+        check.message.value = message
+        check.created_at.value = created_at
+        check.severity.value = "error" if failed else "success"
+        check.conclusion.value = "failure" if failed else "success"
+        check.save()

--- a/backend/tests/unit/proposed_change/test_repository_user_tests.py
+++ b/backend/tests/unit/proposed_change/test_repository_user_tests.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from infrahub_sdk.client import Config as InfrahubClientConfig
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.proposed_change.tasks import _run_repository_tests
+from infrahub.pytest_plugin import SESSION_CHECK_ORIGIN, InfrahubBackendPlugin
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+ADDRESS = "http://localhost:8000"
+
+REPOSITORY_CONFIG = """---
+jinja2_transforms:
+  - name: my_transform
+    query: my_query
+    template_path: templates/my_template.j2
+"""
+
+PASSING_INFRAHUB_TEST = """---
+infrahub_tests:
+  - resource: Jinja2Transform
+    resource_name: my_transform
+    tests:
+      - name: smoke_test
+        spec:
+          kind: jinja2-transform-smoke
+"""
+
+# `resource` is not a value the loader knows, so building the test file model raises during collect().
+MALFORMED_INFRAHUB_TEST = """---
+infrahub_tests:
+  - resource: NotAResourceKind
+    resource_name: my_transform
+    tests:
+      - name: smoke_test
+        spec:
+          kind: jinja2-transform-smoke
+"""
+
+BROKEN_PYTHON_TEST = """import a_module_that_does_not_exist  # noqa: F401
+
+
+def test_something_the_user_cares_about() -> None:
+    assert True
+"""
+
+BROKEN_CONFTEST = "import a_module_that_does_not_exist  # noqa: F401\n"
+
+
+# Fields the plugin reads back as `node.<field>.id` rather than `node.<field>.value`.
+RELATIONSHIP_FIELDS = {"repository", "proposed_change", "validator"}
+
+
+@dataclass
+class FakeAttribute:
+    value: Any = None
+
+
+@dataclass
+class FakeReference:
+    id: str
+
+
+@dataclass
+class FakePeer:
+    peer: FakeNode
+
+
+class FakeRelationship:
+    def __init__(self) -> None:
+        self.peers: list[FakePeer] = []
+
+    def fetch(self) -> None:
+        return None
+
+
+class FakeNode:
+    """Stands in for InfrahubNodeSync, whose fields are read and written as `node.<field>.value`."""
+
+    def __init__(
+        self,
+        node_id: str,
+        typename: str,
+        data: dict[str, Any] | None = None,
+        relationships: tuple[str, ...] = (),
+    ) -> None:
+        self.id = node_id
+        self.typename = typename
+        self.save_count = 0
+
+        fields: dict[str, Any] = {name: FakeRelationship() for name in relationships}
+        for name, value in (data or {}).items():
+            fields[name] = (
+                FakeReference(id=value if isinstance(value, str) else value.id)
+                if name in RELATIONSHIP_FIELDS
+                else FakeAttribute(value)
+            )
+        self._fields = fields
+
+    def __getattr__(self, name: str) -> Any:
+        fields = self.__dict__["_fields"]
+        if name not in fields:
+            fields[name] = FakeAttribute()
+        return fields[name]
+
+    def save(self) -> None:
+        self.save_count += 1
+
+    def update(self, do_full_update: bool = False) -> None:
+        self.save_count += 1
+
+
+class FakeClient:
+    """Stands in for the Infrahub instance, keeping what the plugin writes so a re-run can find it."""
+
+    def __init__(self) -> None:
+        self.config = InfrahubClientConfig(address=ADDRESS)
+        self.proposed_change = FakeNode(node_id="pc-1", typename="CoreProposedChange", relationships=("validations",))
+        self.nodes: list[FakeNode] = []
+
+    def get(self, kind: str, id: str, **kwargs: Any) -> FakeNode:
+        return self.proposed_change
+
+    def create(self, kind: str, data: dict[str, Any]) -> FakeNode:
+        node = FakeNode(node_id=f"{kind}-{len(self.nodes)}", typename=kind, data=data, relationships=("checks",))
+        self.nodes.append(node)
+
+        if kind == InfrahubKind.REPOSITORYVALIDATOR:
+            self.proposed_change.validations.peers.append(FakePeer(peer=node))
+        elif kind == InfrahubKind.STANDARDCHECK:
+            for candidate in self.nodes:
+                if candidate.id == data["validator"]:
+                    candidate.checks.peers.append(FakePeer(peer=node))
+
+        return node
+
+    def session_checks(self) -> list[FakeNode]:
+        return [node for node in self.nodes if node.origin.value == SESSION_CHECK_ORIGIN]
+
+
+@dataclass
+class Repository:
+    directory: Path
+    config_file: Path
+    tests: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.tests = self.directory / "tests"
+
+
+def build_repository(
+    root: Path,
+    *,
+    infrahub_test: str | None = None,
+    python_test: str | None = None,
+    conftest: str | None = None,
+) -> Repository:
+    directory = root / "user_repository"
+    (directory / "tests").mkdir(parents=True)
+    (directory / "templates").mkdir()
+
+    config_file = directory / ".infrahub.yml"
+    config_file.write_text(REPOSITORY_CONFIG, encoding="utf-8")
+    (directory / "templates" / "my_template.j2").write_text("hello {{ name }}\n", encoding="utf-8")
+
+    if infrahub_test is not None:
+        (directory / "tests" / "test_infrahub.yml").write_text(infrahub_test, encoding="utf-8")
+    if python_test is not None:
+        (directory / "tests" / "test_user_code.py").write_text(python_test, encoding="utf-8")
+    if conftest is not None:
+        (directory / "tests" / "conftest.py").write_text(conftest, encoding="utf-8")
+
+    return Repository(directory=directory, config_file=config_file)
+
+
+@dataclass
+class SessionResult:
+    exit_code: int | pytest.ExitCode
+    validator: FakeNode | None
+    tests_run: list[str]
+
+    @property
+    def conclusion(self) -> str | None:
+        return self.validator.conclusion.value if self.validator else None
+
+    @property
+    def state(self) -> str | None:
+        return self.validator.state.value if self.validator else None
+
+
+# The session under test runs nested inside this one, so it has to be cut off from the plugins of
+# the outer run. A git agent only ever has the SDK plugin loaded, which is what this reproduces.
+ISOLATED_SESSION_ENV = {
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+    "PYTEST_ADDOPTS": "-p infrahub_sdk.pytest_plugin.plugin",
+}
+
+
+def run_repository_tests(
+    repository: Repository,
+    client: FakeClient | None = None,
+    address: str | None = ADDRESS,
+) -> SessionResult:
+    client = client or FakeClient()
+    with (
+        patch.dict(os.environ, ISOLATED_SESSION_ENV),
+        patch("infrahub.pytest_plugin.InfrahubClientSync", return_value=client),
+    ):
+        plugin = InfrahubBackendPlugin(
+            config=client.config,
+            repository_id="repository-1",
+            proposed_change_id="pc-1",
+        )
+        exit_code = _run_repository_tests(
+            test_directory=repository.tests,
+            config_file=str(repository.config_file),
+            address=address,
+            plugin=plugin,
+        )
+
+    tests_run = [nodeid for nodeid in plugin.checks if "::" in nodeid]
+    return SessionResult(
+        exit_code=exit_code,
+        validator=plugin.validator if plugin.validator_loaded else None,
+        tests_run=tests_run,
+    )
+
+
+def test_infrahub_tests_still_run_when_a_user_python_test_cannot_be_imported(tmp_path: Path) -> None:
+    """A user's own broken test file must not stop the Infrahub tests from running."""
+    repository = build_repository(tmp_path, infrahub_test=PASSING_INFRAHUB_TEST, python_test=BROKEN_PYTHON_TEST)
+
+    result = run_repository_tests(repository)
+
+    assert len(result.tests_run) == 1
+    assert result.tests_run[0].endswith("infrahub_jinja2_transform__my_transform__smoke_test")
+    assert result.conclusion == "success"
+
+
+def test_user_python_tests_are_never_executed(tmp_path: Path) -> None:
+    """Only Infrahub tests belong to this session, so a user's passing test must not be collected either."""
+    passing_python_test = "def test_something_the_user_cares_about() -> None:\n    assert True\n"
+    repository = build_repository(tmp_path, infrahub_test=PASSING_INFRAHUB_TEST, python_test=passing_python_test)
+
+    result = run_repository_tests(repository)
+
+    assert not [nodeid for nodeid in result.tests_run if "test_user_code" in nodeid]
+    assert len(result.tests_run) == 1
+
+
+def test_validator_reports_failure_when_a_test_file_cannot_be_collected(tmp_path: Path) -> None:
+    """Collection is interrupted, so no test runs — the validator must not claim success."""
+    repository = build_repository(tmp_path, infrahub_test=MALFORMED_INFRAHUB_TEST)
+
+    result = run_repository_tests(repository)
+
+    assert result.tests_run == []
+    assert result.conclusion == "failure"
+    assert result.state == "completed"
+
+
+def test_validator_reports_failure_when_conftest_cannot_be_imported(tmp_path: Path) -> None:
+    """The session gives up before it starts, so the outcome has to be recorded by the caller."""
+    repository = build_repository(tmp_path, infrahub_test=PASSING_INFRAHUB_TEST, conftest=BROKEN_CONFTEST)
+
+    result = run_repository_tests(repository)
+
+    assert result.tests_run == []
+    assert result.conclusion == "failure"
+    assert result.state == "completed"
+
+
+def test_validator_reports_failure_when_the_session_stops_before_the_tests(tmp_path: Path) -> None:
+    """An unusable address makes the SDK plugin bail out with a passing exit code — still no result."""
+    repository = build_repository(tmp_path, infrahub_test=PASSING_INFRAHUB_TEST)
+
+    result = run_repository_tests(repository, address=None)
+
+    assert result.tests_run == []
+    assert result.conclusion == "failure"
+    assert result.state == "completed"
+
+
+def test_fixing_the_repository_clears_the_reported_session_failure(tmp_path: Path) -> None:
+    """The validator is reused across runs, so the failure of an earlier run must not outlive it."""
+    client = FakeClient()
+    repository = build_repository(tmp_path, infrahub_test=MALFORMED_INFRAHUB_TEST)
+
+    first_run = run_repository_tests(repository, client=client)
+    assert first_run.conclusion == "failure"
+
+    (repository.tests / "test_infrahub.yml").write_text(PASSING_INFRAHUB_TEST, encoding="utf-8")
+    second_run = run_repository_tests(repository, client=client)
+
+    assert second_run.conclusion == "success"
+    assert len(client.session_checks()) == 1
+    assert client.session_checks()[0].conclusion.value == "success"
+
+
+def test_failing_infrahub_test_still_reports_failure(tmp_path: Path) -> None:
+    """A test that runs and fails must keep driving the conclusion, not be masked by the exit code."""
+    repository = build_repository(tmp_path, infrahub_test=PASSING_INFRAHUB_TEST)
+    # The smoke test parses the template, so invalid Jinja2 syntax fails it at call time.
+    (repository.directory / "templates" / "my_template.j2").write_text("hello {{ name %}\n", encoding="utf-8")
+
+    result = run_repository_tests(repository)
+
+    assert len(result.tests_run) == 1
+    assert result.conclusion == "failure"
+    assert result.state == "completed"

--- a/changelog/2221.fixed.md
+++ b/changelog/2221.fixed.md
@@ -1,0 +1,1 @@
+Fixed repository tests in a proposed change reporting success when no test had run. A Python test file belonging to the repository is no longer imported while collecting Infrahub tests, and a test session that ends before the tests run is now reported as a failure with the reason attached to the validator.

--- a/docs/docs/testing-framework/overview.mdx
+++ b/docs/docs/testing-framework/overview.mdx
@@ -140,6 +140,10 @@ Tests can also run as part of the Infrahub CI pipeline. This is a feature which 
 
 This means that the Infrahub Task worker will take care of running the `pytest` process on behalf of users after creating a proposed change or updating it with new changes. User defined tests, if found, will be run as part of the CI pipeline and be logged in checks. One check per test is created which allows to see the outcome of it and an optional message that gives more details in case of failure.
 
+Only the YAML test files described above take part in this pipeline. Python test files that a repository keeps under `tests/` for its own purposes are not collected, so they neither run nor interfere with the Infrahub tests.
+
+When the test session cannot run at all, for example because a test file or a `conftest.py` cannot be parsed, the repository validator reports a failure and the reason is recorded as a check. A validator concludes successfully only once the Infrahub tests have actually run.
+
 ## How testing work
 
 :::note


### PR DESCRIPTION
# Why

Repository tests in a proposed change reported `success` whenever the pytest session ended before the test loop ran. The conclusion was derived from a check collection that is empty in exactly that case, so a proposed change could show a green repository validator while zero tests executed.

A single `test_*.py` belonging to the repository was enough to trigger it: pytest imported it during collection, an import error interrupted the session, and the validator was still saved as completed/success.

Goal: a repository validator that is green only when the Infrahub tests actually ran.

Non-goal: no change to the SDK's pytest plugin. Someone running `pytest` in their own repository should keep collecting their own tests.

Closes #2221

## What changed

Behavioral changes:

- A repository's own Python test files are no longer imported while collecting Infrahub tests, so a broken file that is not ours to run can no longer interrupt the session. Infrahub tests come from YAML and are unaffected.
- A session that ends before the tests run now concludes `failure` instead of `success`, with the reason attached to the validator as a check rather than only reaching the git agent logs.
- That covers three ways the session can end early: collection interrupted, a `tests/conftest.py` that cannot be imported (pytest gives up before any plugin hook runs, so the runner records the outcome), and the SDK plugin aborting during startup on an unusable address — which exits with a *passing* code.

What stayed the same: no schema or API changes. A session that runs its tests concludes exactly as before, and a failing test still drives the validator to `failure`.

Implementation note: the `pytest.main()` call moved into a module-level `_run_repository_tests` so this is testable without a live Infrahub.

## How to review

Start with `record_outcome` in `backend/infrahub/pytest_plugin.py` — that is where the false pass lived. Then `_run_repository_tests` in `backend/infrahub/proposed_change/tasks.py`.

Worth extra scrutiny: `_record_session_check`. The validator is reused across runs, so a session-failure check from an earlier run has to be cleared when a later run succeeds, or it outlives the problem it reported.

## How to test

```bash
uv run pytest backend/tests/unit/proposed_change/test_repository_user_tests.py
```

The seven tests run a real nested pytest session against a generated repository fixture and assert on the validator conclusion, not just the exit code. Each was watched failing before the fix, and each of the five production changes was reverted individually to confirm a distinct test catches it.

Manually: add a repository with a `tests/test_anything.py` that fails to import, open a proposed change, and confirm the validator now reports a failure explaining that no test ran.

## Impact & rollout

- **Backward compatibility:** nothing breaks. Repositories whose tests already ran keep the same conclusion; this only affects sessions that previously produced a result that was not real.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy. Proposed changes that were silently passing will start reporting a real failure — that is the point, and the attached check explains why.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] External docs updated
- [ ] Internal .md docs updated (no internal docs cover this area)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

