### PR TITLE
docs(cut-release): avoid release-* branch names for patch releases

### DIFF
--- a/.agents/commands/cut-release.md
+++ b/.agents/commands/cut-release.md
@@ -41,7 +41,13 @@ Before proceeding, verify:
    ```bash
    git branch --show-current
    ```
-   Inform the user which branch they're on.
+   Inform the user which branch they're on. The release commits must go on a
+   dedicated branch that is PR'd into `stable` (never commit them to `stable` or
+   `develop` directly). Do NOT name that branch `release-<version>` or anything
+   matching `release-*`: GitHub branch protection on `release-*` blocks
+   follow-up pushes, which patch releases often need when extra commits are
+   added after the first. Prefer a non-matching name such as
+   `chore/release-<version>`.
 
 3. **Preview towncrier output**:
    ```bash
@@ -180,11 +186,17 @@ Present a summary of changes made:
 
 Suggest next steps (DO NOT execute these automatically):
 1. Review the changes: `git diff`
-2. Stage and commit: `git add -A && git commit -m "chore: release <version>"`
-3. Push the branch: `git push -u origin <branch_name>`
-4. Open a PR targeting `stable`
-5. Merge the PR
-6. Create a GitHub release at https://github.com/opsmill/infrahub/releases/new with tag `infrahub-v<version>`
+2. Create a dedicated release branch off the current base. Do NOT name it
+   `release-<version>` or anything matching `release-*`: GitHub branch
+   protection on `release-*` blocks follow-up pushes, which is a problem for
+   patch releases where you may need to add commits after the first one. Use a
+   non-matching name such as `chore/release-<version>`:
+   `git switch -c chore/release-<version>`
+3. Stage and commit: `git add -A && git commit -m "chore: release <version>"`
+4. Push the branch: `git push -u origin chore/release-<version>`
+5. Open a PR targeting `stable`
+6. Merge the PR
+7. Create a GitHub release at https://github.com/opsmill/infrahub/releases/new with tag `infrahub-v<version>`
 
 **IMPORTANT: Do NOT automatically commit or push. Let the user review and execute these steps manually.**
 

--- a/.agents/commands/cut-release.md
+++ b/.agents/commands/cut-release.md
@@ -37,17 +37,24 @@ Before proceeding, verify:
    ```
    Report how many fragments exist. If none, warn the user but allow proceeding (they may want to release without new changes).
 
-2. **Show current branch** (informational):
+2. **Confirm the base branch and create the dedicated release branch** (do this
+   before any of the edits in Steps 3-7, so those edits land on the right branch
+   cut from the right base):
    ```bash
    git branch --show-current
    ```
-   Inform the user which branch they're on. The release commits must go on a
-   dedicated branch that is PR'd into `stable` (never commit them to `stable` or
-   `develop` directly). Do NOT name that branch `release-<version>` or anything
-   matching `release-*`: GitHub branch protection on `release-*` blocks
-   follow-up pushes, which patch releases often need when extra commits are
-   added after the first. Prefer a non-matching name such as
-   `chore/release-<version>`.
+   Releases are PR'd into `stable`, so the release branch must be cut from
+   `stable` (never commit release changes to `stable` or `develop` directly). If
+   the current branch is not `stable`, tell the user and switch first
+   (`git switch stable && git pull`) unless they intend a different base. Then
+   create the dedicated branch:
+   ```bash
+   git switch -c chore/release-<version>
+   ```
+   Do NOT name that branch `release-<version>` or anything matching `release-*`:
+   GitHub branch protection on `release-*` blocks follow-up pushes, which patch
+   releases often need when extra commits are added after the first. Prefer a
+   non-matching name such as `chore/release-<version>`.
 
 3. **Preview towncrier output**:
    ```bash
@@ -184,19 +191,14 @@ Present a summary of changes made:
 - Files modified/created
 - Number of changelog entries included
 
-Suggest next steps (DO NOT execute these automatically):
+Suggest next steps (DO NOT execute these automatically). These land on the
+dedicated `chore/release-<version>` branch created in Step 2:
 1. Review the changes: `git diff`
-2. Create a dedicated release branch off the current base. Do NOT name it
-   `release-<version>` or anything matching `release-*`: GitHub branch
-   protection on `release-*` blocks follow-up pushes, which is a problem for
-   patch releases where you may need to add commits after the first one. Use a
-   non-matching name such as `chore/release-<version>`:
-   `git switch -c chore/release-<version>`
-3. Stage and commit: `git add -A && git commit -m "chore: release <version>"`
-4. Push the branch: `git push -u origin chore/release-<version>`
-5. Open a PR targeting `stable`
-6. Merge the PR
-7. Create a GitHub release at https://github.com/opsmill/infrahub/releases/new with tag `infrahub-v<version>`
+2. Stage and commit: `git add -A && git commit -m "chore: release <version>"`
+3. Push the branch: `git push -u origin chore/release-<version>`
+4. Open a PR targeting `stable`
+5. Merge the PR
+6. Create a GitHub release at https://github.com/opsmill/infrahub/releases/new with tag `infrahub-v<version>`
 
 **IMPORTANT: Do NOT automatically commit or push. Let the user review and execute these steps manually.**
 


### PR DESCRIPTION
# Why

The `/cut-release` command left the working-branch name entirely to the operator's judgment. During the 1.10.7 release the branch was named `release-1.10.7`, which matched the repository's `release-*` branch protection rule. That protection blocks follow-up pushes, which is a problem for patch releases where extra commits are often needed after the initial version bump.

Goal: bake the branch-naming convention into the command so future releases avoid the `release-*` collision.

Non-goals: no change to the release mechanics themselves (version bump, towncrier, release notes). This does not touch the actual 1.10.7 release branch, which is handled separately.

## What changed

- Step 2 (Pre-flight Checks): the branch-check point now warns, before any edits are made, that release commits go on a dedicated branch PR'd into `stable` (never `stable`/`develop` directly) and must not match `release-*`. Recommends `chore/release-<version>`.
- Step 8 (Next Steps): added the previously-missing explicit "create the branch" step, explained the `release-*` protection problem, and replaced the undefined `<branch_name>` placeholder with the concrete `chore/release-<version>` convention in both the create and push commands.

What stayed the same: the release procedure (version bump, changelog, release notes, sidebar) is unchanged.

## How to review

Read the two edited sections of `.agents/commands/cut-release.md`. Confirm the suggested `chore/release-<version>` name does not match the `release-*` protection glob and that it lines up with the existing `chore: release <version>` commit message.

## How to test

Docs-only change to a slash-command definition; no automated test. Verify by reading the rendered command.

## Impact & rollout

- **Backward compatibility:** none affected; guidance-only change.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

