### PR TITLE
docs(objects): add Create objects overview page

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -32,6 +32,7 @@ Ceph
 changelog
 conftest
 Conftest
+cron
 check_color_tags_name
 check_definitions
 class_name
@@ -173,6 +174,7 @@ Observium
 OIDC
 Okta
 Onboarding
+onboarding
 OpenAPI
 order_by
 order_weight

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -5,31 +5,31 @@ title: Create objects
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-How you create an object depends on what drives it. Create objects directly through one of Infrahub's interfaces, declare them in a file that lives in Git alongside your schema, or have a workflow create them from data that already exists.
+How you create an object depends on what starts the work. Create objects directly through an Infrahub interface, declare them in a YAML file stored in Git alongside your schema, or configure a workflow that creates them from data you already have.
 
 ## Create objects directly
 
-Infrahub has four interfaces, and all of them produce the same object and enforce the same schema constraints. Pick the one that fits how you are working.
+Four interfaces create objects. All four produce the same object and enforce the same schema constraints, so pick the one that matches how you are already working.
 
 The example below creates a device named `atl1-edge1` at site `atl1`. On `InfraDevice`, `name` and `type` are required and `site` is a relationship.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
-Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which of them are required, and validates values as you type. That makes it the quickest way to learn what a kind actually needs before you script against it.
+Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which ones are required, and validates values as you type.
 
 1. Open the Device list from the left menu.
 2. Select **Add Device**. The **Create Device** panel opens.
 3. Fill in the name and type.
 4. Select a site, then save.
 
-The form is also the only place where Object Templates, Profiles, and resource pools appear as selectable controls. The other interfaces accept the same values as fields.
+In the web form you can also pick an Object Template, assign Profiles, and allocate from a resource pool while filling in the object. The other interfaces accept the same values as fields.
 
 </TabItem>
 
   <TabItem value="infrahubctl" label="infrahubctl">
 
-Use `infrahubctl` for interactive work and for scripting one object at a time. It fits the point where you already know the kind and the values and want the object created without leaving the terminal — onboarding a device during a maintenance window, or a shell script that creates a few objects as one step in a longer task.
+Use `infrahubctl` for interactive work and for scripting one object at a time — onboarding a device during a maintenance window, or a shell script that creates a few objects as one step in a longer task.
 
 ```bash
 infrahubctl object create InfraDevice \
@@ -46,7 +46,7 @@ Relationship values resolve by name, so `site=atl1` looks up the site and links 
 
   <TabItem value="sdk" label="Python SDK">
 
-Use the Python SDK for custom scripts and integrations — when a program decides what to create rather than a person. The SDK handles authentication, query construction, and serialization, so the script works with objects instead of HTTP calls. Transformations, Generators, and checks run against this same client, so a script you write standalone can later run inside Infrahub's pipeline without changes.
+Use the Python SDK for custom scripts and integrations — when a program decides what to create rather than a person. The SDK handles authentication, query construction, and serialization, so your code works with objects rather than HTTP requests. Transformations, Generators, and checks run against this same client, so a script you write standalone runs unchanged inside Infrahub's pipeline.
 
 ```python
 from infrahub_sdk import InfrahubClientSync
