### PR TITLE
chore: run the release-notes vale check in /pre-ci

### DIFF
--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -19,7 +19,7 @@ Run all locally-executable CI checks to catch issues before pushing.
 
 **Options:**
 
-- `--fast` — Run only formatting and fast lint checks (~20s). Skips backend lint (ty/mypy), Betterer, docs lint, generated file and doc validation, schema validation, and unit tests.
+- `--fast` — Run only formatting and fast lint checks (~20s). Skips backend lint (ty/mypy), Betterer, docs lint, generated file and doc validation, schema validation, release notes style, and unit tests.
 
 ## Phase 1 — Auto-fix formatting (sequential)
 
@@ -65,7 +65,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 
 ## Phase 3 — Slow checks (parallel)
 
-**IMPORTANT: Send ALL 7 commands below in a SINGLE message with 7 parallel Bash tool calls.** Do NOT run them one at a time.
+**IMPORTANT: Send ALL 8 commands below in a SINGLE message with 8 parallel Bash tool calls.** Do NOT run them one at a time.
 
 1. `uv run invoke backend.lint` — Run separately from main.lint to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. If ruff reports issues, they were not auto-fixable — report them to the user.
 2. `cd frontend/app && npx betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
@@ -74,6 +74,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 5. `uv run invoke schema.validate-graphqlschema` — Ensures `schema/schema.graphql` is up to date. Regenerates the file then checks for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
 6. `uv run invoke schema.validate-jsonschema` — Ensures `schema/openapi.json` is up to date. Same approach as GraphQL schema validation.
 7. `uv run invoke docs.validate` — Ensures generated reference documentation (CLI, schema, events, repository config, config) is up to date. Regenerates the docs then checks for uncommitted diffs. If validation fails, the correct files are already on disk — stage and commit them.
+8. `uv run invoke release.vale` - Runs the same vale check as CI's `validate-release-notes-style` job, covering `changelog/`, `docs/docs/release-notes/infrahub/` and `CHANGELOG.md`. Catches prose style errors in towncrier fragments before they reach CI, since a fragment's text becomes the release notes. Only errors fail the check; warnings are reported but do not.
 
 ## Phase 4 — Unit tests
 
@@ -104,6 +105,7 @@ Summarize results in a table:
 | GraphQL schema validation | ... |
 | JSON schema validation | ... |
 | Generated docs validation | ... |
+| Release notes style | ... |
 | Unit tests | ... |
 
 If `--fast` was used, show skipped checks as "skipped".


### PR DESCRIPTION
## Problem

CI's `validate-release-notes-style` job (`.github/workflows/ci.yml:1062-1085`) runs
vale over `changelog/`, `docs/docs/release-notes/infrahub/` and `CHANGELOG.md`.
`.vale.ini` applies `BasedOnStyles = Infrahub` to `changelog/**/*.md`, so towncrier
fragments genuinely are style-checked there.

Nothing in the local pre-push flow ran an equivalent:

- `/pre-ci` ran `docs.lint`, whose `docs.vale` step only covers `./docs`.
- `docs.validate` only regenerates docs and runs `git diff --exit-code docs`.
- `.pre-commit-config.yaml` covers whitespace, ruff, yaml and toml. No prose linting.

So the first signal that a fragment had a style error was a failed CI job after the
push. Fragments are the source text for release notes, which makes these the errors
most worth catching early.

## Change

Adds `uv run invoke release.vale` as an eighth Phase 3 check in `/pre-ci`.
`release.vale` (`tasks/release.py:35-47`) already existed and runs the identical vale
invocation as the CI job. Nothing routed to it.

Also updates the `--fast` skip list and the summary table.

`.claude/commands` is a symlink to `.agents/commands`, so the single file edit covers
both views.

## Verification

Passes on the current tree, and warnings do not fail the check:

```
$ uv run invoke release.vale
0 errors, 3 warnings and 0 suggestions in 120 files.
exit=0
```

The 3 warnings are pre-existing, in release-note mdx files, and CI tolerates them
today.

Catches a bad fragment end to end:

```
$ printf 'Fixed a bug in the graphQL api.\n' > changelog/99999.fixed.md
$ uv run invoke release.vale
 changelog/99999.fixed.md
 1:28  error  Did you really mean 'api'?  Infrahub.spelling
exit=1
```

## Notes

Deliberately uses `release.vale` rather than `release.lint`. `release.lint` also runs
`release.markdownlint`, which fails today for reasons unrelated to fragment prose
(MD041 fires on every fragment by design, plus pre-existing `CHANGELOG.md`
violations). That is handled in a separate PR; once it lands, this line can be
upgraded to `release.lint` to pick up the towncrier draft check too.

No changelog fragment: this is developer tooling with no user-facing effect.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

