### PR TITLE
chore: upgrade ty to 0.0.69 and clear the new type-check violations

### DIFF
--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -120,15 +120,15 @@ class ObjectConflictValidatorRecorder:
             return validator_obj
 
     async def initialize_validator(self, validator: CoreValidator) -> None:
-        validator.state.value = ValidatorState.IN_PROGRESS.value  # type: ignore[misc]
-        validator.conclusion.value = ValidatorConclusion.UNKNOWN.value  # type: ignore[misc]
+        validator.state.value = ValidatorState.IN_PROGRESS.value  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        validator.conclusion.value = ValidatorConclusion.UNKNOWN.value  # type: ignore[misc]  # ty: ignore[invalid-assignment]
         validator.started_at.value = Timestamp().to_string()  # type: ignore[attr-defined]
         validator.completed_at.value = ""  # type: ignore[attr-defined]
         await validator.save(db=self.db)
 
     async def finalize_validator(self, validator: CoreValidator, is_success: bool) -> None:
-        validator.state.value = ValidatorState.COMPLETED.value  # type: ignore[misc]
-        validator.conclusion.value = (  # type: ignore[misc]
+        validator.state.value = ValidatorState.COMPLETED.value  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        validator.conclusion.value = (  # type: ignore[misc]  # ty: ignore[invalid-assignment]
             ValidatorConclusion.SUCCESS.value if is_success else ValidatorConclusion.FAILURE.value
         )
         validator.completed_at.value = Timestamp().to_string()  # type: ignore[attr-defined]

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1390,7 +1390,9 @@ def _get_cardinality_one_identifiers_by_kind(
         cardinality_one_rel_identifiers_in_fields = {
             rel_schema.identifier: rel_schema.direction
             for rel_schema in node_schema.relationships
-            if rel_schema.cardinality is RelationshipCardinality.ONE and rel_schema.name in field_names_set
+            if rel_schema.identifier is not None
+            and rel_schema.cardinality is RelationshipCardinality.ONE
+            and rel_schema.name in field_names_set
         }
         cardinality_one_fields_by_kind[node_schema.kind] = cardinality_one_rel_identifiers_in_fields
     return cardinality_one_fields_by_kind

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1388,11 +1388,9 @@ def _get_cardinality_one_identifiers_by_kind(
         if node_schema.kind in cardinality_one_fields_by_kind:
             continue
         cardinality_one_rel_identifiers_in_fields = {
-            rel_schema.identifier: rel_schema.direction
+            rel_schema.get_identifier(): rel_schema.direction
             for rel_schema in node_schema.relationships
-            if rel_schema.identifier is not None
-            and rel_schema.cardinality is RelationshipCardinality.ONE
-            and rel_schema.name in field_names_set
+            if rel_schema.cardinality is RelationshipCardinality.ONE and rel_schema.name in field_names_set
         }
         cardinality_one_fields_by_kind[node_schema.kind] = cardinality_one_rel_identifiers_in_fields
     return cardinality_one_fields_by_kind

--- a/backend/infrahub/core/merge/failure_recoverer.py
+++ b/backend/infrahub/core/merge/failure_recoverer.py
@@ -347,5 +347,5 @@ class MergeFailureRecoverer:
         if proposed_change is None:
             return
         # The state attribute is enum-backed: reads coerce back to the enum, writes take the raw value.
-        proposed_change.state.value = ProposedChangeState.OPEN.value  # type: ignore[misc]
+        proposed_change.state.value = ProposedChangeState.OPEN.value  # type: ignore[misc]  # ty: ignore[invalid-assignment]
         await proposed_change.save(db=self.db)

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -104,7 +104,7 @@ async def schema_path_migrate(
         if not migration_class:
             raise ValueError(f"Unable to find the migration class for {migration_name}")
 
-        migration = migration_class(  # type: ignore[call-arg]
+        migration = migration_class(  # type: ignore[call-arg]  # ty: ignore[missing-argument]
             new_node_schema=new_node_schema,  # type: ignore[arg-type]
             previous_node_schema=previous_node_schema,  # type: ignore[arg-type]
             schema_path=schema_path,

--- a/backend/infrahub/graphql/mutations/diff_conflict.py
+++ b/backend/infrahub/graphql/mutations/diff_conflict.py
@@ -76,6 +76,6 @@ class ResolveDiffConflict(Mutation):
             # Generated protocols type enum-backed attributes as stdlib `enum.Enum`, whose `.value`
             # is read-only. At runtime the attribute is an infrahub Enum/Dropdown with a writable
             # value.
-            cdc.keep_branch.value = keep_branch  # type: ignore[misc]
+            cdc.keep_branch.value = keep_branch  # type: ignore[misc]  # ty: ignore[invalid-assignment]
             await cdc.save(db=graphql_context.db)
         return cls(ok=True)

--- a/backend/tests/component/computed_attribute/_base.py
+++ b/backend/tests/component/computed_attribute/_base.py
@@ -156,7 +156,7 @@ class ScopedRecomputeTestBase(TestInfrahubAppBase):
 
     @staticmethod
     def _context(admin_account: CoreAccount, branch: Branch) -> EventContext:
-        account = AccountSession(auth_type=AuthType.JWT, authenticated=True, account_id=admin_account.id, role="admin")
+        account = AccountSession(auth_type=AuthType.JWT, authenticated=True, account_id=admin_account.id)
         return InfrahubContext.init(branch=branch, account=account).to_event_context()
 
     def _submitted_attribute_names(self, recorder: WorkflowRecorder) -> set[str]:

--- a/backend/tests/component/core/migrations/graph/test_031.py
+++ b/backend/tests/component/core/migrations/graph/test_031.py
@@ -46,7 +46,7 @@ class TestMigration031(TestInfrahubApp):
         await node.save()
 
         # Run the migration without strict mode, nothing should happen
-        migration = Migration031(db=db)
+        migration = Migration031()
         execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)
@@ -73,7 +73,7 @@ class TestMigration031(TestInfrahubApp):
 
         # Run the migration with strict mode to make sure it doesn't raise an error now that the node has been fixed
         config.SETTINGS.main.schema_strict_mode = True
-        migration = Migration031(db=db)
+        migration = Migration031()
         execution_result = await migration.execute(migration_input=MigrationInput(db=db))
         assert not execution_result.errors
 

--- a/backend/tests/component/core/migrations/graph/test_043_044.py
+++ b/backend/tests/component/core/migrations/graph/test_043_044.py
@@ -610,7 +610,7 @@ DETACH DELETE attr
     ) -> None:
         await branch.rebase(db=db)
         async with db.start_session() as dbs:
-            migration = Migration043(migrations=[])
+            migration = Migration043()
             execution_result = await migration.execute_against_branch(
                 migration_input=MigrationInput(db=dbs), branch=branch
             )
@@ -676,7 +676,7 @@ DETACH DELETE attr
 
         # test adding display label and HFID attributes on default branch
         async with db.start_session() as dbs:
-            migration = Migration043(migrations=[])
+            migration = Migration043()
             execution_result = await migration.execute(migration_input=MigrationInput(db=dbs))
             assert not execution_result.errors
 

--- a/backend/tests/component/git/test_git_rpc.py
+++ b/backend/tests/component/git/test_git_rpc.py
@@ -254,7 +254,6 @@ class TestAddReadOnly:
             infrahub_branch_name="read-only-branch",
             infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
             internal_status="active",
-            client=ANY,
         )
 
         self.mock_repo.import_objects_from_files = AsyncMock()

--- a/backend/tests/functional/convert_object_type/test_convert_repositories.py
+++ b/backend/tests/functional/convert_object_type/test_convert_repositories.py
@@ -244,7 +244,6 @@ class TestConvertRepository(TestInfrahubApp):
             client=service.client,
             ref=read_only_repo.ref.value,
             infrahub_branch_name=default_branch.name,
-            service=service,
         )
         repo_intern.validate_local_directories()
 
@@ -554,7 +553,6 @@ class TestConvertRepository(TestInfrahubApp):
             client=service.client,
             default_branch_name=branch.name,
             infrahub_branch_name=branch.name,
-            service=service,
         )
         repo_intern.validate_local_directories()
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -29,8 +29,7 @@ from tests.helpers.file_repo import FileRepo
 @pytest.fixture(scope="session")
 def event_loop() -> Generator:
     """Overrides pytest default function scoped event loop."""
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
+    loop = asyncio.new_event_loop()
     yield loop
     loop.close()
 

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -124,7 +124,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         self, schema_person_03_unique_fields: dict[str, Any]
     ) -> dict[str, Any]:
         """Rename the name attribute."""
