### PR TITLE
fix: send complex attribute values as GraphQL variables (closes #9739)

### DIFF
--- a/changelog/9739.fixed.md
+++ b/changelog/9739.fixed.md
@@ -1,0 +1,1 @@
+Fixed saving objects whose JSON attribute values contain keys with hyphens or other special characters

--- a/frontend/app/src/entities/nodes/object/api/create-object-from-api.test.ts
+++ b/frontend/app/src/entities/nodes/object/api/create-object-from-api.test.ts
@@ -1,0 +1,45 @@
+import { type FieldNode, type OperationDefinitionNode, valueFromASTUntyped } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+
+import { createObjectFromApi } from "./create-object-from-api";
+
+vi.mock("@/shared/api/graphql/graphqlClientApollo", () => ({
+  default: { mutate: vi.fn() },
+}));
+
+const getSentMutationData = () => {
+  const mutateOptions = vi.mocked(graphqlClient.mutate).mock.calls[0]![0];
+  const operation = mutateOptions.mutation.definitions.find(
+    (definition): definition is OperationDefinitionNode => definition.kind === "OperationDefinition"
+  )!;
+  const mutationField = operation.selectionSet.selections[0] as FieldNode;
+  const dataArgument = mutationField.arguments!.find((argument) => argument.name.value === "data")!;
+  return valueFromASTUntyped(dataArgument.value, mutateOptions.variables);
+};
+
+describe("createObjectFromApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(graphqlClient.mutate).mockResolvedValue({ data: {} });
+  });
+
+  it("sends JSON attribute values whose keys are not valid GraphQL names", async () => {
+    // GIVEN a JSON attribute value with a key that cannot be expressed as a GraphQL name
+    const data = {
+      name: { value: "deSEC" },
+      settings: { value: { "auth-token": "pass://Domain Management/deSEC.io/auth-token" } },
+    };
+
+    // WHEN
+    await createObjectFromApi({ data, objectKind: "DnsCredential", branchName: "main" });
+
+    // THEN the mutation reaches the client with the JSON value intact
+    expect(graphqlClient.mutate).toHaveBeenCalledTimes(1);
+    expect(getSentMutationData()).toEqual({
+      name: { value: "deSEC" },
+      settings: { value: { "auth-token": "pass://Domain Management/deSEC.io/auth-token" } },
+    });
+  });
+});

--- a/frontend/app/src/entities/nodes/object/api/create-object-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/create-object-from-api.ts
@@ -4,6 +4,8 @@ import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import type { BranchContextParams } from "@/shared/api/types";
 
