### PR TITLE
fix: validate preference timezone at write and correct the UI source hint (closes #10174)

### DIFF
--- a/backend/infrahub/core/preferences/validation.py
+++ b/backend/infrahub/core/preferences/validation.py
@@ -4,9 +4,9 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from infrahub.exceptions import ValidationError
 
-# Implementation-defined entries browsers reject; rejected explicitly so the guarantee holds
-# regardless of which zone tree the runtime ships.
-_REJECTED_KEYS = frozenset({"localtime"})
+# Implementation-defined entries a full zone tree resolves but browsers reject; listed explicitly
+# so they are refused regardless of which zone tree the runtime ships.
+_REJECTED_KEYS = frozenset({"localtime", "posixrules"})
 _REJECTED_PREFIXES = ("posix/", "right/")
 
 

--- a/backend/infrahub/core/preferences/validation.py
+++ b/backend/infrahub/core/preferences/validation.py
@@ -10,14 +10,14 @@ _REJECTED_KEYS = frozenset({"localtime", "posixrules"})
 _REJECTED_PREFIXES = ("posix/", "right/")
 
 
-def normalize_timezone(value: str | None) -> str | None:
-    """Return a stored-ready timezone, rejecting anything a client should not store.
+def validate_timezone(value: str | None) -> str | None:
+    """Validate a timezone for storage; empty becomes None, a valid value is returned unchanged.
 
-    An empty value is normalized to None (nothing stored) so the write reply agrees with every
-    later read, which treats a falsy timezone as unset. A non-empty value must resolve against the
-    runtime's zone database and not be an implementation-defined entry; validating by construction
-    (rather than an enumerated allowlist) keeps the check independent of an enumeration that varies
-    by runtime and avoids a filesystem walk.
+    A non-empty value must resolve against the runtime's zone database and not be an
+    implementation-defined key. It is checked by construction rather than an allowlist, so
+    backward-compatibility aliases are accepted and stored as given. The accepted set follows the
+    interpreter's own tzdata, so confirm new accept/reject behavior against a running instance,
+    not by unit test alone.
 
     Raises:
         ValidationError: the value is non-empty but is not a storable IANA timezone.

--- a/backend/infrahub/core/preferences/validation.py
+++ b/backend/infrahub/core/preferences/validation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from infrahub.exceptions import ValidationError
+
+
+def normalize_timezone(value: str | None) -> str | None:
+    """Return a stored-ready timezone, rejecting anything the runtime cannot resolve.
+
+    An empty value is normalized to None (nothing stored) so the write reply agrees with every
+    later read, which treats a falsy timezone as unset. A non-empty value must resolve against the
+    runtime's zone database; validating by construction accepts every zone that has a data file
+    (backward-compatibility aliases included), rather than an enumerated allowlist that would reject
+    aliases a client legitimately offers.
+
+    Raises:
+        ValidationError: the value is non-empty but names no timezone the runtime can resolve.
+
+    """
+    if not value:
+        return None
+    try:
+        # OSError covers keys the resolver rejects at the filesystem layer (e.g. an over-long name);
+        # ValueError covers malformed keys; ZoneInfoNotFoundError covers well-formed-but-absent ones.
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError, OSError) as exc:
+        raise ValidationError(input_value=f"'{value}' is not a valid IANA timezone") from exc
+    return value

--- a/backend/infrahub/core/preferences/validation.py
+++ b/backend/infrahub/core/preferences/validation.py
@@ -4,22 +4,29 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from infrahub.exceptions import ValidationError
 
+# Implementation-defined entries browsers reject; rejected explicitly so the guarantee holds
+# regardless of which zone tree the runtime ships.
+_REJECTED_KEYS = frozenset({"localtime"})
+_REJECTED_PREFIXES = ("posix/", "right/")
+
 
 def normalize_timezone(value: str | None) -> str | None:
