### PR TITLE
Document mermaid support in artifacts

### DIFF
--- a/docs/docs/artifacts/overview.mdx
+++ b/docs/docs/artifacts/overview.mdx
@@ -16,9 +16,10 @@ The following MIME types or formats are supported and will be rendered properly 
 - application/hcl
 - text/plain
 - text/markdown
-  - Fenced ```mermaid code blocks render as diagrams.
 - text/csv
 - image/svg+xml
+
+Rendering follows the format: JSON, YAML, XML, HCL, and plain text display as syntax-highlighted code; Markdown renders as formatted text, including diagrams from fenced ```mermaid code blocks; CSV renders as a table; and SVG renders as an image.
 
 :::success Examples
 

--- a/docs/docs/artifacts/overview.mdx
+++ b/docs/docs/artifacts/overview.mdx
@@ -19,7 +19,7 @@ The following MIME types or formats are supported and will be rendered properly 
 - text/csv
 - image/svg+xml
 
-In Infrahub's web interface, rendering follows the format: JSON, YAML, XML, HCL, and plain text display as syntax-highlighted code; Markdown renders as formatted text, including diagrams from fenced ```mermaid code blocks; CSV renders as a table; and SVG renders as an image.
+In Infrahub's web interface, rendering follows the format: JSON, YAML, XML, HCL, and plain text display as syntax-highlighted code; Markdown renders as formatted text, including diagrams from fenced mermaid code blocks; CSV renders as a table; and SVG renders as an image.
 
 :::success Examples
 

--- a/docs/docs/artifacts/overview.mdx
+++ b/docs/docs/artifacts/overview.mdx
@@ -19,7 +19,7 @@ The following MIME types or formats are supported and will be rendered properly 
 - text/csv
 - image/svg+xml
 
-Rendering follows the format: JSON, YAML, XML, HCL, and plain text display as syntax-highlighted code; Markdown renders as formatted text, including diagrams from fenced ```mermaid code blocks; CSV renders as a table; and SVG renders as an image.
+In Infrahub's web interface, rendering follows the format: JSON, YAML, XML, HCL, and plain text display as syntax-highlighted code; Markdown renders as formatted text, including diagrams from fenced ```mermaid code blocks; CSV renders as a table; and SVG renders as an image.
 
 :::success Examples
 

--- a/docs/docs/artifacts/overview.mdx
+++ b/docs/docs/artifacts/overview.mdx
@@ -16,6 +16,7 @@ The following MIME types or formats are supported and will be rendered properly 
 - application/hcl
 - text/plain
 - text/markdown
+  - Fenced ```mermaid code blocks render as diagrams.
 - text/csv
 - image/svg+xml
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Document per-type artifact rendering in the Infrahub web interface, including Mermaid diagram support in Markdown. This updates docs to match existing behavior; no code or UI changes.

<sup>Written for commit 21f802d941d421faa14a77b95a241b5fc8760f74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