+import { hoistAttributeValuesToVariables } from "@/entities/nodes/object/utils/hoist-attribute-values-to-variables";
+
 export interface CreateObjectFromApiParams extends BranchContextParams {
   objectKind: string;
   data: Record<string, unknown>;
@@ -18,13 +20,22 @@ export function createObjectFromApi({
   branchName,
   file,
 }: CreateObjectFromApiParams) {
+  const {
+    data: hoistedData,
+    variableDefinitions,
+    variableValues,
+  } = hoistAttributeValuesToVariables(data);
+  const hasVariables = file !== undefined || Object.keys(variableDefinitions).length > 0;
+
   const mutation = jsonToGraphQLQuery({
     mutation: {
-      ...(file && { __variables: { file: "Upload!" } }),
+      ...(hasVariables && {
+        __variables: { ...(file && { file: "Upload!" }), ...variableDefinitions },
+      }),
       [`${objectKind}Create`]: {
         __args: {
           data: {
-            ...data,
+            ...hoistedData,
             ...(profileIds.length && { profiles: profileIds.map((id) => ({ id })) }),
           },
           ...(file && { file: new VariableType("file") }),
@@ -41,7 +52,7 @@ export function createObjectFromApi({
 
   return graphqlClient.mutate({
     mutation: gql(mutation),
-    variables: file ? { file } : undefined,
+    variables: hasVariables ? { ...(file && { file }), ...variableValues } : undefined,
     context: {
       branch: branchName,
     },

--- a/frontend/app/src/entities/nodes/object/api/update-object-from-api.test.ts
+++ b/frontend/app/src/entities/nodes/object/api/update-object-from-api.test.ts
@@ -1,0 +1,50 @@
+import { type FieldNode, type OperationDefinitionNode, valueFromASTUntyped } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+
+import { updateObjectFromApi } from "./update-object-from-api";
+
+vi.mock("@/shared/api/graphql/graphqlClientApollo", () => ({
+  default: { mutate: vi.fn() },
+}));
+
+const getSentMutationData = () => {
+  const mutateOptions = vi.mocked(graphqlClient.mutate).mock.calls[0]![0];
+  const operation = mutateOptions.mutation.definitions.find(
+    (definition): definition is OperationDefinitionNode => definition.kind === "OperationDefinition"
+  )!;
+  const mutationField = operation.selectionSet.selections[0] as FieldNode;
+  const dataArgument = mutationField.arguments!.find((argument) => argument.name.value === "data")!;
+  return valueFromASTUntyped(dataArgument.value, mutateOptions.variables);
+};
+
+describe("updateObjectFromApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(graphqlClient.mutate).mockResolvedValue({ data: {} });
+  });
+
+  it("sends JSON attribute values whose keys are not valid GraphQL names", async () => {
+    // GIVEN a JSON attribute value with a key that cannot be expressed as a GraphQL name,
+    // alongside a relationship input that must stay untouched
+    const data = {
+      id: "credential-1",
+      name: { value: "deSEC" },
+      settings: { value: { "auth-token": "pass://Domain Management/deSEC.io/auth-token" } },
+      provider: { id: "provider-1" },
+    };
+
+    // WHEN
+    await updateObjectFromApi({ data, objectKind: "DnsCredential", branchName: "main" });
+
+    // THEN the mutation reaches the client with the JSON value intact
+    expect(graphqlClient.mutate).toHaveBeenCalledTimes(1);
+    expect(getSentMutationData()).toEqual({
+      id: "credential-1",
+      name: { value: "deSEC" },
+      settings: { value: { "auth-token": "pass://Domain Management/deSEC.io/auth-token" } },
+      provider: { id: "provider-1" },
+    });
+  });
+});

--- a/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
@@ -9,6 +9,7 @@ import {
 } from "@/shared/components/form/constants";
 
 import { getRelationshipMutation } from "@/entities/nodes/object/utils/get-relationship-mutations";
+import { hoistAttributeValuesToVariables } from "@/entities/nodes/object/utils/hoist-attribute-values-to-variables";
 
 export interface UpdateObjectFromApiParams extends BranchContextParams {
   objectKind: string;
@@ -75,12 +76,21 @@ export function updateObjectFromApi({
     };
   }, {});
 
+  const {
+    data: hoistedObjectData,
+    variableDefinitions,
+    variableValues,
+  } = hoistAttributeValuesToVariables(objectData);
+  const hasVariables = file !== undefined || Object.keys(variableDefinitions).length > 0;
+
   const objectMutation = {
-    ...(file && { __variables: { file: "Upload!" } }),
+    ...(hasVariables && {
+      __variables: { ...(file && { file: "Upload!" }), ...variableDefinitions },
+    }),
     [`${objectKind}Update`]: {
       __args: {
         data: {
-          ...objectData,
+          ...hoistedObjectData,
           ...(profileIds !== undefined
             ? { profiles: profileIds.map((profileId) => ({ id: profileId })) }
             : {}),
@@ -124,7 +134,7 @@ export function updateObjectFromApi({
 
   return graphqlClient.mutate({
     mutation: gql(mutation),
-    variables: file ? { file } : undefined,
+    variables: hasVariables ? { ...(file && { file }), ...variableValues } : undefined,
     context: {
       branch: branchName,
     },

--- a/frontend/app/src/entities/nodes/object/utils/hoist-attribute-values-to-variables.ts
+++ b/frontend/app/src/entities/nodes/object/utils/hoist-attribute-values-to-variables.ts
@@ -1,0 +1,50 @@
+import { VariableType } from "json-to-graphql-query";
+
+interface HoistedMutationData {
+  data: Record<string, unknown>;
+  variableDefinitions: Record<string, string>;
+  variableValues: Record<string, unknown>;
+}
+
+const hasComplexValue = (
+  fieldInput: unknown
+): fieldInput is Record<string, unknown> & { value: object } => {
+  if (typeof fieldInput !== "object" || fieldInput === null || Array.isArray(fieldInput)) {
+    return false;
+  }
+  const { value } = fieldInput as Record<string, unknown>;
+  return typeof value === "object" && value !== null;
+};
+
+/**
+ * GraphQL object literals only accept keys matching the Name grammar
+ * (`[_A-Za-z][_0-9A-Za-z]*`), while JSON and List attribute values may contain
+ * arbitrary keys (e.g. `{"auth-token": "..."}`). Such values cannot be inlined
+ * in a mutation document; they must be sent as GraphQL variables instead.
+ *
+ * Replaces every attribute input value that is an object or array with a
+ * `$value_<fieldName>` variable reference, and returns the matching variable
+ * definitions (typed `GenericScalar`) and values to attach to the request.
+ * Relationship inputs carry no `value` key and pass through untouched.
+ */
+export const hoistAttributeValuesToVariables = (
+  data: Record<string, unknown>
+): HoistedMutationData => {
+  const variableDefinitions: Record<string, string> = {};
+  const variableValues: Record<string, unknown> = {};
+
+  const dataWithVariableReferences = Object.fromEntries(
+    Object.entries(data).map(([fieldName, fieldInput]) => {
+      if (!hasComplexValue(fieldInput)) {
+        return [fieldName, fieldInput];
+      }
+
+      const variableName = `value_${fieldName}`;
+      variableDefinitions[variableName] = "GenericScalar";
+      variableValues[variableName] = fieldInput.value;
+      return [fieldName, { ...fieldInput, value: new VariableType(variableName) }];
+    })
+  );
+
+  return { data: dataWithVariableReferences, variableDefinitions, variableValues };
+};


### PR DESCRIPTION
# Why

Saving an object with a `kind: JSON` attribute fails in the web UI whenever the JSON value contains a key that is not a valid GraphQL name, e.g. `{"auth-token": "..."}`, while `{"authToken": "..."}` works. The frontend inlines attribute values into the GraphQL mutation document as object literals, and GraphQL object-literal keys must match the Name grammar (`[_A-Za-z][_0-9A-Za-z]*`), so the document fails to parse inside `gql()` before any request is sent.

The backend is not at fault: verified against a live stack that `GenericScalar` accepts, stores, and returns hyphenated keys intact when the value is passed as a GraphQL variable.

Non-goals: the Python SDK has the same flaw (`convert_to_graphql_as_string` renders dict keys bare) and needs a separate fix in `opsmill/infrahub-sdk-python`; the raw HTTP 500 the server returns for unparseable documents is a separate papercut, untouched here.

Closes #9739

## What changed

- Object and array attribute values are hoisted out of the mutation document into GraphQL variables typed `GenericScalar`, in both the create and update mutation builders (`create-object-from-api.ts`, `update-object-from-api.ts`).
- New helper `hoist-attribute-values-to-variables.ts` does the hoisting: every top-level `data` entry shaped `{ value: <object|array> }` gets its value replaced with a `$value_<fieldName>` reference; the values travel in the request's `variables`.
- This also covers List attributes (same `GenericScalar` input type), which had the same latent bug for list members not expressible as GraphQL literals.
- What stayed the same: relationship inputs (`{id}`, `{hfid}`, arrays of those, `from_pool`), `null` resets, and `{is_default: true}` profile resets carry no complex `value` key and are still inlined; the existing `file: Upload!` variable mechanics are merged with, not replaced. No schema changes, no backend changes.

## How to review

- `hoist-attribute-values-to-variables.ts` is the core: check the `hasComplexValue` predicate against the payload shapes produced by `getCreateMutationFromFormData` / `getUpdateMutationFromFormData`.
- In `update-object-from-api.ts`, hoisting runs on the already-partitioned `objectData` so the bulk-relationship prefix handling is unaffected.
- The tests resolve the document's `data` argument with `valueFromASTUntyped(node, variables)`, so they assert the effective payload regardless of which channel (literal vs variable) each field uses.

## How to test

```bash
cd frontend/app && pnpm exec vitest run src/entities/nodes/object/api/create-object-from-api.test.ts src/entities/nodes/object/api/update-object-from-api.test.ts
```

Both tests fail on `stable` with `GraphQLError: Syntax Error: Invalid number, expected digit but got: "t"` and pass with this change. Full frontend suite: 839 tests pass.

Manual check: create a node whose schema has a `kind: JSON` attribute and save `{"auth-token": "x"}` as its value; the save succeeds and the value round-trips.

## Impact & rollout

- **Backward compatibility:** none broken; mutation payloads are semantically identical, only the transport of complex values moved from literals to variables.
- **Deployment notes:** safe to deploy, frontend-only.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) — N/A
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) — N/A
- [x] I have reviewed AI generated content

<!-- AGENT_TEST_COMPLETE -->
<!-- AGENT_FIX_COMPLETE -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