-    """Return a stored-ready timezone, rejecting anything the runtime cannot resolve.
+    """Return a stored-ready timezone, rejecting anything a client should not store.
 
     An empty value is normalized to None (nothing stored) so the write reply agrees with every
     later read, which treats a falsy timezone as unset. A non-empty value must resolve against the
-    runtime's zone database; validating by construction accepts every zone that has a data file
-    (backward-compatibility aliases included), rather than an enumerated allowlist that would reject
-    aliases a client legitimately offers.
+    runtime's zone database and not be an implementation-defined entry; validating by construction
+    (rather than an enumerated allowlist) keeps the check independent of an enumeration that varies
+    by runtime and avoids a filesystem walk.
 
     Raises:
-        ValidationError: the value is non-empty but names no timezone the runtime can resolve.
+        ValidationError: the value is non-empty but is not a storable IANA timezone.
 
     """
     if not value:
         return None
+    if value in _REJECTED_KEYS or value.startswith(_REJECTED_PREFIXES):
+        raise ValidationError(input_value=f"'{value}' is not a valid IANA timezone")
     try:
         # OSError covers keys the resolver rejects at the filesystem layer (e.g. an over-long name);
         # ValueError covers malformed keys; ZoneInfoNotFoundError covers well-formed-but-absent ones.

--- a/backend/infrahub/graphql/mutations/preferences.py
+++ b/backend/infrahub/graphql/mutations/preferences.py
@@ -12,7 +12,7 @@ from infrahub.core.preferences.constants import DateFormat as DateFormatEnum
 from infrahub.core.preferences.models import Preference
 from infrahub.core.preferences.permissions import MANAGE_GLOBAL_PREFERENCES_PERMISSION
 from infrahub.core.preferences.repository import PreferenceRepository
-from infrahub.core.preferences.validation import normalize_timezone
+from infrahub.core.preferences.validation import validate_timezone
 from infrahub.database import retry_db_transaction
 from infrahub.graphql.types.preferences import DateFormat, PreferenceWriteScope, PreferenceWriteScopeType
 
@@ -79,7 +79,7 @@ class InfrahubSetPreferences(Mutation):
             owner_id = account_id
 
         if timezone is not _UNSET:
-            timezone = normalize_timezone(timezone)
+            timezone = validate_timezone(timezone)
 
         return await cls._set(
             graphql_context, owner_id=owner_id, actor_id=account_id, date_format=date_format, timezone=timezone

--- a/backend/infrahub/graphql/mutations/preferences.py
+++ b/backend/infrahub/graphql/mutations/preferences.py
@@ -12,6 +12,7 @@ from infrahub.core.preferences.constants import DateFormat as DateFormatEnum
 from infrahub.core.preferences.models import Preference
 from infrahub.core.preferences.permissions import MANAGE_GLOBAL_PREFERENCES_PERMISSION
 from infrahub.core.preferences.repository import PreferenceRepository
+from infrahub.core.preferences.validation import normalize_timezone
 from infrahub.database import retry_db_transaction
 from infrahub.graphql.types.preferences import DateFormat, PreferenceWriteScope, PreferenceWriteScopeType
 
@@ -76,6 +77,9 @@ class InfrahubSetPreferences(Mutation):
             owner_id = GLOBAL_OWNER_ID
         else:
             owner_id = account_id
+
+        if timezone is not _UNSET:
+            timezone = normalize_timezone(timezone)
 
         return await cls._set(
             graphql_context, owner_id=owner_id, actor_id=account_id, date_format=date_format, timezone=timezone

--- a/backend/tests/component/graphql/mutations/test_preferences.py
+++ b/backend/tests/component/graphql/mutations/test_preferences.py
@@ -209,6 +209,7 @@ async def test_user_rejects_non_iana_timezone(
     )
     assert result.errors is not None
     assert len(result.errors) == 1
+    assert result.errors[0].message == "'Not/AZone' is not a valid IANA timezone"
     assert await PreferenceRepository(db=db).get_for_owner(owner_id=first_account.id) is None
 
 

--- a/backend/tests/component/graphql/mutations/test_preferences.py
+++ b/backend/tests/component/graphql/mutations/test_preferences.py
@@ -189,6 +189,29 @@ async def test_user_rejects_unknown_date_format(
     assert await PreferenceRepository(db=db).get_for_owner(owner_id=first_account.id) is None
 
 
+async def test_user_rejects_non_iana_timezone(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    first_account: Node,
+    session_first_account: AccountSession,
+) -> None:
+    """Reject a timezone that is not a valid IANA name, and persist nothing.
+
+    A timezone must be an IANA zone the runtime can resolve; a string that names no zone is
+    rejected at the write path and no Preference row is created.
+    """
+    result = await run_mutation(
+        db=db,
+        branch=default_branch,
+        account_session=session_first_account,
+        variables={"scope": "USER", "timezone": "Not/AZone"},
+    )
+    assert result.errors is not None
+    assert len(result.errors) == 1
+    assert await PreferenceRepository(db=db).get_for_owner(owner_id=first_account.id) is None
+
+
 # --------------------------------------------------------------------------------------------
 # scope=GLOBAL — gated on manage_global_preferences; nothing written when denied.
 # --------------------------------------------------------------------------------------------

--- a/backend/tests/unit/core/test_preference_validation.py
+++ b/backend/tests/unit/core/test_preference_validation.py
@@ -43,6 +43,7 @@ REJECT_CASES = [
     RejectCase(name="injection_string", value="'; DROP TABLE--"),
     RejectCase(name="overlong_string", value="A" * 300),
     RejectCase(name="localtime_pseudo_zone", value="localtime"),
+    RejectCase(name="posixrules_pseudo_zone", value="posixrules"),
     RejectCase(name="posix_implementation_key", value="posix/UTC"),
     RejectCase(name="right_implementation_key", value="right/UTC"),
 ]

--- a/backend/tests/unit/core/test_preference_validation.py
+++ b/backend/tests/unit/core/test_preference_validation.py
@@ -41,6 +41,9 @@ REJECT_CASES = [
     RejectCase(name="offset_is_not_a_zone", value="UTC+25"),
     RejectCase(name="injection_string", value="'; DROP TABLE--"),
     RejectCase(name="overlong_string", value="A" * 300),
+    RejectCase(name="localtime_pseudo_zone", value="localtime"),
+    RejectCase(name="posix_implementation_key", value="posix/UTC"),
+    RejectCase(name="right_implementation_key", value="right/UTC"),
 ]
 
 

--- a/backend/tests/unit/core/test_preference_validation.py
+++ b/backend/tests/unit/core/test_preference_validation.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.core.preferences.validation import normalize_timezone
+from infrahub.exceptions import ValidationError
+
+
+@dataclass
+class NormalizeCase:
+    name: str
+    value: str | None
+    expected: str | None
+
+
+NORMALIZE_CASES = [
+    NormalizeCase(name="iana_region_city", value="Asia/Tokyo", expected="Asia/Tokyo"),
+    NormalizeCase(name="iana_europe", value="Europe/Paris", expected="Europe/Paris"),
+    NormalizeCase(name="utc", value="UTC", expected="UTC"),
+    NormalizeCase(name="empty_string_is_unset", value="", expected=None),
+    NormalizeCase(name="none_is_unset", value=None, expected=None),
+]
+
+
+@pytest.mark.parametrize("case", NORMALIZE_CASES, ids=lambda case: case.name)
+def test_normalize_timezone_accepts_and_normalizes(case: NormalizeCase) -> None:
+    assert normalize_timezone(case.value) == case.expected
+
+
+@dataclass
+class RejectCase:
+    name: str
+    value: str
+
+
+REJECT_CASES = [
+    RejectCase(name="unknown_zone", value="Not/AZone"),
+    RejectCase(name="offset_is_not_a_zone", value="UTC+25"),
+    RejectCase(name="injection_string", value="'; DROP TABLE--"),
+    RejectCase(name="overlong_string", value="A" * 300),
+]
+
+
+@pytest.mark.parametrize("case", REJECT_CASES, ids=lambda case: case.name)
+def test_normalize_timezone_rejects_non_iana(case: RejectCase) -> None:
+    expected = f"'{case.value}' is not a valid IANA timezone"
+    with pytest.raises(ValidationError, match=rf"^{re.escape(expected)}$"):
+        normalize_timezone(case.value)

--- a/backend/tests/unit/core/test_preference_validation.py
+++ b/backend/tests/unit/core/test_preference_validation.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from infrahub.core.preferences.validation import normalize_timezone
+from infrahub.core.preferences.validation import validate_timezone
 from infrahub.exceptions import ValidationError
 
 
@@ -27,8 +27,8 @@ NORMALIZE_CASES = [
 
 
 @pytest.mark.parametrize("case", NORMALIZE_CASES, ids=lambda case: case.name)
-def test_normalize_timezone_accepts_and_normalizes(case: NormalizeCase) -> None:
-    assert normalize_timezone(case.value) == case.expected
+def test_validate_timezone_accepts_and_normalizes(case: NormalizeCase) -> None:
+    assert validate_timezone(case.value) == case.expected
 
 
 @dataclass
@@ -50,7 +50,7 @@ REJECT_CASES = [
 
 
 @pytest.mark.parametrize("case", REJECT_CASES, ids=lambda case: case.name)
-def test_normalize_timezone_rejects_non_iana(case: RejectCase) -> None:
+def test_validate_timezone_rejects_non_iana(case: RejectCase) -> None:
     expected = f"'{case.value}' is not a valid IANA timezone"
     with pytest.raises(ValidationError, match=rf"^{re.escape(expected)}$"):
-        normalize_timezone(case.value)
+        validate_timezone(case.value)

--- a/backend/tests/unit/core/test_preference_validation.py
+++ b/backend/tests/unit/core/test_preference_validation.py
@@ -20,6 +20,7 @@ NORMALIZE_CASES = [
     NormalizeCase(name="iana_region_city", value="Asia/Tokyo", expected="Asia/Tokyo"),
     NormalizeCase(name="iana_europe", value="Europe/Paris", expected="Europe/Paris"),
     NormalizeCase(name="utc", value="UTC", expected="UTC"),
+    NormalizeCase(name="etc_offset_zone", value="Etc/GMT+5", expected="Etc/GMT+5"),
     NormalizeCase(name="empty_string_is_unset", value="", expected=None),
     NormalizeCase(name="none_is_unset", value=None, expected=None),
 ]

--- a/dev/knowledge/backend/preferences.md
+++ b/dev/knowledge/backend/preferences.md
@@ -27,10 +27,18 @@ Fields:
 |-------|------|-------|
 | `owner_id` | `str` | plain string, not a graph relationship |
 | `date_format` | `DateFormat` enum, nullable | a semantic key (e.g. `ISO_DATETIME`), not a render pattern; each client maps the key to its own formatter |
-| `timezone` | `str` (IANA name), nullable | currently accepts any string; no backend validation |
+| `timezone` | `str` (IANA name), nullable | validated at write, not on the model (see below) |
 
 `date_format` is enum-typed, so an unknown key is rejected at construction, including when a row is
 loaded from the database. It round-trips as a plain string because the enum subclasses `str`.
+
+`timezone` is validated on the **write path only**, never on the model. A model-level validator
+would run on every read (rows are reconstructed from the database), and since user and global rows
+are fetched together, one bad stored value would break effective-preference reads for every user.
+The set mutation validates a provided timezone by resolving it against the runtime's zone database
+(construction, not an enumerated allowlist — so backward-compatibility aliases a client offers are
+accepted) and normalizes an empty value to unset so the write reply agrees with later reads. Reads
+stay lenient, so any value stored before this validation existed is still returned as-is.
 
 ## Reads never create a row
 

--- a/frontend/app/src/entities/preferences/ui/preference-fields.tsx
+++ b/frontend/app/src/entities/preferences/ui/preference-fields.tsx
@@ -10,6 +10,7 @@ import type { FormAttributeValue } from "@/shared/components/form/type";
 import { Combobox, type ComboboxItem } from "@/shared/components/inputs/combobox";
 import { FormField } from "@/shared/components/ui/form";
 import { formatWithPreferences } from "@/shared/context/date-preferences-context";
+import { supportedTimezone } from "@/shared/utils/date";
 
 import type { Preference } from "@/entities/preferences/domain/model/preference";
 import {
@@ -138,15 +139,25 @@ export function DateFormatField({
   );
 }
 
+/** Resolves the (i) hint for a timezone, correcting the source claim when this browser can't apply it.
+ * A resolved zone this runtime cannot render is silently displayed in the browser's own zone, so the
+ * hint must report that fallback rather than claim the stored zone is in effect. */
+function timezoneSourceMessage(preference: Preference, browserZone: string): string {
+  if (preference.value && !supportedTimezone(preference.value)) {
+    return `This browser can't display ${preference.value}; times are shown in ${browserZone}.`;
+  }
+  return sourceMessage(preference, {
+    formatGlobalValue: (value) => value,
+    browserValue: browserZone,
+  });
+}
+
 export function TimezoneField({
   preference,
   emptyValueLabel = EMPTY_VALUE_LABEL,
 }: PreferenceFieldProps) {
   const message = preference
-    ? sourceMessage(preference, {
-        formatGlobalValue: (value) => value,
-        browserValue: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      })
+    ? timezoneSourceMessage(preference, Intl.DateTimeFormat().resolvedOptions().timeZone)
     : null;
 
   return (

--- a/frontend/app/src/entities/preferences/ui/user-preferences-card.test.tsx
+++ b/frontend/app/src/entities/preferences/ui/user-preferences-card.test.tsx
@@ -271,6 +271,35 @@ describe("UserPreferencesCard", () => {
     await initPointerTracking(component.locator);
   });
 
+  test("the (i) tooltip reports the browser fallback when the stored zone can't be rendered here", async () => {
+    vi.mocked(getEffectivePreferences).mockResolvedValue({
+      ...baseEffective,
+      timezone: { value: "Not/AZone", source: "USER" },
+    });
+
+    const component = await render(<UserPreferencesCard />);
+
+    await expect.element(component.getByRole("button", { name: /timezone/i })).toBeVisible();
+
+    const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    // The timezone field is the second info trigger.
+    const triggers = component.getByRole("button", { name: "Where this value comes from" });
+    await initPointerTracking(component.locator);
+    await triggers.nth(1).hover();
+
+    await expect
+      .element(
+        component.getByRole("tooltip", {
+          name: `This browser can't display Not/AZone; times are shown in ${browserZone}.`,
+        })
+      )
+      .toBeVisible();
+
+    // Park the pointer away from the trigger so the tooltip closes before the next test renders.
+    await initPointerTracking(component.locator);
+  });
+
   test("the (i) tooltip falls back to the browser source when neither user nor global is set", async () => {
     vi.mocked(getEffectivePreferences).mockResolvedValue({
       ...baseEffective,

--- a/frontend/app/src/entities/preferences/ui/user-preferences-card.test.tsx
+++ b/frontend/app/src/entities/preferences/ui/user-preferences-card.test.tsx
@@ -300,6 +300,35 @@ describe("UserPreferencesCard", () => {
     await initPointerTracking(component.locator);
   });
 
+  test("the (i) tooltip reports the browser fallback for an unrenderable organisation-default zone", async () => {
+    vi.mocked(getEffectivePreferences).mockResolvedValue({
+      ...baseEffective,
+      timezone: { value: "Not/AZone", source: "GLOBAL" },
+    });
+
+    const component = await render(<UserPreferencesCard />);
+
+    await expect.element(component.getByRole("button", { name: /timezone/i })).toBeVisible();
+
+    const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    // The timezone field is the second info trigger.
+    const triggers = component.getByRole("button", { name: "Where this value comes from" });
+    await initPointerTracking(component.locator);
+    await triggers.nth(1).hover();
+
+    await expect
+      .element(
+        component.getByRole("tooltip", {
+          name: `This browser can't display Not/AZone; times are shown in ${browserZone}.`,
+        })
+      )
+      .toBeVisible();
+
+    // Park the pointer away from the trigger so the tooltip closes before the next test renders.
+    await initPointerTracking(component.locator);
+  });
+
   test("the (i) tooltip falls back to the browser source when neither user nor global is set", async () => {
     vi.mocked(getEffectivePreferences).mockResolvedValue({
       ...baseEffective,

--- a/frontend/app/src/shared/utils/date.ts
+++ b/frontend/app/src/shared/utils/date.ts
@@ -15,7 +15,7 @@ export interface FormatDateOptions {
 // A zone valid on the preference setter's machine may be absent on the viewer's browser;
 // `@date-fns/tz` builds a `TZDate` for an unknown zone without complaint and only throws lazily
 // on use, so we validate up front with `Intl`, which rejects an unknown zone synchronously.
-function supportedTimezone(timezone?: string | null): string | undefined {
+export function supportedTimezone(timezone?: string | null): string | undefined {
   if (!timezone) {
     return;
   }


### PR DESCRIPTION
## Why

`InfrahubSetPreferences` accepted and persisted any string as `timezone` (`Not/AZone`, injection strings, ...), and the preferences screen then reported an unusable zone as "Your preference." while timestamps silently rendered in the browser's own zone.

**Goal:** reject a non-IANA `timezone` at write, and stop the UI claiming a stored zone is in effect when it cannot be applied.

Closes #10174

## What changed

**Behavioral changes**

- Setting a `USER` or `GLOBAL` preference `timezone` now rejects a value that is not a resolvable IANA zone — including implementation-defined keys like `localtime`, `posix/*`, `right/*` — with a `ValidationError` (HTTP 422); nothing is persisted on rejection.
- An empty-string `timezone` normalizes to unset, so the mutation's echoed value agrees with every later read (previously the write reply echoed `""` while reads treated it as unset).
- The preferences screen no longer labels a stored zone "Your preference." when the viewer's browser cannot render it; the info hint now reports the browser fallback ("This browser can't display X; times are shown in Y.").

**Implementation notes**

- Validation lives at the **write path only** (`normalize_timezone`).
- Validation resolves the value with `zoneinfo.ZoneInfo(...)` rather than checking membership in `available_timezones()`: the enumerated set is environment- and version-dependent. `ZoneInfoNotFoundError`, `ValueError`, and `OSError` (e.g. an over-long key) all map to a rejection. Implementation-defined keys (`localtime`, `posix/*`, `right/*`) are rejected before construction, so the outcome does not depend on which zone tree the runtime ships (verified: the slim runtime resolves `localtime`).
- The frontend reuses the existing `Intl`-based `supportedTimezone` probe (now exported) to decide renderability.

## How to review

- Backend: `backend/infrahub/core/preferences/validation.py` (the helper) and its single call site in `backend/infrahub/graphql/mutations/preferences.py`.
- Frontend: `frontend/app/src/entities/preferences/ui/preference-fields.tsx` (`timezoneSourceMessage`) and the `supportedTimezone` export in `frontend/app/src/shared/utils/date.ts`.
- Knowledge doc: `dev/knowledge/backend/preferences.md` updated to reflect write-only validation.

## How to test

```bash
# Backend unit (validation matrix: reject + accept + empty-normalization)
uv run pytest backend/tests/unit/core/test_preference_validation.py -v

# Backend component (mutation rejects a non-IANA zone and persists nothing)
uv run pytest backend/tests/component/graphql/mutations/test_preferences.py -v

# Frontend (tooltip reports browser fallback for an unrenderable stored zone)
cd frontend/app && pnpm test -- --run src/entities/preferences/ui/user-preferences-card.test.tsx
```
## Checklist

- [x] Tests added/updated
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