@@ -62,7 +62,7 @@ device = client.create(
 device.save()
 ```
 
-To create many objects in one run, group the calls into a batch with a concurrency limit. The synchronous client suits straightforward scripting; the async client suits work that benefits from concurrent I/O.
+To create many objects in one run, group the calls into a batch with a concurrency limit. Use the synchronous client for scripting, and the async client for work with concurrent I/O.
 
 See the [Python SDK]($(base_url)python-sdk/introduction) documentation.
 
@@ -99,7 +99,7 @@ See [Queries & mutations](../development-resources/graphql/queries-and-mutations
 
 ## Create objects from a file
 
-Use object files for data that changes rarely and should be reviewed before it does, or as a starting dataset for a new instance. The file is YAML in a Git repository, so a change to your data goes through the same review as a change to your code.
+Use object files for data that changes rarely and needs review before it changes, or as a starting dataset for a new instance. The file is YAML in a Git repository, so a change to your data goes through the same review as a change to your code.
 
 ```yaml
 ---
@@ -126,19 +126,26 @@ Generators and Infrahub Sync both run from a configuration you set up, rather th
 
 ### Generators
 
-Use a Generator when the objects you need follow from data Infrahub already holds — an IP address for every new interface, or the circuits a service definition implies. You describe the rule once, and it applies to every target, including ones added later.
+Use a Generator when the objects you need are determined by data Infrahub already holds — an IP address for every new interface, or the circuits required by a service definition. You describe the rule once, and it applies to every target, including targets added later.
 
-A Generator has three parts: a GraphQL query that collects the data, the Python that acts on the results, and a target Group naming the objects it works on. Infrahub creates one run per member of that group, so a Generator targeting a group of ten racks produces ten independent runs, each seeing only its own rack's data.
+A Generator has three parts: a GraphQL query that collects the data, the Python that acts on the results, and a target Group that lists the objects it runs against. Infrahub creates one run per member of that group, so a Generator targeting a group of ten racks produces ten independent runs, each reading only its own rack's data.
 
-Objects are created when a run executes. That happens when you open a Proposed Change affecting the targets and the Generator runs as part of the CI checks, when you run the definition from the UI under **Actions > Generator Definitions**, when an Event rule you configured fires, or when you run it locally with `infrahubctl` while developing. Each run also removes objects it created earlier that the current data no longer requires.
+Objects are created when a run executes. A run starts when you:
+
+- Open a Proposed Change that affects the targets, where the Generator runs as one of the CI checks.
+- Run the definition from the UI under **Actions > Generator Definitions**.
+- Trigger it with an Event rule you configured.
+- Run it locally with `infrahubctl` while developing.
+
+Each run also deletes objects it created earlier that the current data no longer requires.
 
 See [Generators](../generators/overview.mdx).
 
 ### Infrahub Sync
 
-Use Infrahub Sync when another system holds data you need in Infrahub and stays the system of record for it. Sync moves infrastructure data between Infrahub and external systems — NetBox, Nautobot, IP Fabric, Slurp'it, Cisco ACI, Peering Manager, and any system with a REST API. It also runs the other direction, publishing Infrahub data into monitoring, observability, or CMDB systems that need a current view of the infrastructure.
+Use Infrahub Sync when another system holds data you need in Infrahub and stays the system of record for it. Sync moves infrastructure data between Infrahub and external systems — NetBox, Nautobot, IP Fabric, Slurp'it, Cisco ACI, Peering Manager, and any system with a REST API. Sync also runs in the other direction, publishing Infrahub data into monitoring, observability, or CMDB systems.
 
-Define a sync project in YAML that maps the source system's models onto your schema. Three commands drive it: `generate` builds the adapter code from that mapping, `diff` shows what would change without applying it, and `sync` applies the changes. Objects are created in Infrahub on the `sync` run, for every record in the source with no match in Infrahub. Each run calculates a fresh diff and applies only the deltas, so a run that fails partway can be repeated safely.
+Define a sync project in YAML that maps the source system's models onto your schema. Three commands run it: `generate` builds the adapter code from that mapping, `diff` shows what would change without applying it, and `sync` applies the changes. Objects are created in Infrahub on the `sync` run, for every record in the source with no match in Infrahub. Each run calculates a fresh diff and applies only the deltas, so a run that fails partway can be repeated safely.
 
 Sync runs as a CLI, so you schedule it with the tooling you already use — cron, a CI job, or Prefect.
 
@@ -148,11 +155,13 @@ See [Infrahub Sync]($(base_url)sync) for adapters, mapping rules, and configurat
 
 A new object exists on the branch it was created on. On a branch other than the default, it remains isolated until that branch merges through a [proposed change](../proposed-changes/overview.mdx).
 
-Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). A value is either entered directly or supplied by one of three features, each of which applies whichever method created the object:
+Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). You either entered the value while creating the object, or you set it up in advance so that you do not fill it in each time:
 
