### PR TITLE
refactor(core): generalize the dependent-node resolver out of uniqueness

### DIFF
--- a/backend/infrahub/core/query/dependent_nodes.py
+++ b/backend/infrahub/core/query/dependent_nodes.py
@@ -10,12 +10,12 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-class AffectedUniquenessDependentsQuery(Query):
+class DependentNodesQuery(Query):
     """Return the nodes of a kind related, through a named relationship, to any of a set of peer nodes.
 
     The path is traversed in the relationship's own direction, so a kind whose relationship points at
-    its own kind resolves only the nodes on the constrained side of the peers, not those on the
-    opposite side.
+    its own kind resolves only the nodes on the owning side of the peers, not those on the opposite
+    side.
 
     Considers edges at the timestamp on the input branch, default branch, and global branch, regardless
     of when the input branch forked from the default branch. That is, changes made on the default branch
@@ -27,7 +27,7 @@ class AffectedUniquenessDependentsQuery(Query):
     branch if changes conflict.
     """
 
-    name = "affected_uniqueness_dependents"
+    name = "relationship_dependents"
     type = QueryType.READ
 
     def __init__(

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, assert_never
 
 from infrahub.core import registry
 from infrahub.core.query_group.subscribers import fetch_subscriber_refs
-from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolver
+from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
-    from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolverInterface
+    from infrahub.core.relationship.dependent_resolver import DependentNodeResolverInterface
 
 
 async def get_field_level_impacted_subscribers(
@@ -69,7 +69,7 @@ async def get_field_level_impacted_subscribers(
         case ChangedNodes(node_ids=node_ids):
             member_ids = node_ids
         case RelationshipReachedChanges():
-            dependent_resolver = UniquenessDependentResolver(db=db, branch=query_branch_obj)
+            dependent_resolver = DependentNodeResolver(db=db, branch=query_branch_obj)
             member_ids = sorted(await ReachedMemberResolver(resolver=dependent_resolver).resolve(assessment))
         case _ as unreachable:
             assert_never(unreachable)
@@ -87,7 +87,7 @@ class ReachedMemberResolver:
     resolved member set is a superset too.
     """
 
-    def __init__(self, *, resolver: UniquenessDependentResolverInterface) -> None:
+    def __init__(self, *, resolver: DependentNodeResolverInterface) -> None:
         self.resolver = resolver
 
     async def resolve(self, changes: RelationshipReachedChanges) -> set[str]:

--- a/backend/infrahub/core/relationship/dependent_resolver.py
+++ b/backend/infrahub/core/relationship/dependent_resolver.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from infrahub.core import registry
-
-from .query import AffectedUniquenessDependentsQuery
+from infrahub.core.query.dependent_nodes import DependentNodesQuery
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -13,12 +12,11 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-class UniquenessDependentResolverInterface(Protocol):
-    """Resolve which nodes of a kind reference a set of changed peer nodes.
+class DependentNodeResolverInterface(Protocol):
+    """Resolve which nodes of a kind reference a set of peer nodes through a relationship.
 
-    A uniqueness path such as "owner__name" makes a kind's constraint depend on a peer kind's
-    attribute; when the peer changes, the constrained nodes themselves are absent from the diff and
-    must be resolved by traversal before they can be node-scoped.
+    When a peer is changed it is present in a diff, but the nodes that reach it through a relationship
+    are not; they have to be resolved by traversal before they can be acted on node by node.
     """
 
     async def resolve(
@@ -30,8 +28,8 @@ class UniquenessDependentResolverInterface(Protocol):
     ) -> set[str]: ...
 
 
-class UniquenessDependentResolver:
-    """Resolve which nodes of a kind reference changed peer nodes, for cross-kind uniqueness scoping."""
+class DependentNodeResolver:
+    """Resolve which nodes of a kind reference peer nodes through a named relationship."""
 
     def __init__(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> None:
         self.db = db
@@ -47,15 +45,15 @@ class UniquenessDependentResolver:
     ) -> set[str]:
         """Return the uuids of `node_kind` nodes related via `relationship_identifier` to any peer in `peer_uuids`.
 
-        The relationship is traversed in `relationship_direction`, so only the nodes on the
-        constrained side of the peers are returned even when the peer kind is the node kind itself.
-        Only relationships visible from this branch (its own, its base, and the global branch) are
+        The relationship is traversed in `relationship_direction`, so only the nodes on the owning
+        side of the peers are returned even when the peer kind is the node kind itself. Only
+        relationships visible from this branch (its own, its base, and the global branch) are
         considered. The result is a superset of the truly-related nodes and is empty when no peer
         uuids are given or none are referenced.
         """
         if not peer_uuids:
             return set()
-        query = await AffectedUniquenessDependentsQuery.init(
+        query = await DependentNodesQuery.init(
             db=self.db,
             branch=self.branch,
             at=self.at,

--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 from infrahub import config
 from infrahub.core.constants import RelationshipDirection, RelationshipKind
+from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.query import QueryNode, QueryRel, QueryRelDirection
-from infrahub.core.relationship import Relationship
 from infrahub.exceptions import InitializationError
 
 from .generated.relationship_schema import GeneratedRelationshipSchema
@@ -44,9 +44,6 @@ class RelationshipSchema(GeneratedRelationshipSchema):
             if isinstance(value, Enum):
                 data[field_name] = value.value
         return data
-
-    def get_class(self) -> type[Relationship]:
-        return Relationship
 
     def get_peer_schema(self, db: InfrahubDatabase, branch: Branch | str | None = None) -> MainSchemaTypes:
         return db.schema.get(name=self.peer, branch=branch, duplicate=False)
@@ -93,7 +90,7 @@ class RelationshipSchema(GeneratedRelationshipSchema):
 
         query_params[f"{prefix}_rel_name"] = self.identifier
 
-        rel_type = self.get_class().rel_type
+        rel_type = DatabaseEdgeType.IS_RELATED.value
         peer_schema = self.get_peer_schema(db=db, branch=branch)
 
         if include_match:

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -6,11 +6,11 @@ from infrahub.core.constants import RelationshipKind, SchemaPathType
 from infrahub.core.constants.schema import UpdateSupport
 from infrahub.core.models import SchemaUpdateConstraintInfo
 from infrahub.core.path import SchemaPath
+from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
 from infrahub.core.schema.attribute_parameters import AttributeParameters
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
 from infrahub.core.validators.node_diff_index import NodeDiffIndex
-from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolver
 from infrahub.core.validators.uniqueness.scope import UniquenessConstraintScoper
 from infrahub.exceptions import SchemaNotFoundError
 from infrahub.log import get_logger
@@ -283,7 +283,7 @@ def build_constraint_validator_determiner(
     """Wire a determiner with its node-diff index and uniqueness scoper for a single operation."""
     node_diff_index = NodeDiffIndex()
     uniqueness_scoper = UniquenessConstraintScoper(
-        dependent_resolver=UniquenessDependentResolver(db=db, branch=branch, at=at),
+        dependent_resolver=DependentNodeResolver(db=db, branch=branch, at=at),
         node_diff_index=node_diff_index,
     )
     return ConstraintValidatorDeterminer(node_diff_index=node_diff_index, uniqueness_scoper=uniqueness_scoper)

--- a/backend/infrahub/core/validators/uniqueness/query/__init__.py
+++ b/backend/infrahub/core/validators/uniqueness/query/__init__.py
@@ -1,10 +1,8 @@
 from ..model import QueryAttributePathValued, QueryRelationshipPathValued
-from .affected_dependents import AffectedUniquenessDependentsQuery
 from .targeted_validation import TargetedUniquenessValidationQuery, TargetedUniquenessViolation
 from .validation import NodeUniqueAttributeConstraintQuery, UniquenessValidationQuery
 
 __all__ = [
-    "AffectedUniquenessDependentsQuery",
     "NodeUniqueAttributeConstraintQuery",
     "QueryAttributePathValued",
     "QueryRelationshipPathValued",

--- a/backend/infrahub/core/validators/uniqueness/scope.py
+++ b/backend/infrahub/core/validators/uniqueness/scope.py
@@ -10,12 +10,11 @@ LOG = get_logger(__name__)
 
 if TYPE_CHECKING:
     from infrahub.core.constants import RelationshipDirection
+    from infrahub.core.relationship.dependent_resolver import DependentNodeResolverInterface
     from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.core.validators.node_diff_index import NodeDiffIndex
-
-    from .dependent_resolver import UniquenessDependentResolverInterface
 
 
 @dataclass(frozen=True)
@@ -72,7 +71,7 @@ class UniquenessConstraintScoper:
 
     def __init__(
         self,
-        dependent_resolver: UniquenessDependentResolverInterface,
+        dependent_resolver: DependentNodeResolverInterface,
         node_diff_index: NodeDiffIndex,
     ) -> None:
         self.dependent_resolver = dependent_resolver

--- a/backend/tests/component/core/relationship/test_dependent_resolver.py
+++ b/backend/tests/component/core/relationship/test_dependent_resolver.py
@@ -6,9 +6,9 @@ from infrahub.core.constants import RelationshipCardinality, RelationshipDirecti
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.relationship_schema import RelationshipSchema
-from infrahub.core.validators.uniqueness.dependent_resolver import UniquenessDependentResolver
 from infrahub.database import InfrahubDatabase
 
 TREE_NODE_KIND = "TestingTreeNode"
@@ -47,7 +47,7 @@ def _owner_relationship(default_branch: Branch) -> RelationshipSchema:
     return car_schema.get_relationship("owner")
 
 
-class TestUniquenessDependentResolver:
+class TestDependentNodeResolver:
     async def test_resolves_nodes_referencing_changed_peers(
         self,
         db: InfrahubDatabase,
@@ -58,7 +58,7 @@ class TestUniquenessDependentResolver:
         person_john_main: Node,
         default_branch: Branch,
     ) -> None:
-        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+        resolver = DependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -74,7 +74,7 @@ class TestUniquenessDependentResolver:
     async def test_empty_peer_uuids_returns_empty(
         self, db: InfrahubDatabase, car_accord_main: Node, default_branch: Branch
     ) -> None:
-        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+        resolver = DependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -99,7 +99,7 @@ class TestUniquenessDependentResolver:
         await latecomer_car.new(db=db, name="latecomer", nbr_seats=2, is_electric=False, owner=person_john_main.id)
         await latecomer_car.save(db=db)
 
-        resolver = UniquenessDependentResolver(db=db, branch=feature_branch)
+        resolver = DependentNodeResolver(db=db, branch=feature_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -127,7 +127,7 @@ class TestUniquenessDependentResolver:
         accord_on_main = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
         await accord_on_main.delete(db=db)
 
-        resolver = UniquenessDependentResolver(db=db, branch=input_branch)
+        resolver = DependentNodeResolver(db=db, branch=input_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -152,7 +152,7 @@ class TestUniquenessDependentResolver:
         accord_on_branch = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=input_branch)
         await accord_on_branch.delete(db=db)
 
-        resolver = UniquenessDependentResolver(db=db, branch=input_branch)
+        resolver = DependentNodeResolver(db=db, branch=input_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -167,7 +167,7 @@ class TestUniquenessDependentResolver:
         assert car_prius_main.id in dependents
 
 
-class TestUniquenessDependentResolverSelfReferential:
+class TestDependentNodeResolverSelfReferential:
     @pytest.fixture
     async def tree(self, db: InfrahubDatabase, default_branch: Branch) -> dict[str, Node]:
         registry.schema.register_schema(schema=SchemaRoot(nodes=[TREE_NODE]), branch=default_branch.name)
@@ -188,7 +188,7 @@ class TestUniquenessDependentResolverSelfReferential:
         self, db: InfrahubDatabase, default_branch: Branch, tree: dict[str, Node]
     ) -> None:
         """A change to `middle` implicates the node whose `parent` is `middle`, not `middle`'s parent."""
-        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+        resolver = DependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind=TREE_NODE_KIND,
@@ -203,7 +203,7 @@ class TestUniquenessDependentResolverSelfReferential:
         self, db: InfrahubDatabase, default_branch: Branch, tree: dict[str, Node]
     ) -> None:
         """The same edges seen from `children` implicate the node holding `middle` as a child."""
-        resolver = UniquenessDependentResolver(db=db, branch=default_branch)
+        resolver = DependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind=TREE_NODE_KIND,


### PR DESCRIPTION
Stacked on #10262.

## What

The reverse "which nodes reference these changed peers through a relationship" traversal is generic; it lived in `validators/uniqueness/` only because that was its first caller. This moves it to a neutral home so the selective-regeneration narrowing depends on a general component rather than the uniqueness validators.

- `DependentNodeResolver` (+ interface) → `core/relationship/` (its domain).
- `DependentNodesQuery` → `core/query/` (it is a query, alongside the existing relationship queries).
- Uniqueness callers repointed; behavior unchanged.

## The import cycle

Moving the resolver into `core/relationship/` surfaced a latent import cycle in that package. Its root: `relationship_schema` imported the `Relationship` **class** only to read `Relationship.rel_type` through a `get_class()` that nothing else calls. Dropping the dead `get_class()` and reading the edge type from `DatabaseEdgeType.IS_RELATED` removes `relationship_schema`'s dependency on the `relationship` package and breaks the cycle at its root.

## Tests

Uniqueness scope/determiner and the relocated resolver component tests stay green; the resolver imports in isolation without triggering the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


