### PR TITLE
fix: drop --diff from ruff check in lint tasks [#3658]

### DIFF
--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -91,7 +91,7 @@ def format_all(context: Context) -> None:
 def ruff(context: Context) -> None:
     """Run ruff linter against backend Python files."""
     print(f" - [{NAMESPACE}] Check code with ruff")
-    exec_cmd = f"uv run ruff check --diff {MAIN_DIRECTORY}"
+    exec_cmd = f"uv run ruff check {MAIN_DIRECTORY}"
 
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -36,7 +36,7 @@ def format_all(context: Context) -> None:
 def _lint_ruff(context: Context) -> None:
     """Run ruff to check that Python files adherence to standards."""
     print(f" - [{NAMESPACE}] Check code with ruff")
-    exec_cmd = f"uv run ruff check --diff {' '.join(DIRECTORIES)}"
+    exec_cmd = f"uv run ruff check {' '.join(DIRECTORIES)}"
 
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -42,7 +42,7 @@ def ruff(context: Context) -> None:
     """Run ruff linter against Python SDK files."""
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_directory = MAIN_DIRECTORY_PATH
-    exec_cmd = f"ruff check --diff {exec_directory} --config {exec_directory / 'pyproject.toml'}"
+    exec_cmd = f"ruff check {exec_directory} --config {exec_directory / 'pyproject.toml'}"
 
     with context.cd(exec_directory):
         context.run(exec_cmd)


### PR DESCRIPTION
## Why

Closes #3658

`ruff check --diff` reports only the violations that have an **available fix**. A violation with no fix (or only an unsafe one) produces no output at all and the command exits `0`.

Reproduced on the pinned ruff (0.15.0), so this is not a behaviour that has been fixed upstream:

```console
$ ruff check --isolated --select ARG001 --diff .
$ echo $?
0

$ ruff check --isolated --select ARG001 .
ARG001 Unused function argument: `unused_arg`
 --> nofix.py:1:7
Found 1 error.
$ echo $?
1
```

Three invoke tasks still used that form:

- `tasks/backend.py` - `invoke backend.ruff`
- `tasks/main.py` - `invoke main.lint`
- `tasks/sdk.py` - `invoke sdk.ruff`

CI's `python-lint` job was already fixed to use the plain form (`uv run ruff check . --exclude python_sdk`), so the two had drifted apart: `invoke lint` and `/pre-ci` could pass locally on code that CI then rejected.

## What changed

Removed `--diff` from the three `ruff check` invocations. Nothing else - `ruff format --check --diff` is left as-is, since `format --check` does exit non-zero correctly and the diff output is useful there.

No `ruff check --diff` remains outside the `python_sdk` submodule.

## Testing

All three tasks run clean against the current tree:

```console
$ uv run invoke backend.ruff
 - [BACKEND] Check code with ruff
All checks passed!
1918 files already formatted

$ uv run invoke main.lint
 - [MAIN] Check code with ruff
All checks passed!

$ uv run invoke sdk.ruff
 - [SDK] Check code with ruff
All checks passed!
```

No changelog fragment: developer tooling only, nothing user-facing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

