### PR TITLE
docs(objects): clarify kind/identifier are required but ignored with --file

### DIFF
--- a/docs/docs/objects/manage-from-cli.mdx
+++ b/docs/docs/objects/manage-from-cli.mdx
@@ -106,7 +106,7 @@ infrahubctl object update InfraDevice spine01 --set status=active
 
 An update only changes the fields you provide. Attributes and relationships you leave out keep their current values — omitting a field does not clear it.
 
-With `--file`, the file defines which objects to update and what to change, so the kind and identifier on the command line are ignored:
+With `--file`, the file defines which objects to update and what to change. The kind and identifier are still required on the command line, but their values are ignored — the file supplies the targets:
 
 ```bash
 infrahubctl object update InfraDevice spine01 --file updates.yml


### PR DESCRIPTION
The `infrahubctl object update` doc said that with `--file` "the kind and identifier on the command line are ignored", which could read as if they can be omitted.

They can't: `kind` and `identifier` are `typer.Argument(...)` — required positional args — so the command errors without them. In `--file` mode their *values* are ignored and the file supplies the targets (the CLI even prints a note to that effect). Reword to state both facts.

Docs-only clarification, so it targets `stable`. Surfaced by a Cubic comment on #10213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

