### PR TITLE
chore(backend): enforce import-at-top (PLC0415) for backend/**

### DIFF
--- a/.agents/rules/python-module-layout.md
+++ b/.agents/rules/python-module-layout.md
@@ -15,3 +15,9 @@ Do not put functions or classes in a file named `constants.py` — only module-l
 Why: readers grep and import from `constants.py` expecting inert values with no behavior and no import-time or call-time side effects. A function hiding there muddies that contract and gets overlooked when reasoning about runtime behavior.
 
 If the value genuinely never changes at runtime, prefer an actual constant over a function returning one.
+
+## Imports at the top
+
+Keep imports at the top of the module. Do not import inside functions, methods, or classes. Ruff enforces this (`PLC0415`).
+
+A function-local import is acceptable only to break a genuine circular import or to defer an optional or heavy dependency that must not load on every import. Mark each such import with `# noqa: PLC0415` and a short reason.

--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -13,10 +13,6 @@ paths:
 
 Full reference: `dev/guidelines/backend/testing.md`
 
-## Import at the top
-
-All imports should be at the top of the test file. Do not import inside of test functions or classes.
-
 ## No mocking
 
 Do NOT use `unittest.mock`, `pytest-mock`, `MagicMock`, `patch`, or `Mock`.

--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -45,20 +45,22 @@ async def _init_shell(config_file: str) -> None:
 @app.command()
 def shell() -> None:
     """Start a python shell within Infrahub context (requires IPython)."""
-    from infrahub_sdk import InfrahubClient
-    from IPython import start_ipython
-    from traitlets.config import Config
+    # Imported lazily: IPython/traitlets are optional dependencies, and this keeps the
+    # heavy Infrahub imports off every other CLI invocation.
+    from infrahub_sdk import InfrahubClient  # noqa: PLC0415
+    from IPython import start_ipython  # noqa: PLC0415
+    from traitlets.config import Config  # noqa: PLC0415
 
-    from infrahub import config
-    from infrahub.components import ComponentType
-    from infrahub.core.branch import Branch
-    from infrahub.core.initialization import initialization
-    from infrahub.core.manager import NodeManager
-    from infrahub.core.registry import registry
-    from infrahub.dependencies.registry import build_component_registry
-    from infrahub.lock import initialize_lock
-    from infrahub.services import InfrahubServices
-    from infrahub.workers.dependencies import (
+    from infrahub import config  # noqa: PLC0415
+    from infrahub.components import ComponentType  # noqa: PLC0415
+    from infrahub.core.branch import Branch  # noqa: PLC0415
+    from infrahub.core.initialization import initialization  # noqa: PLC0415
+    from infrahub.core.manager import NodeManager  # noqa: PLC0415
+    from infrahub.core.registry import registry  # noqa: PLC0415
+    from infrahub.dependencies.registry import build_component_registry  # noqa: PLC0415
+    from infrahub.lock import initialize_lock  # noqa: PLC0415
+    from infrahub.services import InfrahubServices  # noqa: PLC0415
+    from infrahub.workers.dependencies import (  # noqa: PLC0415
         get_cache,
         get_component,
         get_database,

--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -1,10 +1,25 @@
 import typer
+from infrahub_sdk import InfrahubClient
 from infrahub_sdk.async_typer import AsyncTyper
 
 from infrahub import config
+from infrahub.components import ComponentType
+from infrahub.core.branch import Branch
 from infrahub.core.initialization import initialization
+from infrahub.core.manager import NodeManager
+from infrahub.core.registry import registry
+from infrahub.dependencies.registry import build_component_registry
+from infrahub.lock import initialize_lock
+from infrahub.services import InfrahubServices
 
-from ..workers.dependencies import get_database
+from ..workers.dependencies import (
+    get_cache,
+    get_component,
+    get_database,
+    get_http,
+    get_workflow,
+    set_component_type,
+)
 from .context import CliContext
 from .db import app as db_app
 from .dev import app as dev_app
@@ -45,29 +60,10 @@ async def _init_shell(config_file: str) -> None:
 @app.command()
 def shell() -> None:
     """Start a python shell within Infrahub context (requires IPython)."""
-    # Imported lazily: IPython/traitlets are optional dependencies, and this keeps the
-    # heavy Infrahub imports off every other CLI invocation.
-    from infrahub_sdk import InfrahubClient  # noqa: PLC0415
+    # IPython and traitlets are optional dependencies, imported lazily so the rest of
+    # the CLI keeps working when they are not installed.
     from IPython import start_ipython  # noqa: PLC0415
     from traitlets.config import Config  # noqa: PLC0415
-
-    from infrahub import config  # noqa: PLC0415
-    from infrahub.components import ComponentType  # noqa: PLC0415
-    from infrahub.core.branch import Branch  # noqa: PLC0415
-    from infrahub.core.initialization import initialization  # noqa: PLC0415
-    from infrahub.core.manager import NodeManager  # noqa: PLC0415
-    from infrahub.core.registry import registry  # noqa: PLC0415
-    from infrahub.dependencies.registry import build_component_registry  # noqa: PLC0415
-    from infrahub.lock import initialize_lock  # noqa: PLC0415
-    from infrahub.services import InfrahubServices  # noqa: PLC0415
-    from infrahub.workers.dependencies import (  # noqa: PLC0415
-        get_cache,
-        get_component,
-        get_database,
-        get_http,
-        get_workflow,
-        set_component_type,
-    )
 
     async def initialize_service() -> InfrahubServices:
         config.load_and_exit()

--- a/backend/infrahub/core/metadata/query/node_metadata.py
+++ b/backend/infrahub/core/metadata/query/node_metadata.py
@@ -5,9 +5,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.query import Query, QueryType
+from infrahub.core.timestamp import Timestamp
 
 if TYPE_CHECKING:
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -224,8 +224,6 @@ RETURN n.uuid AS node_uuid, n.kind AS node_kind, node_is_deleted,
 
     def get_metadatas(self) -> list[NodeMetadata]:
         """Process query results into NodeMetadata dataclasses."""
-        from infrahub.core.timestamp import Timestamp
-
         nodes: list[NodeMetadata] = []
 
         for result in self.get_results():

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -272,7 +272,7 @@ class InternalSchemaMigration(BaseMigration):
 
     @staticmethod
     def get_internal_schema() -> SchemaBranch:
-        from infrahub.core.schema.schema_branch import SchemaBranch
+        from infrahub.core.schema.schema_branch import SchemaBranch  # noqa: PLC0415  # avoid circular import
 
         # load the internal schema from
         schema = SchemaRoot(**internal_schema)

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from infrahub_sdk.utils import compare_lists, deep_merge_dict, duplicates, intersection
 from pydantic import BaseModel, ConfigDict, Field
+from rich import print as rprint
 from typing_extensions import Self
 
 from infrahub.core.constants import (
@@ -435,8 +436,6 @@ class HashableModel(BaseModel):
                 md5hash.update(item)
 
         if display_values:
-            from rich import print as rprint
-
             rprint(tuple(values))
 
         return md5hash.hexdigest()

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -13,6 +13,9 @@ from neo4j.graph import Node as Neo4jNode
 from neo4j.graph import Path as Neo4jPath
 from neo4j.graph import Relationship as Neo4jRelationship
 from opentelemetry import trace
+from rich import print as rprint
+from rich.console import Console
+from rich.table import Table
 
 from infrahub import config
 from infrahub.core.constants import SYSTEM_USER_ID, PermissionLevel
@@ -719,9 +722,6 @@ class Query:
         return len([result for result in self.results if not result.has_deleted_rels])
 
     def print_table(self) -> None:
-        from rich.console import Console
-        from rich.table import Table
-
         console = Console()
 
         table = Table(title=f"Query {self.name} : params: {self.params}")
@@ -736,8 +736,6 @@ class Query:
         console.print(table)
 
     def print(self, include_var: bool = False) -> None:
-        from rich import print as rprint
-
         print("-------------------------------------------------------")
         print(self.get_query(var=include_var))
         if self.params:

--- a/backend/infrahub/graphql/error_formatter.py
+++ b/backend/infrahub/graphql/error_formatter.py
@@ -22,6 +22,7 @@ from infrahub.errors.payloads import (
     TokenExpiredData,
     UndefinedErrorData,
 )
+from infrahub.errors.validation import MultiFieldValidationError
 from infrahub.exceptions import (
     AuthorizationError,
     BranchNotFoundError,
@@ -149,8 +150,6 @@ def catalogue_error_formatter(error: GraphQLError) -> GraphQLFormattedError:
 
 def format_graphql_errors(errors: list[GraphQLError]) -> list[GraphQLFormattedError]:
     """Format a list of GraphQL errors, expanding any ``MultiFieldValidationError`` fan-outs."""
-    from infrahub.errors.validation import MultiFieldValidationError
-
     out: list[GraphQLFormattedError] = []
     for error in errors:
         original = error.original_error

--- a/backend/infrahub/prefect_server/app.py
+++ b/backend/infrahub/prefect_server/app.py
@@ -16,10 +16,10 @@ router.include_router(events.router)
 
 async def _init_prefect() -> None:
     # Import there in case we are running Prefect within a testsuite using the original Prefect container
-    from infrahub import lock
-    from infrahub.lock import initialize_lock
-    from infrahub.services import InfrahubServices
-    from infrahub.workers.dependencies import get_cache
+    from infrahub import lock  # noqa: PLC0415
+    from infrahub.lock import initialize_lock  # noqa: PLC0415
+    from infrahub.services import InfrahubServices  # noqa: PLC0415
+    from infrahub.workers.dependencies import get_cache  # noqa: PLC0415
 
     cache = await get_cache()
     service = await InfrahubServices.new(cache=cache)
@@ -35,7 +35,7 @@ def create_infrahub_prefect() -> FastAPI:
         and os.getenv("PREFECT_API_DATABASE_MIGRATE_ON_START") == "false"
     ):
         # We are probably running distributed mode
-        from infrahub import config
+        from infrahub import config  # noqa: PLC0415
 
         config.SETTINGS.initialize_and_exit()
         asyncio.run(_init_prefect())

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -25,7 +25,7 @@ def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: In
 
     """
     # avoid circular imports
-    from infrahub.services import InfrahubServices
+    from infrahub.services import InfrahubServices  # noqa: PLC0415
 
     if service_parameter_name := get_parameter_name(func=func, types=[InfrahubServices.__name__, InfrahubServices]):
         if any(isinstance(param_value, InfrahubServices) for param_value in parameters):

--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -25,7 +25,7 @@ def client(
     dependency_provider: Provider, nats: dict[int, int] | None, redis: dict[int, int] | None
 ) -> Generator[TestClient, None, None]:
     # In order to mock some methods later we can't load app by default because it will automatically load all import in main.py as well
-    from infrahub.server import app
+    from infrahub.server import app  # noqa: PLC0415
 
     async def _db(singleton: bool = True) -> InfrahubDatabase:
         return await build_database(singleton=False)

--- a/backend/tests/component/core/migrations/graph/test_068_cleanup_branch_schema_parameters.py
+++ b/backend/tests/component/core/migrations/graph/test_068_cleanup_branch_schema_parameters.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub.core import registry
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.initialization import create_branch
 from infrahub.core.migrations.graph.m068_cleanup_branch_schema_parameters import (
     ALL_NULL_PARAMETER_VALUES,
@@ -218,8 +219,6 @@ async def test_migration_068_skips_merged_branches(
     schema_data: SchemaManager,
 ) -> None:
     """Migration should skip merged branches even if they have spurious parameters."""
-    from infrahub.core.branch.enums import BranchStatus
-
     node_attrs = _get_node_attr_ids(schema_data, default_branch.name)
     merged_branch = await create_branch(db=db, branch_name="merged-branch")
 

--- a/backend/tests/component/core/test_node.py
+++ b/backend/tests/component/core/test_node.py
@@ -21,6 +21,7 @@ from infrahub.core.utils import count_relationships, get_paths_between_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.constants import KIND_GRAPHQL_FIELD_NAME
+from infrahub.profiles.node_applier import NodeProfilesApplier
 
 
 async def test_node_init(
@@ -946,8 +947,6 @@ async def test_node_create_with_object_template_with_profile(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
 ) -> None:
     """Test creating a device from a template with profile application."""
-    from infrahub.profiles.node_applier import NodeProfilesApplier
-
     # Define schemas
     DUMMY = NodeSchema(
         name="Dummy",
@@ -1058,8 +1057,6 @@ async def test_node_create_with_object_template_with_profile_and_components(
     - Interface templates can have profiles
     - Profiles are applied correctly to interface templates
     """
-    from infrahub.profiles.node_applier import NodeProfilesApplier
-
     # Define schemas
     INTERFACE = NodeSchema(
         name="Interface",

--- a/backend/tests/component/graphql/test_app.py
+++ b/backend/tests/component/graphql/test_app.py
@@ -10,7 +10,7 @@ from infrahub.database import InfrahubDatabase
 @pytest.fixture
 def client(nats: dict[int, int] | None, redis: dict[int, int] | None) -> TestClient:
     # In order to mock some methods later we can't load app by default because it will automatically load all import in main.py as well
-    from infrahub.server import app
+    from infrahub.server import app  # noqa: PLC0415
 
     return TestClient(app)
 

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -91,8 +91,6 @@ class TestBranchMutations(TestInfrahubApp):
         return client_repository.id
 
     async def test_branch_delete_async(self, initial_dataset: str, client: InfrahubClient) -> None:
-        from infrahub.core import registry
-
         branch = await client.branch.create(branch_name="branch_to_delete", sync_with_git=True)
         branch_server_id = registry.branch[branch.name].uuid
 

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -8,6 +8,7 @@ import pytest
 from infrahub.core.constants import InfrahubKind
 from infrahub.webhook.models import EventContext
 from infrahub.webhook.tasks import convert_node_to_webhook, webhook_process
+from infrahub.workers.dependencies import build_http_service
 from tests.adapters.http import MemoryHTTP
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -105,8 +106,6 @@ class TestWebhookProcess(TestInfrahubApp):
         webhook_deployment: None,
         dependency_provider: Provider,
     ) -> None:
-        from infrahub.workers.dependencies import build_http_service
-
         http = MemoryHTTP()
         http.add_post_response(
             url="https://url.mock",
@@ -132,8 +131,6 @@ class TestWebhookProcess(TestInfrahubApp):
         webhook_deployment: None,
         dependency_provider: Provider,
     ) -> None:
-        from infrahub.workers.dependencies import build_http_service
-
         http = MemoryHTTP()
         http.add_post_response(
             url="https://url.mock",

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -195,9 +195,6 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         context: InfrahubContext,
         service: InfrahubServices,
     ) -> None:
-        from infrahub.core import registry
-        from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
-
         await client.branch.create(branch_name="branch", sync_with_git=False)
         branch = await registry.get_branch(db=db, branch="branch")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -606,7 +606,6 @@ allow-dunder-method-names = [
     "PERF403",  # Use a dictionary comprehension instead of a for-loop
     "PGH003",   # Use specific rule codes when ignoring type issues
     "PGH004",   # Use specific rule codes when using `noqa`
-    "PLC0415",  # `import` should be at the top-level of a file
     "PLR0904",  # Too many public methods
     "PLR0912",  # Too many branches
     "PLR0913",  # Too many arguments in function definition
@@ -891,7 +890,6 @@ allow-dunder-method-names = [
     "INP001",   # File is part of an implicit namespace package
     "N806",     # Variable in function should be lowercase
     "PGH003",   # Use specific rule codes when ignoring type issues
-    "PLC0415",  # `import` should be at the top-level of a file
     "PLC2701",  # Private name import from external module
     "PLR0904",  # Too many public methods
     "PLR0913",  # Too many arguments in function definition
@@ -921,7 +919,6 @@ allow-dunder-method-names = [
     "FIX",      # flake8-fixme
     "INP001",   # File is part of an implicit namespace package
     "PERF401",  # Use a list comprehension to create a transformed list
-    "PLC0415",  # `import` should be at the top-level of a file
     "PLR0904",  # Too many public methods
     "PLR0913",  # Too many arguments in function definition
     "PLR0914",  # Too many local variables
@@ -998,7 +995,6 @@ allow-dunder-method-names = [
     "PERF401",  # Use a list comprehension to create a transformed list
     "PGH003",   # Use specific rule codes when ignoring type issues
     "PGH004",   # Use specific rule codes when using `noqa`
-    "PLC0415",  # `import` should be at the top-level of a file
     "PLC2701",  # Private name import from external module
     "PLR0904",  # Too many public methods
     "PLR0912",  # Too many branches


### PR DESCRIPTION
## Why

`PLC0415` ("import should be at the top of the file") was suppressed via ruff per-file-ignores across the backend, so accidental function-local imports went unflagged. This removes the blanket suppression for `backend/**` and enforces the rule, keeping only genuinely-justified lazy imports as explicit exceptions.

Goal: import-at-top enforced across `backend/**` and `python_testcontainers/**`; every remaining function-local import is a deliberate, documented exception.

**This is the first step toward removing all of these exceptions.** Dropping the blanket suppression is the enabler: each function-local import that must remain is now surfaced as an individual `# noqa: PLC0415` with a stated reason, instead of being hidden behind a file-wide ignore. That makes the exceptions visible and reviewable, so they can be revisited and eliminated one by one in follow-up PRs (see Follow-ups). This PR does not attempt to remove every exception at once — it removes the suppression and pays down only the accidental cases.

Non-goals: the `tasks/**` and `tests/e2e/**` suppressions are intentionally left in place (out of scope for this change).

## What changed

- Removed the `PLC0415` per-file-ignore for `backend/infrahub/**` and the `component` / `functional` / `integration` test trees.
- Hoisted the accidental function-local imports to the module top, including the whole `infrahub`/SDK block of the CLI `shell` command (those modules already load at the CLI top level, so nothing was actually deferred).
- Kept the genuinely-lazy imports behind a targeted `# noqa: PLC0415`, each with a reason.
- Moved the "imports at the top" instruction from `.agents/rules/testing-python.md` into the general `.agents/rules/python-module-layout.md` so it applies to all backend Python, not just tests.

What stayed the same: no schema, API, or runtime behavior changes. Every moved import was verified in a fresh interpreter to confirm it introduces no circular import, and the two cycles kept behind `noqa` were confirmed by reproducing the `ImportError`.

## Follow-ups

The remaining `# noqa: PLC0415` markers are candidates for removal in later PRs, in decreasing order of confidence:

- **Removable but needs owner sign-off** — the Prefect-testsuite isolation in `prefect_server/app.py` and the deferred app load in the two API test fixtures: no cycle, but each carries a deliberate runtime/test-design rationale to confirm before changing.
- **Keep** — the optional `IPython` dependency and the two verified circular imports (`workers/utils.py`, `core/migrations/shared.py`).

## How to test

```bash
uv run invoke main.lint
uv run invoke backend.lint          # ruff + ty + mypy
uv run invoke backend.test-unit
```

All green locally (1427 unit tests passed); `ruff check backend --select PLC0415` reports zero violations.
