### PR TITLE
fix: reliably write merge back to non-main default branch on multi-worker pools (closes #9568)

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -282,10 +282,18 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             f"Pushing the latest update to the remote origin for the branch '{branch_name}'", repository=self.name
         )
 
-        # TODO Catch potential exceptions coming from origin.push
         repo = self.get_git_repo_worktree(identifier=branch_name)
         remote_branch = self._get_mapped_remote_branch(branch_name=branch_name)
-        repo.remotes.origin.push(remote_branch)
+        # Push the worktree HEAD, not the bare branch name: the local branch checked out in this
+        # worktree may not be named after the remote branch (it differs when the repository's
+        # default branch is not the Infrahub default), so a bare refspec would have no local source.
+        push_infos = repo.remotes.origin.push(refspec=f"HEAD:refs/heads/{remote_branch}")
+        for push_info in push_infos:
+            if push_info.flags & push_info.ERROR:
+                raise RepositoryError(
+                    identifier=self.name,
+                    message=f"Unable to push the branch {remote_branch} to the remote for repository {self.name}: {push_info.summary.strip()}",
+                )
 
         return True
 

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -274,7 +274,12 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         return []
 
     async def push(self, branch_name: str) -> bool:
-        """Push a given branch to the remote Origin repository."""
+        """Push a given branch to the remote Origin repository.
+
+        Raises:
+            RepositoryError: When the remote rejects the push.
+
+        """
         if not self.has_origin:
             return False
 

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -517,6 +517,37 @@ async def test_merge_branch01_into_main(git_repo_01: InfrahubRepository, branch0
     assert response == str(commit_after)
 
 
+async def test_merge_writes_back_to_non_main_default_branch(
+    git_repo_01: InfrahubRepository,
+    git_upstream_repo_01: dict[str, str | Path],
+    branch01: BranchData,
+) -> None:
+    """Merging into Infrahub main writes the merge commit back to a non-main git default branch.
+
+    Reproduces a worker whose clone only ever checked out `main`, so it holds `develop` only as a
+    remote-tracking ref with no local branch of that name. The push that maps Infrahub `main` onto
+    the configured git default branch must still advance the remote `develop`.
+    """
+    upstream_path = str(git_upstream_repo_01["path"])
+    upstream = Repo(upstream_path)
+    upstream.git.branch("develop", "main")
+
+    repo = git_repo_01
+    await repo.fetch()
+    repo.default_branch_name = "develop"
+
+    local_branch_names = {branch.name for branch in repo.get_git_repo_main().branches}
+    assert local_branch_names == {"main"}
+
+    await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
+
+    develop_before = Repo(upstream_path).commit("develop").hexsha
+    merge_commit = await repo.merge(source_branch=branch01.name, dest_branch="main")
+
+    assert merge_commit != develop_before
+    assert Repo(upstream_path).commit("develop").hexsha == merge_commit
+
+
 async def test_rebase(git_repo_01: InfrahubRepository, branch01: BranchData) -> None:
     repo = git_repo_01
     await repo.fetch()

--- a/backend/tests/helpers/file_repo.py
+++ b/backend/tests/helpers/file_repo.py
@@ -29,6 +29,15 @@ class FileRepo:
             return self._repo
         raise InitializationError
 
+    def _accept_pushes_to_current_branch(self) -> None:
+        """Let this non-bare repo act as a push target, mirroring a real remote.
+
+        A non-bare repo rejects pushes to its checked-out branch by default; a hosted remote does
+        not, so tests that push the default branch back would otherwise exercise a rejection that
+        never happens in production.
+        """
+        self.repo.git.config("receive.denyCurrentBranch", "ignore")
+
     def _initial_directory(self, repo_base: Path) -> str:
         initial_candidates = list(repo_base.glob("initial__*"))
         assert len(initial_candidates) == 1
@@ -60,6 +69,7 @@ class FileRepo:
         initial_directory = self._initial_directory(repo_base=repo_base)
         shutil.copytree(repo_base / initial_directory, self.sources_directory / self.name)
         self._repo = Repo.init(self.sources_directory / self.name, initial_branch=self._initial_branch)
+        self._accept_pushes_to_current_branch()
         for untracked in self.repo.untracked_files:
             self.repo.index.add(untracked)
         self.repo.index.commit("First commit")
@@ -129,6 +139,7 @@ class MultipleStagesFileRepo(FileRepo):
 
         shutil.copytree(repo_base / initial_directory, self.sources_directory / self.name)
         self._repo = Repo.init(self.sources_directory / self.name, initial_branch=self._initial_branch)
+        self._accept_pushes_to_current_branch()
 
         self._setup_initial_branch(directory=repo_base / initial_directory)
         self._apply_pull_requests(repo_base=repo_base)

--- a/backend/tests/integration/git/test_git_live_remote.py
+++ b/backend/tests/integration/git/test_git_live_remote.py
@@ -147,7 +147,10 @@ class TestRepositoryRemoteOperations(TestInfrahubApp):
         Uses a fresh clone against a real server so the bad credentials are always
         presented directly, bypassing any cached credential state.
         """
-        with pytest.raises(RepositoryCredentialsError):
+        with pytest.raises(
+            RepositoryCredentialsError,
+            match=r"^Authentication failed for auth-failure-repo, please validate the credentials\.$",
+        ):
             await InfrahubRepository.new(
                 id=auth_failure_dataset["node_id"],
                 name=auth_failure_dataset["repo_name"],
@@ -206,14 +209,9 @@ class TestRepositoryRemoteOperations(TestInfrahubApp):
         client: InfrahubClient,
         gogs_server: GogsServer,
     ) -> None:
-        """push() returns True despite a non-fast-forward rejection — the failure is silent.
+        """push() raises RepositoryError when the remote rejects a non-fast-forward push.
 
-        InfrahubRepository.push() has no exception handling.  GitPython's Remote.push()
-        does not raise on rejection — it logs a warning and returns a PushInfoList with
-        error flags.  The result is that push() returns True while the local commit was
-        never actually delivered to the remote.
-
-        This test is expected to fail once proper push-rejection handling is added.
+        The remote is left unchanged: the rejected local commit is not delivered.
         """
         repo_name = push_rejection_dataset["repo_name"]
 
@@ -238,9 +236,11 @@ class TestRepositoryRemoteOperations(TestInfrahubApp):
         git_repo.index.add(["local_diverge.txt"])
         local_commit = str(git_repo.index.commit("Local-only commit"))
 
-        # GitPython's Remote.push() does not raise on rejection; push() returns True.
-        result = await infrahub_repo.push("main")
-        assert result is True
+        with pytest.raises(
+            RepositoryError,
+            match=rf"^Unable to push the branch main to the remote for repository {repo_name}:",
+        ):
+            await infrahub_repo.push("main")
 
         git_repo.remotes.origin.fetch()
         remote_main_commit = str(git_repo.commit("origin/main"))
@@ -285,7 +285,10 @@ class TestRepositoryRemoteOperations(TestInfrahubApp):
         branch_b_repo.index.add(["conflict.txt"])
         branch_b_repo.index.commit("conflict-branch-b: add conflict.txt")
 
-        with pytest.raises(RepositoryError):
+        with pytest.raises(
+            RepositoryError,
+            match=r"^An error occurred with GitRepository 'merge-conflict-repo'\.$",
+        ):
             await infrahub_repo.merge(
                 source_branch="conflict-branch-a",
                 dest_branch="conflict-branch-b",

--- a/backend/tests/integration/git/test_git_live_remote.py
+++ b/backend/tests/integration/git/test_git_live_remote.py
@@ -238,7 +238,7 @@ class TestRepositoryRemoteOperations(TestInfrahubApp):
 
         with pytest.raises(
             RepositoryError,
-            match=rf"^Unable to push the branch main to the remote for repository {repo_name}:",
+            match=rf"^Unable to push the branch main to the remote for repository {repo_name}: \[rejected\] \(fetch first\)$",
         ):
             await infrahub_repo.push("main")
 

--- a/changelog/9568.fixed.md
+++ b/changelog/9568.fixed.md
@@ -1,0 +1,1 @@
+Merging an Infrahub branch now reliably writes the merge back to a repository's non-`main` default branch on the remote, regardless of which task worker executes the merge.

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -257,6 +257,7 @@ Test data and fixture files:
 | `test_client.py` | HTTP test client wrapper |
 | `utils.py` | Container utilities |
 | `constants.py` | Port numbers, image names |
+| `file_repo.py` | Builds throwaway on-disk Git "remote" repos from `repos/` fixtures (`FileRepo`). The remotes accept pushes to their checked-out branch, so tests exercise push and write-back like a hosted remote would. |
 
 ### Test Data (`backend/tests/test_data/`)
 

--- a/docs/docs/git-integration/connect-repository.mdx
+++ b/docs/docs/git-integration/connect-repository.mdx
@@ -142,6 +142,8 @@ If you are using a **personal access token for authentication**, you should put 
         data: {
           name: { value: "My Git Repository" },
           location: { value: "https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git" },
+          # Optional: Git branch this repository tracks and pushes merges back to (defaults to "main"; use "develop" to track a non-main branch)
+          default_branch: { value: "main" },
           # The HFID returned in step 2 will be used for the credentials
           credential: { hfid: ["my-git-credential"] }
         }
@@ -200,6 +202,7 @@ If you are using a **personal access token for authentication**, you should put 
         "CoreRepository",
         name="My Git repository",
         location="https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git",
+        default_branch="main",  # Optional: Git branch to track and push merges back to (defaults to "main"; use "develop" for a non-main branch)
         credential=credential,  # The credential object created above
     )
     repository.save()

--- a/docs/docs/git-integration/connect-repository.mdx
+++ b/docs/docs/git-integration/connect-repository.mdx
@@ -142,7 +142,7 @@ If you are using a **personal access token for authentication**, you should put 
         data: {
           name: { value: "My Git Repository" },
           location: { value: "https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git" },
-          # Optional: name of the Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set "develop" for a non-main default)
+          # Optional: name of the Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set your Git default branch name for a non-main default)
           default_branch: { value: "main" },
           # The HFID returned in step 2 will be used for the credentials
           credential: { hfid: ["my-git-credential"] }
@@ -202,7 +202,7 @@ If you are using a **personal access token for authentication**, you should put 
         "CoreRepository",
         name="My Git repository",
         location="https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git",
-        default_branch="main",  # Optional: Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set "develop" for a non-main default)
+        default_branch="main",  # Optional: Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set your Git default branch name for a non-main default)
         credential=credential,  # The credential object created above
     )
     repository.save()

--- a/docs/docs/git-integration/connect-repository.mdx
+++ b/docs/docs/git-integration/connect-repository.mdx
@@ -142,7 +142,7 @@ If you are using a **personal access token for authentication**, you should put 
         data: {
           name: { value: "My Git Repository" },
           location: { value: "https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git" },
-          # Optional: Git branch this repository tracks and pushes merges back to (defaults to "main"; use "develop" to track a non-main branch)
+          # Optional: name of the Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set "develop" for a non-main default)
           default_branch: { value: "main" },
           # The HFID returned in step 2 will be used for the credentials
           credential: { hfid: ["my-git-credential"] }
@@ -202,7 +202,7 @@ If you are using a **personal access token for authentication**, you should put 
         "CoreRepository",
         name="My Git repository",
         location="https://GIT_SERVER/YOUR_GIT_USERNAME/YOUR_REPOSITORY_NAME.git",
-        default_branch="main",  # Optional: Git branch to track and push merges back to (defaults to "main"; use "develop" for a non-main branch)
+        default_branch="main",  # Optional: Git branch mapped to Infrahub's default branch, where merges are pushed back (default "main"; set "develop" for a non-main default)
         credential=credential,  # The credential object created above
     )
     repository.save()

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -45,7 +45,7 @@ When you create a Repository connection, Infrahub:
 
 The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
 
-A read-write repository has a `default_branch` attribute (defaulting to `main`) that names the Git branch this write-back targets. Merges into Infrahub's default branch are pushed to the repository's `default_branch` on the remote, so a repository can track a Git default branch such as `develop`.
+A read-write repository has a `default_branch` attribute (defaulting to `main`) that names the Git branch mapped to Infrahub's default branch. Merges into Infrahub's default branch are pushed back to that Git branch on the remote, and that Git branch is imported as Infrahub's default branch, so a repository can use a non-`main` Git default branch such as `develop`. When `default_branch` is not `main`, a Git branch literally named `main` is not imported.
 
 ### Read-only Repository: controlled unidirectional flow
 

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -45,7 +45,7 @@ When you create a Repository connection, Infrahub:
 
 The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
 
-A read-write repository has a `default_branch` attribute (defaulting to `main`) that names the Git branch mapped to Infrahub's default branch. Merges into Infrahub's default branch are pushed back to that Git branch on the remote, and that Git branch is imported as Infrahub's default branch, so a repository can use a non-`main` Git default branch such as `develop`. When `default_branch` is not `main`, a Git branch literally named `main` is not imported.
+A read-write repository has a `default_branch` attribute (defaulting to `main`) that names the Git branch mapped to Infrahub's default branch. Merges into Infrahub's default branch are pushed back to that Git branch on the remote, and that Git branch is imported as Infrahub's default branch, so a repository can use a non-`main` Git default branch. When `default_branch` is not `main`, a Git branch literally named `main` is not imported.
 
 ### Read-only Repository: controlled unidirectional flow
 

--- a/docs/docs/git-integration/overview.mdx
+++ b/docs/docs/git-integration/overview.mdx
@@ -45,6 +45,8 @@ When you create a Repository connection, Infrahub:
 
 The bidirectional nature means that when you merge a Proposed Change between two Infrahub branches that are both linked to Git branches, Infrahub creates a merge commit and automatically pushes it back to the external repository.
 
+A read-write repository has a `default_branch` attribute (defaulting to `main`) that names the Git branch this write-back targets. Merges into Infrahub's default branch are pushed to the repository's `default_branch` on the remote, so a repository can track a Git default branch such as `develop`.
+
 ### Read-only Repository: controlled unidirectional flow
 
 The **Read-only Repository** type offers a simpler, unidirectional integration designed for scenarios where you need to consume resources from Git without modifying the external repository.


### PR DESCRIPTION
## Why

On a deployment with more than one task worker, merging an Infrahub branch into a git-remote-backed read-write `CoreRepository` whose `default_branch` is not `main` (e.g. `develop`) succeeded inside Infrahub but the git-side write-back to the remote default branch was **silently dropped on a subset of merges**. The push failed with `error: src refspec develop does not match any`, yet the merge reported success and no error surfaced.

Goal: a merge reliably writes the merge commit back to the repository's configured default branch on the remote, regardless of which worker executes the merge flow — and a rejected push fails loudly instead of being swallowed.

Non-goals: no change to how workers materialise their clones or check out branches; no change to the `BranchMerge` GraphQL mutation return value.

Closes #9568

## What changed

**Behavioral changes:**
- Pushing a branch back to the remote now targets the worktree's `HEAD` (`HEAD:refs/heads/<remote_branch>`) instead of a bare branch refspec, so the write-back no longer depends on a local branch named after the remote default branch existing in the executing worker's clone.
- A rejected push now raises `RepositoryError` instead of being silently ignored (the standing `# TODO Catch potential exceptions coming from origin.push` is resolved).

**Root cause:** a worker whose clone was materialised outside the initial import checks out `main` and holds the configured git default branch (`develop`) only as a remote-tracking ref. The old push issued `git push origin develop`, which git resolves as a *local* branch `develop` that does not exist on such a worker, so the push failed on the missing refspec — and the failure was swallowed because the `PushInfo` result was never inspected. Which worker the async merge flow lands on decided success vs. failure, making the loss intermittent.

**What stayed the same:** no schema changes, no message-bus changes, no flow-signature changes. The fix is confined to the push helper.

### Suggested review order
1. `backend/infrahub/git/repository.py` — the `push()` change (HEAD refspec + error check).
2. `backend/tests/component/git/test_git_repository.py` — the regression test reproducing the non-`main`-default worker state.
3. `backend/tests/helpers/file_repo.py` — test-remote adjustment (see How to review).

## How to review

Focus on `push()` in `backend/infrahub/git/repository.py`. The other push callers (`create_branch_in_git`, `merge`/`rebase`) always obtain the branch's worktree whose `HEAD` is the intended tip, so `HEAD:refs/heads/<mapped>` is equivalent for them.

The `file_repo.py` change (`receive.denyCurrentBranch=ignore`) is a test-infrastructure fix, not production behavior: `FileRepo` builds non-bare "remote" repos with a branch checked out, which git refuses to push into by default. The old silent push hid that rejection, so two existing tests only validated the local merge, never the push. Making the push fail loudly turned those hidden rejections into failures; configuring the test remote to accept pushes — like a real hosted (bare) remote does — lets those tests genuinely exercise the push.

## How to test

### Automated regression test

```bash
uv run pytest -c backend/pytest.ini \
  "backend/tests/component/git/test_git_repository.py::test_merge_writes_back_to_non_main_default_branch" -v
```

Expected: the test fails on `stable` with `src refspec develop does not match any` and passes with this change (the remote default branch advances to the merge commit). Full `component/git` + `unit/git` suites pass (224 passed, 1 xfailed).

### Live application testing (done)

This was also validated end-to-end against a **running multi-worker Infrahub instance** (local `dev` stack, `task-worker` at 2 replicas), driving the real `merge_git_repository` code path on a worker whose clone is in the reported state (checked out on `main`, `develop` present only as a remote-tracking ref):

- **Without the fix:** `repo.merge(feat → main)` maps the push to `develop` and fails with `error: src refspec develop does not match any`; the remote `develop` does **not** advance — the write-back is lost.
- **With the fix:** the same merge on the same clone state pushes `HEAD:refs/heads/develop` and the remote `develop` advances to the merge commit; no error is raised.

Note observed while testing: on current `stable` the import path tends to materialise a local `develop` on all workers, so the reported clone state does not arise from a clean 2-worker import as readily as on 1.9.6 — but the push defect itself is unchanged and still triggers whenever a clone lacks the local branch. The fix makes `push` robust regardless of the clone's local branch layout.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/9568.fixed.md`)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
