### PR TITLE
fix(recompute): keep the branch and node tags on a task that writes

### DIFF
--- a/backend/infrahub/core/recompute/dispatch.py
+++ b/backend/infrahub/core/recompute/dispatch.py
@@ -14,7 +14,6 @@ from infrahub.core.registry import registry
 from infrahub.events.constants import NodeMutationOrigin
 from infrahub.exceptions import BranchNotFoundError
 from infrahub.workers.dependencies import get_database, get_event_service, get_workflow
-from infrahub.workflows.utils import add_tags
 
 if TYPE_CHECKING:
     from infrahub.core.recompute.bulk_write import AttributeValueWrite
@@ -53,7 +52,6 @@ class BulkRecomputeDispatcher:
         if not writes:
             return
 
-        await add_tags(db_change=True)
         try:
             branch = await registry.get_branch(db=self._db, branch=branch_name)
         except BranchNotFoundError:


### PR DESCRIPTION
# Why

Tasks for Python computed attributes disappear from the task list when it is filtered by a branch, and the count drops while the tasks run. The task button in the header applies that filter, so this is the normal view.

A recompute task tags its branch and each node it recomputes at the start of the run, then loses those tags when it writes its results. It falls out of the branch filter and out of the task list of a node.

Ticket: [IFC-3006](https://opsmill.atlassian.net/browse/IFC-3006)

## What changed

`BulkRecomputeDispatcher.dispatch()` no longer calls `add_tags(db_change=True)`. A recompute task now keeps its branch tag and its related node tags for the whole run.

`add_tags()` rebuilds the whole tag list from `prefect.runtime.flow_run.tags`. That value is the snapshot taken when the run started and a tag update never refreshes it, so a second call in the same run overwrites what the first one added. `process_transform` tags up to 250 node ids, so one run could lose 250 node tags plus its branch tag.

The call was redundant. `computed_attribute_process_transform`, `computed_attribute_process_jinja2`, `display-label-process-jinja2` and `hfid-process` all declare `WorkflowTag.DATABASE_CHANGE` on their workflow definition, and Prefect merges the deployment tags into the run when it creates it (`tags=set(deployment.tags).union(flow_run_request.tags)`).

`add_tags()` itself is unchanged. It still drops tags if a flow calls it twice. Nothing does today.

## How to review

The change is two deleted lines. What makes the deletion safe is that the four flows above carry the database-change tag from their workflow definition rather than from inside the run, so `Tasks.resolve_branch_status` still finds them. That matters most for scheduled and pending runs, which cannot have tagged themselves yet.

## How to test

```bash
INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest backend/tests/functional/computed_attributes backend/tests/functional/hfid backend/tests/functional/display_labels
```

Checked on a live stack with the AI/DC solution and a Python computed attribute on `NetworkInterface.description`. 260 interfaces recomputed in a branch, and all 260 runs of `computed_attribute_process_transform` keep their branch tag, keep a related node tag, and still carry the database change tag.

## Impact & rollout

- **Backward compatibility:** no API or schema change. Only the tags on a flow run change.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] Tests added/updated (the fix is a deletion, covered by the existing recompute suites)
- [ ] Changelog entry added (not needed, the code that introduced the bug is not released yet)
- [ ] External docs updated (no user-facing doc change)
- [x] I have reviewed AI generated content


[IFC-3006]: https://opsmill.atlassian.net/browse/IFC-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