-        updated_schema = {**schema_person_03_unique_fields}
+        updated_schema: dict[str, Any] = {**schema_person_03_unique_fields}
         for attr in updated_schema["attributes"]:
             if attr["name"] == "name":
                 attr["name"] = "real_name"
@@ -139,7 +139,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         self, schema_person_04_rename_original_unique_fields: dict[str, Any]
     ) -> dict[str, Any]:
         """Delete the name attribute."""
-        updated_schema = {**schema_person_04_rename_original_unique_fields}
+        updated_schema: dict[str, Any] = {**schema_person_04_rename_original_unique_fields}
         for attr in updated_schema["attributes"]:
             if attr["name"] == "real_name":
                 attr["state"] = "absent"
@@ -153,7 +153,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
     @pytest.fixture(scope="class")
     def schema_generic_06_delete_unique_field(self, schema_generic_01: dict[str, Any]) -> dict[str, Any]:
         """Delete the unique attribute."""
-        updated_schema = {**schema_generic_01}
+        updated_schema: dict[str, Any] = {**schema_generic_01}
         for attr in updated_schema["attributes"]:
             if attr["name"] == "unique_attr":
                 attr["state"] = "absent"

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -229,7 +229,7 @@ class TestLogForwardingExceptionHandler:
         assert response.status_code == 403
 
     async def test_no_log_forwarding_does_not_raise(self, request_fixture: RequestFixture) -> None:
