### PR TITLE
docs: document Neo4j memory sizing and what the sizing presets assume

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -142,6 +142,7 @@ loopback
 Loopback
 Loopbacks
 loopless
+Lucene
 markdownlint
 Markdownlint
 max_concurrent_queries

--- a/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
+++ b/docs/docs/deploy-manage/install-configure/hardware-requirements.mdx
@@ -76,6 +76,10 @@ For enterprise deployments, use these guidelines:
 | Large Data         | 32        | 64GB | SSD and/or >= 5000 IOPS    |
 | Large Action       | 32        | 64GB | SSD and/or >= 5000 IOPS    |
 
+Each RAM figure covers a full deployment — the API servers, the task workers, the task manager, and the database — on hosts of that size. The Docker Compose and Helm [sizing presets](./install/enterprise.mdx#using-curl-and-docker-compose) set the per-component values for a deployment of that size.
+
+The database is the largest allocation in every preset, and the one to check against the machine that runs it. Where Neo4j has a dedicated host or pod, the heap and page cache values in the preset were sized for a different machine than the one they now run on: measure that host instead, with `neo4j-admin server memory-recommendation`. See [Neo4j memory](./performance-tuning.mdx#neo4j-memory) for how the two pools are used, and why an oversized heap consumes memory on an empty database.
+
 For detailed information about enterprise products and their features, see the [OpsMill pricing page](https://opsmill.com/pricing/).
 
 ## Performance benchmark utility

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -43,6 +43,20 @@ You can also specify a sizing preset in the URL. This will automatically configu
 | large       | 64 GB                 | 4           | 8            | 4                        | 2                              | 31G          | 16G                |
 | large-data  | 64 GB                 | 4           | 2            | 1                        | 1                              | 31G          | 16G                |
 
+The heap and page cache values are defaults for a host of that size, not measured against your data. Override them per environment, and validate them on the machine that runs the database. On a 32 GB host that runs only Neo4j, for example:
+
+```shell title=".env"
+NEO4J_server_memory_heap_initial__size=12G
+NEO4J_server_memory_heap_max__size=12G
+NEO4J_server_memory_pagecache_size=12G
+```
+
+:::warning
+
+Heap is reserved at startup rather than as it is used, so an oversized heap consumes its full size on an empty database and can push the host into swap. Run `neo4j-admin server memory-recommendation` on that host and compare it against the preset before you deploy — in particular when Neo4j runs on its own machine, where the services the preset expects alongside it are no longer there. See [Neo4j memory](../performance-tuning.mdx#neo4j-memory).
+
+:::
+
 ### Prerequisites
 
 - [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)

--- a/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
+++ b/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
@@ -143,12 +143,14 @@ When the two pools plus the operating system exceed physical memory, the host sw
 
 ### Bound transaction memory
 
-`dbms.memory.transaction.total.max` and `db.memory.transaction.max` are unlimited by default, so a single expensive transaction can claim the whole heap. Bounding them keeps one import or merge from exhausting the memory every other query needs:
+`dbms.memory.transaction.total.max` bounds what every running transaction holds together, and defaults to 70% of the heap. `db.memory.transaction.max` bounds a single transaction and is unlimited by default, so one import or merge can claim that entire 70% share on its own and leave nothing for the queries running beside it. Setting both keeps that from happening:
 
 ```yaml title="docker-compose.yml"
 NEO4J_dbms_memory_transaction_total_max: "6G"
 NEO4J_db_memory_transaction_max: "2G"
 ```
+
+Those values suit a 12 GB heap. An explicit `dbms.memory.transaction.total.max` only tightens the default share, so it has to be revisited whenever the heap changes — raising the heap without raising this value leaves the total where you pinned it.
 
 **What you trade.** A large migration or import that exceeds the limit fails with `Transaction memory limit reached` instead of competing for heap. For how to lift the limit for the duration of an upgrade, see [known issues](../maintain-upgrade/upgrade/overview.mdx#migration-failing-because-of-transaction-memory-limit-reached-in-neo4j).
 

--- a/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
+++ b/docs/docs/deploy-manage/install-configure/performance-tuning.mdx
@@ -6,6 +6,8 @@ Infrahub's defaults target a general-purpose deployment. As an instance grows �
 
 Start with the [hardware requirements](./hardware-requirements.mdx): no setting compensates for an undersized machine or slow storage. Then change one setting at a time and measure the result against your own data.
 
+The settings in the table below belong to Infrahub. The database has its own, set on Neo4j rather than on Infrahub, and on a host that is short of memory they matter more than any of them — see [Neo4j memory](#neo4j-memory).
+
 | Symptom | Setting | Default |
 |---|---|---|
 | Merges queue a burst of tasks while several branches are open | `INFRAHUB_DIFF_UPDATE_AFTER_MERGE` | `true` |
@@ -94,6 +96,71 @@ INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD=0
 ```
 
 **What you trade.** A cached count can be up to a minute old, so the total shown alongside a task list lags behind tasks that started or finished within that window.
+
+## Neo4j memory
+
+Neo4j reserves its memory in two pools, and the split between them matters more than the total:
+
+- **Page cache** (`server.memory.pagecache.size`) holds the graph read from disk — nodes, relationships, properties, and native indexes. A page cache large enough for your store keeps queries in memory.
+- **Heap** (`server.memory.heap.initial_size` and `server.memory.heap.max_size`) holds transaction state, query execution, and intermediate results. Infrahub's write transactions — schema loads, imports, branch merges, and diff calculation — are what use it.
+
+What you do not give to either pool goes to the operating system, Lucene indexes, the network layer, and any monitoring agent attached to the JVM. On a 32 GB host Neo4j asks for around 8 GB of that headroom.
+
+Set the values through your deployment method: `NEO4J_server_memory_heap_max__size` and the equivalent variables in Docker Compose, `config:` keys in the Neo4j Helm chart, or `neo4j.conf` on bare metal.
+
+### Heap is reserved at startup, not as it is used
+
+Neo4j's default JVM arguments include `-XX:+AlwaysPreTouch`, which commits and touches the entire heap when the process starts. A 24 GB heap is 24 GB of resident memory within seconds of boot, on an empty database, before a single node exists. Resident memory tells you what the heap is **set to**, not how much of it holds anything, and wiping the database does not change it.
+
+The startup block in `debug.log` reports both, alongside what the host has left:
+
+```text
+server.memory.heap.max_size=24.00GiB
+server.memory.pagecache.size=4.00GiB
+Total Physical memory: 31.30GiB
+Free Physical memory:  238.3MiB
+Total swap 4.000GiB / Free swap 1.170GiB
+G1 Old Gen: committed=22.75GiB, used=0B
+```
+
+`committed=22.75GiB, used=0B` is a heap that reserves 22.75 GB and holds nothing. Read this block after every change to confirm the values Neo4j resolved, rather than the values you set.
+
+### Size the pools for the host
+
+Run Neo4j's own tool on the machine that runs the database:
+
+```shell
+neo4j-admin server memory-recommendation
+```
+
+It prints a heap size, a page cache size, and the memory it leaves for the operating system, calculated from the RAM of that host. It also prints the size of your data and native indexes as a separate figure, as an input to sizing rather than a recommendation.
+
+- **Heap.** Start from the recommended value. Raising it past what your write transactions need buys nothing and costs the same amount of resident memory.
+- **Page cache.** The tool sizes it as a share of RAM, not against your data. Where you can measure the store, roughly 1.2 × (data + indexes) covers it. Where you cannot yet measure it — a new deployment, or an environment whose data is still growing — keep the recommended value.
+- **Headroom.** Keep heap plus page cache below total RAM by the margin the tool reserves. Subtract anything else on the host as well: co-located Infrahub services, and monitoring agents that attach to the JVM with `-agentpath` and allocate outside the heap.
+
+When the two pools plus the operating system exceed physical memory, the host swaps the JVM out. A swapped heap produces stop-the-world pauses that look like garbage collection but report `gcTime=0, gcCount=0` in `debug.log`.
+
+### Bound transaction memory
+
+`dbms.memory.transaction.total.max` and `db.memory.transaction.max` are unlimited by default, so a single expensive transaction can claim the whole heap. Bounding them keeps one import or merge from exhausting the memory every other query needs:
+
+```yaml title="docker-compose.yml"
+NEO4J_dbms_memory_transaction_total_max: "6G"
+NEO4J_db_memory_transaction_max: "2G"
+```
+
+**What you trade.** A large migration or import that exceeds the limit fails with `Transaction memory limit reached` instead of competing for heap. For how to lift the limit for the duration of an upgrade, see [known issues](../maintain-upgrade/upgrade/overview.mdx#migration-failing-because-of-transaction-memory-limit-reached-in-neo4j).
+
+### Symptoms and causes
+
+| Symptom | Cause |
+|---|---|
+| Neo4j uses all host memory on an empty or recently wiped database | Heap is set too large; `AlwaysPreTouch` reserves all of it at startup |
+| Swap in use while the database is idle | Heap plus page cache leaves too little for the operating system and the memory the JVM allocates outside the heap |
+| Long stop-the-world pauses with `gcTime=0, gcCount=0` | The operating system is swapping the JVM out, rather than the JVM collecting garbage |
+| Queries read from disk on a dataset that fits in RAM | Page cache is smaller than the store |
+| Infrahub logs `Database Service unavailable`, or a server replica fails to start | The database is unresponsive or unreachable, which a host with no memory to spare produces under load |
 
 ## Related resources
 

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
@@ -182,6 +182,8 @@ For large database/schema migrations, you may encounter a `Transaction memory li
 
 To work around this, you can disable the transaction memory limit by setting the `dbms.memory.transaction.total.max` to `0` in your Neo4j configuration.
 
+Restore the limit once the migration completes. Unlimited transaction memory lets a single transaction claim the whole heap during normal operation, which affects every other query on the instance. See [Neo4j memory](../../install-configure/performance-tuning.mdx#bound-transaction-memory).
+
 :::
 
 We are working on a more robust solution to handle large migrations without hitting this limit in future releases.

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
@@ -182,7 +182,7 @@ For large database/schema migrations, you may encounter a `Transaction memory li
 
 To work around this, you can disable the transaction memory limit by setting the `dbms.memory.transaction.total.max` to `0` in your Neo4j configuration.
 
-Restore the limit once the migration completes. Unlimited transaction memory lets a single transaction claim the whole heap during normal operation, which affects every other query on the instance. See [Neo4j memory](../../install-configure/performance-tuning.mdx#bound-transaction-memory).
+Restore the limit once the migration completes. `0` removes the default ceiling of 70% of the heap, which lets transactions claim all of it during normal operation and affects every other query on the instance. See [Bound transaction memory](../../install-configure/performance-tuning.mdx#bound-transaction-memory).
 
 :::
 


### PR DESCRIPTION
## Why

A customer ran every environment with Neo4j consuming all 32 GB of RAM plus swap, on databases holding under 100 MB, and asked how that was possible on a wiped instance. The configuration was `24G` heap and `4G` page cache — the `medium` sizing preset, which we ship in Docker Compose and Helm and publish in the install docs.

The docs could not have answered the question. Nothing explained what heap and page cache hold, that Neo4j reserves the whole heap at startup so resident memory reflects the setting rather than the contents, or how to size either pool for a host. `Tune performance` covered only `INFRAHUB_*` settings, so a reader with a memory problem found nothing about the process using the memory. When we recommended smaller values, the customer pushed back by citing our own enterprise sizing table.

## What changed

- **`performance-tuning.mdx`** — a `Neo4j memory` section: the two pools and what each holds, `-XX:+AlwaysPreTouch` and why an oversized heap is resident on an empty database, reading the resolved values from the `debug.log` startup block, sizing with `neo4j-admin server memory-recommendation`, bounding transaction memory, and a symptoms-and-causes table.
- **`hardware-requirements.mdx`** — what the enterprise RAM figures cover, and that the database values need checking against the machine that runs Neo4j rather than assumed from the tier.
- **`install/enterprise.mdx`** — the preset heap and page cache values are defaults for a host of that size, how to override them per environment, and a warning to validate before deploying.
- **`upgrade/overview.mdx`** — the `dbms.memory.transaction.total.max=0` workaround now says to restore the limit afterwards, and why.
- **`.vale/styles/spelling-exceptions.txt`** — adds `Lucene`.

## Worth a reviewer's attention

- **The preset values themselves are a separate problem.** `medium` reserves 28 GB of 32 GB (88%) where Neo4j's own tool asks for 12G heap / 12G page cache / 8 GB reserved, and the ratio is inverted — page cache is what holds the graph. `small` reserves 56% and `large` 73%, so `medium` is the outlier. These docs explain how to override the preset; they do not defend its numbers. A separate issue against `infrahub-helm` covers changing them, and this page will need a pass if they change.
- **The claim that each enterprise RAM figure covers a full deployment.** Verified against the Compose presets, where every service runs on one host. Confirm it holds for how the Helm flavored charts are meant to be read.
- **The `12G / 12G` example in `install/enterprise.mdx`** is scoped to a 32 GB host running only Neo4j. It sits under a table covering `small` through `large`, so check the framing reads unambiguously.
- **The `debug.log` excerpt** is a real startup block, with nothing identifying in it.

## Checks

- `npm run build` — passes, no broken links or anchors
- `vale` — 0 errors, 0 warnings (installed locally; the invoke task skips silently when it is missing)
- `markdownlint-cli2` — 0 errors

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

