### PR TITLE
Remove ignore statements for resolved typing violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ disable_error_code = [
     "attr-defined",
     "misc",
     "operator",
-    "return",
     "union-attr",
 ]
 
@@ -232,8 +231,6 @@ module = "infrahub.core.manager"
 disable_error_code = [
     "assignment",
     "attr-defined",
-    "index",
-    "no-untyped-def",
     "return-value",
     "union-attr",
 ]
@@ -244,18 +241,9 @@ disable_error_code = [
     "arg-type",
     "assignment",
     "attr-defined",
-    "list-item",
-    "no-redef",
     "override",
-    "return",
     "union-attr",
     "var-annotated",
-]
-
-[[tool.mypy.overrides]]
-module = "infrahub.core.node.base"
-disable_error_code = [
-    "no-untyped-def",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
# Why

Prevent resolved violations from reappearing

## What changed

* Remove ignored typing violations that we no longer have (changes in pyproject.toml)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

