### PR TITLE
chore(types): enforce ty no-matching-overload for git/base.py

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -1103,11 +1103,12 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 error=error, name=self.name, location=self.location, branch_name=branch_name or self.default_branch
             )
         except RepositoryError as exc:
+            status_by_error: dict[type[RepositoryError], RepositoryOperationalStatus] = {
+                RepositoryConnectionError: RepositoryOperationalStatus.ERROR_CONNECTION,
+                RepositoryCredentialsError: RepositoryOperationalStatus.ERROR_CRED,
+            }
             await self._update_operational_status(
-                status={
-                    RepositoryConnectionError: RepositoryOperationalStatus.ERROR_CONNECTION,
-                    RepositoryCredentialsError: RepositoryOperationalStatus.ERROR_CRED,
-                }.get(type(exc), RepositoryOperationalStatus.ERROR)
+                status=status_by_error.get(type(exc), RepositoryOperationalStatus.ERROR)
             )
             raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1702,7 +1702,6 @@ unresolved-attribute = "ignore"
 
 [[tool.ty.overrides]]
 include = [
-    "backend/infrahub/git/base.py",
     "backend/infrahub/git/integrator.py",
     "backend/infrahub/git/repository.py",
     "backend/infrahub/git/tasks.py",


### PR DESCRIPTION
# Why

`backend/infrahub/git/**` carries per-file `ty` type-check debt in `pyproject.toml`, where each override's `include` list is the remaining to-do list for a rule. `base.py` had a single `no-matching-overload` violation keeping the whole file exempt from that rule.

Goal: resolve that one violation with a behaviour-neutral annotation and start enforcing `no-matching-overload` on `base.py`.

Non-goals: no attempt to clear the other `ty` debt rules on `base.py` (it stays exempt from `invalid-argument-type` and `invalid-return-type`).

## What changed

- Annotate the error-to-status mapping in `_raise_enriched_error` as `dict[type[RepositoryError], RepositoryOperationalStatus]` so `.get(type(exc), ...)` type-checks. The dict was previously an inline literal whose key type `ty` inferred too narrowly to match the `type[RepositoryError]` lookup key.
- Drop `base.py` from the `no-matching-overload` override list in `pyproject.toml`, enforcing that rule on the file going forward.

No runtime behaviour change: the mapping contents and lookup are identical, only annotated and hoisted to a local.

## How to review

Two small, coupled changes. The pyproject removal is only safe because `base.py:1107` was the file's sole `no-matching-overload` violation.

## How to test

```bash
uv run ty check .
```

Expected: `All checks passed!` (with `base.py` now enforced for `no-matching-overload`).

## Impact & rollout

- **Backward compatibility:** no behaviour change.
- **Performance:** none.
- **Config/env changes:** `pyproject.toml` `ty` override list tightened.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

