### PR TITLE
refactor(frontend): tokenize input surfaces for dark mode

### DIFF
--- a/frontend/app/src/shared/components/ui/style.ts
+++ b/frontend/app/src/shared/components/ui/style.ts
@@ -5,7 +5,7 @@ export const focusWithinStyle =
   "transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-ring-halo focus-within:border-ring";
 
 export const inputStyle =
-  "min-h-10 flex items-center w-full rounded-xl border bg-white p-2 text-sm placeholder:text-subtle-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring-halo focus-visible:border-ring disabled:cursor-not-allowed disabled:bg-gray-100 shadow-[0_2px_4px_rgba(0,0,0,0.04)]";
+  "min-h-10 flex items-center w-full rounded-xl border border-input-border bg-input p-2 text-sm placeholder:text-subtle-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring-halo focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-60 shadow-input";
 
 export const inputErrorStyle =
   "border-red-500 focus-within:border-red-500 focus-within:ring-red-500/25 focus:border-red-500 focus:ring-red-500/25 focus-visible:border-red-500 focus-visible:ring-red-500/25";

--- a/frontend/packages/ui/src/components/button/button.tsx
+++ b/frontend/packages/ui/src/components/button/button.tsx
@@ -61,8 +61,7 @@ const buttonVariants = tv({
         "data-pressed:bg-neutral-200",
       ],
       input: [
-        "bg-white text-foreground",
-        "shadow-[0_2px_4px_rgba(0,0,0,0.04)]",
+        "border-input-border bg-input text-foreground shadow-input",
         "data-pressed:scale-100",
       ],
     },

--- a/frontend/packages/ui/src/components/select/select.tsx
+++ b/frontend/packages/ui/src/components/select/select.tsx
@@ -17,8 +17,8 @@ import { Popover, type PopoverProps } from "../popover/popover";
 export const selectTriggerVariants = tv({
   base: [
     "flex w-full items-center gap-2 rounded-lg border border-border-strong outline-none",
-    "bg-white text-sm placeholder:text-subtle-muted",
-    "disabled:cursor-not-allowed disabled:bg-neutral-100",
+    "bg-input text-sm placeholder:text-subtle-muted",
+    "disabled:cursor-not-allowed disabled:opacity-60",
     focusVisibleStyle,
   ],
   variants: {

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -14,6 +14,10 @@
   --ring: var(--color-cyan-700);
   --ring-halo: --alpha(var(--ring) / 25%);
 
+  --input: var(--color-white);
+  --input-border: var(--border);
+  --input-shadow: 0 2px 4px rgb(0 0 0 / 0.04);
+
   --popover: --alpha(var(--color-stone-100) / 70%);
 
   --card: linear-gradient(to bottom, var(--color-stone-50) 0%, var(--color-white) 10%);
@@ -48,6 +52,10 @@
 
   --ring: var(--color-cyan-700);
   --ring-halo: --alpha(var(--ring) / 25%);
+
+  --input: var(--color-stone-900);
+  --input-border: var(--border-strong);
+  --input-shadow: 0 2px 4px rgb(0 0 0 / 0.35);
 
   --popover: --alpha(var(--color-stone-900) / 70%);
 
@@ -85,6 +93,10 @@
 
   --color-ring: var(--ring);
   --color-ring-halo: var(--ring-halo);
+
+  --color-input: var(--input);
+  --color-input-border: var(--input-border);
+  --shadow-input: var(--input-shadow);
 
   --color-popover: var(--popover);
 


### PR DESCRIPTION
# Why

Input surfaces were hardcoded to `bg-white` with a light-only box shadow and
`bg-gray-100`/`bg-neutral-100` disabled states, so they stayed white in dark mode.

Goal: route every input surface through theme tokens so it follows the palette.

Non-goals: no visual change in light mode, no new components.

## What changed

Behavioral changes:

- Text inputs, `input`-variant buttons and select triggers now use the themed
  input surface, so they render dark in dark mode instead of white.
- Disabled inputs dim via `opacity-60` instead of switching to a light grey fill,
  which reads correctly in both themes.

Implementation notes:

- New tokens in `theme.css`: `--input`, `--input-border`, `--input-shadow`
  (exposed as `bg-input`, `border-input-border`, `shadow-input`), defined per
  theme — white/subtle shadow in light, `stone-900`/stronger shadow in dark.
- Replaces the inline `shadow-[0_2px_4px_rgba(0,0,0,0.04)]` duplicated across
  `inputStyle` and the button `input` variant.

What stayed the same: light-mode appearance, component APIs, no new props.

## How to review

`frontend/packages/ui/src/styles/theme.css` first (the token definitions), then
the three consumers.

## How to test

```bash
cd frontend/app && pnpm exec biome ci . && pnpm test
```

Then `pnpm dev` and toggle the theme — check inputs, select triggers, and
`input`-variant buttons in both themes, including disabled states.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

