### PR TITLE
feat(regeneration): narrow relationship-reached changes to owning members (IFC-2946)

### DIFF
--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -118,7 +118,7 @@ class ReachedMemberResolver:
 
     Each hop resolves the current node ids to the owners referencing them, feeding the next hop, so
     a chain ends at the root members. Every hop returns a superset of the truly-related nodes, so the
-    resolved member set is a superset too -- it never omits a member that genuinely needs to run.
+    resolved member set is a superset too.
     """
 
     resolver: UniquenessDependentResolverInterface

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, assert_never
 
 from infrahub.core import registry
@@ -100,8 +101,8 @@ async def get_field_level_impacted_subscribers(
         case ChangedNodes(node_ids=node_ids):
             member_ids = node_ids
         case RelationshipReachedChanges():
-            resolver = UniquenessDependentResolver(db=db, branch=query_branch_obj)
-            member_ids = sorted(await _resolve_reached_members(changes=assessment, resolver=resolver))
+            dependent_resolver = UniquenessDependentResolver(db=db, branch=query_branch_obj)
+            member_ids = sorted(await ReachedMemberResolver(resolver=dependent_resolver).resolve(assessment))
         case _ as unreachable:
             assert_never(unreachable)
 
@@ -111,29 +112,32 @@ async def get_field_level_impacted_subscribers(
     return TargetSelection(ids=ids, widened=False)
 
 
-async def _resolve_reached_members(
-    changes: RelationshipReachedChanges, resolver: UniquenessDependentResolverInterface
-) -> set[str]:
-    """Walk each change's relationship chain back to the group members that read it.
+@dataclass(frozen=True)
+class ReachedMemberResolver:
+    """Walk each relationship-reached change back to the group members that read it.
 
     Each hop resolves the current node ids to the owners referencing them, feeding the next hop, so
     a chain ends at the root members. Every hop returns a superset of the truly-related nodes, so the
     resolved member set is a superset too -- it never omits a member that genuinely needs to run.
     """
