### PR TITLE
refactor(frontend): tokenize the popover surface color

### DIFF
--- a/frontend/app/src/shared/components/ui/dropdown-menu.tsx
+++ b/frontend/app/src/shared/components/ui/dropdown-menu.tsx
@@ -26,7 +26,7 @@ export const DropdownMenuContent = ({ className, ref, ...props }: DropdownMenuCo
         sideOffset={4}
         ref={ref}
         className={classNames(
-          "z-50 min-w-32 space-y-1 overflow-hidden rounded-xl bg-white p-2 shadow-lg",
+          "z-50 min-w-32 space-y-1 overflow-hidden rounded-xl bg-popover p-2 shadow-lg backdrop-blur-lg",
           "data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in",
           "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -90,7 +90,7 @@ export const DropdownMenuSubContent = ({
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={classNames(
-      "min-w-32 space-y-1 overflow-hidden rounded-xl bg-white p-2 shadow-lg",
+      "min-w-32 space-y-1 overflow-hidden rounded-xl bg-popover p-2 shadow-lg backdrop-blur-lg",
       "data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in",
       "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out",
       "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/frontend/app/src/shared/components/ui/popover.tsx
+++ b/frontend/app/src/shared/components/ui/popover.tsx
@@ -32,7 +32,7 @@ export const PopoverContent = ({
         align={align}
         sideOffset={sideOffset}
         className={classNames(
-          "z-10 max-w-[100vw] rounded-md border bg-white p-2 text-sm shadow-xl outline-hidden",
+          "z-10 max-w-[100vw] rounded-md border bg-popover p-2 text-sm shadow-xl outline-hidden backdrop-blur-lg",
           "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
           "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -65,7 +65,7 @@ export const PopoverTabsTrigger = ({ className, ref, ...props }: PopoverTabsTrig
   <TabsPrimitive.Trigger
     ref={ref}
     className={classNames(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-t-md bg-white px-3 py-1.5 font-medium text-sm transition-all",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-t-md bg-popover px-3 py-1.5 font-medium text-sm transition-all",
       "outline-hidden",
       "disabled:pointer-events-none disabled:opacity-50",
       "data-[state=active]:-mb-px data-[state=active]:border-x data-[state=active]:border-t",

--- a/frontend/packages/ui/src/components/popover/popover.tsx
+++ b/frontend/packages/ui/src/components/popover/popover.tsx
@@ -13,7 +13,7 @@ export const PopoverTrigger = AriaDialogTrigger;
 
 const popoverStyles = tv({
   base: [
-    "z-50 rounded-xl border border-border-strong bg-stone-100/70 shadow-md outline-hidden backdrop-blur-lg duration-100",
+    "z-50 rounded-xl border border-border-strong bg-popover shadow-md outline-hidden backdrop-blur-lg duration-100",
     "data-[placement=bottom]:slide-in-from-top-10 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2",
   ],
   variants: {

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -8,6 +8,8 @@
   --ring: var(--color-cyan-700);
   --ring-halo: --alpha(var(--ring) / 25%);
 
+  --popover: --alpha(var(--color-stone-100) / 70%);
+
   --card: linear-gradient(to bottom, var(--color-stone-50) 0%, var(--color-white) 10%);
   --card-header: linear-gradient(to bottom, var(--color-white) 0%, var(--color-neutral-50) 100%);
   --card-header-foreground: var(--color-neutral-700);
@@ -16,6 +18,10 @@
     inset 0 2px 0 rgb(255 255 255), inset 0 -1px 2px 1px rgb(0 0 0 / 0.03),
     0 1px 1px rgb(0 0 0 / 0.02);
   --card-header-shadow: inset 0 1px 0 rgb(255 255 255 / 0.85);
+}
+
+.dark {
+  --popover: --alpha(var(--color-stone-900) / 70%);
 }
 
 @theme inline {
@@ -27,6 +33,8 @@
 
   --color-ring: var(--ring);
   --color-ring-halo: var(--ring-halo);
+
+  --color-popover: var(--popover);
 
   --background-image-card: var(--card);
   --background-image-card-header: var(--card-header);


### PR DESCRIPTION
## What

Declares a `--popover` color token in the design-system theme and points every popover-style surface at it:

- `theme.css`: `--popover` is `--alpha(var(--color-stone-100) / 70%)` on `:root`, with a `.dark` counterpart at `--alpha(var(--color-stone-900) / 70%)` — inert for now since nothing on `develop` sets the `.dark` class, but it keeps the surface pair declared in one place for the upcoming dark theme.
- `@infrahub/ui` Popover: `bg-stone-100/70` → `bg-popover` (border, blur, shadow, radius untouched).
- Legacy Radix popover (`shared/components/ui/popover.tsx`): `bg-white` → `bg-popover` on the content and tabs trigger, plus `backdrop-blur-lg` on the content so the 70%-alpha surface stays readable.
- Dropdown menu (`shared/components/ui/dropdown-menu.tsx`): same swap on `Content` and `SubContent`.

## Why

The popover surface color was hardcoded per component (`bg-stone-100/70` in the design system, opaque `bg-white` in the legacy popover and dropdown menu), so it couldn't follow a theme. This unifies them on one token; the visible change is the legacy surfaces going from opaque white to the same translucent stone glass as the design-system popover.

## Testing

- `pnpm exec biome ci .` — clean
- `pnpm knip` — clean
- `pnpm exec betterer ci` — no regression
- `pnpm test` — 176 files / 1190 tests passed
- `pnpm build` — emitted CSS contains `.bg-popover` and both token values

🤖 Generated with [Claude Code](https://claude.com/claude-code)