### PR TITLE
fix(ci): retry cosign transparency-log writes and upload SBOMs first

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -202,9 +202,33 @@ jobs:
           password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Sign manifest
+        env:
+          IMAGE: ${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}
         run: |
-          cosign sign --yes --recursive --new-bundle-format=false --use-signing-config=false \
-            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
+          # cosign gives up after two internal attempts when a Sigstore transparency
+          # log write fails, so a brief rekor.sigstore.dev blip is enough to fail a
+          # release. Retry the whole command instead; five attempts 60s apart cover a
+          # ~4-minute outage. The sbom job carries a verbatim copy of this function:
+          # the jobs run on separate runners, so sharing it would take a checkout or a
+          # third-party action in the signing path. Keep the two copies identical.
+          retry() {
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "${attempt}" -lt 5 ]; then
+                echo "::warning::${1} ${2} failed (attempt ${attempt}/5), retrying in 60s"
+                sleep 60
+              fi
+            done
+            echo "::error::${1} ${2} failed after 5 attempts"
+            return 1
+          }
+
+          retry cosign sign --yes --recursive \
+            --new-bundle-format=false --use-signing-config=false \
+            "${IMAGE}"
 
   sbom:
     needs: merge
@@ -236,20 +260,16 @@ jobs:
             "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}" \
             --output cyclonedx-json=infrahub-sbom.cdx.json
 
-      - name: Attest SBOM (SPDX)
-        run: |
-          cosign attest --yes \
-            --type spdxjson \
-            --predicate infrahub-sbom.spdx.json \
-            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
-
-      - name: Attest SBOM (CycloneDX)
-        run: |
-          cosign attest --yes \
-            --type cyclonedx \
-            --predicate infrahub-sbom.cdx.json \
-            "${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}"
-
+      # Uploaded before the attestations so that a transparency-log outage cannot cost
+      # us the SBOMs themselves: v1.10.7 shipped without any because the attest step
+      # failed first and skipped this one.
+      #
+      # overwrite is required precisely because this now runs before a step that can
+      # fail. Artifacts are scoped to the run rather than the attempt, so on a re-run
+      # this name already exists from the earlier attempt and the default overwrite:
+      # false would fail the upload, breaking the recovery path this ordering exists to
+      # protect. Every caller passes a version unique to its invocation, so the only
+      # artifact this can replace is the same SBOM from a previous attempt.
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -258,3 +278,37 @@ jobs:
             infrahub-sbom.spdx.json
             infrahub-sbom.cdx.json
           retention-days: 90
+          overwrite: true
+
+      - name: Attest SBOMs
+        env:
+          IMAGE: ${{ vars.HARBOR_HOST }}/${{ github.repository }}@${{ needs.merge.outputs.digest }}
+        run: |
+          # Same transparency-log flakiness the sign job guards against; this is a
+          # verbatim copy of that job's retry function (separate runners, so it cannot
+          # be shared without a checkout or a third-party action in the signing path).
+          # Keep the two copies identical.
+          retry() {
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "${attempt}" -lt 5 ]; then
+                echo "::warning::${1} ${2} failed (attempt ${attempt}/5), retrying in 60s"
+                sleep 60
+              fi
+            done
+            echo "::error::${1} ${2} failed after 5 attempts"
+            return 1
+          }
+
+          retry cosign attest --yes \
+            --type spdxjson \
+            --predicate infrahub-sbom.spdx.json \
+            "${IMAGE}"
+
+          retry cosign attest --yes \
+            --type cyclonedx \
+            --predicate infrahub-sbom.cdx.json \
+            "${IMAGE}"


### PR DESCRIPTION
## Problem

The v1.10.7 release failed in `publish-docker-image / sbom` ([run 31521732131](https://github.com/opsmill/infrahub/actions/runs/31521732131/job/93882940631)) at the `Attest SBOM (SPDX)` step:

```
Error: signing ...infrahub@sha256:fabec4d2...: signing bundle: error signing bundle:
Post "https://rekor.sigstore.dev/api/v1/log/entries": giving up after 2 attempt(s)
```

Rekor was only briefly unavailable. Evidence it was transient, not a config break:

- The `sign` job succeeded at 18:21:53 against the same Sigstore infrastructure; `sbom` failed at 18:26–18:27.
- The identical `sbom` job passed on the next run ([31549394917](https://github.com/opsmill/infrahub/actions/runs/31549394917)) with no code change.

cosign retries a failed transparency-log write only twice before giving up, which is short enough that a blip of a few minutes fails an entire release.

### Why it mattered more than it should have

`Attest SBOM (CycloneDX)` and `Upload SBOM artifacts` never ran, so:

- **v1.10.7 shipped with no SBOM artifacts** — it is the only gap in the `sbom-infrahub-v1.10.0` … `v1.10.6` sequence (since re-run manually).
- **`repository-dispatch` was skipped.** It declares `needs: publish-docker-image` (`release.yml:137-141`), so downstream repos were never notified of v1.10.7.

## Changes

1. **Retry with exponential backoff** (5 attempts: 15s/30s/60s/120s) around `cosign sign` and both `cosign attest` calls. Both talk to the same transparency log and are equally exposed; only `attest` happened to lose the coin flip this time.
2. **Upload SBOM artifacts before attesting them**, so a transparency-log outage can no longer cost us the SBOMs. Attestation failure still fails the job — that is the correct outcome for a supply-chain step — but the artifacts survive.

The two `Attest SBOM (*)` steps are consolidated into one `Attest SBOMs` step so the retry helper is defined once.

## Verification

- `yamllint -c .yamllint.yml` passes on the modified workflow.
- The retry logic was exercised under `bash -e` with a stubbed `cosign` for three cases: succeeds first try (exit 0), recovers after 3 failures (exit 0, the real-world scenario), and exhausts all 5 attempts (exit 1, step fails).
- Confirmed against the pinned cosign v3.0.6 binary (what `cosign-installer@v4.1.2` installs) that no flag semantics changed; the cosign invocations themselves are unchanged apart from moving the image reference into an `IMAGE` env var.

## Deliberately not changed — needs a decision

`cosign sign` is pinned to the old signing path (`--new-bundle-format=false --use-signing-config=false`), added in 550d134ed with the note *"Use old bundle format and disable signing config until we upgrade Harbor to 2.15."* The two `cosign attest` calls never received those flags, so **attestations still run through the new sigstore-go bundle path** — which is precisely the code path that emitted `signing bundle: error signing bundle` here.

I have left that asymmetry alone: flipping the attestation bundle format changes what is stored in the registry and how consumers verify it, which is a supply-chain behaviour change rather than a resilience fix. @fatih-acar — was excluding `attest` from those flags intentional, or should it match `sign`?

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

