### PR TITLE
refactor(frontend): tokenize the page background

### DIFF
--- a/frontend/app/.betterer.results
+++ b/frontend/app/.betterer.results
@@ -38,7 +38,7 @@ exports[`fix ts error`] = {
       [354, 22, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"],
       [356, 32, 11, "tsc: \'fileContent\' is possibly \'undefined\'.", "1561581386"]
     ],
-    "src/entities/diff/ui/node-diff/index.tsx:123254081": [
+    "src/entities/diff/ui/node-diff/index.tsx:2908665840": [
       [87, 8, 15, "tsc: Type \'unknown\' is not assignable to type \'Date\'.", "140489382"],
       [121, 31, 4, "tsc: Type \'unknown\' is not assignable to type \'Date | null | number | string | undefined\'.", "2087377937"]
     ],

--- a/frontend/app/src/entities/diff/ui/checks/checks.tsx
+++ b/frontend/app/src/entities/diff/ui/checks/checks.tsx
@@ -29,7 +29,7 @@ export const Checks = () => {
 
   if (!validators.length) {
     return (
-      <div className="grow bg-stone-100 text-sm">
+      <div className="grow bg-background text-sm">
         <ChecksSummary isLoading={isPending} validators={validators} />
         <NoDataFound message="No checks for this proposed change." />
       </div>
@@ -37,7 +37,7 @@ export const Checks = () => {
   }
 
   return (
-    <div className="grow bg-stone-100 text-sm">
+    <div className="grow bg-background text-sm">
       <ChecksSummary isLoading={isPending} validators={validators} />
       <div className="space-y-2 p-4 pt-0">
         {validators.map((item) => (

--- a/frontend/app/src/entities/diff/ui/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/ui/node-diff/index.tsx
@@ -134,7 +134,7 @@ export const NodeDiff = ({ branch, filters }: NodeDiffProps) => {
           <DiffTree nodes={nodes} className="w-full" />
         </nav>
 
-        <main className="col-start-2 col-end-5 space-y-4 overflow-auto bg-stone-100 p-4">
+        <main className="col-start-2 col-end-5 space-y-4 overflow-auto bg-background p-4">
           {changedNodes.length ? (
             changedNodes.map((node) => (
               <DiffNode

--- a/frontend/app/src/entities/repository/ui/repository-form.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-form.tsx
@@ -50,7 +50,7 @@ const RepositoryForm = ({
 
   return (
     <Form
-      className="h-full overflow-auto bg-stone-100 p-2"
+      className="h-full overflow-auto bg-background p-2"
       onSubmit={async (formData) => {
         if (onSubmit) return onSubmit({ formData, fields });
 

--- a/frontend/app/src/entities/schema/ui/styled.tsx
+++ b/frontend/app/src/entities/schema/ui/styled.tsx
@@ -129,7 +129,7 @@ export const TabPanelStyled = ({ className, ...props }: TabPanelProps) => {
   return (
     <TabPanel
       className={classNames(
-        "min-h-0 grow space-y-2 overflow-auto bg-gray-100 p-2 outline-hidden",
+        "min-h-0 grow space-y-2 overflow-auto bg-background p-2 outline-hidden",
         focusVisibleStyle,
         className
       )}

--- a/frontend/app/src/pages/app-layout.tsx
+++ b/frontend/app/src/pages/app-layout.tsx
@@ -5,7 +5,7 @@ import { AppSidebar } from "@/entities/navigation/ui/sidebar/app-sidebar";
 
 function AppLayout() {
   return (
-    <div className="h-screen w-screen bg-stone-100 p-0.5 text-stone-800">
+    <div className="h-screen w-screen bg-background p-0.5 text-stone-800">
       <div className="flex h-full w-full gap-0.5">
         <AppSidebar />
 

--- a/frontend/app/src/pages/login.tsx
+++ b/frontend/app/src/pages/login.tsx
@@ -20,7 +20,7 @@ function LoginPage() {
   const errors = location?.state?.errors as RestErrorItem[] | undefined;
 
   return (
-    <div className="h-screen w-screen overflow-auto bg-stone-100 py-[25vh]">
+    <div className="h-screen w-screen overflow-auto bg-background py-[25vh]">
       <div className="m-auto flex w-full max-w-sm flex-col items-center gap-6">
         <InfrahubLogo className="h-12" />
 

--- a/frontend/app/src/shared/components/errors/error-fallback.tsx
+++ b/frontend/app/src/shared/components/errors/error-fallback.tsx
@@ -40,7 +40,7 @@ function ErrorFallback({ error, onReset }: ErrorFallbackProps) {
   };
 
   return (
-    <Col className="h-screen items-center justify-center bg-gray-100">
+    <Col className="h-screen items-center justify-center bg-background">
       <Card className="mb-4">
         <CardContent>
           <Col className="items-center gap-4">

--- a/frontend/app/src/shared/components/loading/infrahub-loading.tsx
+++ b/frontend/app/src/shared/components/loading/infrahub-loading.tsx
@@ -4,7 +4,7 @@ import infrahubLogo from "@/assets/infrahub-logo.svg";
 
 export const InfrahubLoading = ({ children }: { children?: React.ReactNode }) => {
   return (
-    <div className="flex h-screen w-screen flex-col items-center justify-center bg-stone-100">
+    <div className="flex h-screen w-screen flex-col items-center justify-center bg-background">
       <img src={infrahubLogo} alt="Infrahub logo" className="h-14 animate-bounce" />
       <span className="font-medium text-neutral-900">{children}</span>
     </div>

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -1,4 +1,5 @@
 :root {
+  --background: var(--color-stone-100);
   --foreground: var(--color-stone-800);
 
   --border: var(--color-neutral-200);
@@ -18,6 +19,7 @@
 }
 
 @theme inline {
+  --color-background: var(--background);
   --color-foreground: var(--foreground);
 
   --color-border: var(--border);


### PR DESCRIPTION
# Why

The page background was hardcoded at every page and view root, split across two ramps that are the same lightness: `bg-stone-100` (warm) and `bg-gray-100` (cool). So the app shell, the login page and the error screen all painted "the page ground" in slightly different temperatures.

Goal: one token owns the page ground.

Non-goals: no dark-mode values, no surface/panel tokens, no state backgrounds.

## What changed

**Behavioral / visual**

- Two of the nine sites move from `gray-100` to `stone-100` — same lightness, warmer. The other seven are already `stone-100` and are unchanged visually.

**Implementation**

- `packages/ui/src/styles/theme.css` gains `--background: var(--color-stone-100)`, exposed via `@theme inline` as `--color-background` → `bg-background`.
- Nine page and view grounds now use it:

| file | container |
|---|---|
| `pages/app-layout.tsx` | `h-screen w-screen` app shell |
| `pages/login.tsx` | `h-screen w-screen` |
| `shared/components/loading/infrahub-loading.tsx` | `h-screen w-screen` |
| `shared/components/errors/error-fallback.tsx` | `h-screen` (was `gray-100`) |
| `entities/repository/ui/repository-form.tsx` | `h-full overflow-auto` pane |
| `entities/diff/ui/node-diff/index.tsx` | `<main> overflow-auto` pane |
| `entities/diff/ui/checks/checks.tsx` ×2 | `grow` pane |
| `entities/schema/ui/styled.tsx` | `grow overflow-auto` scroll pane (was `gray-100`) |

## What stayed raw

Twelve other `bg-stone-100` and several `bg-gray-100` sites share the colour but not the role, and would be wrong to repaint with the page ground:

- popover and search-dialog surfaces (`popover.tsx`, `search-anywhere-dialog.tsx`)
- `kbd` key chips, group-item chips, the about-modal inner panel
- hover and selected states (`filter-tag`, `filter-suggestion-tag`, `breadcrumbs`, `styled.tsx:119`)
- Storybook fixtures

Also skipped: `modal.tsx` `absolute inset-0 bg-gray-600/25`, which is the modal scrim rather than a ground.

## How to review

`theme.css` is 2 lines. The other eight files are one-word swaps.

Worth a look: `entities/schema/ui/styled.tsx` has three `bg-gray-100` occurrences and only the third (line 132, the scroll pane) is a ground. Lines 52 (a panel) and 119 (a hover/focus state) are deliberately untouched.

## How to test

```bash
cd frontend/app
pnpm exec biome ci .      # 1532 files, clean
pnpm knip                 # clean
pnpm exec betterer ci     # 188 issues, unchanged
pnpm test                 # 1190 tests / 176 files
pnpm build
```

Built CSS should contain `.bg-background{background-color:var(--background)}`.

Manually: the app shell, login, the loading screen and the error screen should look unchanged except the error screen being a touch warmer.

## Impact & rollout

- **Backward compatibility:** CSS-only.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Notes

- Nothing sets the page background in CSS — there is no `body` rule. Every page root has to remember `bg-background` itself. Adding `body { background: var(--background) }` would make it the default, but that is a separate change.
- This touches `theme.css` in the same region as #10247 (text colors), so whichever merges second will likely need a trivial conflict resolution on the token list.

## Checklist

- [x] Tests added/updated — no new tests; existing 1190 pass and no test asserts on these classes
- [x] Changelog entry — intentionally skipped (`ci/skip-changelog`), no user-facing behaviour change
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

