### PR TITLE
docs(guidelines): fix double-attribution in testing adapters example

### DIFF
--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -278,7 +278,7 @@ Instead of mocking, design code with explicit boundaries using adapters, interfa
 
 Both implement the same `InfrahubMessageBus` protocol. Tests inject the test adapter—no mocking required, and refactoring the RabbitMQ implementation won't silently break tests.
 
-`BusRecorder` illustrates the two doubles worth writing for any injected collaborator. A **recording** double keeps what crossed the boundary, in order, so the test asserts the exact calls and values rather than "was called". A **failing** double raises on every call, to test the path a `Mock` never exercises: that a broken collaborator is handled the way the code claims — the operation still completes, state is intact, and anything queued behind it still runs. Keep both in the shared adapters package or a `helpers.py` beside the test package rather than redefining them per file.
+Two doubles are worth writing for any injected collaborator. A **recording** double — like `BusRecorder` — keeps what crossed the boundary, in order, so the test asserts the exact calls and values rather than "was called". A **failing** double raises on every call, to test the path a `Mock` never exercises: that a broken collaborator is handled the way the code claims — the operation still completes, state is intact, and anything queued behind it still runs. Keep both in the shared adapters package or a `helpers.py` beside the test package rather than redefining them per file.
 
 ### When mocking seems necessary
 


### PR DESCRIPTION
The testing guideline claimed `BusRecorder` "illustrates the two doubles", including a **failing** double that "raises on every call".

That is inaccurate. `BusRecorder` (`backend/tests/adapters/message_bus.py`) is a **recording** double only: `publish` records messages, while `reply`/`rpc` raise `ValueError("… should not be called")` — should-not-be-called guards, not error injection. Its main method never fails, so it does not illustrate a failing double, and there is no shared failing double in that package for a reader to reuse.

Reword so the recording and failing doubles read as the two patterns worth writing, with `BusRecorder` as the recording example and the failing double as a pattern to add.

Surfaced by a Cubic review comment on #10213 (release-1.11 → develop merge). Fixing at the source on `release-1.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

