### PR TITLE
docs(knowledge): correct observer fan-out description in api-backpressure

### DIFF
--- a/dev/knowledge/backend/api-backpressure.md
+++ b/dev/knowledge/backend/api-backpressure.md
@@ -63,8 +63,10 @@ one decision, so a sink implements them together. Separate interfaces belong to 
 which is why the pool, the policy, and the tracker each have their own.
 
 The events are named methods rather than a callable protocol, so a sink can carry several of them
-and each one says which event fired. Each component fans out through a single private `_notify`,
-which is also where the per-observer failure containment lives.
+and each one says which event fired. Each component confines its fan-out to sinks behind private
+methods where the per-observer failure containment also lives — a single `_notify` in the slot
+pool, the retry policy, and the load tracker, and one `_observe_*` method per event in the
+admission controller.
 
 The concrete sinks in `observers.py` are named only where the object graph is wired: `server.py`
 passes them to `build_admission_controller`, which takes them as arguments rather than choosing them,


### PR DESCRIPTION
The api-backpressure knowledge doc claimed every component fans out through a single private `_notify`, and that this is where per-observer failure containment lives.

That is inaccurate for the `AdmissionController`: it has no `_notify` and instead fans out through four per-event methods — `_observe_offered`, `_observe_admitted`, `_observe_rejected`, `_observe_sojourn` — each wrapping the sink call in `_contained_observer_failure()`. Only `PrioritySlotPool`, `RetryAfterPolicy`, and `ReferenceQueryLoadTracker` use a single `_notify`.

Reword the sentence to describe both fan-out shapes so the doc matches the code.

Surfaced by a Cubic review comment on #10213 (release-1.11 → develop merge). Fixing at the source on `release-1.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