-- [Object Templates](../object-templates/overview.mdx) supply structure — which components the new object starts with.
-- [Profiles](../profiles/overview.mdx) supply attribute values the object inherits and can override.
-- [Resource Manager](../resource-manager/overview.mdx) allocates a value, such as an IP address or a VLAN ID, from a pool.
+- Pick an [Object Template](../object-templates/overview.mdx) to start the object with a set of components already in place.
+- Assign a [Profile](../profiles/overview.mdx) to give the object attribute values it inherits, and override any of them on the object itself.
+- Allocate from a [Resource Manager](../resource-manager/overview.mdx) pool to take the next free IP address or VLAN ID.
+
+All three work whichever method created the object.
 
 ## Related
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -5,7 +5,11 @@ title: Create objects
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-How you create an object depends on what starts the work. Create objects directly through an Infrahub interface, declare them in a YAML file stored in Git alongside your schema, or configure a workflow that creates them from data you already have.
+How you create an object depends on what starts the work. There are three ways:
+
+- **[Directly](#create-objects-directly)** — create each object through the web interface, `infrahubctl`, the Python SDK, or GraphQL. Use this when you are deciding what to create as you go.
+- **[From a file](#create-objects-from-a-file)** — declare objects in YAML kept in Git, then load the file. Use this when the data should be reviewed and versioned like code.
+- **[From a workflow](#create-objects-from-a-workflow)** — configure a Generator or Infrahub Sync once, and it creates objects from data you already have. Use this when a rule or another system determines what should exist.
 
 ## Create objects directly
 
@@ -122,7 +126,7 @@ There are two ways to load a file, and they differ in what happens afterwards. `
 
 ## Create objects from a workflow
 
-Generators and Infrahub Sync both run from a configuration you set up, rather than from a command you type each time.
+Both run from a configuration you set up, rather than from a command you type each time. A Generator works from data already in Infrahub. Infrahub Sync works from data in another system.
 
 ### Generators
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -1,0 +1,22 @@
+---
+title: Create objects
+---
+
+Infrahub supports several ways to create objects. Pick the one that matches how the data reaches you — a one-off change in the web interface, a batch of records tracked in Git, or a script driving an API.
+
+| Method | Best for | Where to go |
+|---|---|---|
+| Web interface | One-off objects, exploring a new schema | Open the kind's list from the left-hand menu and select **Create \<Kind\>** |
+| `infrahubctl` (CLI) | Interactive work and scripting one object at a time | [Manage objects with infrahubctl](./manage-from-cli.mdx) |
+| YAML object files | Data that changes rarely, tracked in Git, or a bootstrap dataset loaded on demand with `infrahubctl object` | [Load data using YAML file](./load-from-yaml.mdx) |
+| Python SDK | Custom scripts and integrations | [Python SDK]($(base_url)python-sdk/introduction) |
+| GraphQL API | Mutations from any GraphQL client | [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx) |
+| Generators | New objects generated automatically from existing data | [Generators](../generators/overview.mdx) |
+| Infrahub Sync | Import from an external system such as NetBox or Nautobot | [Infrahub Sync]($(base_url)sync) |
+
+Which method fits best often depends on where you are with a given dataset: importing an existing inventory favors YAML files or Infrahub Sync, while day-to-day changes to an established dataset favor the web interface, the CLI, or the SDK.
+
+## Related
+
+- [Convert object kind](./convert-object-kind.mdx)
+- [Metadata & lineage](./metadata.mdx)

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -163,13 +163,13 @@ See [Infrahub Sync]($(base_url)sync) for adapters, mapping rules, and configurat
 
 A new object exists on the branch it was created on. On a branch other than the default, it remains isolated until that branch merges through a [proposed change](../proposed-changes/overview.mdx).
 
-Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). You either entered the value while creating the object, or you set it up in advance so that you do not fill it in each time:
+Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). You either entered the value while creating the object, or you set it up in advance so the object receives it on creation:
 
 - Choose an [Object Template](../object-templates/overview.mdx) to start the object with a set of components already in place.
 - Assign a [Profile](../profiles/overview.mdx) to give the object attribute values it inherits, and override any of them on the object itself.
 - Allocate from a [Resource Manager](../resource-manager/overview.mdx) pool to take the next free IP address or VLAN ID.
 
-All three work whichever method created the object.
+Templates, Profiles, and pools apply whichever of the three ways you used to create the object — directly, from a file, or from a workflow.
 
 ## Related
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -5,11 +5,11 @@ title: Create objects
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-How you create an object depends on what starts the work. There are three ways:
+How you create objects depends on how many you are creating and where their definition comes from. There are three ways:
 
-- **[Directly](#create-objects-directly)** — create each object through the web interface, `infrahubctl`, the Python SDK, or GraphQL. Use this when you are deciding what to create as you go.
-- **[From a file](#create-objects-from-a-file)** — declare objects in YAML kept in Git, then load the file. Use this when the data should be reviewed and versioned like code.
-- **[From a workflow](#create-objects-from-a-workflow)** — configure a Generator or Infrahub Sync once, and it creates objects from data you already have. Use this when a rule or another system determines what should exist.
+- **[Directly](#create-objects-directly)** — create objects one at a time through the web interface, `infrahubctl`, the Python SDK, or GraphQL. Use this for a single device, a few prefixes, or any change small enough to enter manually or in a short script.
+- **[From a file](#create-objects-from-a-file)** — declare many objects in a YAML file kept in Git, then load them together. Use this to populate a new instance, or for data that someone should review before it changes.
+- **[From a workflow](#create-objects-from-a-workflow)** — configure a Generator or Infrahub Sync once, then objects are created and updated as the underlying data changes. Use this when a rule determines what should exist, or when another system is already the source.
 
 ## Create objects directly
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -2,21 +2,170 @@
 title: Create objects
 ---
 
-Infrahub supports several ways to create objects. Pick the one that matches how the data reaches you — a one-off change in the web interface, a batch of records tracked in Git, or a script driving an API.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-| Method | Best for | Where to go |
-|---|---|---|
-| Web interface | One-off objects, exploring a new schema | Open the kind's list from the left-hand menu and select **Create \<Kind\>** |
-| `infrahubctl` (CLI) | Interactive work and scripting one object at a time | [Manage objects with infrahubctl](./manage-from-cli.mdx) |
-| YAML object files | Data that changes rarely, tracked in Git, or a bootstrap dataset loaded on demand with `infrahubctl object` | [Load data using YAML file](./load-from-yaml.mdx) |
-| Python SDK | Custom scripts and integrations | [Python SDK]($(base_url)python-sdk/introduction) |
-| GraphQL API | Mutations from any GraphQL client | [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx) |
-| Generators | New objects generated automatically from existing data | [Generators](../generators/overview.mdx) |
-| Infrahub Sync | Import from an external system such as NetBox or Nautobot | [Infrahub Sync]($(base_url)sync) |
+There are several ways to create or add objects in Infrahub:
 
-Which method fits best often depends on where you are with a given dataset: importing an existing inventory favors YAML files or Infrahub Sync, while day-to-day changes to an established dataset favor the web interface, the CLI, or the SDK.
+| Method | Use when |
+|---|---|
+| Web interface | One-off objects, exploring a new schema |
+| `infrahubctl` | Interactive work and scripting one object at a time |
+| Python SDK | Custom scripts and integrations |
+| GraphQL API | Mutations from any GraphQL client |
+| Object files | Data that changes rarely, tracked in Git, or a starting dataset loaded on demand |
+
+Every method produces the same objects and enforces the same schema constraints, so the choice is about workflow.
+
+Objects can also be created from workflows, using Generators or Infrahub Sync:
+
+- **Generators** create objects from data already in Infrahub — allocate an IP address for every new interface, or build the circuits a service definition implies.
+- **Infrahub Sync** creates objects from data in another system, such as NetBox or Nautobot, and keeps the two in sync as that data changes.
+
+## Create an object
+
+The example below creates a device named `atl1-edge1` at site `atl1`. On `InfraDevice`, `name` and `type` are required and `site` is a relationship.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Web interface" default>
+
+Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which of them are required, and validates values as you type — which makes it the quickest way to see what a kind actually needs before you script against it.
+
+1. Open the Device list from the left menu.
+2. Select **Add Device**. The **Create Device** panel opens.
+3. Fill in the name and type.
+4. Select a site, then save.
+
+This is also the only method that offers Object Templates, Profiles, and resource pools as selectable controls. The other methods accept the same values, but you supply them yourself.
+
+</TabItem>
+
+  <TabItem value="infrahubctl" label="infrahubctl">
+
+Use `infrahubctl` for interactive work and for scripting one object at a time. It fits the point where you already know the kind and the values and want the object created without leaving the terminal — onboarding a device during a maintenance window, or a shell script that creates a few objects as one step in a longer task.
+
+```bash
+infrahubctl object create InfraDevice \
+  --set name=atl1-edge1 \
+  --set type=7280R3 \
+  --set site=atl1
+```
+
+Relationship values resolve by name, so `site=atl1` looks up the site and links it. [Manage objects with infrahubctl](./manage-from-cli.mdx) covers querying, updating, and deleting.
+
+</TabItem>
+
+  <TabItem value="sdk" label="Python SDK">
+
+Use the Python SDK for custom scripts and integrations — when a program decides what to create rather than a person. The SDK handles authentication, query construction, and serialization, so the script works with objects instead of HTTP calls.
+
+```python
+from infrahub_sdk import InfrahubClientSync
+
+client = InfrahubClientSync(address="http://localhost:8000")
+
+device = client.create(
+    kind="InfraDevice",
+    name="atl1-edge1",
+    type="7280R3",
+    site="atl1",
+)
+device.save()
+```
+
+Transformations, Generators, and checks run against this same client, so a script you write here can run inside Infrahub's pipeline without changes. To create many objects in one run, group the calls into a batch with a concurrency limit. The synchronous client suits straightforward scripting; the async client suits work that benefits from concurrent I/O. See the [Python SDK]($(base_url)python-sdk/introduction) documentation.
+
+</TabItem>
+
+  <TabItem value="graphql" label="GraphQL">
+
+Use the GraphQL API when the client is not Python, or when you are already querying Infrahub over GraphQL and want to create objects through the same interface.
+
+```graphql
+mutation {
+  InfraDeviceCreate(
+    data: {
+      name: { value: "atl1-edge1" }
+      type: { value: "7280R3" }
+      site: { hfid: ["atl1"] }
+    }
+  ) {
+    ok
+    object {
+      id
+      hfid
+    }
+  }
+}
+```
+
+Infrahub generates four mutations for every model in your schema, named from its namespace and name — `InfraDeviceCreate`, `InfraDeviceUpdate`, `InfraDeviceUpsert`, and `InfraDeviceDelete`. Use `Upsert` when the object may already exist and you want one call to cover both cases. To create the object on a branch, post to `/graphql/<branch_name>`. See [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx).
+
+</TabItem>
+</Tabs>
+
+## Load objects from a file
+
+Use object files for data that changes rarely and should be reviewed before it does, or as a starting dataset for a new instance. The file is YAML in a Git repository, so a change to your data goes through the same review as a change to your code.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: InfraDevice
+  data:
+    - name: atl1-edge1
+      type: 7280R3
+      site: atl1
+    - name: atl1-edge2
+      type: 7280R3
+      site: atl1
+```
+
+There are two ways to load a file, and they differ in what happens afterwards. `infrahubctl object load` imports the file once, and Infrahub keeps no link to it. Declaring the file under `objects:` in a repository's `.infrahub.yml` means Infrahub tracks it, so removing a record from the file deletes the object on the next import.
+
+[Load data using YAML file](./load-from-yaml.mdx) covers the file format, nested objects, and load order.
+
+## Generate and import objects
+
+Both of these run from a configuration you set up, rather than from a command you type each time.
+
+### Generators
+
+Use a Generator when the objects you need follow from data Infrahub already holds — an IP address for every new interface, or the circuits a service definition implies. You describe the rule once, and it applies to every target, including ones added later.
+
+A Generator has three parts: a GraphQL query that collects the data, the Python that acts on the results, and a target Group naming the objects it works on. Infrahub creates one run per member of that group, so a Generator targeting a group of ten racks produces ten independent runs, each seeing only its own rack's data.
+
+Objects are created when a run executes. That happens when you open a Proposed Change affecting the targets and the Generator runs as part of the CI checks, when you run the definition from the UI under **Actions > Generator Definitions**, when an Event rule you configured fires, or when you run it locally with `infrahubctl` while developing. Each run also removes objects it created earlier that the current data no longer requires.
+
+See [Generators](../generators/overview.mdx).
+
+### Infrahub Sync
+
+Use Infrahub Sync when another system holds data you need in Infrahub and stays the system of record for it. Sync moves infrastructure data between Infrahub and external systems — NetBox, Nautobot, IP Fabric, Slurp'it, Cisco ACI, Peering Manager, and any system with a REST API. It also runs the other direction, publishing Infrahub data into monitoring, observability, or CMDB systems that need a current view of the infrastructure.
+
+Define a sync project in YAML that maps the source system's models onto your schema. Three commands drive it: `generate` builds the adapter code from that mapping, `diff` shows what would change without applying it, and `sync` applies the changes. Objects are created in Infrahub on the `sync` run, for every record in the source with no match in Infrahub. Each run calculates a fresh diff and applies only the deltas, so a run that fails partway can be repeated safely.
+
+Sync runs as a CLI, so you schedule it with the tooling you already use — cron, a CI job, or Prefect.
+
+See [Infrahub Sync]($(base_url)sync) for adapters, mapping rules, and configuration.
+
+## Templates, Profiles, and resource pools
+
+Creating many objects of the same kind usually means repeating the same structure and the same values. Three features cover that, whichever method you use:
+
+- [Object Templates](../object-templates/overview.mdx) supply structure — which components the new object starts with.
+- [Profiles](../profiles/overview.mdx) supply attribute values the object inherits and can override.
+- [Resource Manager](../resource-manager/overview.mdx) allocates a value, such as an IP address or a VLAN ID, from a pool at create time.
+
+The web form offers these as selectable controls. The other methods accept the same values as fields.
+
+## After an object is created
+
+A new object exists on the branch it was created on. On a branch other than the default, it remains isolated until that branch merges through a [proposed change](../proposed-changes/overview.mdx). Every attribute records how its value was set — entered directly, inherited from a Profile, or allocated from a pool — which you can read back through [metadata and lineage](./metadata.mdx).
 
 ## Related
 
-- [Convert object kind](./convert-object-kind.mdx)
-- [Metadata & lineage](./metadata.mdx)
+- [Objects](./overview.mdx) — what an object is and how it relates to schema nodes
+- [Convert object kind](./convert-object-kind.mdx) — change the schema kind of an existing object

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -13,14 +13,14 @@ How you create objects depends on how many you are creating and where their defi
 
 ## Create objects directly
 
-Four interfaces create objects. All four produce the same object and enforce the same schema constraints, so pick the one that matches how you are already working.
+Four interfaces create objects, and all four produce the same result: the same object, validated against the same schema constraints, on the branch you are working in. What differs is where you are working — a browser, a terminal, a Python program, or any GraphQL client.
 
 The example below creates a device named `atl1-edge1` at site `atl1`. On `InfraDevice`, `name` and `type` are required and `site` is a relationship.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
-Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which ones are required, and validates values as you type.
+Use the web interface for a single object, and for the first object of a kind you have not created before. The form is built from the schema, so it shows every field the kind defines, marks which ones are required, and validates values as you type — which also tells you what a script will need to supply later.
 
 1. Open the Device list from the left menu.
 2. Select **Add Device**. The **Create Device** panel opens.
@@ -74,7 +74,7 @@ See the [Python SDK]($(base_url)python-sdk/introduction) documentation.
 
   <TabItem value="graphql" label="GraphQL">
 
-Use the GraphQL API when the client is not Python, or when you are already querying Infrahub over GraphQL and want to create objects through the same interface.
+Use the GraphQL API to create objects from any language or tool that can send an HTTP request — Go, TypeScript, or a shell script using `curl`. It is also where to write from when you are already reading data over GraphQL and want both in the same place.
 
 ```graphql
 mutation {
@@ -103,7 +103,9 @@ See [Queries & mutations](../development-resources/graphql/queries-and-mutations
 
 ## Create objects from a file
 
-Use object files for data that changes rarely and needs review before it changes, or as a starting dataset for a new instance. The file is YAML in a Git repository, so a change to your data goes through the same review as a change to your code.
+An object file declares a set of objects in YAML: which kind they are and what values they carry. Keeping that file in a Git repository makes the data reproducible — you can rebuild an instance from it, promote the same dataset from development to production, and review a change to your data in a pull request before it reaches Infrahub.
+
+Use object files for the reference data your instance is built on and that rarely changes afterwards — sites, roles, platforms, device types, standard tags — and for the dataset that populates a new instance.
 
 ```yaml
 ---
@@ -126,7 +128,9 @@ There are two ways to load a file, and they differ in what happens afterwards. `
 
 ## Create objects from a workflow
 
-Both run from a configuration you set up, rather than from a command you type each time. A Generator works from data already in Infrahub. Infrahub Sync works from data in another system.
+Both create objects from a configuration you set up once, rather than from a command you type each time, and both keep the result correct as the source data changes. That is what suits them to data no one should be maintaining manually — the objects that ought to exist because something else is true.
+
+A Generator works from data already in Infrahub. Infrahub Sync works from data in another system.
 
 ### Generators
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -5,7 +5,7 @@ title: Create objects
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-How you create objects depends on how many you are creating and where their definition comes from. There are three ways:
+There are three ways to add objects to Infrahub. Which one you need depends on how many objects you are creating and where their definition comes from:
 
 - **[Directly](#create-objects-directly)** — create objects one at a time through the web interface, `infrahubctl`, the Python SDK, or GraphQL. Use this for a single device, a few prefixes, or any change small enough to enter manually or in a short script.
 - **[From a file](#create-objects-from-a-file)** — declare many objects in a YAML file kept in Git, then load them together. Use this to populate a new instance, or for data that someone should review before it changes.
@@ -13,7 +13,7 @@ How you create objects depends on how many you are creating and where their defi
 
 ## Create objects directly
 
-Four interfaces create objects, and all four produce the same result: the same object, validated against the same schema constraints, on the branch you are working in. What differs is where you are working — a browser, a terminal, a Python program, or any GraphQL client.
+There are four ways to create an object one at a time, and all four produce the same result: the same object, validated against the same schema constraints, on the branch you are working in. Choose based on where you are already working — a browser, a terminal, a Python program, or a GraphQL client.
 
 The example below creates a device named `atl1-edge1` at site `atl1`. On `InfraDevice`, `name` and `type` are required and `site` is a relationship.
 
@@ -27,7 +27,7 @@ Use the web interface for a single object, and for the first object of a kind yo
 3. Fill in the name and type.
 4. Select a site, then save.
 
-In the web form you can also pick an Object Template, assign Profiles, and allocate from a resource pool while filling in the object. The other interfaces accept the same values as fields.
+In the web form you can also choose an Object Template, assign Profiles, and allocate from a resource pool while filling in the object. The other three accept the same values as fields.
 
 </TabItem>
 
@@ -128,9 +128,9 @@ There are two ways to load a file, and they differ in what happens afterwards. `
 
 ## Create objects from a workflow
 
-Both create objects from a configuration you set up once, rather than from a command you type each time, and both keep the result correct as the source data changes. That is what suits them to data no one should be maintaining manually — the objects that ought to exist because something else is true.
+Some objects exist because other data does, and they have to stay correct as that data changes. Maintaining them manually means repeating the same work every time something upstream changes.
 
-A Generator works from data already in Infrahub. Infrahub Sync works from data in another system.
+Configure a Generator or an Infrahub Sync project once, and it creates those objects and updates them when the source data changes. A Generator works from data already in Infrahub. Infrahub Sync works from data in another system.
 
 ### Generators
 
@@ -165,7 +165,7 @@ A new object exists on the branch it was created on. On a branch other than the 
 
 Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). You either entered the value while creating the object, or you set it up in advance so that you do not fill it in each time:
 
-- Pick an [Object Template](../object-templates/overview.mdx) to start the object with a set of components already in place.
+- Choose an [Object Template](../object-templates/overview.mdx) to start the object with a set of components already in place.
 - Assign a [Profile](../profiles/overview.mdx) to give the object attribute values it inherits, and override any of them on the object itself.
 - Allocate from a [Resource Manager](../resource-manager/overview.mdx) pool to take the next free IP address or VLAN ID.
 

--- a/docs/docs/objects/create-objects.mdx
+++ b/docs/docs/objects/create-objects.mdx
@@ -5,38 +5,25 @@ title: Create objects
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-There are several ways to create or add objects in Infrahub:
+How you create an object depends on what drives it. Create objects directly through one of Infrahub's interfaces, declare them in a file that lives in Git alongside your schema, or have a workflow create them from data that already exists.
 
-| Method | Use when |
-|---|---|
-| Web interface | One-off objects, exploring a new schema |
-| `infrahubctl` | Interactive work and scripting one object at a time |
-| Python SDK | Custom scripts and integrations |
-| GraphQL API | Mutations from any GraphQL client |
-| Object files | Data that changes rarely, tracked in Git, or a starting dataset loaded on demand |
+## Create objects directly
 
-Every method produces the same objects and enforces the same schema constraints, so the choice is about workflow.
-
-Objects can also be created from workflows, using Generators or Infrahub Sync:
-
-- **Generators** create objects from data already in Infrahub — allocate an IP address for every new interface, or build the circuits a service definition implies.
-- **Infrahub Sync** creates objects from data in another system, such as NetBox or Nautobot, and keeps the two in sync as that data changes.
-
-## Create an object
+Infrahub has four interfaces, and all of them produce the same object and enforce the same schema constraints. Pick the one that fits how you are working.
 
 The example below creates a device named `atl1-edge1` at site `atl1`. On `InfraDevice`, `name` and `type` are required and `site` is a relationship.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
-Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which of them are required, and validates values as you type — which makes it the quickest way to see what a kind actually needs before you script against it.
+Use the web interface for one-off objects, and when you are working with a schema you have not used before. The form is built from the schema, so it shows every field the kind defines, marks which of them are required, and validates values as you type. That makes it the quickest way to learn what a kind actually needs before you script against it.
 
 1. Open the Device list from the left menu.
 2. Select **Add Device**. The **Create Device** panel opens.
 3. Fill in the name and type.
 4. Select a site, then save.
 
-This is also the only method that offers Object Templates, Profiles, and resource pools as selectable controls. The other methods accept the same values, but you supply them yourself.
+The form is also the only place where Object Templates, Profiles, and resource pools appear as selectable controls. The other interfaces accept the same values as fields.
 
 </TabItem>
 
@@ -51,13 +38,15 @@ infrahubctl object create InfraDevice \
   --set site=atl1
 ```
 
-Relationship values resolve by name, so `site=atl1` looks up the site and links it. [Manage objects with infrahubctl](./manage-from-cli.mdx) covers querying, updating, and deleting.
+Relationship values resolve by name, so `site=atl1` looks up the site and links it.
+
+[Manage objects with infrahubctl](./manage-from-cli.mdx) covers querying, updating, and deleting.
 
 </TabItem>
 
   <TabItem value="sdk" label="Python SDK">
 
-Use the Python SDK for custom scripts and integrations — when a program decides what to create rather than a person. The SDK handles authentication, query construction, and serialization, so the script works with objects instead of HTTP calls.
+Use the Python SDK for custom scripts and integrations — when a program decides what to create rather than a person. The SDK handles authentication, query construction, and serialization, so the script works with objects instead of HTTP calls. Transformations, Generators, and checks run against this same client, so a script you write standalone can later run inside Infrahub's pipeline without changes.
 
 ```python
 from infrahub_sdk import InfrahubClientSync
@@ -73,7 +62,9 @@ device = client.create(
 device.save()
 ```
 
-Transformations, Generators, and checks run against this same client, so a script you write here can run inside Infrahub's pipeline without changes. To create many objects in one run, group the calls into a batch with a concurrency limit. The synchronous client suits straightforward scripting; the async client suits work that benefits from concurrent I/O. See the [Python SDK]($(base_url)python-sdk/introduction) documentation.
+To create many objects in one run, group the calls into a batch with a concurrency limit. The synchronous client suits straightforward scripting; the async client suits work that benefits from concurrent I/O.
+
+See the [Python SDK]($(base_url)python-sdk/introduction) documentation.
 
 </TabItem>
 
@@ -99,12 +90,14 @@ mutation {
 }
 ```
 
-Infrahub generates four mutations for every model in your schema, named from its namespace and name — `InfraDeviceCreate`, `InfraDeviceUpdate`, `InfraDeviceUpsert`, and `InfraDeviceDelete`. Use `Upsert` when the object may already exist and you want one call to cover both cases. To create the object on a branch, post to `/graphql/<branch_name>`. See [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx).
+Infrahub generates four mutations for every model in your schema, named from its namespace and name — `InfraDeviceCreate`, `InfraDeviceUpdate`, `InfraDeviceUpsert`, and `InfraDeviceDelete`. Use `Upsert` when the object may already exist and you want one call to cover both cases. To create the object on a branch, post to `/graphql/<branch_name>`.
+
+See [Queries & mutations](../development-resources/graphql/queries-and-mutations.mdx).
 
 </TabItem>
 </Tabs>
 
-## Load objects from a file
+## Create objects from a file
 
 Use object files for data that changes rarely and should be reviewed before it does, or as a starting dataset for a new instance. The file is YAML in a Git repository, so a change to your data goes through the same review as a change to your code.
 
@@ -127,9 +120,9 @@ There are two ways to load a file, and they differ in what happens afterwards. `
 
 [Load data using YAML file](./load-from-yaml.mdx) covers the file format, nested objects, and load order.
 
-## Generate and import objects
+## Create objects from a workflow
 
-Both of these run from a configuration you set up, rather than from a command you type each time.
+Generators and Infrahub Sync both run from a configuration you set up, rather than from a command you type each time.
 
 ### Generators
 
@@ -151,19 +144,15 @@ Sync runs as a CLI, so you schedule it with the tooling you already use — cron
 
 See [Infrahub Sync]($(base_url)sync) for adapters, mapping rules, and configuration.
 
-## Templates, Profiles, and resource pools
+## After an object is created
 
-Creating many objects of the same kind usually means repeating the same structure and the same values. Three features cover that, whichever method you use:
+A new object exists on the branch it was created on. On a branch other than the default, it remains isolated until that branch merges through a [proposed change](../proposed-changes/overview.mdx).
+
+Every attribute records how its value was set, which you can read back through [metadata and lineage](./metadata.mdx). A value is either entered directly or supplied by one of three features, each of which applies whichever method created the object:
 
 - [Object Templates](../object-templates/overview.mdx) supply structure — which components the new object starts with.
 - [Profiles](../profiles/overview.mdx) supply attribute values the object inherits and can override.
-- [Resource Manager](../resource-manager/overview.mdx) allocates a value, such as an IP address or a VLAN ID, from a pool at create time.
-
-The web form offers these as selectable controls. The other methods accept the same values as fields.
-
-## After an object is created
-
-A new object exists on the branch it was created on. On a branch other than the default, it remains isolated until that branch merges through a [proposed change](../proposed-changes/overview.mdx). Every attribute records how its value was set — entered directly, inherited from a Profile, or allocated from a pool — which you can read back through [metadata and lineage](./metadata.mdx).
+- [Resource Manager](../resource-manager/overview.mdx) allocates a value, such as an IP address or a VLAN ID, from a pool.
 
 ## Related
 

--- a/docs/docs/objects/load-from-yaml.mdx
+++ b/docs/docs/objects/load-from-yaml.mdx
@@ -1,5 +1,5 @@
 ---
-title: Load data in bulk using YAML file
+title: Load data using YAML file
 ---
 
 # Object files
@@ -93,7 +93,7 @@ infrahubctl schema load /path/to/schema.yml
 
 ## Defining a object file
 
-Our goal is to define data that can be loaded into Infrahub based on the schema we just defined. We will create an object file that defines a Country and a Site.
+Our goal is to define data that can be loaded into Infrahub based on the schema defined above. We will create an object file that defines a Country and a Site.
 
 ```yaml
 ---

--- a/docs/docs/objects/manage-from-cli.mdx
+++ b/docs/docs/objects/manage-from-cli.mdx
@@ -1,10 +1,10 @@
 ---
-title: Manage objects from the command line
+title: Manage objects with infrahubctl
 ---
 
 Use `infrahubctl` to query, create, update, and delete objects directly from your terminal. The commands accept any schema kind in your instance and can display results as a table, JSON, CSV, or YAML.
 
-These commands operate on individual objects, which suits interactive work and scripting. To load many objects at once from version-controlled files, see [Load data in bulk using YAML file](./load-from-yaml.mdx).
+These commands operate on individual objects, which suits interactive work and scripting. To load many objects at once from version-controlled files, see [Load data using YAML file](./load-from-yaml.mdx). For an overview of every way to create an object, see [Create objects](./create-objects.mdx).
 
 ## Prerequisites
 

--- a/docs/docs/objects/overview.mdx
+++ b/docs/docs/objects/overview.mdx
@@ -34,10 +34,3 @@ Objects, their attribute values, and their relationships all carry metadata. At 
 | Object | A concrete record that follows a schema node definition |
 | Object Template | A reusable structural starting point for creating objects of a given kind |
 | Group | A collection of objects used for querying or automation targeting |
-
-## What you can do with objects
-
-- **[Manage objects from the command line](./manage-from-cli.mdx)** — Query, create, update, and delete individual objects with `infrahubctl`
-- **[Convert object kind](./convert-object-kind.mdx)** — Change the schema kind of an existing object while preserving its data
-- **[Metadata & lineage](./metadata.mdx)** — Inspect where each attribute value came from and track data origin
-- **[Load data in bulk using YAML file](./load-from-yaml.mdx)** — Bulk-create or update objects by loading structured YAML files

--- a/docs/docs/objects/overview.mdx
+++ b/docs/docs/objects/overview.mdx
@@ -34,3 +34,11 @@ Objects, their attribute values, and their relationships all carry metadata. At 
 | Object | A concrete record that follows a schema node definition |
 | Object Template | A reusable structural starting point for creating objects of a given kind |
 | Group | A collection of objects used for querying or automation targeting |
+
+## In this section
+
+- [Create objects](./create-objects.mdx) — Compare every way to create an object, and see one created four ways
+- [Manage objects with infrahubctl](./manage-from-cli.mdx) — Query, create, update, and delete individual objects from your terminal
+- [Load data using YAML file](./load-from-yaml.mdx) — Author object files and load them, once or tracked in a Git repository
+- [Convert object kind](./convert-object-kind.mdx) — Change the schema kind of an existing object while preserving its data
+- [Metadata & lineage](./metadata.mdx) — Trace where each attribute value came from

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -148,10 +148,11 @@ const sidebars: SidebarsConfig = {
           label: 'Objects',
           link: { type: 'doc', id: 'objects/overview' }, // hub
           items: [
-            { type: 'doc', id: 'objects/manage-from-cli', label: 'Manage objects from the command line' },
+            { type: 'doc', id: 'objects/create-objects', label: 'Create objects' },
+            { type: 'doc', id: 'objects/manage-from-cli', label: 'Manage objects with infrahubctl' },
+            { type: 'doc', id: 'objects/load-from-yaml', label: 'Load data using YAML file' },
             { type: 'doc', id: 'objects/convert-object-kind', label: 'Convert object kind' },
             { type: 'doc', id: 'objects/metadata', label: 'Metadata & lineage' },
-            { type: 'doc', id: 'objects/load-from-yaml', label: 'Load data in bulk using YAML file' },
           ],
         },
         {


### PR DESCRIPTION
# Why

New users had no single place to see every way to create objects in Infrahub —
each method (web UI, CLI, YAML files, SDK, GraphQL, Generators, Sync) was only
discoverable by already knowing which page to look at.

## What changed

- Added `docs/docs/objects/create-objects.mdx`: a comparison table of all object-creation
  methods with guidance on when to use each, linked from the sidebar and from
  `manage-from-cli.mdx`.
- Removed the redundant "What you can do with objects" list from `overview.mdx` (superseded
  by the new page and existing sidebar).
- Shortened two page titles (`Manage objects from the command line` → `Manage objects with
  infrahubctl`, `Load data in bulk using YAML file` → `Load data using YAML file`) for
  consistency with the new page's table.

No schema, API, or code changes — docs only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

