### PR TITLE
chore: remove ruff ignore rules that no longer suppress anything

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -602,6 +602,10 @@ allow-dunder-method-names = [
     "UP035",    # `typing.List` is deprecated, use `list` instead
 ]
 
+"**/graphql_queries/*.py" = [
+    "E501",  # ruff check --fix produces a long single-line union before ruff format wraps it
+]
+
 "backend/infrahub/cli/db.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -602,10 +602,6 @@ allow-dunder-method-names = [
     "UP035",    # `typing.List` is deprecated, use `list` instead
 ]
 
-"**/graphql_queries/*.py" = [
-    "E501",  # ruff check --fix produces a long single-line union before ruff format wraps it
-]
-
 "backend/infrahub/cli/db.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
@@ -636,19 +632,6 @@ allow-dunder-method-names = [
     "UP045",  # Use X | Y for type annotations
 ]
 
-"backend/infrahub/core/node/__init__.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-]
-
-"backend/infrahub/core/query/**.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "UP007",  # Use X | Y for type annotations
-]
-
 "backend/infrahub/core/models.py" = [
     ##################################################################################################
     # Refactor code and remove the ignore rule
@@ -664,20 +647,6 @@ allow-dunder-method-names = [
     "PLR0915", # Too many statements
 ]
 
-
-"backend/infrahub/core/query/relationship.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "PLR0915", # Too many statements
-]
-
-"backend/infrahub/core/schema/manager.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "PLR0915", # Too many statements
-]
 
 "backend/infrahub/graphql/app.py" = [
     ##################################################################################################
@@ -743,7 +712,6 @@ allow-dunder-method-names = [
     # credentials/tokens, function-local imports for optional async paths).
     "ARG001",   # Unused function argument (fixtures requested for their side effects)
     "ARG002",   # Unused method argument
-    "ARG003",   # Unused class method argument
     "DOC501",   # Raised exception missing from docstring
     "INP001",   # File is part of an implicit namespace package
     "PLC0415",  # `import` should be at the top-level of a file
@@ -753,7 +721,6 @@ allow-dunder-method-names = [
     "RUF001",   # Ambiguous unicode char (matching UI strings verbatim, e.g. the × chip glyph)
     "S101",     # Use of assert detected
     "S105",     # Possible hardcoded password assigned to variable
-    "S106",     # Possible hardcoded password assigned to argument
     "S404",     # Suspicious use of the subprocess module
     "SLF001",   # Private member accessed
 ]
@@ -869,7 +836,6 @@ allow-dunder-method-names = [
     "PLR0917",  # Too many positional arguments
     "PLR2004",  # Magic value used in comparison
     "PLR6301",  # Method could be a function, class method, or static method
-    "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
     "RUF005",   # Consider spread operator instead of concatenation
     "RUF015",   # Prefer `next(...)` over single element slice
@@ -899,9 +865,7 @@ allow-dunder-method-names = [
     "PLR2004",  # Magic value used in comparison
     "PLR6201",  # Use a `set` literal when testing for membership
     "PLR6301",  # Method could be a function, class method, or static method
-    "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`
     "PT007",    # Wrong values type in `pytest.mark.parametrize`
-    "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
     "PT012",    # `pytest.raises()` block should contain a single simple statement
     "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
@@ -959,7 +923,6 @@ allow-dunder-method-names = [
     "ASYNC240", # Async functions should not use pathlib.Path methods
     "ERA001",   # Found commented-out code
     "FIX",      # flake8-fixme
-    "FURB118",  # Use `operator.itemgetter(1)` instead of defining a lambda
     "FURB192",  # Prefer `min` over `sorted()` to compute the minimum value
     "INP001",   # File is part of an implicit namespace package
     "N802",     # Function name should be lowercase
@@ -984,7 +947,6 @@ allow-dunder-method-names = [
     "PT011",    # `pytest.raises(ValueError)` is too broad
     "PT012",    # `pytest.raises()` block should contain a single simple statement
     "RUF005",   # Consider spread operator instead of concatenation
-    "RUF010",   # Use explicit conversion flag
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",   # Prefer `next(...)` over single element slice
     "RUF029",   # Function is declared `async`, but doesn't `await`
@@ -1035,17 +997,6 @@ allow-dunder-method-names = [
     "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 
-"backend/tests/integration_docker/test_schema_migration.py" = [
-    ##################################################################################################
-    # Review and change the below later                                                              #
-    ##################################################################################################
-    "ASYNC230", # Async functions should not open files with blocking methods like `open`
-]
-
-"backend/tests/component/graphql/test_schema_sort.py" = [
-    "W293", # Blank line contains whitespace
-]
-
 "models/**.py" = [
     ##################################################################################################
     # Rules that have violations in models/ directory                                                #
@@ -1064,8 +1015,6 @@ allow-dunder-method-names = [
     "RUF010",   # Use explicit conversion flag
     "RUF029",   # Function is declared `async`, but doesn't `await`
     "S101",     # Use of `assert` detected
-    "SIM102",   # Use a single `if` statement instead of nested `if` statements
-    "UP031",    # Use format specifiers instead of percent format
 ]
 
 "models/infrastructure_edge.py" = [
@@ -1093,24 +1042,6 @@ allow-dunder-method-names = [
     "PGH004", #Use specific rule codes when using `ruff: noqa`
 ]
 
-"python_testcontainers/**.py" = [
-    ##################################################################################################
-    # Rules that have violations in python_testcontainers/ directory                                 #
-    ##################################################################################################
-    "PERF203",  # `try`-`except` within a loop incurs performance overhead
-    "PLR0912",  # Too many branches
-    "PLR6301",  # Method could be a function, class method, or static method
-    "RUF010",   # Use explicit conversion flag
-    "S101",     # Use of `assert` detected
-]
-
-"python_testcontainers/infrahub_testcontainers/helpers.py" = [
-    ##################################################################################################
-    # Refactor code and remove the ignore rule
-    ##################################################################################################
-    "PT021",   # Use `yield` instead of `request.addfinalizer`
-]
-
 "tasks/**.py" = [
     "ERA001",   # Found commented-out code
     "FURB118",  # Use `operator.itemgetter(1)` instead of defining a lambda
@@ -1128,7 +1059,6 @@ allow-dunder-method-names = [
     "SIM108",   # Use ternary operator instead of `if`-`else`-block
     "SIM401",   # Use `dict.get(key, default)` instead of an `if` block
     "SLF001",   # Private member accessed
-    "UP031",    # Use format specifiers instead of percent format
 ]
 
 "tasks/release.py" = [
@@ -1146,8 +1076,6 @@ allow-dunder-method-names = [
     "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
     "ERA001",   # Found commented-out code
     "LOG015",   # `info()` call on root logger
-    "N806",     # Variable in function should be lowercase
-    "PLR0912",  # Too many branches
     "PLR0913",  # Too many arguments in function definition
     "PLR0917",  # Too many positional arguments
     "PLR6201",  # Use a `set` literal when testing for membership
@@ -1156,7 +1084,6 @@ allow-dunder-method-names = [
     "S311",     # Standard pseudo-random generators are not suitable for crypto
     "SIM108",   # Use ternary operator instead of `if`-`else`-block
     "SIM117",   # Use a single `with` statement with multiple contexts
-    "UP031",    # Use format specifiers instead of percent format
     "UP035",    # `typing.List` is deprecated, use `list` instead
 ]
 


### PR DESCRIPTION
## What changed

Removed 73 lines of dead `ruff` configuration from the root `pyproject.toml`.

Every ignore entry was tested mechanically: drop it from the full config, re-run `ruff check .`, keep the removal only if ruff stays clean. Nothing here relies on judgement about whether a rule "should" apply.

### Whole blocks removed

Their last remaining rule was dead, or the block was already empty:

- `backend/infrahub/core/node/__init__.py` — empty list, ignored nothing
- `backend/infrahub/core/query/**.py` (UP007), `core/query/relationship.py` (PLR0915), `core/schema/manager.py` (PLR0915)
- `backend/tests/integration_docker/test_schema_migration.py` (ASYNC230), `backend/tests/component/graphql/test_schema_sort.py` (W293)
- `python_testcontainers/**.py` and `python_testcontainers/infrahub_testcontainers/helpers.py`

The last two were never consulted at all. `python_testcontainers/` carries its own `[tool.ruff]` config, so `ruff check --show-settings` resolves those files against `python_testcontainers/pyproject.toml` and the root patterns never appear in the resolved settings.

### Individual dead rules

`tests/e2e` (ARG003, S106) · `backend/tests/functional` (PT011) · `backend/tests/integration` (PT006, plus a duplicated PT007 line) · `backend/tests/component` (FURB118, RUF010) · `models/**` (SIM102, UP031) · `tasks/**` (UP031) · `utilities/**` (N806, PLR0912, UP031)

## What was deliberately left alone

**The global `ignore` list is unchanged.** D203/D213 (and ISC in the `python_testcontainers` config) test as removable only because ruff auto-disables them as incompatible with D211/D212 and the formatter. Dropping them would trade a clean run for permanent `warning: ... are incompatible` output.

**A pre-existing config bug, not addressed here.** In ruff's per-file-ignores globs `*` crosses `/`, so `backend/tests/*.py` is equivalent to `backend/tests/**.py` and matches the whole test tree recursively. Removing that block surfaces 601 violations in `backend/tests/unit/` alone. It sits directly below an explicit `backend/tests/**.py` block, so the two are duplicates with different rule lists, and it silently shadows roughly 45 entries in the narrower sub-blocks (`component`, `integration`, `functional`, `helpers`, `benchmark`, `adapters`, `scale`, `test_data`, `integration_docker`).

Those shadowed entries are individually deletable today, but only because the broad block covers them. Tightening `backend/tests/*.py` to be non-recursive would re-expose real violations across the test tree, so it needs its own decision and its own PR.

## Testing

- `ruff check .` clean from the repo root
- `ruff check .` clean inside `python_testcontainers/` under its own config

No changelog fragment: lint configuration only, no user-facing change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

