### PR TITLE
fix: reject artifacts whose transform returned no payload (closes #5303)

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -180,6 +180,31 @@ class ObjectImportPlan:
     artifact_definitions: dict[str, InfrahubRepositoryArtifactDefinitionConfig]
 
 
+def serialize_artifact_content(
+    content: Any, content_type: str, repository_name: str, commit: str, location: str
+) -> str:
+    """Convert the payload returned by a transform into the content stored for an artifact.
+
+    Raises:
+        TransformError: When the transform returned no payload.
+
+    """
+    if content is None:
+        raise TransformError(
+            repository_name=repository_name,
+            commit=commit,
+            location=location,
+            message=f"The transform at {location} did not return a payload",
+        )
+
+    if content_type == ContentType.APPLICATION_JSON.value and isinstance(content, dict):
+        return ujson.dumps(content, indent=2)
+    if content_type == ContentType.APPLICATION_YAML.value and isinstance(content, dict):
+        return yaml.dump(content, indent=2)
+
+    return str(content)
+
+
 class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     """This class provides interfaces to read and process information from .infrahub.yml files and can perform.
 
@@ -1725,9 +1750,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         )
 
         if transformation.typename == InfrahubKind.TRANSFORMJINJA2:
+            transformation_location = transformation.template_path.value
             artifact_content = await self.render_jinja2_template.with_options(
                 timeout_seconds=transformation.timeout.value
-            )(commit=commit, location=transformation.template_path.value, data=response)  # type: ignore[call-overload]
+            )(commit=commit, location=transformation_location, data=response)  # type: ignore[call-overload]
         elif transformation.typename == InfrahubKind.TRANSFORMPYTHON:
             transformation_location = f"{transformation.file_path.value}::{transformation.class_name.value}"
             artifact_content = await self.execute_python_transform.with_options(
@@ -1741,12 +1767,13 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 convert_query_response=transformation.convert_query_response.value,
             )  # type: ignore[call-overload]
 
-        if definition.content_type.value == ContentType.APPLICATION_JSON.value and isinstance(artifact_content, dict):
-            artifact_content_str = ujson.dumps(artifact_content, indent=2)
-        elif definition.content_type.value == ContentType.APPLICATION_YAML.value and isinstance(artifact_content, dict):
-            artifact_content_str = yaml.dump(artifact_content, indent=2)
-        else:
-            artifact_content_str = str(artifact_content)
+        artifact_content_str = serialize_artifact_content(
+            content=artifact_content,
+            content_type=definition.content_type.value,
+            repository_name=self.name,
+            commit=commit,
+            location=transformation_location,
+        )
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
 
@@ -1801,12 +1828,13 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 convert_query_response=message.convert_query_response,
             )  # type: ignore[call-overload]
 
-        if message.content_type == ContentType.APPLICATION_JSON.value and isinstance(artifact_content, dict):
-            artifact_content_str = ujson.dumps(artifact_content, indent=2)
-        elif message.content_type == ContentType.APPLICATION_YAML.value and isinstance(artifact_content, dict):
-            artifact_content_str = yaml.dump(artifact_content, indent=2)
-        else:
-            artifact_content_str = str(artifact_content)
+        artifact_content_str = serialize_artifact_content(
+            content=artifact_content,
+            content_type=message.content_type,
+            repository_name=self.name,
+            commit=message.commit,
+            location=message.transform_location,
+        )
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
 

--- a/backend/tests/component/git/conftest.py
+++ b/backend/tests/component/git/conftest.py
@@ -417,19 +417,20 @@ async def git_repo_transforms(
     """Git Repository with git_upstream_repo_02 as remote.
 
     The repo has 1 local branch: main.
-    The main branch contains 2 transforms: transform01 and transform02.
-    Transform01 will change to uppercase the keys in the data dict always and Transform02 is not valid.
+    The main branch contains 3 transforms: transform01, transform02 and transform03.
+    Transform01 will change to uppercase the keys in the data dict always, Transform02 is not valid and
+    Transform03 returns no payload.
     """
     checks_fixture_dir = get_fixtures_dir() / "transforms"
     upstream = Repo(git_upstream_repo_02["path"])
 
-    files_to_copy = ["transform01.py", "transform02.py"]
+    files_to_copy = ["transform01.py", "transform02.py", "transform03.py"]
 
     for file_to_copy in files_to_copy:
         shutil.copyfile(checks_fixture_dir / file_to_copy, git_upstream_repo_02["path"] / file_to_copy)
         upstream.index.add(file_to_copy)
 
-    upstream.index.commit("Add 2 Transforms files")
+    upstream.index.commit("Add 3 Transforms files")
 
     return await InfrahubRepository.new(
         id=UUIDT.new(),

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -14,6 +14,8 @@ from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.uuidt import UUIDT
 from pytest_httpx._httpx_mock import HTTPXMock
 
+from infrahub.auth.session import AnonymousSession
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.registry import registry
@@ -35,6 +37,7 @@ from infrahub.git.integrator import (
     ArtifactGenerateResult,
     CheckDefinitionInformation,
 )
+from infrahub.git.models import RequestArtifactGenerate
 from infrahub.git.sync import RepositoryFileImporter, RepositorySyncer
 from infrahub.git.worktree import Worktree
 from infrahub.lock import InfrahubLockRegistry
@@ -915,6 +918,50 @@ async def test_artifact_generate_jinja2_new(
         artifact_id=artifact_node_01.id,
     )
     assert result == expected_data
+
+
+async def test_render_artifact_python_without_payload(
+    client: InfrahubClient,
+    prefect_test_fixture: None,
+    git_repo_transforms_w_client: InfrahubRepository,
+    artifact_node_01: InfrahubNode,
+    mock_gql_query_03: HTTPXMock,
+) -> None:
+    repo = git_repo_transforms_w_client
+    commit_main = repo.get_commit_value(branch_name="main", remote=False)
+    branch = Branch(name="main", uuid=uuid4())
+    registry.branch[branch.name] = branch
+
+    message = RequestArtifactGenerate(
+        artifact_name="myartifact",
+        artifact_definition="c4908d78-7b24-45e2-9252-96d0fb3e2c78",
+        artifact_definition_name="artifactdef01",
+        commit=commit_main,
+        content_type="text/plain",
+        transform_type=InfrahubKind.TRANSFORMPYTHON,
+        transform_location="transform03.py::Transform03",
+        repository_id=str(repo.id),
+        repository_name=repo.name,
+        repository_kind=InfrahubKind.REPOSITORY,
+        branch_name=branch.name,
+        target_id="b663d7a4-5f95-48dd-b04d-e03169e7fcf3",
+        target_kind="TestElectricCar",
+        target_name="bolt",
+        query="my_query",
+        query_id="47800bff-adf1-450d-8388-b04ef2ffb129",
+        timeout=10,
+        variables={"name": "bolt"},
+        context=InfrahubContext(branch=BranchContext(name=branch.name), account=AnonymousSession()),
+    )
+
+    with pytest.raises(
+        TransformError, match=r"^The transform at transform03\.py::Transform03 did not return a payload$"
+    ):
+        await repo.render_artifact(artifact=artifact_node_01, artifact_created=True, message=message)
+
+    assert artifact_node_01.status.value == "Pending"
+    assert artifact_node_01.checksum.value is None
+    assert artifact_node_01.storage_id.value is None
 
 
 async def test_execute_python_transform_file_missing(

--- a/backend/tests/fixtures/transforms/transform03.py
+++ b/backend/tests/fixtures/transforms/transform03.py
@@ -1,0 +1,14 @@
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class Transform03(InfrahubTransform):
+    """Transform without a payload, as happens when conditional logic returns early."""
+
+    query = "my_query"
+    url = "transform03"
+
+    def transform(self, data: dict) -> None:
+        return None
+
+
+INFRAHUB_TRANSFORMS = [Transform03]

--- a/backend/tests/unit/git/test_integrator.py
+++ b/backend/tests/unit/git/test_integrator.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
-import ujson
-import yaml
 
 from infrahub.core.constants import ContentType
 from infrahub.exceptions import TransformError
@@ -23,13 +21,13 @@ SERIALIZATION_CASES = [
         name="dict_as_json",
         content={"key1": "value1"},
         content_type=ContentType.APPLICATION_JSON.value,
-        expected=ujson.dumps({"key1": "value1"}, indent=2),
+        expected='{\n  "key1": "value1"\n}',
     ),
     SerializationCase(
         name="dict_as_yaml",
         content={"key1": "value1"},
         content_type=ContentType.APPLICATION_YAML.value,
-        expected=yaml.dump({"key1": "value1"}, indent=2),
+        expected="key1: value1\n",
     ),
     SerializationCase(
         name="string_as_text",

--- a/backend/tests/unit/git/test_integrator.py
+++ b/backend/tests/unit/git/test_integrator.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import ujson
+import yaml
+
+from infrahub.core.constants import ContentType
+from infrahub.exceptions import TransformError
+from infrahub.git.integrator import serialize_artifact_content
+
+
+@dataclass
+class SerializationCase:
+    name: str
+    content: Any
+    content_type: str
+    expected: str
+
+
+SERIALIZATION_CASES = [
+    SerializationCase(
+        name="dict_as_json",
+        content={"key1": "value1"},
+        content_type=ContentType.APPLICATION_JSON.value,
+        expected=ujson.dumps({"key1": "value1"}, indent=2),
+    ),
+    SerializationCase(
+        name="dict_as_yaml",
+        content={"key1": "value1"},
+        content_type=ContentType.APPLICATION_YAML.value,
+        expected=yaml.dump({"key1": "value1"}, indent=2),
+    ),
+    SerializationCase(
+        name="string_as_text",
+        content="Lorem ipsum",
+        content_type=ContentType.TEXT_PLAIN.value,
+        expected="Lorem ipsum",
+    ),
+    SerializationCase(
+        name="empty_string_is_a_valid_payload",
+        content="",
+        content_type=ContentType.TEXT_PLAIN.value,
+        expected="",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", SERIALIZATION_CASES, ids=lambda c: c.name)
+def test_serialize_artifact_content(case: SerializationCase) -> None:
+    assert (
+        serialize_artifact_content(
+            content=case.content,
+            content_type=case.content_type,
+            repository_name="my-repository",
+            commit="d9b3b6f9e2c0a1d4e5f60718293a4b5c6d7e8f90",
+            location="transform01.py::Transform01",
+        )
+        == case.expected
+    )
+
+
+def test_serialize_artifact_content_without_payload() -> None:
+    with pytest.raises(
+        TransformError, match=r"^The transform at transform01\.py::Transform01 did not return a payload$"
+    ):
+        serialize_artifact_content(
+            content=None,
+            content_type=ContentType.TEXT_PLAIN.value,
+            repository_name="my-repository",
+            commit="d9b3b6f9e2c0a1d4e5f60718293a4b5c6d7e8f90",
+            location="transform01.py::Transform01",
+        )

--- a/changelog/5303.fixed.md
+++ b/changelog/5303.fixed.md
@@ -1,0 +1,1 @@
+Fixed artifact generation storing the text None when a transform returned no data, it now fails with an error naming the transform instead.


### PR DESCRIPTION
# Why

When an artifact definition uses a Python transform that returns nothing — the normal outcome of a
`try/except` or an early `return` — artifact rendering had nothing to serialize and never noticed.
The reporter saw the pipeline fail with `Failed to render artifact: encoding without a string argument`,
which says nothing about the real problem.

The symptom has since changed, and got worse. Commit `3bcf0e136` replaced the `text/plain` branch with a
`str()` fallback, so current `stable` raises nothing at all: `str(None)` produces the four-character
string `"None"`, which is checksummed, uploaded to the object store and saved with status `Ready`. The
defect degraded from a wrong error message into silent data corruption — for an `application/json`
artifact, into a body that is not even valid JSON.

Goal: fail the artifact with an error that names the transform that produced no payload.

Non-goals: the neighbouring `str()` fallback for non-`dict` JSON/YAML payloads is left alone (a transform
returning a `list` for `application/json` still yields a Python repr). Real, but a separate defect with a
different blast radius.

Closes #5303

## What changed

Behavioral changes:

- An artifact whose transform returns no payload now fails with
  `The transform at <location> did not return a payload` instead of storing the text `None` and reporting
  success. Surfaced by the artifact check as
  `Failed to render artifact: The transform at transforms/foo.py::Foo did not return a payload`.
- The artifact is left with status `Error` and nothing is uploaded to the object store.

Implementation notes:

- The serialization block was duplicated verbatim in `render_artifact` and `artifact_generate`, so a guard
  clause would have had to be written twice and could drift. It now lives in one module-level
  `serialize_artifact_content()` in `backend/infrahub/git/integrator.py`, which rejects a missing payload
  before serializing. Both call sites are validated by construction.
- The guard is `content is None`, not a truthiness test: `""` and `{}` are legitimate artifact payloads and
  must keep working. There is a test case pinning that.
- `TransformError` was chosen because it is what `execute_python_transform` already raises for its own
  failures, and because both callers of `render_artifact` already catch `Exception`, set the artifact status
  to `Error` and surface `str(exc)`. No change was needed in `artifacts/tasks.py` or `git/tasks.py`.
- In `artifact_generate` the Jinja2 branch now assigns `transformation_location` before use, so the helper
  can be given a location for both transform types.

What stayed the same: no schema changes, no GraphQL or REST API changes, no migrations. The check-message
plumbing in `backend/infrahub/artifacts/tasks.py` and `backend/infrahub/git/tasks.py` is untouched. The
`isinstance(..., dict)` dispatch semantics for JSON and YAML are unchanged, so existing artifact content
and checksums are unaffected.

## How to review

Start with `backend/infrahub/git/integrator.py` — the new `serialize_artifact_content()` and the two call
sites that replace the duplicated block. Everything else is test scaffolding: the component test in
`backend/tests/component/git/test_git_repository.py` drives the production path end to end, and
`backend/tests/unit/git/test_integrator.py` pins the serialization matrix around it, including the
empty-string case.

The part worth extra scrutiny is the deliberate absence of an object-store mock in the new test. Adding one
would make the test fail `pytest_httpx`'s "all registered responses were requested" check now that the fix
short-circuits before the upload — so its absence is what proves nothing is stored.

Alternative considered and rejected: pushing the check down into `execute_python_transform`. That task is
shared with webhooks, computed attributes and the REST transform endpoint, where a `None` result means
something different. "An artifact must have content" is a contract of artifact rendering, not of running a
transform.

## How to test

```bash
uv run pytest backend/tests/component/git/test_git_repository.py::test_render_artifact_python_without_payload -x -v
```

Passes on this branch. On `stable` it fails inside `integrator.py:1818` — `object_store.upload()` is called
with the string `"None"`, one line past the missing validation, which is the bug.

Wider run, no regressions:

```bash
uv run pytest backend/tests/unit/git backend/tests/component/git
uv run invoke backend.test-unit
```

`224 passed, 1 xfailed` for the git suites and `1407 passed` for the backend unit suite. `invoke format`
clean, `mypy` clean on `integrator.py`, `invoke backend.lint` reports the same 103 pre-existing `ty`
diagnostics as before this change (none in the files touched here — the two hits inside them are the
`from tests.conftest import TestHelper` warning that also appears in five sibling files). The generation
tasks (`backend.generate`, `schema.generate-*`, `docs.generate`) produce no diff, as expected for a change
that touches no schema, event, CLI or config surface.

## Impact & rollout

- **Backward compatibility:** a behavior change for anyone whose transform silently returned nothing. Those
  artifacts currently contain the text `None` and report success; they will now fail loudly with a named
  cause. That is the point of the fix, but it can surface pipelines that looked green.
- **Performance:** none.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) — N/A, no documented behavior changes
- [ ] Internal .md docs updated — N/A, no architectural change to record
- [x] I have reviewed AI generated content

<!-- AGENT_TEST_COMPLETE -->
<!-- AGENT_FIX_COMPLETE -->
