### PR TITLE
refactor(frontend): add Card secondary and panel surface variants

### DIFF
--- a/frontend/app/src/entities/events/ui/event-card.tsx
+++ b/frontend/app/src/entities/events/ui/event-card.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@infrahub/ui";
 import { useLocation } from "react-router";
 
 import { DateDisplay } from "@/shared/components/display/date-display";
@@ -85,7 +86,7 @@ export const EventCard = (props: EventType) => {
     <div className="flex gap-2">
       <TimelineBorder />
 
-      <div className="flex min-w-0 grow flex-col gap-3 rounded-md border bg-white p-2 text-sm shadow-xs">
+      <Card className="min-w-0 grow gap-3 rounded-md p-2 text-sm">
         <EventContent {...props} />
 
         <div className="flex justify-between text-gray-500">
@@ -103,7 +104,7 @@ export const EventCard = (props: EventType) => {
             {pathname !== "/" && <EventDetailsPopover {...props} />}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/frontend/app/src/entities/homepage/ui/home-card.tsx
+++ b/frontend/app/src/entities/homepage/ui/home-card.tsx
@@ -12,10 +12,7 @@ interface HomeCardProps {
 const HomeCardTitle = ({ className, ...props }: HomeCardProps) => {
   return (
     <CardHeader
-      className={classNames(
-        "flex items-center justify-between from-white font-semibold",
-        className
-      )}
+      className={classNames("flex items-center justify-between font-semibold", className)}
       {...props}
     />
   );

--- a/frontend/app/src/entities/navigation/ui/app-header.tsx
+++ b/frontend/app/src/entities/navigation/ui/app-header.tsx
@@ -7,7 +7,7 @@ import { TaskStatus } from "@/entities/tasks/ui/task-status";
 
 export function AppHeader() {
   return (
-    <Card className="h-12.5 shrink-0 flex-row items-center gap-2 p-2">
+    <Card variant="secondary" className="h-12.5 shrink-0 flex-row items-center gap-2 p-2">
       <TimeFrameSelector />
 
       <BranchSelector />

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-body.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-body.tsx
@@ -31,7 +31,7 @@ export function ObjectDetailsBody({ objectSchema, objectId, permission }: Object
   return (
     <Col className="gap-0 overflow-auto p-1">
       <ObjectDetailsTabs objectSchema={objectSchema} objectData={objectData} />
-      <Card className="overflow-auto bg-neutral-50">
+      <Card variant="panel" className="overflow-auto">
         <Outlet
           context={{ objectSchema, objectData, permission } satisfies ObjectDetailsOutletContext}
         />

--- a/frontend/app/src/shared/components/layout/content.tsx
+++ b/frontend/app/src/shared/components/layout/content.tsx
@@ -47,7 +47,7 @@ export const ContentTitle = ({
 };
 
 export const ContentCard = ({ className, ...props }: CardProps) => {
-  return <Card className={classNames("overflow-auto", className)} {...props} />;
+  return <Card variant="secondary" className={classNames("overflow-auto", className)} {...props} />;
 };
 
 export type ContentCardTitleProps = {

--- a/frontend/app/src/shared/components/layout/sidebar.tsx
+++ b/frontend/app/src/shared/components/layout/sidebar.tsx
@@ -48,6 +48,7 @@ export function Sidebar({ className, children, ...props }: React.ComponentProps<
 
   return (
     <Card
+      variant="secondary"
       className={classNames(
         "group w-64 shrink-0 overflow-hidden transition-[width] duration-200 ease-linear data-[state=collapsed]:w-14",
         className

--- a/frontend/packages/ui/src/components/card/card.stories.tsx
+++ b/frontend/packages/ui/src/components/card/card.stories.tsx
@@ -26,6 +26,18 @@ export const AllVariants: StoryObj = {
           CardHeader and CardContent handle their own padding. No overrides needed on Card.
         </CardContent>
       </Card>
+
+      <Card variant="secondary" className="max-w-sm">
+        <CardContent className="text-sm text-neutral-700">
+          The secondary surface is for app chrome — header, sidebar, content shell.
+        </CardContent>
+      </Card>
+
+      <Card variant="panel" className="max-w-sm">
+        <CardContent className="text-sm text-neutral-700">
+          The panel surface recedes behind the cards it contains.
+        </CardContent>
+      </Card>
     </div>
   ),
 };

--- a/frontend/packages/ui/src/components/card/card.tsx
+++ b/frontend/packages/ui/src/components/card/card.tsx
@@ -1,26 +1,28 @@
 import type React from "react";
 
-import { cn } from "tailwind-variants";
+import { cn, tv, type VariantProps } from "tailwind-variants";
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+const cardVariants = tv({
+  base: "flex flex-col rounded-2xl border",
+  variants: {
+    variant: {
+      card: "bg-card shadow-card",
+      secondary: "bg-secondary shadow-secondary",
+      panel: "border-border-strong bg-panel shadow-panel",
+    },
+  },
+  defaultVariants: {
+    variant: "card",
+  },
+});
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-export function Card({ className, ref, ...props }: CardProps) {
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "flex flex-col",
-        "rounded-2xl",
-        "bg-card",
-        "border",
-        "shadow-card",
-        className,
-      )}
-      {...props}
-    />
-  );
+export function Card({ className, ref, variant, ...props }: CardProps) {
+  return <div ref={ref} className={cardVariants({ variant, class: className })} {...props} />;
 }
 
 export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -20,10 +20,24 @@
     inset 0 2px 0 rgb(255 255 255), inset 0 -1px 2px 1px rgb(0 0 0 / 0.03),
     0 1px 1px rgb(0 0 0 / 0.02);
   --card-header-shadow: inset 0 1px 0 rgb(255 255 255 / 0.85);
+
+  --secondary: var(--card);
+  --secondary-shadow: var(--card-shadow);
+
+  --panel: linear-gradient(var(--color-gray-50), var(--color-gray-50));
+  --panel-shadow: 0 0 #0000;
 }
 
 .dark {
   --popover: --alpha(var(--color-stone-900) / 70%);
+
+  --secondary:
+    radial-gradient(120% 55% at 0% 0%, rgb(255 255 255 / 0.005), transparent 62%),
+    linear-gradient(180deg, #1a1817 0%, #0d0c0b 18%, #000000 100%);
+  --secondary-shadow: 0 0 #0000;
+
+  --panel: linear-gradient(180deg, oklch(1 0 0 / 0.06) 0%, oklch(0.4 0 0 / 0.3) 80%);
+  --panel-shadow: inset 0 2px 4px 0 oklch(0.8 0 0 / 0.05);
 }
 
 @theme inline {
@@ -44,6 +58,12 @@
 
   --shadow-card: var(--card-shadow);
   --shadow-card-header: var(--card-header-shadow);
+
+  --background-image-secondary: var(--secondary);
+  --shadow-secondary: var(--secondary-shadow);
+
+  --background-image-panel: var(--panel);
+  --shadow-panel: var(--panel-shadow);
 }
 
 @layer base {


### PR DESCRIPTION
## Why

`Card` exposed a single surface, so everything that isn't a card either reused the card surface (app header, sidebar, content shell) or painted its own — `bg-neutral-50` on the object details body, a hand-rolled `border bg-white shadow-xs` div in `EventCard`. Those surfaces can't move independently of cards today.

## What

- `Card` becomes a `tv()` component with three surfaces:
  - `card` (default) — unchanged
  - `secondary` — app chrome: header, sidebar, content shell
  - `panel` — the recessed container that sits behind cards
- New `--secondary` / `--panel` tokens (plus their shadows) in `theme.css`, mapped as `bg-secondary` / `bg-panel` / `shadow-secondary` / `shadow-panel`.
- Call sites adopt the variants: `AppHeader`, `Sidebar`, `ContentCard` → `secondary`; `ObjectDetailsBody` → `panel` (drops `bg-neutral-50`).
- `EventCard` drops its hand-rolled card div for `<Card>`; `HomeCardTitle` drops the now-redundant `from-white` on `CardHeader`.

## Rendering

Light mode is a no-op by construction: `--secondary` resolves to `var(--card)` and `--panel` to the `gray-50` the details body already used. The only visual change is `EventCard`, which now gets the standard card surface instead of flat white plus `shadow-xs`.

Dark values are defined alongside, following the same both-themes pattern as #10261 — that's where the two surfaces actually diverge from `--card`.

## Verification

- `pnpm exec biome check .` clean
- `oxfmt --check` / `oxlint` clean on the touched `packages/ui` files
- `pnpm exec betterer ci` — 188 issues, unchanged
- `pnpm test` — 176 files, 1190 tests passing
- `pnpm build` — succeeds; `bg-secondary`, `bg-panel`, `shadow-secondary`, `shadow-panel` all present in the emitted CSS

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

