### PR TITLE
fix: create branches imported from git with sync_with_git enabled [IFC-3001]

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -653,11 +653,15 @@ class InfrahubRepositoryBase(BaseModel, ABC):
     async def create_branch_in_graph(self, branch_name: str) -> BranchData:
         """Create a new branch in the graph.
 
+        The branch originates from a git repository, so it must sync with git: merging it, running
+        its repository checks and generating its artifacts are all gated on that flag. It is passed
+        explicitly rather than left to the client default, which does not sync with git.
+
         NOTE We need to validate that we are not gonna end up with a race condition
         since a call to the GraphQL API will trigger a new RPC call to add a branch in this repo.
         """
         # TODO need to handle the exception properly
-        branch = await self.sdk.branch.create(branch_name=branch_name)
+        branch = await self.sdk.branch.create(branch_name=branch_name, sync_with_git=True)
 
         log.debug(f"Branch {branch_name} created in the Graph", repository=self.name, branch=branch_name)
         return branch

--- a/backend/tests/integration/git/conftest.py
+++ b/backend/tests/integration/git/conftest.py
@@ -214,3 +214,16 @@ def delete_git_branch_after_merge_reset_config() -> Generator[None, None, None]:
     original = config.SETTINGS.git.delete_git_branch_after_merge
     yield
     config.SETTINGS.git.delete_git_branch_after_merge = original
+
+
+@pytest.fixture
+def import_every_remote_branch() -> Generator[None, None, None]:
+    """Import every remote branch, whatever INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES holds in the ambient environment.
+
+    An empty list disables branch-name filtering. Without this, a value exported in the developer's
+    shell leaks into the test process and silently drops the branches the test relies on.
+    """
+    original = config.SETTINGS.git.import_sync_branch_names
+    config.SETTINGS.git.import_sync_branch_names = []
+    yield
+    config.SETTINGS.git.import_sync_branch_names = original

--- a/backend/tests/integration/git/test_sync_branch_flag.py
+++ b/backend/tests/integration/git/test_sync_branch_flag.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from git.repo import Repo
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.git import InfrahubRepository
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+    from tests.helpers.file_repo import FileRepo
+
+NEW_BRANCH = "branch-from-git"
+
+
+class TestSyncBranchFlag(TestInfrahubApp):
+    async def test_branch_imported_from_git_syncs_with_git(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        git_repo_car_dealership: FileRepo,
+        git_repos_dir: Path,
+    ) -> None:
+        """A branch discovered on the remote must be created with sync_with_git enabled.
+
+        Merging the branch, running its repository checks and generating its artifacts are all gated
+        on that flag, so a branch imported without it silently skips the git side of a merge.
+        """
+        obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)
+        await obj.new(
+            db=db,
+            name=git_repo_car_dealership.name,
+            description="test repository",
+            location=git_repo_car_dealership.path,
+        )
+        await obj.save(db=db)
+
+        repo = await InfrahubRepository.new(
+            id=obj.id,
+            name=git_repo_car_dealership.name,
+            location=git_repo_car_dealership.path,
+            client=client,
+        )
+
+        # The branch is created after the clone so the sync treats it as a new remote branch.
+        Repo(git_repo_car_dealership.path).git.branch(NEW_BRANCH, "main")
+
+        collected = await repo.collect_pending_imports()
+        assert [pending.infrahub_branch_name for pending in collected.imports] == [NEW_BRANCH]
+
+        branch = await client.branch.get(branch_name=NEW_BRANCH)
+        assert branch.sync_with_git is True

--- a/backend/tests/integration/git/test_sync_branch_flag.py
+++ b/backend/tests/integration/git/test_sync_branch_flag.py
@@ -27,6 +27,7 @@ class TestSyncBranchFlag(TestInfrahubApp):
         client: InfrahubClient,
         git_repo_car_dealership: FileRepo,
         git_repos_dir: Path,
+        import_every_remote_branch: None,
     ) -> None:
         """A branch discovered on the remote must be created with sync_with_git enabled.
 

--- a/changelog/10208.fixed.md
+++ b/changelog/10208.fixed.md
@@ -1,0 +1,1 @@
+Fixed branches imported from a Git repository being created without the sync with Git flag, which caused merges to skip the Git side.


### PR DESCRIPTION
# Why

Branches discovered on a Git repository remote are created in Infrahub with `sync_with_git` disabled, so merging one silently skips the Git side: the Git branch is never merged into the repository's default branch, nothing is pushed to the remote, and the recorded commit never advances.

`create_branch_in_graph` did not pass `sync_with_git` and relied on the SDK client default, which flipped from `True` to `False` in opsmill/infrahub-sdk-python#1025 (`9b75f1c`). The SDK always sends the value explicitly in the mutation input, so the server-side default (`BranchCreateModel.sync_with_git = True`) never applies. The regression reached Infrahub with the submodule bump `f2c63f085` and affects every 1.10.x release; 1.9.x is unaffected.

Goal: a branch that originates from a Git repository is created with `sync_with_git` enabled, so merges, repository checks and artifact generation behave as they did before 1.10.0.

Non-goals: repairing branches already imported with the flag disabled (see Impact & rollout), and changing the SDK default itself, which is correct for user-created branches.

Closes #10208

## What changed

Behavioral changes:

- A branch created in the graph by the Git agent for a branch found on a repository remote now has `sync_with_git` enabled. Merging it merges the corresponding Git branch into the repository's default branch and advances the recorded commit again.

Implementation notes: the flag is passed explicitly at the call site rather than relying on the client default, and the docstring records why, so it does not get pruned as redundant later. The eight downstream code paths gated on `sync_with_git` are untouched - they were behaving correctly given the input they received.

What stayed the same: no schema changes, no migration, no API contract change. The SDK default is unchanged, so branches created by users or by `infrahubctl` still default to not syncing with Git.

## How to review

The whole change is one keyword argument in `backend/infrahub/git/base.py`. The interesting part is the test, which exercises the real import path end to end rather than asserting on the call.

The test pins `import_sync_branch_names` to an empty list through the new `import_every_remote_branch` fixture. Without it, an `INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES` value exported in your shell leaks into pytest, filters the new remote branch out of the sync and fails the first assertion with an empty import list - a failure that looks like the fix, but is not.

## How to test

```bash
uv run pytest backend/tests/integration/git/test_sync_branch_flag.py -q

# neighbouring sync/merge coverage (not guarded against the env var, so clear it)
env -u INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES \
  uv run pytest backend/tests/integration/git/test_sync_merged_branch.py \
                backend/tests/integration/git/test_repository_branch.py -q
```

The new test fails on `stable` without the fix (`assert False is True`) and passes with it, including with `INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES='["nomatch-.*"]'` exported. The neighbouring tests pass both before and after (3 passed). `ruff format --check` and `ruff check` are clean on the changed files.

## Impact & rollout

- **Backward compatibility:** No breaking changes. Branches imported **while the defect was present** keep `sync_with_git = False` and are not repaired by this PR. There is no reliable way to identify them - `Branch` carries no provenance, so an imported branch and a deliberately non-syncing user branch are indistinguishable on the node - and `BranchUpdateInput` accepts only `description`, so the flag cannot be changed after creation via the API. Repairing one means re-importing the branch or writing the property directly in the database. Wrongly flipping a user branch would be worse than leaving it, so no migration is proposed.
- **Performance:** None.
- **Config/env changes:** None.
- **Deployment notes:** Safe to deploy. Targets `stable`.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) - not needed, restores documented behaviour
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) - not needed, no new concepts
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


