### PR TITLE
refactor(frontend): tokenize the sheet frame and surface colors

### DIFF
--- a/frontend/packages/ui/src/components/sheet/sheet.tsx
+++ b/frontend/packages/ui/src/components/sheet/sheet.tsx
@@ -39,7 +39,7 @@ export function Sheet({
               <AriaModal
                 className={cn(
                   "fixed top-2 bottom-2 w-100 overflow-hidden rounded-2xl p-1 outline-hidden transition-all",
-                  "border border-sheet-frame-border bg-sheet-frame shadow-sheet backdrop-blur-xl",
+                  "border border-sheet-frame-border bg-sheet-frame shadow-sheet backdrop-blur-lg",
                   "data-entering:animate-in data-entering:duration-200 data-entering:ease-out data-entering:slide-in-from-right-1/2",
                   "data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in data-exiting:slide-out-to-right-1/2",
                 )}

--- a/frontend/packages/ui/src/components/sheet/sheet.tsx
+++ b/frontend/packages/ui/src/components/sheet/sheet.tsx
@@ -39,7 +39,7 @@ export function Sheet({
               <AriaModal
                 className={cn(
                   "fixed top-2 bottom-2 w-100 overflow-hidden rounded-2xl p-1 outline-hidden transition-all",
-                  "border bg-white/25 shadow-xl backdrop-blur",
+                  "border border-sheet-frame-border bg-sheet-frame shadow-sheet backdrop-blur-xl",
                   "data-entering:animate-in data-entering:duration-200 data-entering:ease-out data-entering:slide-in-from-right-1/2",
                   "data-exiting:animate-out data-exiting:duration-150 data-exiting:ease-in data-exiting:slide-out-to-right-1/2",
                 )}
@@ -53,7 +53,7 @@ export function Sheet({
                 <AriaDialog
                   aria-label={ariaLabel ?? `sheet ${totalCount - depth}`}
                   className={cn(
-                    "no-scrollbar h-full overflow-auto rounded-xl bg-white p-3 outline-hidden",
+                    "no-scrollbar h-full overflow-auto rounded-xl bg-secondary p-3 outline-hidden",
                     className,
                   )}
                 >

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -27,6 +27,10 @@
 
   --panel: linear-gradient(var(--color-gray-50), var(--color-gray-50));
   --panel-shadow: 0 0 #0000;
+
+  --sheet-frame: --alpha(var(--color-white) / 25%);
+  --sheet-frame-border: var(--border);
+  --sheet-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 }
 
 .dark {
@@ -39,6 +43,14 @@
 
   --panel: linear-gradient(180deg, oklch(1 0 0 / 0.06) 0%, oklch(0.4 0 0 / 0.3) 80%);
   --panel-shadow: inset 0 2px 4px 0 oklch(0.8 0 0 / 0.05);
+
+  /* Frosted-glass sheet frame: ivory glass fill with a lit top lip; the
+     dialog inside reuses --secondary. */
+  --sheet-frame: rgb(255 251 246 / 0.14);
+  --sheet-frame-border: rgb(255 255 255 / 0.22);
+  --sheet-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.12), 0 28px 70px rgb(0 0 0 / 0.75),
+    0 6px 20px rgb(0 0 0 / 0.5);
 }
 
 @theme inline {
@@ -66,6 +78,10 @@
 
   --background-image-panel: var(--panel);
   --shadow-panel: var(--panel-shadow);
+
+  --color-sheet-frame: var(--sheet-frame);
+  --color-sheet-frame-border: var(--sheet-frame-border);
+  --shadow-sheet: var(--sheet-shadow);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Extracts the sheet styling work from the dark-theme branch into a standalone change: the sheet's frame and dialog colors no longer hardcode light values and instead flow through theme tokens, so the sheet is ready to render correctly when the dark theme lands.

## Key Changes

- The sheet dialog now sits on a new `--secondary` surface token (light: the existing card recipe, so rendering is unchanged; dark: a fade-to-black surface).
- The sheet frame is tokenized as `--sheet-frame` / `--sheet-frame-border` / `--sheet-shadow`. In dark it renders as a frosted-glass border — ivory glass fill, bright 1px edge, lit top lip — over a `backdrop-blur-xl`.
- Light mode is visually unchanged except the frame's backdrop blur going from 8px to 24px, which is barely perceptible on the translucent rim.
- The dark values are inert until a `.dark` class is applied; nothing on `develop` toggles it today.

## Test Plan

- `pnpm build` in `frontend/app` passes against this branch; the compiled CSS contains the new utilities (`bg-sheet-frame`, `border-sheet-frame-border`, `shadow-sheet`, `bg-secondary`).
- Verified visually in the running app (light unchanged; with `.dark` forced on the root, the sheet renders the frost-glass frame over the fade surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

