### PR TITLE
refactor(frontend): replace Popover matchTriggerWidth boolean with a width enum

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -101,7 +101,7 @@ exports[`fix ts error`] = {
     "src/entities/nodes/object/ui/object-relationship-list.tsx:54284658": [
       [38, 54, 5, "tsc: Property \'items\' does not exist on type \'NodeObject[]\'.", "179721187"]
     ],
-    "src/entities/nodes/object/ui/object-template/object-template-form.tsx:236579240": [
+    "src/entities/nodes/object/ui/object-template/object-template-form.tsx:291373955": [
       [86, 44, 5, "tsc: Property \'edges\' does not exist on type \'NodeAttribute<string | NodeRelationshipMany | NodeRelationshipOne | boolean | null> | number | string | string[] | string[]\'.\\n  Property \'edges\' does not exist on type \'string\'.", "165200885"]
     ],
     "src/entities/nodes/relationships/ui/queries/get-default-parent.query.ts:1805247483": [

--- a/frontend/app/src/entities/branches/ui/branch-selector.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-selector.tsx
@@ -71,7 +71,7 @@ export function BranchSelector() {
         <ChevronsUpDownIcon className="ml-0.5" />
       </Button>
 
-      <Popover placement="bottom start">
+      <Popover placement="bottom start" width="min-trigger">
         <PopoverDialog>
           {({ close }) =>
             isCreating ? (

--- a/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-selector.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-selector.tsx
@@ -47,7 +47,7 @@ export default function IpNamespaceSelector({ className }: IpNamespaceSelectorPr
         </Row>
       </AriaButton>
 
-      <Popover placement="bottom start" className="w-(--trigger-width) bg-white">
+      <Popover placement="bottom start" width="min-trigger" className="bg-white">
         <IpNamespaceComboboxList
           onNamespaceSelection={(value) => {
             setCurrentIpNamespace(value);

--- a/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/filter-condition-select.tsx
@@ -92,7 +92,7 @@ export function FilterConditionSelect({ filterType, ...props }: FilterConditionS
     >
       <SelectTrigger className="h-auto min-h-auto border-transparent bg-transparent px-1 py-0" />
 
-      <SelectList items={getFilterConditionOptions(filterType)} matchTriggerWidth={false}>
+      <SelectList items={getFilterConditionOptions(filterType)} width="content">
         {(item) => <SelectItem>{item.label}</SelectItem>}
       </SelectList>
     </Select>

--- a/frontend/app/src/entities/nodes/object/ui/object-template/object-template-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-template/object-template-form.tsx
@@ -51,7 +51,7 @@ const StartFromTemplateButton = ({
         description="Pick a premade object and customize it"
       />
 
-      <Popover placement="bottom start" className="w-(--trigger-width) bg-white">
+      <Popover placement="bottom start" width="trigger" className="bg-white">
         <Dialog>
           <ObjectTemplateAutocomplete
             autoFocus

--- a/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
+++ b/frontend/app/src/entities/nodes/sort/ui/sort-editor.tsx
@@ -191,7 +191,7 @@ function SortDirectionSelect({ value, onChange }: SortDirectionSelectProps) {
     >
       <SelectTrigger size="sm" />
 
-      <SelectList items={DIRECTION_OPTIONS} matchTriggerWidth={false}>
+      <SelectList items={DIRECTION_OPTIONS} width="content">
         {(option) => <SelectItem>{option.label}</SelectItem>}
       </SelectList>
     </Select>

--- a/frontend/app/src/shared/components/inputs/combobox.tsx
+++ b/frontend/app/src/shared/components/inputs/combobox.tsx
@@ -66,7 +66,7 @@ export function Combobox({
         <ChevronsUpDownIcon className="ml-2 size-3.5 shrink-0 text-gray-400" />
       </Button>
 
-      <Popover placement="bottom start" matchTriggerWidth>
+      <Popover placement="bottom start" width="trigger">
         <Autocomplete>
           <ListBox
             aria-label={label}

--- a/frontend/packages/ui/src/components/popover/popover.stories.tsx
+++ b/frontend/packages/ui/src/components/popover/popover.stories.tsx
@@ -1,38 +1,53 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "../button/button";
-import { Popover, PopoverDialog, PopoverTrigger } from "./popover";
+import { Popover, PopoverDialog, type PopoverProps, PopoverTrigger } from "./popover";
+
+const WIDTHS = ["trigger", "min-trigger", "content"] as const satisfies readonly NonNullable<
+  PopoverProps["width"]
+>[];
+
+const CONTENTS = {
+  short: "Short.",
+  long: "Content that needs more room than the trigger it hangs from.",
+};
 
 const meta: Meta<typeof Popover> = {
   title: "Components/Popover",
   component: Popover,
+  parameters: {
+    layout: "centered",
+  },
 };
 export default meta;
 
-type Story = StoryObj<typeof Popover>;
+type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const AllVariants: Story = {
   render: () => (
-    <PopoverTrigger>
-      <Button>Open popover</Button>
-      <Popover>
-        <PopoverDialog className="p-4">
-          <p className="text-sm">This is the popover content.</p>
-        </PopoverDialog>
-      </Popover>
-    </PopoverTrigger>
-  ),
-};
+    <div className="flex flex-col gap-4">
+      {WIDTHS.map((width) => (
+        <div key={width} className="flex flex-col gap-1">
+          <div className="text-xxs font-medium tracking-wider text-neutral-400 uppercase">
+            {width}
+          </div>
 
-export const MatchTriggerWidth: Story = {
-  render: () => (
-    <PopoverTrigger>
-      <Button>Open a wide popover trigger</Button>
-      <Popover matchTriggerWidth>
-        <PopoverDialog className="p-4">
-          <p className="text-sm">This popover matches the trigger width exactly.</p>
-        </PopoverDialog>
-      </Popover>
-    </PopoverTrigger>
+          <div className="flex gap-2">
+            {Object.entries(CONTENTS).map(([label, content]) => (
+              <PopoverTrigger key={label}>
+                <Button variant="outline" className="w-64">
+                  {label} content
+                </Button>
+                <Popover width={width}>
+                  <PopoverDialog className="p-4">
+                    <p className="text-sm">{content}</p>
+                  </PopoverDialog>
+                </Popover>
+              </PopoverTrigger>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   ),
 };

--- a/frontend/packages/ui/src/components/popover/popover.tsx
+++ b/frontend/packages/ui/src/components/popover/popover.tsx
@@ -5,7 +5,7 @@ import {
   Popover as AriaPopover,
   type PopoverProps as AriaPopoverProps,
 } from "react-aria-components";
-import { tv } from "tailwind-variants";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 
@@ -23,8 +23,10 @@ const popoverStyles = tv({
     isExiting: {
       true: "animate-out fade-out-0 zoom-out-95",
     },
-    matchTriggerWidth: {
-      true: "w-(--trigger-width)",
+    width: {
+      trigger: "w-(--trigger-width)",
+      "min-trigger": "min-w-(--trigger-width)",
+      content: "",
     },
   },
 });
@@ -33,16 +35,15 @@ const popoverDialogStyles = tv({
   base: "outline-hidden",
 });
 
-export interface PopoverProps extends AriaPopoverProps {
-  matchTriggerWidth?: boolean;
-}
+export interface PopoverProps
+  extends AriaPopoverProps, Pick<VariantProps<typeof popoverStyles>, "width"> {}
 
-export function Popover({ className, matchTriggerWidth, ...props }: PopoverProps) {
+export function Popover({ className, width = "content", ...props }: PopoverProps) {
   return (
     <AriaPopover
       offset={4}
       className={composeAriaClassName(className, (renderProps) =>
-        popoverStyles({ ...renderProps, matchTriggerWidth }),
+        popoverStyles({ ...renderProps, width }),
       )}
       {...props}
     />

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -12,7 +12,7 @@ export { Select } from "react-aria-components";
 import { focusVisibleStyle } from "../../styles/focus-visible";
 import { composeAriaClassName } from "../../utils/compose-aria-class-name";
 import { ListBox, ListBoxItem, type ListBoxItemProps } from "../list-box/list-box";
-import { Popover } from "../popover/popover";
+import { Popover, type PopoverProps } from "../popover/popover";
 
 export const selectTriggerVariants = tv({
   base: [
@@ -47,16 +47,11 @@ export function SelectTrigger({ className, size, ...props }: SelectTriggerProps)
   );
 }
 
-export interface SelectListProps<T> extends AriaListBoxProps<T> {
-  matchTriggerWidth?: boolean;
-}
+export interface SelectListProps<T> extends AriaListBoxProps<T>, Pick<PopoverProps, "width"> {}
 
-export function SelectList<T extends object>({
-  matchTriggerWidth = true,
-  ...props
-}: SelectListProps<T>) {
+export function SelectList<T extends object>({ width = "trigger", ...props }: SelectListProps<T>) {
   return (
-    <Popover matchTriggerWidth={matchTriggerWidth}>
+    <Popover width={width}>
       <ListBox selectionMode="single" {...props} />
     </Popover>
   );


### PR DESCRIPTION
## Problem

`Popover`'s `matchTriggerWidth` boolean has two states, and neither is "at least as wide as the trigger, but free to grow". The branch selector needs exactly that: its trigger is `w-64`, so with no width constraint the popover shrank to the width of the word `main`.

The boolean is also a migration hazard. The legacy Radix `ComboboxContent.fitTriggerWidth` has two *different* states — `true` → `width`, `false` → **`minWidth`** — and **16 call sites** pass `fitTriggerWidth={false}`, relying on that floor. Mapping those to `matchTriggerWidth={false}` would have dropped the floor at every one of them, silently.

## Change

```ts
export interface PopoverProps
  extends AriaPopoverProps, Pick<VariantProps<typeof popoverStyles>, "width"> {}
```

| value | CSS | behaviour |
|---|---|---|
| `trigger` | `w-(--trigger-width)` | exactly the trigger width |
| `min-trigger` | `min-w-(--trigger-width)` | never narrower than the trigger, grows for wider content |
| `content` | *(none)* | shrink-to-fit — the popover is out-of-flow, so this is its natural width |

The values are derived from the `tv` variant via `VariantProps`, so they're defined once. `SelectList` picks the same prop off `PopoverProps` rather than re-declaring it.

**Defaults are chosen to keep every existing call site pixel-identical:** `Popover` → `content` (~40 call sites pass no width prop), `SelectList` → `trigger` (matches the old `matchTriggerWidth = true`).

Two call sites that bypassed the prop with a hand-written `className="w-(--trigger-width)"` now use it, so the CSS variable no longer appears in any app `className`.

The three popover stories are unified into one `AllVariants` that shows each width against **short and long** content — the only layout where `min-trigger` is legible, since it looks like `trigger` when content is wide and like `content` when content is narrow.

`src/shared/components/ui/combobox.tsx` is deliberately untouched. it's a legacy component.

## Verification

```
frontend/app:    biome ci clean · betterer ci 188 issues unchanged · knip clean
                 pnpm test — 176 files / 1190 tests passed
packages/ui:     tsc --noEmit → exit 0 · oxfmt --check → 53 files correct
                 oxlint → 1 pre-existing error in tree/tree.tsx:14, untouched here
grep:            matchTriggerWidth → 0 · w-(--trigger-width) in app className → 0
```

`.betterer.results` carries a one-line file-hash update for a pre-existing error in `object-template-form.tsx`.

Not covered by automation: the branch-selector width is a visual change with no assertion behind it — worth an eyeball on the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