-    members: set[str] = set(changes.direct_member_node_ids)
-    for change in changes.reached:
-        peer_uuids = set(change.node_ids)
-        for hop in change.path.hops:
-            if not peer_uuids:
-                break
-            peer_uuids = await resolver.resolve(
-                node_kind=hop.node_kind,
-                relationship_identifier=hop.relationship_identifier,
-                relationship_direction=hop.relationship_direction,
-                peer_uuids=sorted(peer_uuids),
-            )
-        members |= peer_uuids
-    return members
+
+    resolver: UniquenessDependentResolverInterface
+
+    async def resolve(self, changes: RelationshipReachedChanges) -> set[str]:
+        members: set[str] = set(changes.direct_member_node_ids)
+        for change in changes.reached:
+            peer_uuids = set(change.node_ids)
+            for hop in change.path.hops:
+                if not peer_uuids:
+                    break
+                peer_uuids = await self.resolver.resolve(
+                    node_kind=hop.node_kind,
+                    relationship_identifier=hop.relationship_identifier,
+                    relationship_direction=hop.relationship_direction,
+                    peer_uuids=sorted(peer_uuids),
+                )
+            members |= peer_uuids
+        return members
 
 
 async def _get_subscribers_for_nodes(

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -126,17 +126,18 @@ class ReachedMemberResolver:
     async def resolve(self, changes: RelationshipReachedChanges) -> set[str]:
         members: set[str] = set(changes.direct_member_node_ids)
         for change in changes.reached:
-            peer_uuids = set(change.node_ids)
-            for hop in change.path.hops:
-                if not peer_uuids:
-                    break
-                peer_uuids = await self.resolver.resolve(
-                    node_kind=hop.node_kind,
-                    relationship_identifier=hop.relationship_identifier,
-                    relationship_direction=hop.relationship_direction,
-                    peer_uuids=sorted(peer_uuids),
-                )
-            members |= peer_uuids
+            for path in change.paths:
+                peer_uuids = set(change.node_ids)
+                for hop in path.hops:
+                    if not peer_uuids:
+                        break
+                    peer_uuids = await self.resolver.resolve(
+                        node_kind=hop.node_kind,
+                        relationship_identifier=hop.relationship_identifier,
+                        relationship_direction=hop.relationship_direction,
+                        peer_uuids=sorted(peer_uuids),
+                    )
+                members |= peer_uuids
         return members
 
 

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, assert_never
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolver
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -11,7 +12,7 @@ from infrahub.log import get_logger
 from infrahub.message_bus.types import ProposedChangeSubscriber
 from infrahub.workers.dependencies import get_database
 
-from .impact_classifier import ChangedNodes, EveryTarget, QueryImpactClassifier
+from .impact_classifier import ChangedNodes, EveryTarget, QueryImpactClassifier, RelationshipReachedChanges
 from .models import TargetSelection
 
 log = get_logger()
@@ -19,6 +20,8 @@ log = get_logger()
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
+
+    from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolverInterface
 
 
 GATHER_GRAPHQL_QUERY_SUBSCRIBERS = """
@@ -63,10 +66,11 @@ async def get_field_level_impacted_subscribers(
     always receives one authoritative list and never has to resolve a "process everything" case.
     Only the narrowed outcome costs a subscriber lookup.
     """
+    db = await get_database()
     query_schema_branch = registry.schema.get_schema_branch(name=query_branch)
     query_branch_obj = registry.get_branch_from_registry(branch=query_branch)
 
-    graphql_params = await prepare_graphql_params(db=await get_database(), branch=query_branch)
+    graphql_params = await prepare_graphql_params(db=db, branch=query_branch)
     query_report = InfrahubGraphQLQueryAnalyzer(
         query=query_payload,
         branch=query_branch_obj,
@@ -81,6 +85,7 @@ async def get_field_level_impacted_subscribers(
         only_has_unique_targets=query_report.only_has_unique_targets,
         traversed_kinds=query_report.traversed_kinds,
         readable_fields_by_kind=readable_fields_by_kind,
+        reached_paths=query_report.relationship_reached_paths,
     )
     assessment = classifier.assess(diff_summary=diff_summary)
 
@@ -100,8 +105,42 @@ async def get_field_level_impacted_subscribers(
             ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
             log.debug(f"SELECTIVE_REGEN field-impact resolved subscribers: {len(ids)}")
             return TargetSelection(ids=ids, widened=False)
+        case RelationshipReachedChanges():
+            resolver = UniquenessDependentResolver(db=db, branch=query_branch_obj)
+            member_ids = await _resolve_reached_members(changes=assessment, resolver=resolver)
+            subscribers = await _get_subscribers_for_nodes(
+                node_ids=sorted(member_ids), branch=query_branch, client=client
+            )
+            ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
+            log.debug(f"SELECTIVE_REGEN field-impact resolved subscribers: {len(ids)}")
+            return TargetSelection(ids=ids, widened=False)
         case _ as unreachable:
             assert_never(unreachable)
+
+
+async def _resolve_reached_members(
+    changes: RelationshipReachedChanges, resolver: UniquenessDependentResolverInterface
+) -> set[str]:
+    """Walk each change's relationship chain back to the group members that read it.
+
+    Each hop resolves the current node ids to the owners referencing them, feeding the next hop, so
+    a chain ends at the root members. Every hop returns a superset of the truly-related nodes, so the
+    resolved member set is a superset too -- it never omits a member that genuinely needs to run.
+    """
+    members: set[str] = set(changes.direct_member_node_ids)
+    for change in changes.reached:
+        peer_uuids = set(change.node_ids)
+        for hop in change.path.hops:
+            if not peer_uuids:
+                break
+            peer_uuids = await resolver.resolve(
+                node_kind=hop.node_kind,
+                relationship_identifier=hop.relationship_identifier,
+                relationship_direction=hop.relationship_direction,
+                peer_uuids=sorted(peer_uuids),
+            )
+        members |= peer_uuids
+    return members
 
 
 async def _get_subscribers_for_nodes(

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -52,19 +52,16 @@ async def get_field_level_impacted_subscribers(
     every_target: list[str],
     client: InfrahubClient,
 ) -> TargetSelection:
-    """Map data changes on a branch to the subscribers a GraphQL query actually depends on.
+    """Map data changes on `query_branch` to the subscribers a GraphQL query depends on.
 
-    A change is relevant only when at least one field that was modified is also read by the
-    query. This lets us skip regeneration when, for example, only a `description` field changed
-    but the query only reads `name` and `color`. The query analysis, the diff-summary branch tag,
-    and the subscriber lookup all run against `query_branch`, so the caller passes the branch on
-    which the changed data lives (the source branch for a proposed change, the merge target branch
-    for a merge follow-up).
+    A change matters only when a modified field is one the query reads. The query analysis,
+    the diff-summary tag and the subscriber lookup all run on `query_branch`, so the caller
+    passes the branch the changed data lives on (a proposed change's source branch, a merge's
+    target branch).
 
-    `every_target` is what the caller must fall back to when a change cannot be traced to specific
-    subscribers. Taking it as an argument keeps that fallback out of the return type: the caller
-    always receives one authoritative list and never has to resolve a "process everything" case.
-    Only the narrowed outcome costs a subscriber lookup.
+    `every_target` is the fallback when a change cannot be traced to specific subscribers;
+    taking it as an argument keeps "process everything" out of the return type, so the caller
+    always gets one authoritative list.
     """
     db = await get_database()
     query_schema_branch = registry.schema.get_schema_branch(name=query_branch)

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -101,21 +101,17 @@ async def get_field_level_impacted_subscribers(
         case EveryTarget():
             return TargetSelection(ids=every_target, widened=True)
         case ChangedNodes(node_ids=node_ids):
-            subscribers = await _get_subscribers_for_nodes(node_ids=node_ids, branch=query_branch, client=client)
-            ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
-            log.debug(f"SELECTIVE_REGEN field-impact resolved subscribers: {len(ids)}")
-            return TargetSelection(ids=ids, widened=False)
+            member_ids = node_ids
         case RelationshipReachedChanges():
             resolver = UniquenessDependentResolver(db=db, branch=query_branch_obj)
-            member_ids = await _resolve_reached_members(changes=assessment, resolver=resolver)
-            subscribers = await _get_subscribers_for_nodes(
-                node_ids=sorted(member_ids), branch=query_branch, client=client
-            )
-            ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
-            log.debug(f"SELECTIVE_REGEN field-impact resolved subscribers: {len(ids)}")
-            return TargetSelection(ids=ids, widened=False)
+            member_ids = sorted(await _resolve_reached_members(changes=assessment, resolver=resolver))
         case _ as unreachable:
             assert_never(unreachable)
+
+    subscribers = await _get_subscribers_for_nodes(node_ids=member_ids, branch=query_branch, client=client)
+    ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
+    log.debug(f"SELECTIVE_REGEN field-impact resolved subscribers: {len(ids)}")
+    return TargetSelection(ids=ids, widened=False)
 
 
 async def _resolve_reached_members(

--- a/backend/infrahub/core/regeneration/impact_classifier.py
+++ b/backend/infrahub/core/regeneration/impact_classifier.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .predicates import relevant_node_changes
 
 if TYPE_CHECKING:
     from infrahub_sdk.diff import NodeDiff
+
+    from infrahub.graphql.analyzer import ReachedPath
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,7 +30,27 @@ class ChangedNodes:
     node_ids: list[str]
 
 
-type ImpactAssessment = EveryTarget | ChangedNodes
+@dataclass(frozen=True, slots=True)
+class ReachedChange:
+    """Changed nodes of one related kind, paired with the chain that resolves them to owning roots."""
+
+    node_ids: list[str]
+    path: ReachedPath
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipReachedChanges:
+    """Changes that narrow to members, split by how each is mapped back to a group member.
+
+    ``direct_member_node_ids`` already are group members; ``reached`` still needs its relationship
+    chain walked back to the owning members. The two resolve independently and their members union.
+    """
+
+    direct_member_node_ids: list[str]
+    reached: list[ReachedChange]
+
+
+type ImpactAssessment = EveryTarget | ChangedNodes | RelationshipReachedChanges
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -54,24 +76,38 @@ class QueryImpactClassifier:
     only_has_unique_targets: bool
     traversed_kinds: set[str]
     readable_fields_by_kind: dict[str, set[str]]
+    reached_paths: dict[str, ReachedPath] = field(default_factory=dict)
 
     def assess(self, diff_summary: list[NodeDiff]) -> ImpactAssessment:
-        changed_node_ids = self._changed_node_ids(diff_summary=diff_summary, kinds=self.readable_fields_by_kind)
-        if self._must_widen(diff_summary=diff_summary, changed_node_ids=changed_node_ids):
-            return EveryTarget()
-
-        return ChangedNodes(node_ids=changed_node_ids)
-
-    def _must_widen(self, *, diff_summary: list[NodeDiff], changed_node_ids: list[str]) -> bool:
         if not self.only_has_unique_targets:
             # Any number of objects can answer the query, so a changed node cannot be traced back to
             # the targets reading it.
-            return bool(changed_node_ids)
+            any_relevant_change = self._changed_node_ids(diff_summary=diff_summary, kinds=self.readable_fields_by_kind)
+            return EveryTarget() if any_relevant_change else ChangedNodes(node_ids=[])
 
-        traversed_fields_by_kind = {
-            kind: fields for kind, fields in self.readable_fields_by_kind.items() if kind in self.traversed_kinds
+        root_fields_by_kind = {
+            kind: fields for kind, fields in self.readable_fields_by_kind.items() if kind not in self.traversed_kinds
         }
-        return bool(self._changed_node_ids(diff_summary=diff_summary, kinds=traversed_fields_by_kind))
+        member_node_ids = self._changed_node_ids(diff_summary=diff_summary, kinds=root_fields_by_kind)
+
+        reached: list[ReachedChange] = []
+        for kind in sorted(self.traversed_kinds):
+            fields = self.readable_fields_by_kind.get(kind)
+            if not fields:
+                continue
+            changed_ids = self._changed_node_ids(diff_summary=diff_summary, kinds={kind: fields})
+            if not changed_ids:
+                continue
+            path = self.reached_paths.get(kind)
+            if path is None:
+                # A change on this related kind cannot be mapped back to specific members, so every
+                # target has to run rather than risk leaving one stale.
+                return EveryTarget()
+            reached.append(ReachedChange(node_ids=changed_ids, path=path))
+
+        if reached:
+            return RelationshipReachedChanges(direct_member_node_ids=member_node_ids, reached=reached)
+        return ChangedNodes(node_ids=member_node_ids)
 
     def _changed_node_ids(self, *, diff_summary: list[NodeDiff], kinds: dict[str, set[str]]) -> list[str]:
         return relevant_node_changes(

--- a/backend/infrahub/core/regeneration/impact_classifier.py
+++ b/backend/infrahub/core/regeneration/impact_classifier.py
@@ -32,10 +32,14 @@ class ChangedNodes:
 
 @dataclass(frozen=True, slots=True)
 class ReachedChange:
-    """Changed nodes of one related kind, paired with the chain that resolves them to owning roots."""
+    """Changed nodes of one related kind, paired with the chains that resolve them to owning roots.
+
+    The kind may be reached by more than one relationship chain; the changed nodes are mapped back
+    through every one and the resolved owners are unioned.
+    """
 
     node_ids: list[str]
-    path: ReachedPath
+    paths: tuple[ReachedPath, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,7 +80,7 @@ class QueryImpactClassifier:
     only_has_unique_targets: bool
     traversed_kinds: set[str]
     readable_fields_by_kind: dict[str, set[str]]
-    reached_paths: dict[str, ReachedPath] = field(default_factory=dict)
+    reached_paths: dict[str, tuple[ReachedPath, ...]] = field(default_factory=dict)
 
     def assess(self, diff_summary: list[NodeDiff]) -> ImpactAssessment:
         if not self.only_has_unique_targets:
@@ -98,12 +102,12 @@ class QueryImpactClassifier:
             changed_ids = self._changed_node_ids(diff_summary=diff_summary, kinds={kind: fields})
             if not changed_ids:
                 continue
-            path = self.reached_paths.get(kind)
-            if path is None:
+            paths = self.reached_paths.get(kind)
+            if paths is None:
                 # A change on this related kind cannot be mapped back to specific members, so every
                 # target has to run rather than risk leaving one stale.
                 return EveryTarget()
-            reached.append(ReachedChange(node_ids=changed_ids, path=path))
+            reached.append(ReachedChange(node_ids=changed_ids, paths=paths))
 
         if reached:
             return RelationshipReachedChanges(direct_member_node_ids=member_node_ids, reached=reached)

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -147,8 +147,7 @@ class RelationshipHop:
     """One relationship step, expressed from the owner object that carries the relationship.
 
     ``node_kind`` owns ``relationship_identifier``; ``relationship_direction`` is that relationship's
-    direction on the owner. Traversing it from a set of peer uuids yields the owner nodes referencing
-    them, so a chain of hops resolves a changed related object back to the root objects reading it.
+    direction on the owner.
     """
 
     node_kind: str
@@ -158,11 +157,7 @@ class RelationshipHop:
 
 @dataclass(frozen=True, slots=True)
 class ReachedPath:
-    """The relationship chain a query follows from a root object down to a related kind.
-
-    ``hops`` is ordered deepest-first: the first hop resolves the changed related object's immediate
-    owner, and each subsequent hop resolves that owner's owner, ending at the root object.
-    """
+    """The relationship chain a query follows from a root object down to a related kind."""
 
     hops: tuple[RelationshipHop, ...]
 

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -301,7 +301,7 @@ class ReachedPathResolver:
     A kind is resolved only when it is reached by exactly one unambiguous relationship chain of
     concrete objects. A kind reached through a generic peer, through an inline/named fragment, by
     more than one distinct chain, or also read at a root is deliberately absent, so a change there
-    widens rather than resolving to a subset -- over-executing is acceptable, missing an owner is not.
+    widens rather than resolving to a subset.
     """
 
     queries: list[GraphQLQueryNode]

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -302,9 +302,11 @@ def _reached_path_sort_key(path: ReachedPath) -> tuple[tuple[str, str, str], ...
 class ReachedPathResolver:
     """Reconstruct, from a query's node tree, the relationship chains reaching each related kind.
 
-    A kind maps to every unambiguous chain of concrete objects that reaches it. A kind is absent --
-    so a change there widens -- when any way it is reached cannot be pinned: it crosses a generic
-    object, an inline/named fragment refinement, or the kind is also read at a root.
+    A kind maps to every relationship chain of concrete owners that reaches it; a kind reached as a
+    generic peer is resolved to the generic's concrete implementations, since a data change reports
+    the concrete kind. A kind is absent -- so a change there widens -- when a way it is reached cannot
+    be pinned: an owner along the chain is generic, a step is an inline/named fragment refinement, or
+    the kind is also read at a root.
     """
 
     queries: list[GraphQLQueryNode]
@@ -319,18 +321,27 @@ class ReachedPathResolver:
             for node in self._iter_object_nodes(query):
                 if node.at_root or node.infrahub_model is None:
                     continue
-                kind = node.infrahub_model.kind
                 chain = self._clean_hop_chain(node)
-                if chain is None:
-                    ambiguous_kinds.add(kind)
-                else:
-                    chains_by_kind[kind].add(chain)
+                for kind in self._reached_kinds(node):
+                    if chain is None:
+                        ambiguous_kinds.add(kind)
+                    else:
+                        chains_by_kind[kind].add(chain)
 
         return {
             kind: tuple(sorted(chains, key=_reached_path_sort_key))
             for kind, chains in chains_by_kind.items()
             if kind not in ambiguous_kinds and kind not in root_kinds
         }
+
+    def _reached_kinds(self, node: GraphQLQueryNode) -> list[str]:
+        """The concrete kinds a related node stands for: a generic's implementations, else its own."""
+        model = node.infrahub_model
+        if model is None:
+            return []
+        if isinstance(model, GenericSchema):
+            return [implementation.kind for implementation in node.infrahub_node_models]
+        return [model.kind]
 
     def _iter_object_nodes(self, node: GraphQLQueryNode) -> Iterator[GraphQLQueryNode]:
         """Yield every node in the subtree that stands for an Infrahub object."""
@@ -340,16 +351,16 @@ class ReachedPathResolver:
             yield from self._iter_object_nodes(child)
 
     def _clean_hop_chain(self, node: GraphQLQueryNode) -> ReachedPath | None:
-        """The chain from a related node back to its root, or None when any hop cannot be pinned.
+        """The chain from a related node back to its root, or None when a hop cannot be pinned.
 
-        Returns None as soon as a hop crosses a generic peer, a generic owner, or a step whose field is not
-        a relationship on its owner, because none of those resolve a changed node to a single reverse relationship.
+        Returns None as soon as an owner along the chain is generic, or a step's field is not a
+        relationship on its owner (an inline/named fragment refinement), because neither resolves a
+        changed node to a single concrete reverse relationship. The related node's own kind may be a
+        generic; the caller resolves it to its concrete implementations.
         """
         hops: list[RelationshipHop] = []
         current = node
         while not current.at_root:
-            if isinstance(current.infrahub_model, GenericSchema):
-                return None
             owner = self._nearest_object_ancestor(current)
             if owner is None or owner.infrahub_model is None or isinstance(owner.infrahub_model, GenericSchema):
                 return None
@@ -365,8 +376,6 @@ class ReachedPathResolver:
             )
             current = owner
 
-        if isinstance(current.infrahub_model, GenericSchema):
-            return None
         return ReachedPath(hops=tuple(hops))
 
     def _nearest_object_ancestor(self, node: GraphQLQueryNode) -> GraphQLQueryNode | None:

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -339,7 +339,7 @@ class ReachedPathResolver:
     def _clean_hop_chain(self, node: GraphQLQueryNode) -> ReachedPath | None:
         """The chain from a related node back to its root, or None when any hop cannot be pinned.
 
-        Returns None -- signalling a widen -- as soon as a hop crosses a generic peer, a generic
+        Returns None as soon as a hop crosses a generic peer, a generic
         owner, or a step whose field is not a relationship on its owner (an inline/named fragment
         refinement), because none of those resolve a changed node to a single reverse relationship.
         """

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -302,10 +302,9 @@ def _reached_path_sort_key(path: ReachedPath) -> tuple[tuple[str, str, str], ...
 class ReachedPathResolver:
     """Reconstruct, from a query's node tree, the relationship chains reaching each related kind.
 
-    A kind is resolved to every unambiguous relationship chain of concrete objects that reaches it, so
-    a changed node is mapped back through all of them and the owners are unioned. A kind is absent --
-    so a change there widens -- when any way it is reached cannot be pinned: through a generic peer,
-    through an inline/named fragment, or when the kind is also read at a root.
+    A kind maps to every unambiguous chain of concrete objects that reaches it. A kind is absent --
+    so a change there widens -- when any way it is reached cannot be pinned: it crosses a generic
+    object, an inline/named fragment refinement, or the kind is also read at a root.
     """
 
     queries: list[GraphQLQueryNode]

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -294,65 +294,19 @@ class GraphQLQueryNode:
         return models
 
 
-@dataclass
-class GraphQLQueryReport:
+@dataclass(frozen=True)
+class ReachedPathResolver:
+    """Reconstruct, from a query's node tree, the relationship chain reaching each related kind.
+
+    A kind is resolved only when it is reached by exactly one unambiguous relationship chain of
+    concrete objects. A kind reached through a generic peer, through an inline/named fragment, by
+    more than one distinct chain, or also read at a root is deliberately absent, so a change there
+    widens rather than resolving to a subset -- over-executing is acceptable, missing an owner is not.
+    """
+
     queries: list[GraphQLQueryNode]
-    schema_branch: SchemaBranch | None = None
 
-    @property
-    def impacted_models(self) -> list[str]:
-        """Return a list of all Infrahub objects that are impacted by queries within the request."""
-        models: set[str] = set()
-        for query in self.queries:
-            query_models = query.get_models()
-            models.update([query_model.model.kind for query_model in query_models])
-
-        return sorted(models)
-
-    @cached_property
-    def requested_read(self) -> dict[str, ObjectAccess]:
-        """Return Infrahub objects and the fields (attributes and relationships) that this query would attempt to read."""
-        access: dict[str, ObjectAccess] = {}
-        for query in self.queries:
-            query_models = query.get_models()
-            for query_model in query_models:
-                if query_model.model.kind not in access:
-                    access[query_model.model.kind] = ObjectAccess()
-                access[query_model.model.kind].attributes.update(query_model.attributes)
-                access[query_model.model.kind].relationships.update(query_model.relationships)
-
-        return access
-
-    @cached_property
-    def traversed_kinds(self) -> set[str]:
-        """Return the kinds this query reaches by following a relationship.
-
-        A kind is reported here even when a root query also resolves to it. Both read paths share
-        one entry in the requested-read map, so a caller given a changed node of that kind cannot
-        tell which path saw it; reporting the kind as traversed keeps that ambiguity visible rather
-        than resolving it optimistically.
-
-        The concrete kinds standing behind a generic or interface peer are included, because a data
-        change is reported against the concrete kind.
-        """
-        kinds: set[str] = set()
-        for query in self.queries:
-            for query_model in query.get_models():
-                if not query_model.root:
-                    kinds.add(query_model.model.kind)
-
-        return kinds
-
-    @cached_property
-    def relationship_reached_paths(self) -> dict[str, ReachedPath]:
-        """The relationship chain reaching each related kind that can be narrowed to its owning roots.
-
-        A kind appears only when it is reached by exactly one unambiguous relationship chain of
-        concrete objects. A kind reached through a generic peer, through an inline/named fragment,
-        by more than one distinct chain, or also read at a root is deliberately absent, so a change
-        there widens rather than resolving to a subset -- over-executing is acceptable, missing an
-        owner is not.
-        """
+    def resolve(self) -> dict[str, ReachedPath]:
         root_kinds = {
             query_model.model.kind for query in self.queries for query_model in query.get_models() if query_model.root
         }
@@ -421,6 +375,61 @@ class GraphQLQueryReport:
                 return parent
             parent = parent.parent
         return None
+
+
+@dataclass
+class GraphQLQueryReport:
+    queries: list[GraphQLQueryNode]
+    schema_branch: SchemaBranch | None = None
+
+    @property
+    def impacted_models(self) -> list[str]:
+        """Return a list of all Infrahub objects that are impacted by queries within the request."""
+        models: set[str] = set()
+        for query in self.queries:
+            query_models = query.get_models()
+            models.update([query_model.model.kind for query_model in query_models])
+
+        return sorted(models)
+
+    @cached_property
+    def requested_read(self) -> dict[str, ObjectAccess]:
+        """Return Infrahub objects and the fields (attributes and relationships) that this query would attempt to read."""
+        access: dict[str, ObjectAccess] = {}
+        for query in self.queries:
+            query_models = query.get_models()
+            for query_model in query_models:
+                if query_model.model.kind not in access:
+                    access[query_model.model.kind] = ObjectAccess()
+                access[query_model.model.kind].attributes.update(query_model.attributes)
+                access[query_model.model.kind].relationships.update(query_model.relationships)
+
+        return access
+
+    @cached_property
+    def traversed_kinds(self) -> set[str]:
+        """Return the kinds this query reaches by following a relationship.
+
+        A kind is reported here even when a root query also resolves to it. Both read paths share
+        one entry in the requested-read map, so a caller given a changed node of that kind cannot
+        tell which path saw it; reporting the kind as traversed keeps that ambiguity visible rather
+        than resolving it optimistically.
+
+        The concrete kinds standing behind a generic or interface peer are included, because a data
+        change is reported against the concrete kind.
+        """
+        kinds: set[str] = set()
+        for query in self.queries:
+            for query_model in query.get_models():
+                if not query_model.root:
+                    kinds.add(query_model.model.kind)
+
+        return kinds
+
+    @cached_property
+    def relationship_reached_paths(self) -> dict[str, ReachedPath]:
+        """The relationship chain reaching each related kind that can be narrowed to its owning roots."""
+        return ReachedPathResolver(queries=self.queries).resolve()
 
     def fields_by_kind(self, kind: str) -> list[str]:
         fields: list[str] = []

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import deque
+from collections import defaultdict, deque
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -39,12 +39,14 @@ from graphql.language.ast import (
 from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
 from infrahub_sdk.utils import extract_fields
 
-from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
 from infrahub.core.schema import AttributePathParsingError, GenericSchema
 from infrahub.exceptions import SchemaNotFoundError
 from infrahub.graphql.utils import extract_schema_models
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from infrahub.core.branch import Branch
     from infrahub.core.schema import MainSchemaTypes, SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
@@ -138,6 +140,31 @@ class ObjectAccess:
     @property
     def fields(self) -> set[str]:
         return self.attributes.union(self.relationships)
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipHop:
+    """One relationship step, expressed from the owner object that carries the relationship.
+
+    ``node_kind`` owns ``relationship_identifier``; ``relationship_direction`` is that relationship's
+    direction on the owner. Traversing it from a set of peer uuids yields the owner nodes referencing
+    them, so a chain of hops resolves a changed related object back to the root objects reading it.
+    """
+
+    node_kind: str
+    relationship_identifier: str
+    relationship_direction: RelationshipDirection
+
+
+@dataclass(frozen=True, slots=True)
+class ReachedPath:
+    """The relationship chain a query follows from a root object down to a related kind.
+
+    ``hops`` is ordered deepest-first: the first hop resolves the changed related object's immediate
+    owner, and each subsequent hop resolves that owner's owner, ending at the root object.
+    """
+
+    hops: tuple[RelationshipHop, ...]
 
 
 @dataclass
@@ -320,6 +347,85 @@ class GraphQLQueryReport:
                     kinds.add(query_model.model.kind)
 
         return kinds
+
+    @cached_property
+    def relationship_reached_paths(self) -> dict[str, ReachedPath]:
+        """The relationship chain reaching each related kind that can be narrowed to its owning roots.
+
+        A kind appears only when it is reached by exactly one unambiguous relationship chain of
+        concrete objects. A kind reached through a generic peer, through an inline/named fragment,
+        by more than one distinct chain, or also read at a root is deliberately absent, so a change
+        there widens rather than resolving to a subset -- over-executing is acceptable, missing an
+        owner is not.
+        """
+        root_kinds = {
+            query_model.model.kind for query in self.queries for query_model in query.get_models() if query_model.root
+        }
+        chains_by_kind: dict[str, set[ReachedPath]] = defaultdict(set)
+        ambiguous_kinds: set[str] = set()
+        for query in self.queries:
+            for node in self._iter_object_nodes(query):
+                if node.at_root or node.infrahub_model is None:
+                    continue
+                kind = node.infrahub_model.kind
+                chain = self._clean_hop_chain(node)
+                if chain is None:
+                    ambiguous_kinds.add(kind)
+                else:
+                    chains_by_kind[kind].add(chain)
+
+        return {
+            kind: next(iter(chains))
+            for kind, chains in chains_by_kind.items()
+            if len(chains) == 1 and kind not in ambiguous_kinds and kind not in root_kinds
+        }
+
+    def _iter_object_nodes(self, node: GraphQLQueryNode) -> Iterator[GraphQLQueryNode]:
+        """Yield every node in the subtree that stands for an Infrahub object."""
+        if node.infrahub_model is not None:
+            yield node
+        for child in node.children:
+            yield from self._iter_object_nodes(child)
+
+    def _clean_hop_chain(self, node: GraphQLQueryNode) -> ReachedPath | None:
+        """The chain from a related node back to its root, or None when any hop cannot be pinned.
+
+        Returns None -- signalling a widen -- as soon as a hop crosses a generic peer, a generic
+        owner, or a step whose field is not a relationship on its owner (an inline/named fragment
+        refinement), because none of those resolve a changed node to a single reverse relationship.
+        """
+        hops: list[RelationshipHop] = []
+        current = node
+        while not current.at_root:
+            if isinstance(current.infrahub_model, GenericSchema):
+                return None
+            owner = self._nearest_object_ancestor(current)
+            if owner is None or owner.infrahub_model is None or isinstance(owner.infrahub_model, GenericSchema):
+                return None
+            relationship = owner.infrahub_model.get_relationship_or_none(name=current.path)
+            if relationship is None or not relationship.identifier:
+                return None
+            hops.append(
+                RelationshipHop(
+                    node_kind=owner.infrahub_model.kind,
+                    relationship_identifier=relationship.identifier,
+                    relationship_direction=relationship.direction,
+                )
+            )
+            current = owner
+
+        if isinstance(current.infrahub_model, GenericSchema):
+            return None
+        return ReachedPath(hops=tuple(hops))
+
+    def _nearest_object_ancestor(self, node: GraphQLQueryNode) -> GraphQLQueryNode | None:
+        """The closest ancestor that stands for an Infrahub object, skipping structural nodes."""
+        parent = node.parent
+        while parent is not None:
+            if parent.infrahub_model is not None:
+                return parent
+            parent = parent.parent
+        return None
 
     def fields_by_kind(self, kind: str) -> list[str]:
         fields: list[str] = []

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -294,19 +294,23 @@ class GraphQLQueryNode:
         return models
 
 
+def _reached_path_sort_key(path: ReachedPath) -> tuple[tuple[str, str, str], ...]:
+    return tuple((hop.node_kind, hop.relationship_identifier, hop.relationship_direction.value) for hop in path.hops)
+
+
 @dataclass(frozen=True)
 class ReachedPathResolver:
-    """Reconstruct, from a query's node tree, the relationship chain reaching each related kind.
+    """Reconstruct, from a query's node tree, the relationship chains reaching each related kind.
 
-    A kind is resolved only when it is reached by exactly one unambiguous relationship chain of
-    concrete objects. A kind reached through a generic peer, through an inline/named fragment, by
-    more than one distinct chain, or also read at a root is deliberately absent, so a change there
-    widens rather than resolving to a subset.
+    A kind is resolved to every unambiguous relationship chain of concrete objects that reaches it, so
+    a changed node is mapped back through all of them and the owners are unioned. A kind is absent --
+    so a change there widens -- when any way it is reached cannot be pinned: through a generic peer,
+    through an inline/named fragment, or when the kind is also read at a root.
     """
 
     queries: list[GraphQLQueryNode]
 
-    def resolve(self) -> dict[str, ReachedPath]:
+    def resolve(self) -> dict[str, tuple[ReachedPath, ...]]:
         root_kinds = {
             query_model.model.kind for query in self.queries for query_model in query.get_models() if query_model.root
         }
@@ -324,9 +328,9 @@ class ReachedPathResolver:
                     chains_by_kind[kind].add(chain)
 
         return {
-            kind: next(iter(chains))
+            kind: tuple(sorted(chains, key=_reached_path_sort_key))
             for kind, chains in chains_by_kind.items()
-            if len(chains) == 1 and kind not in ambiguous_kinds and kind not in root_kinds
+            if kind not in ambiguous_kinds and kind not in root_kinds
         }
 
     def _iter_object_nodes(self, node: GraphQLQueryNode) -> Iterator[GraphQLQueryNode]:
@@ -426,8 +430,8 @@ class GraphQLQueryReport:
         return kinds
 
     @cached_property
-    def relationship_reached_paths(self) -> dict[str, ReachedPath]:
-        """The relationship chain reaching each related kind that can be narrowed to its owning roots."""
+    def relationship_reached_paths(self) -> dict[str, tuple[ReachedPath, ...]]:
+        """The relationship chains reaching each related kind that can be narrowed to its owning roots."""
         return ReachedPathResolver(queries=self.queries).resolve()
 
     def fields_by_kind(self, kind: str) -> list[str]:

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -339,9 +339,8 @@ class ReachedPathResolver:
     def _clean_hop_chain(self, node: GraphQLQueryNode) -> ReachedPath | None:
         """The chain from a related node back to its root, or None when any hop cannot be pinned.
 
-        Returns None as soon as a hop crosses a generic peer, a generic
-        owner, or a step whose field is not a relationship on its owner (an inline/named fragment
-        refinement), because none of those resolve a changed node to a single reverse relationship.
+        Returns None as soon as a hop crosses a generic peer, a generic owner, or a step whose field is not
+        a relationship on its owner, because none of those resolve a changed node to a single reverse relationship.
         """
         hops: list[RelationshipHop] = []
         current = node

--- a/backend/tests/component/core/regeneration/test_impact.py
+++ b/backend/tests/component/core/regeneration/test_impact.py
@@ -151,17 +151,17 @@ class TestFieldLevelImpact(TestInfrahubApp):
         )
         assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)
 
-    async def test_related_node_change_selects_subscriber(
+    async def test_related_node_change_narrows_to_the_owning_member(
         self,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
     ) -> None:
-        """A change to a field the query reads on a *related* node still selects the subscriber.
+        """A change to a field the query reads on a *related* node narrows to the members owning it.
 
-        The changed owner is not itself a query-group member, so it cannot be mapped back to a
-        subscriber by membership lookup. Leaving the subscriber unselected would under-execute and ship
-        a stale artifact, so the impact mapping has to widen instead of returning nothing.
+        The changed owner is not itself a query-group member, so the relationship the query traverses
+        to reach it is walked back to the cars pointing at that owner, and only their subscribers are
+        selected -- not every member of the definition.
         """
         resolved = await self._resolve(
             dataset=dataset,
@@ -176,4 +176,30 @@ class TestFieldLevelImpact(TestInfrahubApp):
                 )
             ],
         )
-        assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=True)
+        assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)
+
+    async def test_unread_related_field_change_selects_nothing(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        client: InfrahubClient,
+    ) -> None:
+        """A change to a related field the query does not read resolves to no subscriber.
+
+        Field-level precision holds through the relationship: only a change to a field the query
+        actually reads off the owner can implicate the cars that read it.
+        """
+        resolved = await self._resolve(
+            dataset=dataset,
+            default_branch=default_branch,
+            client=client,
+            diff_summary=[
+                node_diff(
+                    node_id=dataset["person_id"],
+                    kind=TestKind.PERSON,
+                    branch=default_branch.name,
+                    field_names=["height"],
+                )
+            ],
+        )
+        assert resolved == TargetSelection(ids=[], widened=False)

--- a/backend/tests/component/graphql/test_relationship_reached_paths.py
+++ b/backend/tests/component/graphql/test_relationship_reached_paths.py
@@ -20,7 +20,7 @@ query { TestingCar { edges { node { owner { node { name { value } } } } } } }
 """
 
 # The car reads its owner's name through two distinct relationships, so the owner kind is reached by
-# two chains and cannot be narrowed to one.
+# two chains and both are kept.
 TWO_RELATIONSHIPS_TO_THE_SAME_KIND = """
 query {
     TestingCar {
@@ -46,7 +46,7 @@ query { TestingDevice { edges { node { interfaces { edges { node { name { value 
 """
 
 
-async def _reached_paths(db: InfrahubDatabase, branch: Branch, query: str) -> dict[str, ReachedPath]:
+async def _reached_paths(db: InfrahubDatabase, branch: Branch, query: str) -> dict[str, tuple[ReachedPath, ...]]:
     schema_branch = registry.schema.get_schema_branch(name=branch.name)
     gql_params = await prepare_graphql_params(db=db, branch=branch)
     report = InfrahubGraphQLQueryAnalyzer(
@@ -68,7 +68,31 @@ class TestReachedPathsFromQueryCarSchema(TestInfrahubApp):
         result = await _reached_paths(db, default_branch, SINGLE_HOP)
 
         assert result == {
-            TestKind.PERSON: ReachedPath(
+            TestKind.PERSON: (
+                ReachedPath(
+                    hops=(
+                        RelationshipHop(
+                            node_kind=TestKind.CAR,
+                            relationship_identifier=owner.identifier,
+                            relationship_direction=owner.direction,
+                        ),
+                    )
+                ),
+            )
+        }
+
+    async def test_a_kind_reached_by_two_relationships_keeps_both(
+        self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
+    ) -> None:
+        car = registry.schema.get(name=TestKind.CAR, branch=default_branch)
+        owner = car.get_relationship("owner")
+        previous_owner = car.get_relationship("previous_owner")
+
+        result = await _reached_paths(db, default_branch, TWO_RELATIONSHIPS_TO_THE_SAME_KIND)
+
+        assert result.keys() == {TestKind.PERSON}
+        assert set(result[TestKind.PERSON]) == {
+            ReachedPath(
                 hops=(
                     RelationshipHop(
                         node_kind=TestKind.CAR,
@@ -76,15 +100,17 @@ class TestReachedPathsFromQueryCarSchema(TestInfrahubApp):
                         relationship_direction=owner.direction,
                     ),
                 )
-            )
+            ),
+            ReachedPath(
+                hops=(
+                    RelationshipHop(
+                        node_kind=TestKind.CAR,
+                        relationship_identifier=previous_owner.identifier,
+                        relationship_direction=previous_owner.direction,
+                    ),
+                )
+            ),
         }
-
-    async def test_a_kind_reached_by_two_relationships_widens(
-        self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
-    ) -> None:
-        result = await _reached_paths(db, default_branch, TWO_RELATIONSHIPS_TO_THE_SAME_KIND)
-
-        assert result == {}
 
     async def test_a_kind_read_at_a_root_and_through_a_relationship_widens(
         self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
@@ -99,9 +125,7 @@ class TestReachedPathsFromQueryDeviceSchema(TestInfrahubApp):
     async def device_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         await load_schema(db=db, schema=DEVICE_SCHEMA, update_db=True)
 
-    async def test_generic_peer_widens(
-        self, db: InfrahubDatabase, default_branch: Branch, device_schema: None
-    ) -> None:
+    async def test_generic_peer_widens(self, db: InfrahubDatabase, default_branch: Branch, device_schema: None) -> None:
         result = await _reached_paths(db, default_branch, GENERIC_PEER)
 
         assert result == {}

--- a/backend/tests/component/graphql/test_relationship_reached_paths.py
+++ b/backend/tests/component/graphql/test_relationship_reached_paths.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer, ReachedPath, RelationshipHop
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, DEVICE_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+SINGLE_HOP = """
+query { TestingCar { edges { node { owner { node { name { value } } } } } } }
+"""
+
+# The car reads its owner's name through two distinct relationships, so the owner kind is reached by
+# two chains and cannot be narrowed to one.
+TWO_RELATIONSHIPS_TO_THE_SAME_KIND = """
+query {
+    TestingCar {
+        edges { node {
+            owner { node { name { value } } }
+            previous_owner { node { name { value } } }
+        } }
+    }
+}
+"""
+
+# The owner kind is read both at a root query and through the car's owner relationship.
+ROOT_AND_TRAVERSED = """
+query {
+    TestingCar { edges { node { owner { node { name { value } } } } } }
+    TestingPerson { edges { node { name { value } } } }
+}
+"""
+
+# The device reaches its interfaces through a relationship whose peer is a generic.
+GENERIC_PEER = """
+query { TestingDevice { edges { node { interfaces { edges { node { name { value } } } } } } } }
+"""
+
+
+async def _reached_paths(db: InfrahubDatabase, branch: Branch, query: str) -> dict[str, ReachedPath]:
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
+    report = InfrahubGraphQLQueryAnalyzer(
+        query=query, schema=gql_params.schema, branch=branch, schema_branch=schema_branch
+    ).query_report
+    return report.relationship_reached_paths
+
+
+class TestReachedPathsFromQueryCarSchema(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def car_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        await load_schema(db=db, schema=CAR_SCHEMA, update_db=True)
+
+    async def test_single_hop_query_narrows_to_the_owner(
+        self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
+    ) -> None:
+        owner = registry.schema.get(name=TestKind.CAR, branch=default_branch).get_relationship("owner")
+
+        result = await _reached_paths(db, default_branch, SINGLE_HOP)
+
+        assert result == {
+            TestKind.PERSON: ReachedPath(
+                hops=(
+                    RelationshipHop(
+                        node_kind=TestKind.CAR,
+                        relationship_identifier=owner.identifier,
+                        relationship_direction=owner.direction,
+                    ),
+                )
+            )
+        }
+
+    async def test_a_kind_reached_by_two_relationships_widens(
+        self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
+    ) -> None:
+        result = await _reached_paths(db, default_branch, TWO_RELATIONSHIPS_TO_THE_SAME_KIND)
+
+        assert result == {}
+
+    async def test_a_kind_read_at_a_root_and_through_a_relationship_widens(
+        self, db: InfrahubDatabase, default_branch: Branch, car_schema: None
+    ) -> None:
+        result = await _reached_paths(db, default_branch, ROOT_AND_TRAVERSED)
+
+        assert result == {}
+
+
+class TestReachedPathsFromQueryDeviceSchema(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def device_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        await load_schema(db=db, schema=DEVICE_SCHEMA, update_db=True)
+
+    async def test_generic_peer_widens(
+        self, db: InfrahubDatabase, default_branch: Branch, device_schema: None
+    ) -> None:
+        result = await _reached_paths(db, default_branch, GENERIC_PEER)
+
+        assert result == {}

--- a/backend/tests/component/graphql/test_relationship_reached_paths.py
+++ b/backend/tests/component/graphql/test_relationship_reached_paths.py
@@ -40,7 +40,8 @@ query {
 }
 """
 
-# The device reaches its interfaces through a relationship whose peer is a generic.
+# The device reaches its interfaces through a relationship whose peer is a generic, so the change is
+# resolved to each concrete interface kind.
 GENERIC_PEER = """
 query { TestingDevice { edges { node { interfaces { edges { node { name { value } } } } } } } }
 """
@@ -125,7 +126,22 @@ class TestReachedPathsFromQueryDeviceSchema(TestInfrahubApp):
     async def device_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         await load_schema(db=db, schema=DEVICE_SCHEMA, update_db=True)
 
-    async def test_generic_peer_widens(self, db: InfrahubDatabase, default_branch: Branch, device_schema: None) -> None:
+    async def test_generic_peer_resolves_to_its_concrete_implementations(
+        self, db: InfrahubDatabase, default_branch: Branch, device_schema: None
+    ) -> None:
+        device = registry.schema.get(name=TestKind.DEVICE, branch=default_branch)
+        interfaces = device.get_relationship("interfaces")
+        interface_generic = registry.schema.get(name=TestKind.INTERFACE, branch=default_branch)
+
         result = await _reached_paths(db, default_branch, GENERIC_PEER)
 
-        assert result == {}
+        chain = ReachedPath(
+            hops=(
+                RelationshipHop(
+                    node_kind=TestKind.DEVICE,
+                    relationship_identifier=interfaces.identifier,
+                    relationship_direction=interfaces.direction,
+                ),
+            )
+        )
+        assert result == {kind: (chain,) for kind in interface_generic.used_by}

--- a/backend/tests/component/graphql/test_relationship_reached_paths.py
+++ b/backend/tests/component/graphql/test_relationship_reached_paths.py
@@ -144,4 +144,4 @@ class TestReachedPathsFromQueryDeviceSchema(TestInfrahubApp):
                 ),
             )
         )
-        assert result == {kind: (chain,) for kind in interface_generic.used_by}
+        assert result == dict.fromkeys(interface_generic.used_by, (chain,))

--- a/backend/tests/unit/core/regeneration/test_impact_classifier.py
+++ b/backend/tests/unit/core/regeneration/test_impact_classifier.py
@@ -5,12 +5,16 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from infrahub.core.constants import RelationshipDirection
 from infrahub.core.regeneration.impact_classifier import (
     ChangedNodes,
     EveryTarget,
     ImpactAssessment,
     QueryImpactClassifier,
+    ReachedChange,
+    RelationshipReachedChanges,
 )
+from infrahub.graphql.analyzer import ReachedPath, RelationshipHop
 from tests.helpers.diff_summary import node_diff
 
 if TYPE_CHECKING:
@@ -24,6 +28,34 @@ BRANCH = "feature/regen"
 TRAVERSED_KINDS = {"TestInterface"}
 READABLE_FIELDS = {"TestDevice": {"name", "interfaces"}, "TestInterface": {"description"}}
 
+# The interface is reached from the device by traversing the ``interfaces`` relationship, so a change
+# to an interface resolves back to its owning device through this single hop.
+INTERFACE_PATH = ReachedPath(
+    hops=(
+        RelationshipHop(
+            node_kind="TestDevice",
+            relationship_identifier="device__interface",
+            relationship_direction=RelationshipDirection.OUTBOUND,
+        ),
+    )
+)
+# A two-hop path: an interface's ip is reached device -> interface -> ip, so a change to the ip walks
+# back to the interface and then to the owning device.
+IP_PATH = ReachedPath(
+    hops=(
+        RelationshipHop(
+            node_kind="TestInterface",
+            relationship_identifier="interface__ip",
+            relationship_direction=RelationshipDirection.OUTBOUND,
+        ),
+        RelationshipHop(
+            node_kind="TestDevice",
+            relationship_identifier="device__interface",
+            relationship_direction=RelationshipDirection.OUTBOUND,
+        ),
+    )
+)
+
 
 @dataclass(frozen=True, kw_only=True)
 class AssessCase:
@@ -33,6 +65,7 @@ class AssessCase:
     expected: ImpactAssessment
     traversed_kinds: set[str] = field(default_factory=lambda: set(TRAVERSED_KINDS))
     readable_fields_by_kind: dict[str, set[str]] = field(default_factory=lambda: dict(READABLE_FIELDS))
+    reached_paths: dict[str, ReachedPath] = field(default_factory=dict)
 
 
 ASSESS_CASES = [
@@ -111,6 +144,60 @@ ASSESS_CASES = [
         ],
         expected=ChangedNodes(node_ids=[]),
     ),
+    AssessCase(
+        name="related_change_with_a_resolvable_path_narrows_to_the_reached_change",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"])],
+        reached_paths={"TestInterface": INTERFACE_PATH},
+        expected=RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[ReachedChange(node_ids=["intf1"], path=INTERFACE_PATH)],
+        ),
+    ),
+    AssessCase(
+        name="root_and_related_change_with_a_path_narrows_to_both",
+        only_has_unique_targets=True,
+        diff_summary=[
+            node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["name"]),
+            node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"]),
+        ],
+        reached_paths={"TestInterface": INTERFACE_PATH},
+        expected=RelationshipReachedChanges(
+            direct_member_node_ids=["dev1"],
+            reached=[ReachedChange(node_ids=["intf1"], path=INTERFACE_PATH)],
+        ),
+    ),
+    AssessCase(
+        name="multi_hop_related_change_narrows_with_the_full_chain",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="ip1", kind="TestIP", branch=BRANCH, field_names=["address"])],
+        traversed_kinds={"TestIP"},
+        readable_fields_by_kind={"TestDevice": {"name"}, "TestIP": {"address"}},
+        reached_paths={"TestIP": IP_PATH},
+        expected=RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[ReachedChange(node_ids=["ip1"], path=IP_PATH)],
+        ),
+    ),
+    AssessCase(
+        name="related_change_without_a_path_widens",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"])],
+        reached_paths={},
+        expected=EveryTarget(),
+    ),
+    AssessCase(
+        name="one_reached_kind_without_a_path_widens_the_whole_assessment",
+        only_has_unique_targets=True,
+        diff_summary=[
+            node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"]),
+            node_diff(node_id="ip1", kind="TestIP", branch=BRANCH, field_names=["address"]),
+        ],
+        traversed_kinds={"TestInterface", "TestIP"},
+        readable_fields_by_kind={"TestDevice": {"name"}, "TestInterface": {"description"}, "TestIP": {"address"}},
+        reached_paths={"TestInterface": INTERFACE_PATH},
+        expected=EveryTarget(),
+    ),
 ]
 
 
@@ -121,6 +208,7 @@ def test_assess(case: AssessCase) -> None:
         only_has_unique_targets=case.only_has_unique_targets,
         traversed_kinds=case.traversed_kinds,
         readable_fields_by_kind=case.readable_fields_by_kind,
+        reached_paths=case.reached_paths,
     )
 
     assessment = classifier.assess(diff_summary=case.diff_summary)

--- a/backend/tests/unit/core/regeneration/test_impact_classifier.py
+++ b/backend/tests/unit/core/regeneration/test_impact_classifier.py
@@ -65,7 +65,7 @@ class AssessCase:
     expected: ImpactAssessment
     traversed_kinds: set[str] = field(default_factory=lambda: set(TRAVERSED_KINDS))
     readable_fields_by_kind: dict[str, set[str]] = field(default_factory=lambda: dict(READABLE_FIELDS))
-    reached_paths: dict[str, ReachedPath] = field(default_factory=dict)
+    reached_paths: dict[str, tuple[ReachedPath, ...]] = field(default_factory=dict)
 
 
 ASSESS_CASES = [
@@ -148,10 +148,10 @@ ASSESS_CASES = [
         name="related_change_with_a_resolvable_path_narrows_to_the_reached_change",
         only_has_unique_targets=True,
         diff_summary=[node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"])],
-        reached_paths={"TestInterface": INTERFACE_PATH},
+        reached_paths={"TestInterface": (INTERFACE_PATH,)},
         expected=RelationshipReachedChanges(
             direct_member_node_ids=[],
-            reached=[ReachedChange(node_ids=["intf1"], path=INTERFACE_PATH)],
+            reached=[ReachedChange(node_ids=["intf1"], paths=(INTERFACE_PATH,))],
         ),
     ),
     AssessCase(
@@ -161,10 +161,10 @@ ASSESS_CASES = [
             node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["name"]),
             node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["description"]),
         ],
-        reached_paths={"TestInterface": INTERFACE_PATH},
+        reached_paths={"TestInterface": (INTERFACE_PATH,)},
         expected=RelationshipReachedChanges(
             direct_member_node_ids=["dev1"],
-            reached=[ReachedChange(node_ids=["intf1"], path=INTERFACE_PATH)],
+            reached=[ReachedChange(node_ids=["intf1"], paths=(INTERFACE_PATH,))],
         ),
     ),
     AssessCase(
@@ -173,10 +173,10 @@ ASSESS_CASES = [
         diff_summary=[node_diff(node_id="ip1", kind="TestIP", branch=BRANCH, field_names=["address"])],
         traversed_kinds={"TestIP"},
         readable_fields_by_kind={"TestDevice": {"name"}, "TestIP": {"address"}},
-        reached_paths={"TestIP": IP_PATH},
+        reached_paths={"TestIP": (IP_PATH,)},
         expected=RelationshipReachedChanges(
             direct_member_node_ids=[],
-            reached=[ReachedChange(node_ids=["ip1"], path=IP_PATH)],
+            reached=[ReachedChange(node_ids=["ip1"], paths=(IP_PATH,))],
         ),
     ),
     AssessCase(
@@ -195,7 +195,7 @@ ASSESS_CASES = [
         ],
         traversed_kinds={"TestInterface", "TestIP"},
         readable_fields_by_kind={"TestDevice": {"name"}, "TestInterface": {"description"}, "TestIP": {"address"}},
-        reached_paths={"TestInterface": INTERFACE_PATH},
+        reached_paths={"TestInterface": (INTERFACE_PATH,)},
         expected=EveryTarget(),
     ),
 ]

--- a/backend/tests/unit/core/regeneration/test_reached_resolver.py
+++ b/backend/tests/unit/core/regeneration/test_reached_resolver.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from infrahub.core.constants import RelationshipDirection
-from infrahub.core.regeneration.impact import _resolve_reached_members
+from infrahub.core.regeneration.impact import ReachedMemberResolver
 from infrahub.core.regeneration.impact_classifier import ReachedChange, RelationshipReachedChanges
 from infrahub.graphql.analyzer import ReachedPath, RelationshipHop
 
@@ -51,9 +51,8 @@ INTERFACE_HOP = RelationshipHop(
 async def test_direct_member_changes_pass_through_without_a_lookup() -> None:
     resolver = RecordingDependentResolver(owners_by_identifier={})
 
-    members = await _resolve_reached_members(
-        changes=RelationshipReachedChanges(direct_member_node_ids=["dev1", "dev2"], reached=[]),
-        resolver=resolver,
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(direct_member_node_ids=["dev1", "dev2"], reached=[])
     )
 
     assert members == {"dev1", "dev2"}
@@ -65,12 +64,11 @@ async def test_single_hop_resolves_the_owning_member() -> None:
         owners_by_identifier={"device__interface": {"intf1": {"dev1"}}},
     )
 
-    members = await _resolve_reached_members(
-        changes=RelationshipReachedChanges(
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
             direct_member_node_ids=[],
             reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
-        ),
-        resolver=resolver,
+        )
     )
 
     assert members == {"dev1"}
@@ -85,12 +83,11 @@ async def test_multi_hop_chains_each_hop_output_into_the_next() -> None:
         },
     )
 
-    members = await _resolve_reached_members(
-        changes=RelationshipReachedChanges(
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
             direct_member_node_ids=[],
             reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
-        ),
-        resolver=resolver,
+        )
     )
 
     assert members == {"dev1", "dev2"}
@@ -103,12 +100,11 @@ async def test_multi_hop_chains_each_hop_output_into_the_next() -> None:
 async def test_a_hop_resolving_to_nothing_stops_the_chain_and_contributes_no_member() -> None:
     resolver = RecordingDependentResolver(owners_by_identifier={"interface__ip": {}})
 
-    members = await _resolve_reached_members(
-        changes=RelationshipReachedChanges(
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
             direct_member_node_ids=["dev9"],
             reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
-        ),
-        resolver=resolver,
+        )
     )
 
     assert members == {"dev9"}
@@ -120,12 +116,11 @@ async def test_direct_and_reached_members_union() -> None:
         owners_by_identifier={"device__interface": {"intf1": {"dev1"}}},
     )
 
-    members = await _resolve_reached_members(
-        changes=RelationshipReachedChanges(
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
             direct_member_node_ids=["dev5"],
             reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
-        ),
-        resolver=resolver,
+        )
     )
 
     assert members == {"dev1", "dev5"}
@@ -135,12 +130,11 @@ async def test_direct_and_reached_members_union() -> None:
 async def test_peer_uuids_are_passed_sorted_for_a_stable_query(peer_uuids: list[str]) -> None:
     resolver = RecordingDependentResolver(owners_by_identifier={"device__interface": {}})
 
-    await _resolve_reached_members(
-        changes=RelationshipReachedChanges(
+    await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
             direct_member_node_ids=[],
             reached=[ReachedChange(node_ids=peer_uuids, path=ReachedPath(hops=(DEVICE_HOP,)))],
-        ),
-        resolver=resolver,
+        )
     )
 
     assert resolver.calls[0][3] == ("ip1", "ip2")

--- a/backend/tests/unit/core/regeneration/test_reached_resolver.py
+++ b/backend/tests/unit/core/regeneration/test_reached_resolver.py
@@ -67,7 +67,7 @@ async def test_single_hop_resolves_the_owning_member() -> None:
     members = await ReachedMemberResolver(resolver=resolver).resolve(
         RelationshipReachedChanges(
             direct_member_node_ids=[],
-            reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
+            reached=[ReachedChange(node_ids=["intf1"], paths=(ReachedPath(hops=(DEVICE_HOP,)),))],
         )
     )
 
@@ -86,7 +86,7 @@ async def test_multi_hop_chains_each_hop_output_into_the_next() -> None:
     members = await ReachedMemberResolver(resolver=resolver).resolve(
         RelationshipReachedChanges(
             direct_member_node_ids=[],
-            reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
+            reached=[ReachedChange(node_ids=["ip1"], paths=(ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)),))],
         )
     )
 
@@ -97,13 +97,44 @@ async def test_multi_hop_chains_each_hop_output_into_the_next() -> None:
     ]
 
 
+async def test_multiple_paths_for_a_change_union_their_owners() -> None:
+    resolver = RecordingDependentResolver(
+        owners_by_identifier={
+            "car__owner": {"p1": {"car1"}},
+            "car__previous_owner": {"p1": {"car2"}},
+        },
+    )
+    owner_hop = RelationshipHop(
+        node_kind="TestCar", relationship_identifier="car__owner", relationship_direction=RelationshipDirection.OUTBOUND
+    )
+    previous_owner_hop = RelationshipHop(
+        node_kind="TestCar",
+        relationship_identifier="car__previous_owner",
+        relationship_direction=RelationshipDirection.OUTBOUND,
+    )
+
+    members = await ReachedMemberResolver(resolver=resolver).resolve(
+        RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[
+                ReachedChange(
+                    node_ids=["p1"],
+                    paths=(ReachedPath(hops=(owner_hop,)), ReachedPath(hops=(previous_owner_hop,))),
+                )
+            ],
+        )
+    )
+
+    assert members == {"car1", "car2"}
+
+
 async def test_a_hop_resolving_to_nothing_stops_the_chain_and_contributes_no_member() -> None:
     resolver = RecordingDependentResolver(owners_by_identifier={"interface__ip": {}})
 
     members = await ReachedMemberResolver(resolver=resolver).resolve(
         RelationshipReachedChanges(
             direct_member_node_ids=["dev9"],
-            reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
+            reached=[ReachedChange(node_ids=["ip1"], paths=(ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)),))],
         )
     )
 
@@ -119,7 +150,7 @@ async def test_direct_and_reached_members_union() -> None:
     members = await ReachedMemberResolver(resolver=resolver).resolve(
         RelationshipReachedChanges(
             direct_member_node_ids=["dev5"],
-            reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
+            reached=[ReachedChange(node_ids=["intf1"], paths=(ReachedPath(hops=(DEVICE_HOP,)),))],
         )
     )
 
@@ -133,7 +164,7 @@ async def test_peer_uuids_are_passed_sorted_for_a_stable_query(peer_uuids: list[
     await ReachedMemberResolver(resolver=resolver).resolve(
         RelationshipReachedChanges(
             direct_member_node_ids=[],
-            reached=[ReachedChange(node_ids=peer_uuids, path=ReachedPath(hops=(DEVICE_HOP,)))],
+            reached=[ReachedChange(node_ids=peer_uuids, paths=(ReachedPath(hops=(DEVICE_HOP,)),))],
         )
     )
 

--- a/backend/tests/unit/core/regeneration/test_reached_resolver.py
+++ b/backend/tests/unit/core/regeneration/test_reached_resolver.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from infrahub.core.constants import RelationshipDirection
+from infrahub.core.regeneration.impact import _resolve_reached_members
+from infrahub.core.regeneration.impact_classifier import ReachedChange, RelationshipReachedChanges
+from infrahub.graphql.analyzer import ReachedPath, RelationshipHop
+
+
+@dataclass
+class RecordingDependentResolver:
+    """Resolver double that records each hop and answers from a fixed per-identifier mapping.
+
+    Keeps the calls in order so a test asserts the exact hop sequence, and returns a superset of the
+    truly-related nodes exactly as the real resolver does, so the chaining is exercised end to end
+    without a database.
+    """
+
+    owners_by_identifier: dict[str, dict[str, set[str]]]
+    calls: list[tuple[str, str, RelationshipDirection, tuple[str, ...]]] = field(default_factory=list)
+
+    async def resolve(
+        self,
+        node_kind: str,
+        relationship_identifier: str,
+        relationship_direction: RelationshipDirection,
+        peer_uuids: list[str],
+    ) -> set[str]:
+        self.calls.append((node_kind, relationship_identifier, relationship_direction, tuple(peer_uuids)))
+        owners: set[str] = set()
+        for peer in peer_uuids:
+            owners |= self.owners_by_identifier.get(relationship_identifier, {}).get(peer, set())
+        return owners
+
+
+DEVICE_HOP = RelationshipHop(
+    node_kind="TestDevice",
+    relationship_identifier="device__interface",
+    relationship_direction=RelationshipDirection.OUTBOUND,
+)
+INTERFACE_HOP = RelationshipHop(
+    node_kind="TestInterface",
+    relationship_identifier="interface__ip",
+    relationship_direction=RelationshipDirection.OUTBOUND,
+)
+
+
+async def test_direct_member_changes_pass_through_without_a_lookup() -> None:
+    resolver = RecordingDependentResolver(owners_by_identifier={})
+
+    members = await _resolve_reached_members(
+        changes=RelationshipReachedChanges(direct_member_node_ids=["dev1", "dev2"], reached=[]),
+        resolver=resolver,
+    )
+
+    assert members == {"dev1", "dev2"}
+    assert resolver.calls == []
+
+
+async def test_single_hop_resolves_the_owning_member() -> None:
+    resolver = RecordingDependentResolver(
+        owners_by_identifier={"device__interface": {"intf1": {"dev1"}}},
+    )
+
+    members = await _resolve_reached_members(
+        changes=RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
+        ),
+        resolver=resolver,
+    )
+
+    assert members == {"dev1"}
+    assert resolver.calls == [("TestDevice", "device__interface", RelationshipDirection.OUTBOUND, ("intf1",))]
+
+
+async def test_multi_hop_chains_each_hop_output_into_the_next() -> None:
+    resolver = RecordingDependentResolver(
+        owners_by_identifier={
+            "interface__ip": {"ip1": {"intf1", "intf2"}},
+            "device__interface": {"intf1": {"dev1"}, "intf2": {"dev2"}},
+        },
+    )
+
+    members = await _resolve_reached_members(
+        changes=RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
+        ),
+        resolver=resolver,
+    )
+
+    assert members == {"dev1", "dev2"}
+    assert resolver.calls == [
+        ("TestInterface", "interface__ip", RelationshipDirection.OUTBOUND, ("ip1",)),
+        ("TestDevice", "device__interface", RelationshipDirection.OUTBOUND, ("intf1", "intf2")),
+    ]
+
+
+async def test_a_hop_resolving_to_nothing_stops_the_chain_and_contributes_no_member() -> None:
+    resolver = RecordingDependentResolver(owners_by_identifier={"interface__ip": {}})
+
+    members = await _resolve_reached_members(
+        changes=RelationshipReachedChanges(
+            direct_member_node_ids=["dev9"],
+            reached=[ReachedChange(node_ids=["ip1"], path=ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)))],
+        ),
+        resolver=resolver,
+    )
+
+    assert members == {"dev9"}
+    assert resolver.calls == [("TestInterface", "interface__ip", RelationshipDirection.OUTBOUND, ("ip1",))]
+
+
+async def test_direct_and_reached_members_union() -> None:
+    resolver = RecordingDependentResolver(
+        owners_by_identifier={"device__interface": {"intf1": {"dev1"}}},
+    )
+
+    members = await _resolve_reached_members(
+        changes=RelationshipReachedChanges(
+            direct_member_node_ids=["dev5"],
+            reached=[ReachedChange(node_ids=["intf1"], path=ReachedPath(hops=(DEVICE_HOP,)))],
+        ),
+        resolver=resolver,
+    )
+
+    assert members == {"dev1", "dev5"}
+
+
+@pytest.mark.parametrize("peer_uuids", [["ip1", "ip2"], ["ip2", "ip1"]])
+async def test_peer_uuids_are_passed_sorted_for_a_stable_query(peer_uuids: list[str]) -> None:
+    resolver = RecordingDependentResolver(owners_by_identifier={"device__interface": {}})
+
+    await _resolve_reached_members(
+        changes=RelationshipReachedChanges(
+            direct_member_node_ids=[],
+            reached=[ReachedChange(node_ids=peer_uuids, path=ReachedPath(hops=(DEVICE_HOP,)))],
+        ),
+        resolver=resolver,
+    )
+
+    assert resolver.calls[0][3] == ("ip1", "ip2")

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -33,6 +33,8 @@ DEVICE = _node("Device", _rel("interfaces", "TestingInterface", "device__interfa
 INTERFACE = _node("Interface", _rel("addresses", "TestingAddress", "interface__address"))
 ADDRESS = _node("Address")
 PERSON = _node("Person")
+PHYSICAL = _node("Physical")
+VIRTUAL = _node("Virtual")
 ENDPOINT = GenericSchema(name="Endpoint", namespace="Testing")
 DEVICE_WITH_GENERIC = _node("Device", _rel("endpoints", "TestingEndpoint", "device__endpoint"))
 DEVICE_TWO_OWNERS = _node(
@@ -77,12 +79,20 @@ def test_multi_hop_records_the_full_chain_deepest_first() -> None:
     }
 
 
-def test_generic_peer_widens() -> None:
-    tree = _tree("TestingDevice", DEVICE_WITH_GENERIC, _tree("endpoints", ENDPOINT))
+def test_generic_peer_resolves_to_its_concrete_implementations() -> None:
+    endpoints = _tree("endpoints", ENDPOINT)
+    endpoints.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    tree = _tree("TestingDevice", DEVICE_WITH_GENERIC, endpoints)
 
     result = ReachedPathResolver(queries=[tree]).resolve()
 
-    assert result == {}
+    endpoint_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__endpoint", relationship_direction=OUT
+    )
+    assert result == {
+        "TestingPhysical": (ReachedPath(hops=(endpoint_hop,)),),
+        "TestingVirtual": (ReachedPath(hops=(endpoint_hop,)),),
+    }
 
 
 def test_field_that_is_not_a_relationship_on_its_owner_widens() -> None:

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -43,6 +43,16 @@ DEVICE_TWO_OWNERS = _node(
     _rel("backup_owner", "TestingPerson", "device__backup"),
 )
 DEVICE_WITH_OWNER = _node("Device", _rel("owner", "TestingPerson", "device__owner"))
+DEVICE_TWO_GENERIC_RELS = _node(
+    "Device",
+    _rel("interfaces", "TestingEndpoint", "device__interface"),
+    _rel("mgmt_interfaces", "TestingEndpoint", "device__mgmt"),
+)
+DEVICE_GENERIC_AND_CONCRETE = _node(
+    "Device",
+    _rel("endpoints", "TestingEndpoint", "device__endpoint"),
+    _rel("physical_ports", "TestingPhysical", "device__physical_port"),
+)
 
 DEVICE_HOP = RelationshipHop(
     node_kind="TestingDevice", relationship_identifier="device__interface", relationship_direction=OUT
@@ -139,3 +149,58 @@ def test_a_query_without_traversal_resolves_nothing() -> None:
     result = ReachedPathResolver(queries=[tree]).resolve()
 
     assert result == {}
+
+
+def test_generic_peer_reached_by_two_relationships_keeps_both_chains_per_implementation() -> None:
+    interfaces = _tree("interfaces", ENDPOINT)
+    interfaces.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    mgmt_interfaces = _tree("mgmt_interfaces", ENDPOINT)
+    mgmt_interfaces.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    tree = _tree("TestingDevice", DEVICE_TWO_GENERIC_RELS, interfaces, mgmt_interfaces)
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    interface_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__interface", relationship_direction=OUT
+    )
+    mgmt_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__mgmt", relationship_direction=OUT
+    )
+    both = (ReachedPath(hops=(interface_hop,)), ReachedPath(hops=(mgmt_hop,)))
+    assert result == {"TestingPhysical": both, "TestingVirtual": both}
+
+
+def test_a_kind_reached_via_a_generic_peer_and_a_concrete_relationship_unions_the_chains() -> None:
+    endpoints = _tree("endpoints", ENDPOINT)
+    endpoints.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    physical_ports = _tree("physical_ports", PHYSICAL)
+    tree = _tree("TestingDevice", DEVICE_GENERIC_AND_CONCRETE, endpoints, physical_ports)
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    endpoint_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__endpoint", relationship_direction=OUT
+    )
+    port_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__physical_port", relationship_direction=OUT
+    )
+    assert result == {
+        "TestingPhysical": (ReachedPath(hops=(endpoint_hop,)), ReachedPath(hops=(port_hop,))),
+        "TestingVirtual": (ReachedPath(hops=(endpoint_hop,)),),
+    }
+
+
+def test_an_implementation_also_reached_un_pinnably_widens_while_its_siblings_narrow() -> None:
+    endpoints = _tree("endpoints", ENDPOINT)
+    endpoints.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    # PHYSICAL is also reached by a node whose path is not a relationship on the device (a fragment
+    # refinement), which cannot be pinned -- so PHYSICAL widens even though the generic peer resolves it.
+    refinement = _tree("TestingPhysical", PHYSICAL)
+    tree = _tree("TestingDevice", DEVICE_WITH_GENERIC, endpoints, refinement)
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    endpoint_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__endpoint", relationship_direction=OUT
+    )
+    assert result == {"TestingVirtual": (ReachedPath(hops=(endpoint_hop,)),)}

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -63,7 +63,7 @@ def test_single_hop_narrows_to_the_owning_root() -> None:
 
     result = ReachedPathResolver(queries=[tree]).resolve()
 
-    assert result == {"TestingInterface": ReachedPath(hops=(DEVICE_HOP,))}
+    assert result == {"TestingInterface": (ReachedPath(hops=(DEVICE_HOP,)),)}
 
 
 def test_multi_hop_records_the_full_chain_deepest_first() -> None:
@@ -72,8 +72,8 @@ def test_multi_hop_records_the_full_chain_deepest_first() -> None:
     result = ReachedPathResolver(queries=[tree]).resolve()
 
     assert result == {
-        "TestingInterface": ReachedPath(hops=(DEVICE_HOP,)),
-        "TestingAddress": ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)),
+        "TestingInterface": (ReachedPath(hops=(DEVICE_HOP,)),),
+        "TestingAddress": (ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)),),
     }
 
 
@@ -95,7 +95,7 @@ def test_field_that_is_not_a_relationship_on_its_owner_widens() -> None:
     assert result == {}
 
 
-def test_kind_reached_by_more_than_one_chain_widens() -> None:
+def test_kind_reached_by_more_than_one_chain_keeps_every_chain() -> None:
     tree = _tree(
         "TestingDevice",
         DEVICE_TWO_OWNERS,
@@ -105,7 +105,13 @@ def test_kind_reached_by_more_than_one_chain_widens() -> None:
 
     result = ReachedPathResolver(queries=[tree]).resolve()
 
-    assert result == {}
+    backup_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__backup", relationship_direction=OUT
+    )
+    primary_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__primary", relationship_direction=OUT
+    )
+    assert result == {"TestingPerson": (ReachedPath(hops=(backup_hop,)), ReachedPath(hops=(primary_hop,)))}
 
 
 def test_kind_read_at_a_root_and_through_a_relationship_widens() -> None:

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -35,6 +35,7 @@ ADDRESS = _node("Address")
 PERSON = _node("Person")
 PHYSICAL = _node("Physical")
 VIRTUAL = _node("Virtual")
+THING = _node("Thing")
 ENDPOINT = GenericSchema(name="Endpoint", namespace="Testing")
 DEVICE_WITH_GENERIC = _node("Device", _rel("endpoints", "TestingEndpoint", "device__endpoint"))
 DEVICE_TWO_OWNERS = _node(
@@ -188,6 +189,28 @@ def test_a_kind_reached_via_a_generic_peer_and_a_concrete_relationship_unions_th
         "TestingPhysical": (ReachedPath(hops=(endpoint_hop,)), ReachedPath(hops=(port_hop,))),
         "TestingVirtual": (ReachedPath(hops=(endpoint_hop,)),),
     }
+
+
+def test_a_kind_owned_by_a_generic_widens_while_the_generic_peer_narrows() -> None:
+    # A kind reached through a relationship on a generic owner cannot be pinned to a concrete
+    # node_kind for the reverse traversal (matching the generic label would miss instances created
+    # before the generic was added to the kind's inheritance -- schema changes do not relabel), so it
+    # widens. The generic peer's own implementations still narrow, since they are matched by uuid.
+    things = _tree("things", THING)
+    endpoints = _tree("endpoints", ENDPOINT, things)
+    endpoints.infrahub_node_models = [PHYSICAL, VIRTUAL]
+    tree = _tree("TestingDevice", DEVICE_WITH_GENERIC, endpoints)
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    endpoint_hop = RelationshipHop(
+        node_kind="TestingDevice", relationship_identifier="device__endpoint", relationship_direction=OUT
+    )
+    assert result == {
+        "TestingPhysical": (ReachedPath(hops=(endpoint_hop,)),),
+        "TestingVirtual": (ReachedPath(hops=(endpoint_hop,)),),
+    }
+    assert "TestingThing" not in result
 
 
 def test_an_implementation_also_reached_un_pinnably_widens_while_its_siblings_narrow() -> None:

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.graphql.analyzer import GraphQLQueryNode, ReachedPath, ReachedPathResolver, RelationshipHop
+
+OUT = RelationshipDirection.OUTBOUND
+
+
+def _rel(name: str, peer: str, identifier: str) -> RelationshipSchema:
+    return RelationshipSchema(
+        name=name,
+        peer=peer,
+        identifier=identifier,
+        cardinality=RelationshipCardinality.MANY,
+        direction=OUT,
+        optional=True,
+    )
+
+
+def _node(name: str, *relationships: RelationshipSchema) -> NodeSchema:
+    return NodeSchema(
+        name=name,
+        namespace="Testing",
+        generate_profile=False,
+        attributes=[AttributeSchema(name="name", kind="Text")],
+        relationships=list(relationships),
+    )
+
+
+DEVICE = _node("Device", _rel("interfaces", "TestingInterface", "device__interface"))
+INTERFACE = _node("Interface", _rel("addresses", "TestingAddress", "interface__address"))
+ADDRESS = _node("Address")
+PERSON = _node("Person")
+ENDPOINT = GenericSchema(name="Endpoint", namespace="Testing")
+DEVICE_WITH_GENERIC = _node("Device", _rel("endpoints", "TestingEndpoint", "device__endpoint"))
+DEVICE_TWO_OWNERS = _node(
+    "Device",
+    _rel("primary_owner", "TestingPerson", "device__primary"),
+    _rel("backup_owner", "TestingPerson", "device__backup"),
+)
+DEVICE_WITH_OWNER = _node("Device", _rel("owner", "TestingPerson", "device__owner"))
+
+DEVICE_HOP = RelationshipHop(
+    node_kind="TestingDevice", relationship_identifier="device__interface", relationship_direction=OUT
+)
+INTERFACE_HOP = RelationshipHop(
+    node_kind="TestingInterface", relationship_identifier="interface__address", relationship_direction=OUT
+)
+
+
+def _tree(path: str, model: NodeSchema | GenericSchema | None, *children: GraphQLQueryNode) -> GraphQLQueryNode:
+    node = GraphQLQueryNode(path=path, infrahub_model=model)
+    for child in children:
+        child.parent = node
+        node.children.append(child)
+    return node
+
+
+def test_single_hop_narrows_to_the_owning_root() -> None:
+    tree = _tree("TestingDevice", DEVICE, _tree("interfaces", INTERFACE))
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {"TestingInterface": ReachedPath(hops=(DEVICE_HOP,))}
+
+
+def test_multi_hop_records_the_full_chain_deepest_first() -> None:
+    tree = _tree("TestingDevice", DEVICE, _tree("interfaces", INTERFACE, _tree("addresses", ADDRESS)))
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {
+        "TestingInterface": ReachedPath(hops=(DEVICE_HOP,)),
+        "TestingAddress": ReachedPath(hops=(INTERFACE_HOP, DEVICE_HOP)),
+    }
+
+
+def test_generic_peer_widens() -> None:
+    tree = _tree("TestingDevice", DEVICE_WITH_GENERIC, _tree("endpoints", ENDPOINT))
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {}
+
+
+def test_field_that_is_not_a_relationship_on_its_owner_widens() -> None:
+    # A node carrying a model whose path is not a relationship on its owner (an inline/named fragment
+    # refinement) cannot be pinned to a reverse relationship.
+    tree = _tree("TestingDevice", DEVICE, _tree("TestingConcrete", PERSON))
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {}
+
+
+def test_kind_reached_by_more_than_one_chain_widens() -> None:
+    tree = _tree(
+        "TestingDevice",
+        DEVICE_TWO_OWNERS,
+        _tree("primary_owner", PERSON),
+        _tree("backup_owner", PERSON),
+    )
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {}
+
+
+def test_kind_read_at_a_root_and_through_a_relationship_widens() -> None:
+    device_tree = _tree("TestingDevice", DEVICE_WITH_OWNER, _tree("owner", PERSON))
+    person_root = _tree("TestingPerson", PERSON)
+
+    result = ReachedPathResolver(queries=[device_tree, person_root]).resolve()
+
+    assert result == {}
+
+
+def test_a_query_without_traversal_resolves_nothing() -> None:
+    tree = _tree("TestingDevice", DEVICE)
+
+    result = ReachedPathResolver(queries=[tree]).resolve()
+
+    assert result == {}

--- a/backend/tests/unit/graphql/test_reached_path_resolver.py
+++ b/backend/tests/unit/graphql/test_reached_path_resolver.py
@@ -192,10 +192,12 @@ def test_a_kind_reached_via_a_generic_peer_and_a_concrete_relationship_unions_th
 
 
 def test_a_kind_owned_by_a_generic_widens_while_the_generic_peer_narrows() -> None:
-    # A kind reached through a relationship on a generic owner cannot be pinned to a concrete
-    # node_kind for the reverse traversal (matching the generic label would miss instances created
-    # before the generic was added to the kind's inheritance -- schema changes do not relabel), so it
-    # widens. The generic peer's own implementations still narrow, since they are matched by uuid.
+    # A kind reached through a relationship on a generic owner cannot currently be pinned to a
+    # concrete node_kind for the reverse traversal (matching the generic label would miss instances
+    # created before the generic was added to the kind's inheritance -- schema changes do not
+    # relabel), so it widens for now. The generic peer's own implementations still narrow, since they
+    # are matched by uuid. This widen is a liftable limitation, not a hard rule: fanning the reverse
+    # traversal out per concrete implementation would narrow it, and this expectation would change then.
     things = _tree("things", THING)
     endpoints = _tree("endpoints", ENDPOINT, things)
     endpoints.infrahub_node_models = [PHYSICAL, VIRTUAL]

--- a/changelog/+selective-regen-relationship-narrowing.changed.md
+++ b/changelog/+selective-regen-relationship-narrowing.changed.md
@@ -1,0 +1,1 @@
+Post-merge regeneration now narrows to the affected members when the changed data is read through a relationship (for example an owner's name rendered by an artifact, or an interface's field on a device), instead of regenerating every member of the definition. Changes that cannot be attributed to specific members unambiguously still regenerate the whole group.


### PR DESCRIPTION
## What

Post-merge (and proposed-change) selective regeneration now narrows to the affected members when the changed data is read **through a relationship** — an owner's name, an interface's field, multi-hop chains, a kind reached by several relationships, and a change behind a generic peer — instead of regenerating every member of the definition.

## How

- **Analyzer** (`ReachedPathResolver`): reconstructs, per related kind, every relationship chain the query traverses down to it; a change reached through a generic peer is resolved to the generic's concrete implementations.
- **Classifier**: a new `RelationshipReachedChanges` assessment carrying those chains; it widens the whole assessment when a change can't be pinned (a generic owner along the chain, a fragment refinement, or a kind also read at a root).
- **Impact** (`ReachedMemberResolver`): walks each chain back to the owning members via the existing dependent-node resolver and unions them with the directly-changed members.

## Invariant

Over-execution is acceptable, under-execution is not: every hop returns a superset and any ambiguity widens to the whole group, so no member that genuinely needs regenerating is skipped.

## Known limitation

A change reached through a relationship whose **owner** is a generic still widens.

Example — a query reading a field on a kind reached through a relationship **defined on a generic**:

```graphql
query { Rack { edges { node {
  devices {              # peer is the generic InterfaceHolder -> resolved to concrete impls (narrows)
    endpoints {          # a relationship on the generic -> its peer kind is owned by a generic
      status { value }   # a change here widens the whole group
    }
  }
} } } }
```

## Tests

- Unit: the two resolvers in isolation (chains and widen cases including generic peer/owner; hop-chaining and multi-chain union, recording double, no mocks) and the classifier variants.
- Integration: real queries through the analyzer assert the reconstructed chains.
- Component: a relationship-reached change narrows to the owning member end-to-end on a real database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