-        request_fixture.mock_log_forwarding = None  # type: ignore[assignment]
+        request_fixture.mock_log_forwarding = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         request_fixture.request.app.state.service.log_forwarding = None
 
         response = await log_forwarding_exception_handler(request_fixture.request, PermissionDeniedError("denied"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dev = [
     "docker==7.1.0",
     "psutil==6.1.0",
     "jwcrypto==1.5.7",
-    "ty==0.0.32",
+    "ty==0.0.69",
     "prek>=0.3.0",
     "coverage==7.14.1",
     "pytest-playwright-asyncio>=0.8.0",
@@ -1410,6 +1410,7 @@ include = [
     "backend/infrahub/core/query/__init__.py",
     "backend/infrahub/core/query/ipam.py",
     "backend/infrahub/core/query/relationship.py",
+    "backend/infrahub/core/schema/basenode_schema.py",
 ]
 
 [tool.ty.overrides.rules]
@@ -1523,6 +1524,7 @@ include = [
     "backend/infrahub/graphql/mutations/schema.py",
     "backend/infrahub/graphql/queries/path.py",
     "backend/infrahub/graphql/queries/reachable.py",
+    "backend/infrahub/graphql/resolvers/resolver.py",
     "backend/infrahub/graphql/subscription/graphql_query.py",
 ]
 
@@ -1596,6 +1598,7 @@ include = [
     "backend/infrahub/graphql/mutations/proposed_change.py",
     "backend/infrahub/graphql/mutations/repository.py",
     "backend/infrahub/graphql/queries/diff/tree.py",
+    "backend/infrahub/graphql/utils.py",
 ]
 
 [tool.ty.overrides.rules]
@@ -1610,6 +1613,7 @@ include = [
     "backend/infrahub/graphql/mutations/node_getter/by_hfid.py",
     "backend/infrahub/graphql/mutations/node_getter/by_id.py",
     "backend/infrahub/graphql/mutations/profile.py",
+    "backend/infrahub/graphql/mutations/schema.py",
     "backend/infrahub/graphql/resolvers/ipam.py",
 ]
 
@@ -1642,6 +1646,7 @@ redundant-cast = "ignore"
 [[tool.ty.overrides]]
 include = [
     "backend/infrahub/graphql/manager.py",
+    "backend/infrahub/graphql/mutations/schema.py",
     "backend/infrahub/graphql/utils.py",
 ]
 
@@ -1879,6 +1884,17 @@ call-top-callable = "ignore"
 invalid-await = "ignore"
 no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
+
+[[tool.ty.overrides]]
+include = ["backend/infrahub/message_bus/operations/__init__.py"]
+
+[tool.ty.overrides.rules]
+##################################################################################################
+# COMMAND_MAP is a heterogeneous dispatch table: each handler takes a specific InfrahubMessage   #
+# subtype, but the dispatch site only has the base type. Scoped to this file so the rest of      #
+# message_bus/ stays enforced.                                                                    #
+##################################################################################################
+invalid-argument-type = "ignore"
 
 [[tool.ty.overrides]]
 include = ["backend/infrahub/artifacts/tasks.py"]

--- a/python_testcontainers/tests/test_container_postgres_backup.py
+++ b/python_testcontainers/tests/test_container_postgres_backup.py
@@ -39,7 +39,7 @@ def fixture_compose_factory(tmp_path: Path) -> Callable[[], InfrahubDockerCompos
 
         instance.get_container = _noop_service  # type: ignore[assignment]
         instance.start_container = _noop_service  # type: ignore[assignment]
-        instance.exec_calls: list[list[str]] = []
+        instance.exec_calls = []
 
         def _exec(command: list[str], service_name: str) -> tuple[str, str, int]:
             _ = service_name

--- a/uv.lock
+++ b/uv.lock
@@ -1603,7 +1603,7 @@ dev = [
     { name = "semver", specifier = ">=3.0.2,<4" },
     { name = "testcontainers", specifier = "==4.8.1" },
     { name = "towncrier", specifier = ">=24.8,<25" },
-    { name = "ty", specifier = "==0.0.32" },
+    { name = "ty", specifier = "==0.0.69" },
     { name = "types-cachetools", specifier = "==6.2.0.20250827" },
     { name = "types-python-slugify", specifier = ">=8.0.0.3,<9" },
     { name = "types-pyyaml" },
@@ -2622,8 +2622,8 @@ name = "pendulum"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "python_full_version < '3.13'" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
 wheels = [
@@ -4158,26 +4158,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.32"
+version = "0.0.69"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5b/7a618632dfe9373b7df572ecd7a08c8f799d772fbc317da82dd3aa363207/ty-0.0.69.tar.gz", hash = "sha256:b65106e9ff24fa76e25e1142fb09c85244e815c40450e3021d2bf652c231bb43", size = 6565094, upload-time = "2026-08-06T10:04:25.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
-    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
-    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
-    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
-    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
-    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
+    { url = "https://files.pythonhosted.org/packages/06/60/6534092f4d2c15e2491807edd609c2e50d527c1fed957acf40b9f110b64a/ty-0.0.69-py3-none-linux_armv6l.whl", hash = "sha256:98bfd383b273540829af673e7f98b9c1c4bcc8547d12a1a3806cd0bec7f0e087", size = 12364185, upload-time = "2026-08-06T10:03:47.137Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2b/5c29689bd4f74c2e3394d983d85e4011b629f2ce3730c9442553b8554bf8/ty-0.0.69-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:964621ddd05771660017c51b4e74078d861d9fc863c21ef2a500db1ab62c9ccf", size = 12042510, upload-time = "2026-08-06T10:03:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/09/46/fa085bde4d23516d7ef14b24736fc5dd7dc498f60f52b3d077e59ffdea20/ty-0.0.69-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ffea4048dd0da4c9c97393b4be0901098a9065b06fa81be2477cbde65d8a151", size = 11549397, upload-time = "2026-08-06T10:03:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/97b9efb2061dcab6fef1e94a4ad99df0bb45bd2cc15d4f5794c787ee0552/ty-0.0.69-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8684d4a70aadd1eab0f41bdba835e3288ef49db8402a8e6ca81bab52ed5d610", size = 12115567, upload-time = "2026-08-06T10:03:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c1/a5e0404965093835f3e62544e661784ec0aa8ef0b006ed50af50b19c107e/ty-0.0.69-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:afaaba240ab4122e2069a796836d10be81b4ddb053ae268b3dff962a0b4ca5c7", size = 12149770, upload-time = "2026-08-06T10:03:55.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/39/8cad6b205a4abe8a044ca0c84aea71e8ccda29b07a75a5f090e310605580/ty-0.0.69-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11ea63ef07d4e33aeb1a775cf5f2c736b3ed22fa6f8b1b608591612c36795044", size = 12941278, upload-time = "2026-08-06T10:03:58.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/8766d96b732c2a060d70dc8ccafcc4d6a54109a2a95f1deb0705de88892b/ty-0.0.69-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb3730b1268e92a2907d7aea3afe8dd1b360ae65862f0557080cf479d481b424", size = 13426509, upload-time = "2026-08-06T10:04:00.621Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1f/e991b2cde953ea5b94d6a9a4c45c87937bd916bc09235f764407bf471c0a/ty-0.0.69-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a544ff57a752ef186ed40b5a2f44c17402af4cdefeb74a311ca02ebd57c4fca0", size = 13106582, upload-time = "2026-08-06T10:04:02.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/bb/73538f1b99e3558fd9db87b98698426f0f60fc8666da0b1efd0e70e275eb/ty-0.0.69-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87ed2cbca20caddfdf8e3e14d213ce91b67e75feed78900f4aaf3ef884954028", size = 12708931, upload-time = "2026-08-06T10:04:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cd/484a5208d74c4ad1155933906295ccdce9aa81a257d8df2ab9e41bd60133/ty-0.0.69-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2684efcbce5b6fe45045faf610b377b50781b6d2aa7e61ea23ecf5b3d2bce421", size = 12985322, upload-time = "2026-08-06T10:04:07.587Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/81/b75003f0d4da9ab3bc8fd4f4802f836cb9921ff7e70f460604f7b769a0b5/ty-0.0.69-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:da9aeb26fdac1d2214937542b59e0d4d1ba94ec7a3f45444f33c846de1eb1d63", size = 12063910, upload-time = "2026-08-06T10:04:09.835Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/088469f547ef63dceefc4a75826aedee5014f9371dc5171cde931896a82c/ty-0.0.69-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:00e7677cd14ede381f705f71104ea7b8ea0ce217a8634e19a89781953de0e9ad", size = 12166823, upload-time = "2026-08-06T10:04:12.114Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c9/ce88a0bec0d46d8ae180b99c6ec014866fecc4cba1727b5feec8877b2765/ty-0.0.69-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d91965eb799649833d0d6042db09cd03d15289125245337cc46a2606effb7bda", size = 12483136, upload-time = "2026-08-06T10:04:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9e/6fae0ff225a0012642cf72c077e20f8f448c0a80771bc3360e8178fe2f32/ty-0.0.69-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f03359cd8e5c412aa0c181118fa9b9061a4dddaedbb61bac0a424fb0814d402", size = 12799025, upload-time = "2026-08-06T10:04:16.445Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/43/78a658d18b2a4ccf35b053392f2213bf12e3c63b2abea512d3b6751d1f4c/ty-0.0.69-py3-none-win32.whl", hash = "sha256:ec460e01586b1eb91894c4a8403bee3e045a47e7a4ada943cc27ce8e348e88cf", size = 11787774, upload-time = "2026-08-06T10:04:18.622Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/88db1f674403f2b81316a853a44a81ed220621fa96f8f7ae586fb6ca7513/ty-0.0.69-py3-none-win_amd64.whl", hash = "sha256:18976ca26a4e28fc3249477f79a695d5502e670803f2e080d89ac905baef3c6e", size = 12864038, upload-time = "2026-08-06T10:04:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/7b/6fc6efd00c69103d70f2bdbe824343089cd70b17b3079170057d3e5a3ac0/ty-0.0.69-py3-none-win_arm64.whl", hash = "sha256:7d4ca3bb74d91cb9947ba3f3b4cb131ad6a2b3ecc76d34040c4ec6092d2e411d", size = 12196693, upload-time = "2026-08-06T10:04:22.902Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

`ty` was pinned at `0.0.32`, many releases behind. Moving to `0.0.69` reports 42 diagnostics that the old version did not: partly new rules, partly improved inference on code that was always wrong.

Goal: land the upgrade with `ty check .` clean, fixing what is genuinely broken and parking the rest in the existing per-file ignore lists.

Non-goals: this does not attempt to pay down pre-existing type debt beyond what the upgrade surfaced, and it does not restructure any of the code the new rules point at.

## What changed

No behavioral changes to shipped code. Everything below is either dead code, a suppression comment, lint config, or one expression rewritten to state an invariant the type checker could not see.

### Fixed at source (14 diagnostics)

These were not appeasement - each one was a real defect the old `ty` could not see.

- **8 x `pydantic-discarded-extra-argument`** (new rule). Test code passing kwargs that are not fields on the target model, so Pydantic silently dropped them: `role=` to `AccountSession`, `db=` to `Migration031`, `migrations=` to `Migration043`, `client=ANY` to `GitRepositoryAddReadOnly`, `service=` to `InfrahubRepository` / `InfrahubReadOnlyRepository`. All were already no-ops at runtime, so deleting them is behaviour-preserving. Two of the call sites keep their `# type: ignore[call-arg]` because mypy still needs it for other reasons.
- **1 x `deprecated`** (new rule). `asyncio.get_event_loop_policy()` in the integration `conftest.py` is deprecated and scheduled for removal in Python 3.16. Replaced with the direct `asyncio.new_event_loop()`, which is what the two-line policy dance was doing anyway.
- **1 x `invalid-type-form`**. `instance.exec_calls: list[list[str]] = []` in the testcontainers test - an annotation on an attribute target is discarded, it never annotated anything. Dropped it, keeping the assignment.
- **3 x `not-iterable`** in `test_unique_field_updates.py`, resolved by annotating the `updated_schema` locals as `dict[str, Any]`. Only the three fixtures that `ty` flagged were touched, rather than reformatting every sibling fixture.
- **1 x `invalid-return-type`** in `NodeManager._get_cardinality_one_identifiers_by_kind`. This is the only non-test source edit that is not a comment. The comprehension keys on `rel_schema.identifier`, typed `str | None`, so it infers as `dict[str | None, RelationshipDirection]` against a declared `dict[str, dict[str, RelationshipDirection]]`. Switched the key to `rel_schema.get_identifier()`, which returns `str` and raises if the identifier is unset.

  That raise is unreachable: `SchemaBranch.process_pre_validation()` calls `generate_identifiers()` (`backend/infrahub/core/schema/schema_branch.py:731`, implementation at 806-818), which assigns an identifier to every relationship missing one before the schema reaches the registry. `get_identifier()` is how the codebase already expresses that invariant - three call sites in this same file (`manager.py:1295`, `1311`, `1326`) use it for the same reason. The `if` clause is untouched, so the diff for this function is a single line.

### Suppressed inline (8 diagnostics)

The key finding of the upgrade: **`ty` does not honor mypy-specific ignore codes.** It only recognizes its own rule names, so `# type: ignore[misc]` reads as "no matching rule" and never suppresses anything. Bare `# type: ignore` and `# ty: ignore[rule]` both work.

Every one of these eight lines already carried a mypy ignore *for the same underlying issue*, so they got a paired `# ty: ignore[...]` appended, matching the existing precedent in `backend/tests/unit/computed_attribute/test_transform_recompute.py`:

- 6 x `invalid-assignment` on enum-backed attribute writes (`conflict_recorder.py`, `failure_recoverer.py`, `diff_conflict.py`). The generated protocols type these attributes as stdlib `enum.Enum`, whose `.value` is read-only; at runtime they are Infrahub `Enum` / `Dropdown` objects with a writable value. Each site already has an explanatory comment.
- 1 x `missing-argument` in `core/migrations/schema/tasks.py`, where `MIGRATION_MAP` yields migration classes with differing required fields.
- 1 x `invalid-assignment` in `test_api_exception_handler.py`, assigning `None` to `RequestFixture.mock_log_forwarding: MagicMock`.

Inline was preferred over a config entry here because it is strictly narrower - a file-scoped ignore would also hide *new* violations of that rule elsewhere in the same file.

### Added to the ignore lists in `pyproject.toml` (20 diagnostics)

The remaining sites carry no mypy ignore and no cheap correct fix, so they follow the pattern already established in the file: rule ignores scoped to the exact files that trip them, where each `include` list doubles as the remaining to-do list. Fix a file, remove it from the glob, and that file starts being enforced again.

Five of the six entries are a single path appended to a list that already exists. All four files already appear in other lists within the same block, so nothing new is being carved out:

| File | Rule | Why not fixed in code |
|---|---|---|
| `core/schema/basenode_schema.py` | `invalid-return-type` (2) | `attr.id` / `rel.id` are `str \| None` flowing into a declared `dict[str, str]`. Fixing means either widening the return type through the callers or dropping entries. |
| `graphql/mutations/schema.py` | `not-iterable` (5), `unsupported-operator` (2) | `AttributeSchema.choices` / `.enum` are `Optional`, and `ty` cannot see through the `validate_kind_dropdown` / `validate_kind_enum` guards. A fix means `or []` at seven separate sites. |
| `graphql/resolvers/resolver.py` | `invalid-argument-type` (2) | `extract_selection` accepts `NodeSchema \| GenericSchema` but receives the wider `MainSchemaTypes`; separately `include_descendants: bool \| None` is passed to a `bool` parameter. The first is a genuine API gap worth its own change. |
| `graphql/utils.py` | `invalid-return-type` (1) | New `hasattr()` intersection narrowing: `GraphQLNamedType & <Protocol with members 'interfaces'>` is not `GrapheneObjectType`. Annotating the accumulator was tried and only relocates the error onto `.append`. |

The one new block is `message_bus/operations/__init__.py` for `invalid-argument-type`. All 8 diagnostics come from the single `await func(message=message)` dispatch line: `COMMAND_MAP` is a heterogeneous table whose handlers each take a specific `InfrahubMessage` subtype, while the dispatch site only holds the base type. Annotating `COMMAND_MAP: dict[str, Any]` would silence it, but at the cost of all type checking on the table. A `message_bus/**` block already exists; this was deliberately scoped to the one file so the rest of the module stays enforced.

Nothing added here is broader than a single file.

### What stayed the same

- No schema, GraphQL contract, migration, or API changes.
- No production behaviour changes. The only non-test source edits are suppression comments plus the `identifier` -> `get_identifier()` swap, which cannot change a reachable outcome.
- No new dependencies; `ty` was already a dev dependency.

## How to review

Start with `pyproject.toml` - the ignore-list additions are the part with lasting consequences.

Then the one-line change in `backend/infrahub/core/manager.py`. What is worth confirming is the invariant, not the call: that `generate_identifiers()` leaves no relationship with a `None` identifier on any schema served from the registry. If that holds, `get_identifier()` cannot raise and nothing about the resulting map changes.

The rest is mechanical: deleted dead kwargs, paired ignore comments, and one annotation removal.

## How to test

```bash
uv run ty check .          # clean
uv run ruff format --check <changed files> && uv run ruff check <changed files>
uv run mypy <changed non-excluded files>
uv run pytest backend/tests/unit/api/test_api_exception_handler.py
uv run pytest python_testcontainers/tests/test_container_postgres_backup.py
```

Locally: `ty check .` passes with 0 diagnostics (from 42). `ruff format --check` and `ruff check` pass on all 14 changed Python files. `mypy` passes on all 10 changed files it actually checks (`backend/tests/component/**` is in mypy's exclude list). The two touched test files that run without containers pass: 16 + 3.

The component, functional, and integration tests touched here need Docker/containers and were not run locally - CI covers them. Their edits are confined to deleting kwargs that Pydantic was already discarding, so no behaviour change is expected.

## Impact & rollout

- **Backward compatibility:** no breaking changes; dev tooling and test-only edits plus one type-narrowing call swap.
- **Performance:** none.
- **Config/env changes:** `ty` pinned `0.0.32` -> `0.0.69` in the `dev` dependency group, plus the scoped rule ignores described above.
- **Deployment notes:** safe to deploy; nothing here reaches a running server.

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

No changelog fragment: this is a dev-tooling upgrade with no user-facing or ops-facing change, matching how dependency bumps are handled on this repo. No new tests: the change adds no behaviour to cover, and the existing suites already exercise every touched file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


