### PR TITLE
fix(backend): update profile/template instances during schema name/namespace/inheritance update

### DIFF
--- a/backend/infrahub/cli/db_commands/check_inheritance.py
+++ b/backend/infrahub/cli/db_commands/check_inheritance.py
@@ -252,20 +252,15 @@ async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> bool:
             migration_query = await NodeDuplicateQuery.init(
                 db=db,
                 branch=branches_by_name[branch_name],
-                previous_node=SchemaNodeInfo(
-                    name=node_schema.name,
-                    namespace=node_schema.namespace,
-                    branch_support=node_schema.branch.value,
-                    labels=list(kind_label_count.labels) + [kind_label_count.kind, InfrahubKind.NODE],
-                    kind=kind_label_count.kind,
-                ),
-                new_node=SchemaNodeInfo(
-                    name=node_schema.name,
-                    namespace=node_schema.namespace,
-                    branch_support=node_schema.branch.value,
-                    labels=list(node_schema.inherit_from) + [kind_label_count.kind, InfrahubKind.NODE],
-                    kind=kind_label_count.kind,
-                ),
+                kind_updates_map={
+                    kind_label_count.kind: SchemaNodeInfo(
+                        name=node_schema.name,
+                        namespace=node_schema.namespace,
+                        branch_support=node_schema.branch.value,
+                        labels=list(node_schema.inherit_from) + [kind_label_count.kind, InfrahubKind.NODE],
+                        kind=kind_label_count.kind,
+                    )
+                },
             )
             await migration_query.execute(db=db)
             rprint("done")

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -407,6 +407,9 @@ class MetadataOptions(Flag):
     USER_TIMESTAMPS = TIMESTAMPS | USERS
 
 
+PROFILE_NAMESPACE = "Profile"
+TEMPLATE_NAMESPACE = "Template"
+
 RESTRICTED_NAMESPACES: list[str] = [
     "Account",
     "Branch",
@@ -418,8 +421,8 @@ RESTRICTED_NAMESPACES: list[str] = [
     "Internal",
     "Lineage",
     "Schema",
-    "Profile",
-    "Template",
+    PROFILE_NAMESPACE,
+    TEMPLATE_NAMESPACE,
 ]
 
 NODE_NAME_REGEX = r"^[A-Z][a-zA-Z0-9]+$"

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -113,14 +113,15 @@ class Migration012AddLabelData(NodeDuplicateQuery):
 
         kwargs.pop("branch", None)
 
-        super().__init__(new_node=new_node, previous_node=previous_node, branch=branch, **kwargs)
+        super().__init__(kind_updates_map={previous_node.kind: new_node}, branch=branch, **kwargs)
 
     def render_match(self) -> str:
-        return f"""
+        return """
         // Find all the active nodes
-        MATCH (node:{self.previous_node.kind})
+        MATCH (node:%(previous_kinds)s)
         WHERE NOT "CoreGenericAccount" IN LABELS(node)
-        """
+        WITH node, $kind_map[node.kind] AS target
+        """ % {"previous_kinds": self.previous_kinds}
 
 
 class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -26,6 +26,10 @@ class NodeDuplicateQuery(Query):
     Creates a copy of each affected Node and sets the new kind/inheritance.
     Adds duplicate edges to the new Node that match all the active edges on the old Node.
     Sets all the edges on the old Node to deleted.
+
+    ``kind_updates_map`` maps each kind being migrated to the schema its vertices should end
+    up with. A kind and the Profile/Template kinds generated from it are disjoint vertex
+    populations that must move together, so they are migrated in a single execution.
     """
 
     name = "node_duplicate"
@@ -34,36 +38,34 @@ class NodeDuplicateQuery(Query):
 
     def __init__(
         self,
-        previous_node: SchemaNodeInfo,
-        new_node: SchemaNodeInfo,
+        kind_updates_map: dict[str, SchemaNodeInfo],
         **kwargs: Any,
     ) -> None:
-        self.previous_node = previous_node
-        self.new_node = new_node
+        if not kind_updates_map:
+            raise ValueError("At least one kind is required to duplicate nodes")
+        self.kind_updates_map = kind_updates_map
         super().__init__(**kwargs)
 
+    @property
+    def previous_kinds(self) -> str:
+        """The kinds to migrate, as a Neo4j label disjunction."""
+        return "|".join(self.kind_updates_map)
+
     def render_match(self) -> str:
-        labels_str = ":".join(self.previous_node.labels)
         return """
         // Find all the active nodes
-        MATCH (node:%(labels_str)s)
-        WITH DISTINCT node
+        MATCH (node:%(previous_kinds)s)
+        WITH DISTINCT node, $kind_map[node.kind] AS target
         // ----------------
         // Filter out nodes that have already been migrated
         // ----------------
-        CALL (node) {
-            WITH labels(node) AS node_labels
-            UNWIND node_labels AS n_label
-            ORDER BY n_label ASC
-            WITH collect(n_label) AS sorted_labels
-
-            RETURN (
-                node.kind = $new_node.kind AND
-                sorted_labels = $new_sorted_labels
-            ) AS already_migrated
-        }
-        WITH node WHERE already_migrated = FALSE
-        """ % {"labels_str": labels_str}
+        WHERE target IS NOT NULL
+        AND NOT (
+            node.kind = target.new_kind
+            AND size(labels(node)) = size(target.new_all_labels)
+            AND all(node_label IN labels(node) WHERE node_label IN target.new_all_labels)
+        )
+        """ % {"previous_kinds": self.previous_kinds}
 
     @staticmethod
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:
@@ -127,14 +129,21 @@ class NodeDuplicateQuery(Query):
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
         self.params.update(branch_params)
 
-        self.params["new_node"] = self.new_node.model_dump()
-        self.params["previous_node"] = self.previous_node.model_dump()
-        self.params["new_sorted_labels"] = sorted(self.new_node.labels + ["Node"])
+        self.params["kind_map"] = {
+            previous_kind: {
+                "new_kind": new_node.kind,
+                "new_labels": sorted(set(new_node.labels)),
+                "new_namespace": new_node.namespace,
+                "new_branch_support": new_node.branch_support,
+                # Neo4j always adds the Node label, so it belongs in the already-migrated comparison
+                "new_all_labels": sorted(set(new_node.labels) | {"Node"}),
+            }
+            for previous_kind, new_node in self.kind_updates_map.items()
+        }
 
         self.params["current_time"] = self.at.to_string()
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
-        self.params["branch_support"] = self.new_node.branch_support
 
         self.params["user_id"] = self.user_id
 
@@ -166,10 +175,10 @@ class NodeDuplicateQuery(Query):
             ORDER BY r.branch_level DESC, r.from DESC
             LIMIT 1
         }
-        WITH active_node
+        WITH target, active_node, is_active
         WHERE is_active = TRUE
-        CREATE (new_node:Node:%(labels)s {
-            uuid: active_node.uuid, kind: $new_node.kind, namespace: $new_node.namespace, branch_support: $new_node.branch_support
+        CREATE (new_node:Node:$(target.new_labels) {
+            uuid: active_node.uuid, kind: target.new_kind, namespace: target.new_namespace, branch_support: target.new_branch_support
         })
         WITH active_node, new_node
         // Set metadata on new Node vertex
@@ -238,7 +247,6 @@ class NodeDuplicateQuery(Query):
         RETURN DISTINCT new_node
         """ % {
             "branch_filter": branch_filter,
-            "labels": ":".join(self.new_node.labels),
             "sub_query_out": sub_query_out,
             "sub_query_in": sub_query_in,
             "sub_query_out_args": sub_query_out_args,

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from ..query import MigrationQuery
 from ..query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
 from ..shared import SchemaMigration
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
+
+
+def _schema_node_info(schema: MainSchemaTypes) -> SchemaNodeInfo:
+    return SchemaNodeInfo(
+        name=schema.name,
+        namespace=schema.namespace,
+        branch_support=schema.branch.value,
+        labels=schema.get_labels(),
+        kind=schema.kind,
+    )
 
 
 class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):
@@ -15,21 +28,19 @@ class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):
         migration: SchemaMigration,
         **kwargs: Any,
     ) -> None:
-        new_node = SchemaNodeInfo(
-            name=migration.new_schema.name,
-            namespace=migration.new_schema.namespace,
-            branch_support=migration.new_schema.branch.value,
-            labels=migration.new_schema.get_labels(),
-            kind=migration.new_schema.kind,
-        )
-        previous_node = SchemaNodeInfo(
-            name=migration.previous_schema.name,
-            namespace=migration.previous_schema.namespace,
-            branch_support=migration.previous_schema.branch.value,
-            labels=migration.previous_schema.get_labels(),
-            kind=migration.previous_schema.kind,
-        )
-        super().__init__(migration=migration, new_node=new_node, previous_node=previous_node, **kwargs)
+        super().__init__(migration=migration, kind_updates_map=self._build_kind_updates(migration=migration), **kwargs)
+
+    def _build_kind_updates(self, migration: SchemaMigration) -> dict[str, SchemaNodeInfo]:
+        kind_updates = {migration.previous_schema.kind: _schema_node_info(schema=migration.new_schema)}
+
+        # The generated Profile/Template kinds never appear in the schema diff, so their vertices
+        # are only relabelled as extra populations of the source kind's own migration
+        for derived in migration.derived_schemas:
+            if derived.previous.kind == derived.new.kind and derived.previous.get_labels() == derived.new.get_labels():
+                continue
+            kind_updates[derived.previous.kind] = _schema_node_info(schema=derived.new)
+
+        return kind_updates
 
     def get_nbr_migrations_executed(self) -> int:
         return self.stats.get_counter(name="nodes_created")

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -10,8 +10,9 @@ from prefect.logging import get_run_logger
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.migrations import MIGRATION_MAP
-from infrahub.core.migrations.shared import MigrationInput
+from infrahub.core.migrations.shared import DerivedSchemaPair, MigrationInput
 from infrahub.core.path import SchemaPath  # noqa: TC001
+from infrahub.core.schema.derived_kinds import get_object_template_kind, get_profile_kind
 from infrahub.core.timestamp import Timestamp
 from infrahub.workers.dependencies import get_database
 from infrahub.workflows.utils import add_branch_tag
@@ -20,8 +21,40 @@ from .models import SchemaApplyMigrationData, SchemaMigrationPathResponseData
 
 if TYPE_CHECKING:
     from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
+
+
+def get_derived_schema_pairs(
+    previous_schema_branch: SchemaBranch,
+    new_schema_branch: SchemaBranch,
+    previous_node_schema: MainSchemaTypes,
+    new_node_schema: MainSchemaTypes | None,
+) -> list[DerivedSchemaPair]:
+    """Pair up the Profile/Template schemas generated from a node across a schema update."""
+    if new_node_schema is None:
+        return []
+
+    def pair_up(previous_kind: str, new_kind: str) -> DerivedSchemaPair | None:
+        if not previous_schema_branch.has(name=previous_kind) or not new_schema_branch.has(name=new_kind):
+            return None
+        return DerivedSchemaPair(
+            previous=previous_schema_branch.get(name=previous_kind, duplicate=False),
+            new=new_schema_branch.get(name=new_kind, duplicate=False),
+        )
+
+    pairs = [
+        pair_up(
+            previous_kind=get_profile_kind(node_kind=previous_node_schema.kind),
+            new_kind=get_profile_kind(node_kind=new_node_schema.kind),
+        ),
+        pair_up(
+            previous_kind=get_object_template_kind(node_kind=previous_node_schema.kind),
+            new_kind=get_object_template_kind(node_kind=new_node_schema.kind),
+        ),
+    ]
+    return [pair for pair in pairs if pair is not None]
 
 
 @flow(name="schema_apply_migrations", flow_run_name="Apply schema migrations", persist_result=True)
@@ -59,6 +92,12 @@ async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str
             migration_name=migration.migration_name,
             new_node_schema=new_node_schema,
             previous_node_schema=previous_node_schema,
+            derived_schemas=get_derived_schema_pairs(
+                previous_schema_branch=message.previous_schema,
+                new_schema_branch=message.new_schema,
+                previous_node_schema=previous_node_schema,
+                new_node_schema=new_node_schema,
+            ),
             schema_path=migration.path,
             database=await get_database(),
             user_id=message.user_id,
@@ -86,6 +125,7 @@ async def schema_path_migrate(
     at: Timestamp,
     new_node_schema: MainSchemaTypes | None = None,
     previous_node_schema: MainSchemaTypes | None = None,
+    derived_schemas: list[DerivedSchemaPair] | None = None,
     user_id: str = SYSTEM_USER_ID,
 ) -> SchemaMigrationPathResponseData:
     log = get_run_logger()
@@ -107,6 +147,7 @@ async def schema_path_migrate(
         migration = migration_class(  # type: ignore[call-arg]
             new_node_schema=new_node_schema,  # type: ignore[arg-type]
             previous_node_schema=previous_node_schema,  # type: ignore[arg-type]
+            derived_schemas=derived_schemas or [],
             schema_path=schema_path,
         )
         execution_result = await migration.execute(

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -120,6 +120,14 @@ def _should_propagate(db: InfrahubDatabase, exc: BaseException) -> bool:
     return db.is_transaction and is_retriable_db_error(exc)
 
 
+class DerivedSchemaPair(BaseModel):
+    """A Profile or Template schema generated from a node, before and after a schema update."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    previous: MainSchemaTypes
+    new: MainSchemaTypes
+
+
 class SchemaMigration(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str = Field(..., description="Name of the migration")
@@ -129,6 +137,10 @@ class SchemaMigration(BaseModel):
 
     new_node_schema: MainSchemaTypes | None = None
     previous_node_schema: MainSchemaTypes | None = None
+    derived_schemas: list[DerivedSchemaPair] = Field(
+        default_factory=list,
+        description="Profile/Template schemas generated from the node",
+    )
     schema_path: SchemaPath
 
     async def execute_pre_queries(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -306,20 +306,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         and the list of Generic this object is inheriting from.
 
         """
-        labels: list[str] = []
-        if isinstance(self._schema, NodeSchema):
-            labels = [self.get_kind()] + self._schema.inherit_from
-            if (
-                self._schema.namespace not in ["Schema", "Internal"]
-                and InfrahubKind.GENERICGROUP not in self._schema.inherit_from
-            ):
-                labels.append(InfrahubKind.NODE)
-            return labels
-
-        if isinstance(self._schema, ProfileSchema | TemplateSchema):
-            return [self.get_kind()] + self._schema.inherit_from
-
-        return [self.get_kind()]
+        return self._schema.get_labels()
 
     def get_branch_based_on_support_type(self) -> Branch:
         """If the attribute is branch aware, return the Branch object associated with this attribute.

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -136,6 +136,13 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
             return self.id
         raise ValueError(f"id is not defined on {self.kind}")
 
+    def get_labels(self) -> list[str]:
+        """Return the graph labels carried by a vertex of this kind.
+
+        Subclasses that support inheritance extend this with their generics.
+        """
+        return [self.kind]
+
     def __hash__(self) -> int:
         """Return a hash of the object.
 

--- a/backend/infrahub/core/schema/derived_kinds.py
+++ b/backend/infrahub/core/schema/derived_kinds.py
@@ -1,0 +1,17 @@
+"""Names of the Profile and Template kinds generated from a node.
+
+A generated kind's name is fully determined by the kind it derives from, so callers that
+only need to look one up do not have to walk the schema.
+"""
+
+from __future__ import annotations
+
+from infrahub.core.constants import PROFILE_NAMESPACE, TEMPLATE_NAMESPACE
+
+
+def get_profile_kind(node_kind: str) -> str:
+    return f"{PROFILE_NAMESPACE}{node_kind}"
+
+
+def get_object_template_kind(node_kind: str) -> str:
+    return f"{TEMPLATE_NAMESPACE}{node_kind}"

--- a/backend/infrahub/core/schema/profile_schema.py
+++ b/backend/infrahub/core/schema/profile_schema.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.schema.basenode_schema import BaseNodeSchema
 
 
@@ -42,7 +41,4 @@ class ProfileSchema(BaseNodeSchema):
         and the list of Generic this object is inheriting from.
 
         """
-        labels: list[str] = [self.kind] + self.inherit_from
-        if self.namespace not in ["Schema", "Internal"] and InfrahubKind.GENERICGROUP not in self.inherit_from:
-            labels.append(InfrahubKind.PROFILE)
-        return labels
+        return [self.kind] + self.inherit_from

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -62,6 +62,7 @@ from infrahub.core.schema.attribute_parameters import (
 )
 from infrahub.core.schema.attribute_schema import get_attribute_schema_class_for_kind
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
+from infrahub.core.schema.derived_kinds import get_object_template_kind, get_profile_kind
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
 from infrahub.core.validators.schema_branch.display_label_validator import DisplayLabelValidator
 from infrahub.core.validators.schema_branch.hierarchical_nodes_restricted_words_validator import (
@@ -2579,7 +2580,7 @@ class SchemaBranch:
                 self.set(name=node_name, schema=node_schema)
 
     def _get_profile_kind(self, node_kind: str) -> str:
-        return f"Profile{node_kind}"
+        return get_profile_kind(node_kind=node_kind)
 
     def generate_profile_from_node(self, node: NodeSchema | GenericSchema) -> ProfileSchema:
         core_profile_schema = self.get(name=InfrahubKind.PROFILE, duplicate=False)
@@ -2644,7 +2645,7 @@ class SchemaBranch:
         return profile
 
     def _get_object_template_kind(self, node_kind: str) -> str:
-        return f"Template{node_kind}"
+        return get_object_template_kind(node_kind=node_kind)
 
     def manage_object_template_relationships(self) -> None:
         """Add an `object_template` relationship to all nodes that can be created from object templates.

--- a/backend/infrahub/core/schema/template_schema.py
+++ b/backend/infrahub/core/schema/template_schema.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.schema.basenode_schema import BaseNodeSchema
 
 
@@ -37,7 +36,4 @@ class TemplateSchema(BaseNodeSchema):
 
     def get_labels(self) -> list[str]:
         """Return the labels for this object, composed of the kind and the list of Generic this object is inheriting from."""
-        labels: list[str] = [self.kind] + self.inherit_from
-        if self.namespace not in ["Schema", "Internal"] and InfrahubKind.GENERICGROUP not in self.inherit_from:
-            labels.append(InfrahubKind.OBJECTTEMPLATE)
-        return labels
+        return [self.kind] + self.inherit_from

--- a/backend/tests/component/core/diff/merge/test_multi_migration.py
+++ b/backend/tests/component/core/diff/merge/test_multi_migration.py
@@ -120,7 +120,7 @@ async def test_diff_and_merge_with_migrated_node_kind_and_migrated_inheritance(
     schema_branch = registry.schema.get_schema_branch(name=branch2.name)
     car_schema_branch = schema_branch.get(name="Test2NewElectricCar", duplicate=True)
     car_schema_branch.inherit_from += ["TestVehicle"]
-    schema_branch.set(name="Test2ElectricNewCar", schema=car_schema_branch)
+    schema_branch.set(name="Test2NewElectricCar", schema=car_schema_branch)
     schema_branch.process()
     await registry.schema.update_schema_branch(
         db=db, branch=branch2, schema=schema_branch, limit=["Test2NewElectricCar"], update_db=True
@@ -207,10 +207,12 @@ async def test_diff_and_merge_with_migrated_node_kind_and_migrated_inheritance(
     assert migrated_car_with_metadata.name._get_updated_by() == SYSTEM_USER_ID
 
     # Validate relationship-level metadata on migrated car after merge
-    # Owner relationship was updated by branch-user
+    # The inheritance migration ran after branch-user set the owner, and a kind update re-creates
+    # every edge of the vertices it moves, so the edge that survives was opened by the migration
+    # even though the update it carries is still branch-user's
     owner_rel = await migrated_car_with_metadata.owner.get(db=db)
     assert owner_rel._get_created_at() == merge_at
-    assert owner_rel._get_created_by() == "branch-user"
+    assert owner_rel._get_created_by() == "migration-user-two"
     assert owner_rel._get_updated_at() == merge_at
     assert owner_rel._get_updated_by() == "branch-user"
 

--- a/backend/tests/component/core/migrations/schema/test_node_kind_update_generated_kinds.py
+++ b/backend/tests/component/core/migrations/schema/test_node_kind_update_generated_kinds.py
@@ -1,0 +1,399 @@
+"""Relabelling of the Profile/Template kinds generated from a node when that node's kind changes.
+
+The schema diff only reports nodes and generics, so the generated kinds ride along with the
+migration of the kind they derive from rather than getting migrations of their own.
+"""
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind, SchemaPathType
+from infrahub.core.initialization import create_branch
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
+from infrahub.core.migrations.schema.tasks import get_derived_schema_pairs
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
+from infrahub.core.schema.definitions.core.template import core_object_component_template, core_object_template
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.utils import count_nodes, count_relationships
+from infrahub.database import InfrahubDatabase
+from tests.helpers.db_validation import verify_graph
+
+GADGET_THING = GenericSchema(
+    name="Thing",
+    namespace="Testing",
+    attributes=[AttributeSchema(name="nbr_things", kind="Number", optional=True)],
+)
+
+GADGET = NodeSchema(
+    name="Gadget",
+    namespace="Testing",
+    generate_template=True,
+    attributes=[AttributeSchema(name="name", kind="Text")],
+)
+
+
+def _profile_labels(kind: str) -> set[str]:
+    """A profile's labels never depend on the generics of the node it derives from."""
+    return {kind, "LineageSource", "CoreProfile", "CoreNode", "Node"}
+
+
+async def _get_active_labels_by_uuid(db: InfrahubDatabase, kind: str, branch_name: str) -> dict[str, set[str]]:
+    """Return ``{node uuid: labels}`` for the vertex of ``kind`` currently active on ``branch_name``.
+
+    A kind update leaves the superseded vertex in place with its old labels, so the branch and the
+    still-open IS_PART_OF edge are what identify the vertex a reader would resolve.
+    """
+    query = """
+    MATCH (n:%(kind)s)-[r:IS_PART_OF {status: "active"}]->(:Root)
+    WHERE r.branch = $branch_name AND r.to IS NULL
+    RETURN n.uuid AS uuid, labels(n) AS labels
+    """ % {"kind": kind}
+    results = await db.execute_query(query=query, params={"branch_name": branch_name})
+    return {row["uuid"]: set(row["labels"]) for row in results}
+
+
+async def _migrate_node_kind(
+    db: InfrahubDatabase, branch: Branch, current_kind: str, **changes: Any
+) -> MigrationResult:
+    """Apply ``changes`` to the TestingGadget node schema, then run the migration."""
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    previous_node = schema.get(name=current_kind)
+
+    candidate_schema = schema.duplicate()
+    new_node = candidate_schema.get(name=current_kind)
+    candidate_schema.delete(name=current_kind)
+    for field_name, value in changes.items():
+        setattr(new_node, field_name, value)
+    candidate_schema.set(name=new_node.kind, schema=new_node)
+    candidate_schema.process()
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=previous_node,
+        new_node_schema=new_node,
+        derived_schemas=get_derived_schema_pairs(
+            previous_schema_branch=schema,
+            new_schema_branch=candidate_schema,
+            previous_node_schema=previous_node,
+            new_node_schema=new_node,
+        ),
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_node.kind, field_name=sorted(changes)[0]
+        ),
+    )
+    registry.schema.set_schema_branch(name=branch.name, schema=candidate_schema)
+    return await migration.execute(migration_input=MigrationInput(db=db), branch=branch)
+
+
+class TestGeneratedKindRelabelling:
+    """Relabelling of the generated Profile/Template kinds when their source kind changes.
+
+    The tests share one schema and one set of vertices and run in order, each building on the
+    graph the previous one left behind.
+    """
+
+    @pytest.fixture(scope="class")
+    async def gadget_schema(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+    ) -> SchemaBranch:
+        registry.schema.register_schema(
+            schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
+            branch=default_branch_scope_class.name,
+        )
+        return registry.schema.register_schema(
+            schema=SchemaRoot(generics=[deepcopy(GADGET_THING)], nodes=[deepcopy(GADGET)]),
+            branch=default_branch_scope_class.name,
+        )
+
+    @pytest.fixture(scope="class")
+    async def gadget_data(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_schema: SchemaBranch
+    ) -> dict[str, str]:
+        gadget = await Node.init(db=db, schema="TestingGadget", branch=default_branch_scope_class)
+        await gadget.new(db=db, name="gadget-1")
+        await gadget.save(db=db)
+
+        profile = await Node.init(db=db, schema="ProfileTestingGadget", branch=default_branch_scope_class)
+        await profile.new(db=db, profile_name="gadget-profile-1")
+        await profile.save(db=db)
+
+        template = await Node.init(db=db, schema="TemplateTestingGadget", branch=default_branch_scope_class)
+        await template.new(db=db, template_name="Gadget Template 1")
+        await template.save(db=db)
+
+        return {"gadget": gadget.id, "profile": profile.id, "template": template.id}
+
+    async def test_template_starts_without_the_generic_label(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        template_uuid = gadget_data["template"]
+        assert set(labels_map) == {template_uuid}
+        assert "TemplateTestingThing" not in labels_map[template_uuid]
+        assert await count_nodes(db=db, label="TemplateTestingThing") == 0
+
+        profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        assert profile_labels_map == {gadget_data["profile"]: _profile_labels(kind="ProfileTestingGadget")}
+
+    async def test_template_gains_generic_label_when_kind_inherits_generic(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        """A template created before its kind inherits a generic must join the generic's template kind."""
+        execution_result = await _migrate_node_kind(
+            db=db, branch=default_branch_scope_class, current_kind="TestingGadget", inherit_from=["TestingThing"]
+        )
+
+        assert not execution_result.errors
+        # the gadget and its template move; the profile's labels do not depend on the node's generics
+        assert execution_result.nbr_migrations_executed == 2
+
+        labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        template_uuid = gadget_data["template"]
+        assert set(labels_map) == {template_uuid}
+        assert "TemplateTestingThing" in labels_map[template_uuid]
+        assert await count_nodes(db=db, label="TemplateTestingThing") == 1
+
+        profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        assert profile_labels_map == {gadget_data["profile"]: _profile_labels(kind="ProfileTestingGadget")}
+        assert await count_nodes(db=db, label="ProfileTestingGadget") == 1
+        await verify_graph(db=db)
+
+    async def test_relabelling_is_idempotent(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        """Re-running the same migration must not duplicate the vertices a second time."""
+        count_rels_before = await count_relationships(db=db)
+
+        execution_result = await _migrate_node_kind(
+            db=db, branch=default_branch_scope_class, current_kind="TestingGadget", inherit_from=["TestingThing"]
+        )
+
+        assert not execution_result.errors
+        assert execution_result.nbr_migrations_executed == 0
+        assert await count_relationships(db=db) == count_rels_before
+        # the kind label is unchanged, so it stays on the superseded vertex as well as its replacement
+        assert await count_nodes(db=db, label="TemplateTestingGadget") == 2
+        assert await count_nodes(db=db, label="TemplateTestingThing") == 1
+
+    async def test_template_loses_generic_label_when_kind_drops_generic(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        """Dropping the generic must stop the template matching the generic's template kind."""
+        execution_result = await _migrate_node_kind(
+            db=db, branch=default_branch_scope_class, current_kind="TestingGadget", inherit_from=[]
+        )
+
+        assert not execution_result.errors
+        assert execution_result.nbr_migrations_executed == 2
+
+        labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        template_uuid = gadget_data["template"]
+        assert set(labels_map) == {template_uuid}
+        assert "TemplateTestingThing" not in labels_map[template_uuid]
+
+        profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTestingGadget", branch_name=default_branch_scope_class.name
+        )
+        assert profile_labels_map == {gadget_data["profile"]: _profile_labels(kind="ProfileTestingGadget")}
+        await verify_graph(db=db)
+
+    async def test_kind_rename_relabels_profile_and_template(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        """A rename changes the generated kinds' names too, so their vertices must follow."""
+        assert await count_nodes(db=db, label="ProfileTesting2NewGadget") == 0
+        assert await count_nodes(db=db, label="TemplateTesting2NewGadget") == 0
+
+        execution_result = await _migrate_node_kind(
+            db=db,
+            branch=default_branch_scope_class,
+            current_kind="TestingGadget",
+            name="NewGadget",
+            namespace="Testing2",
+        )
+
+        assert not execution_result.errors
+        assert execution_result.nbr_migrations_executed == 3
+
+        assert await count_nodes(db=db, label="Testing2NewGadget") == 1
+        assert await count_nodes(db=db, label="ProfileTesting2NewGadget") == 1
+        assert await count_nodes(db=db, label="TemplateTesting2NewGadget") == 1
+
+        renamed_profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTesting2NewGadget", branch_name=default_branch_scope_class.name
+        )
+        assert renamed_profile_labels_map == {gadget_data["profile"]: _profile_labels(kind="ProfileTesting2NewGadget")}
+
+        renamed_template_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTesting2NewGadget", branch_name=default_branch_scope_class.name
+        )
+        assert set(renamed_template_labels_map) == {gadget_data["template"]}
+        await verify_graph(db=db)
+
+    async def test_relabelling_on_a_branch_leaves_the_default_branch_alone(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, gadget_data: dict[str, str]
+    ) -> None:
+        """Labels live on the vertex, so a branch's schema change must reach readers only via its edges."""
+        branch = await create_branch(db=db, branch_name="gadget-inherit-branch")
+
+        execution_result = await _migrate_node_kind(
+            db=db, branch=branch, current_kind="Testing2NewGadget", inherit_from=["TestingThing"]
+        )
+
+        assert not execution_result.errors
+        assert execution_result.nbr_migrations_executed == 2
+
+        on_branch_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTesting2NewGadget", branch_name=branch.name
+        )
+        assert set(on_branch_labels_map) == {gadget_data["template"]}
+        assert "TemplateTestingThing" in on_branch_labels_map[gadget_data["template"]]
+
+        on_main_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateTesting2NewGadget", branch_name=default_branch_scope_class.name
+        )
+        assert set(on_main_labels_map) == {gadget_data["template"]}
+        assert "TemplateTestingThing" not in on_main_labels_map[gadget_data["template"]]
+
+        # an inheritance change leaves the profile alone, so the branch gets no profile vertex of its
+        # own and readers on it fall through to the one the default branch still owns
+        branch_profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTesting2NewGadget", branch_name=branch.name
+        )
+        assert branch_profile_labels_map == {}
+        main_profile_labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="ProfileTesting2NewGadget", branch_name=default_branch_scope_class.name
+        )
+        assert main_profile_labels_map == {gadget_data["profile"]: _profile_labels(kind="ProfileTesting2NewGadget")}
+
+        await verify_graph(db=db)
+
+
+WIDGET_THING = GenericSchema(
+    name="Thing",
+    namespace="Sub",
+    attributes=[AttributeSchema(name="nbr_things", kind="Number", optional=True)],
+)
+
+WIDGET_HOLDER = NodeSchema(
+    name="Holder",
+    namespace="Sub",
+    generate_template=True,
+    attributes=[AttributeSchema(name="name", kind="Text")],
+    relationships=[
+        RelationshipSchema(
+            name="parts",
+            peer="SubPart",
+            kind=RelationshipKind.COMPONENT,
+            cardinality=RelationshipCardinality.MANY,
+            optional=True,
+        )
+    ],
+)
+
+# generates neither a template nor a profile of its own, but is a component peer of SubHolder
+WIDGET_PART = NodeSchema(
+    name="Part",
+    namespace="Sub",
+    generate_template=False,
+    generate_profile=False,
+    attributes=[AttributeSchema(name="name", kind="Text")],
+)
+
+
+class TestSubtemplateRelabelling:
+    """Relabelling of a subtemplate, which exists even though its kind sets generate_template=False.
+
+    A kind pulled in as a component peer of a template-generating kind still gets a Template kind,
+    built on CoreObjectComponentTemplate rather than CoreObjectTemplate, and it still joins the
+    template kinds of any generics it inherits. A profile has no equivalent path.
+    """
+
+    @pytest.fixture(scope="class")
+    async def subtemplate_schema(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+    ) -> SchemaBranch:
+        registry.schema.register_schema(
+            schema=SchemaRoot(generics=[core_object_template, core_object_component_template]),
+            branch=default_branch_scope_class.name,
+        )
+        return registry.schema.register_schema(
+            schema=SchemaRoot(
+                generics=[deepcopy(WIDGET_THING)], nodes=[deepcopy(WIDGET_HOLDER), deepcopy(WIDGET_PART)]
+            ),
+            branch=default_branch_scope_class.name,
+        )
+
+    @pytest.fixture(scope="class")
+    async def subtemplate_data(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, subtemplate_schema: SchemaBranch
+    ) -> dict[str, str]:
+        subtemplate = await Node.init(db=db, schema="TemplateSubPart", branch=default_branch_scope_class)
+        # a subtemplate keeps the optionality of the source attribute, so name is mandatory here
+        await subtemplate.new(db=db, template_name="Part Template 1", name="part-1")
+        await subtemplate.save(db=db)
+        return {"subtemplate": subtemplate.id}
+
+    async def test_subtemplate_exists_without_generate_template(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, subtemplate_data: dict[str, str]
+    ) -> None:
+        """The component peer has a Template kind and instances despite generate_template=False."""
+        schema = registry.schema.get_schema_branch(name=default_branch_scope_class.name)
+        assert schema.get_node(name="SubPart", duplicate=False).generate_template is False
+        assert not schema.has(name="ProfileSubPart")
+
+        labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateSubPart", branch_name=default_branch_scope_class.name
+        )
+        subtemplate_uuid = subtemplate_data["subtemplate"]
+        assert set(labels_map) == {subtemplate_uuid}
+        assert "CoreObjectComponentTemplate" in labels_map[subtemplate_uuid]
+        assert "CoreObjectTemplate" not in labels_map[subtemplate_uuid]
+        assert "TemplateSubThing" not in labels_map[subtemplate_uuid]
+
+    async def test_subtemplate_joins_the_generic_template_kind(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, subtemplate_data: dict[str, str]
+    ) -> None:
+        """The component peer inheriting a generic must pull its subtemplate into the generic's template kind."""
+        execution_result = await _migrate_node_kind(
+            db=db,
+            branch=default_branch_scope_class,
+            current_kind="SubPart",
+            inherit_from=["SubThing"],
+        )
+
+        assert not execution_result.errors
+        assert execution_result.nbr_migrations_executed == 1
+
+        labels_map = await _get_active_labels_by_uuid(
+            db=db, kind="TemplateSubPart", branch_name=default_branch_scope_class.name
+        )
+        subtemplate_uuid = subtemplate_data["subtemplate"]
+        assert set(labels_map) == {subtemplate_uuid}
+        assert "TemplateSubThing" in labels_map[subtemplate_uuid]
+        # the subtemplate stays a component template rather than being promoted
+        assert "CoreObjectComponentTemplate" in labels_map[subtemplate_uuid]
+        assert "CoreObjectTemplate" not in labels_map[subtemplate_uuid]
+        await verify_graph(db=db)

--- a/backend/tests/component/core/test_node_kind_query.py
+++ b/backend/tests/component/core/test_node_kind_query.py
@@ -29,8 +29,9 @@ async def test_node_get_kind_query_with_migrated_nodes_on_branch(
     migration_query = await NodeDuplicateQuery.init(
         db=db,
         branch=branch,
-        previous_node=SchemaNodeInfo(name="Person", namespace="Test", labels=["TestPerson"], kind="TestPerson"),
-        new_node=SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing"),
+        kind_updates_map={
+            "TestPerson": SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing")
+        },
     )
     await migration_query.execute(db=db)
 
@@ -76,8 +77,9 @@ async def test_node_get_kind_query_with_migrated_nodes_on_branch(
     migration_query = await NodeDuplicateQuery.init(
         db=db,
         branch=default_branch,
-        previous_node=SchemaNodeInfo(name="Person", namespace="Test", labels=["TestPerson"], kind="TestPerson"),
-        new_node=SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing"),
+        kind_updates_map={
+            "TestPerson": SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing")
+        },
     )
     await migration_query.execute(db=db)
 

--- a/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_kind_update.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any
 
 import pytest
@@ -17,9 +18,15 @@ from ..shared import load_schema
 from .shared import TestSchemaLifecycleBase
 
 GENERIC_KIND = "TestingGeneric"
+GENERIC_TWO_KIND = "TestingGenericTwo"
 SPECIFIC_ONE_KIND = "TestingSpecificOne"
 SPECIFIC_ONE_KIND_UPDATED = "TestingSpecificOneNew"
 THING_KIND = "TestingThing"
+PROFILE_KIND = f"Profile{SPECIFIC_ONE_KIND}"
+PROFILE_KIND_UPDATED = f"Profile{SPECIFIC_ONE_KIND_UPDATED}"
+TEMPLATE_KIND = f"Template{SPECIFIC_ONE_KIND}"
+TEMPLATE_KIND_UPDATED = f"Template{SPECIFIC_ONE_KIND_UPDATED}"
+TEMPLATE_GENERIC_TWO_KIND = f"Template{GENERIC_TWO_KIND}"
 BRANCH_ONE = "branch-one"
 
 
@@ -73,6 +80,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
             "name": "SpecificOne",
             "namespace": "Testing",
             "inherit_from": ["TestingGeneric"],
+            "generate_template": True,
         }
 
     @pytest.fixture(scope="class")
@@ -119,11 +127,21 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         await deleted_specific_one.save(db=db)
         await deleted_specific_one.delete(db=db)
 
+        specific_one_profile = await Node.init(schema=PROFILE_KIND, db=db)
+        await specific_one_profile.new(db=db, profile_name="specific-one-profile", generic_attr_text="Profiled")
+        await specific_one_profile.save(db=db)
+
+        specific_one_template = await Node.init(schema=TEMPLATE_KIND, db=db)
+        await specific_one_template.new(db=db, template_name="specific-one-template", generic_attr_text="Templated")
+        await specific_one_template.save(db=db)
+
         return {
             "thing_one": thing_one,
             "thing_two": thing_two,
             "thing_three": thing_three,
             "specific_one": specific_one,
+            "specific_one_profile": specific_one_profile,
+            "specific_one_template": specific_one_template,
         }
 
     @pytest.fixture(scope="class")
@@ -132,6 +150,7 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
             "name": "SpecificOneNew",
             "namespace": "Testing",
             "inherit_from": ["TestingGeneric"],
+            "generate_template": True,
         }
 
     @pytest.fixture(scope="class")
@@ -145,6 +164,33 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
             "version": "1.0",
             "generics": [schema_generic_base],
             "nodes": [schema_specific_one_new_kind, schema_thing],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_generic_two(self) -> dict[str, Any]:
+        return {
+            "name": "GenericTwo",
+            "namespace": "Testing",
+            "attributes": [
+                {"name": "generic_two_attr", "kind": "Text", "optional": True},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_04(
+        self,
+        schema_generic_base: dict[str, Any],
+        schema_generic_two: dict[str, Any],
+        schema_specific_one_new_kind: dict[str, Any],
+        schema_thing: dict[str, Any],
+    ) -> dict[str, Any]:
+        """The renamed kind starts inheriting a second generic, which brings its own object template."""
+        specific_one = copy.deepcopy(schema_specific_one_new_kind)
+        specific_one["inherit_from"] = [GENERIC_KIND, GENERIC_TWO_KIND]
+        return {
+            "version": "1.0",
+            "generics": [schema_generic_base, schema_generic_two],
+            "nodes": [specific_one, schema_thing],
         }
 
     @pytest.fixture(scope="class")
@@ -196,6 +242,12 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         specific_ones = await registry.manager.query(db=db, schema=SPECIFIC_ONE_KIND)
         assert len(specific_ones) == 1
 
+        profiles = await registry.manager.query(db=db, schema=PROFILE_KIND)
+        assert [profile.id for profile in profiles] == [initial_dataset["specific_one_profile"].id]
+
+        templates = await registry.manager.query(db=db, schema=TEMPLATE_KIND)
+        assert [template.id for template in templates] == [initial_dataset["specific_one_template"].id]
+
     async def test_step02_check_change_node_kind(
         self,
         db: InfrahubDatabase,
@@ -216,7 +268,22 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         assert response == {
             "diff": {
                 "added": {},
-                "changed": {SPECIFIC_ONE_KIND_UPDATED: {"added": {}, "changed": {"name": None}, "removed": {}}},
+                "changed": {
+                    SPECIFIC_ONE_KIND_UPDATED: {
+                        "added": {},
+                        "changed": {
+                            "name": None,
+                            # the object_template relationship points at the generated template kind,
+                            # whose name is derived from this kind and so is renamed alongside it
+                            "relationships": {
+                                "added": {},
+                                "changed": {"object_template": {"added": {}, "changed": {"peer": None}, "removed": {}}},
+                                "removed": {},
+                            },
+                        },
+                        "removed": {},
+                    }
+                },
                 "removed": {},
             },
             "warnings": [],
@@ -253,6 +320,35 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         updated_specific_one_schema = updated_schema_branch.get(name=SPECIFIC_ONE_KIND_UPDATED, duplicate=False)
         main_specific_one_schema = registry.schema.get(name=SPECIFIC_ONE_KIND, branch=branch_one, duplicate=False)
         assert updated_specific_one_schema.get_id() == main_specific_one_schema.get_id()
+
+    async def test_step02_generated_kinds_follow_the_rename(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset: dict[str, Node],
+        branch_one: Branch,
+        specific_one_update_01: Node,
+    ) -> None:
+        """The Profile/Template instances created before the rename must answer to the renamed kinds."""
+        profiles = await registry.manager.query(db=db, branch=branch_one, schema=PROFILE_KIND_UPDATED)
+        assert [profile.id for profile in profiles] == [initial_dataset["specific_one_profile"].id]
+
+        templates = await registry.manager.query(db=db, branch=branch_one, schema=TEMPLATE_KIND_UPDATED)
+        assert [template.id for template in templates] == [initial_dataset["specific_one_template"].id]
+
+        retrieved_profile = await NodeManager.get_one(
+            db=db, branch=branch_one, id=initial_dataset["specific_one_profile"].id
+        )
+        assert retrieved_profile.get_kind() == PROFILE_KIND_UPDATED
+
+        retrieved_template = await NodeManager.get_one(
+            db=db, branch=branch_one, id=initial_dataset["specific_one_template"].id
+        )
+        assert retrieved_template.get_kind() == TEMPLATE_KIND_UPDATED
+
+        # the default branch keeps the pre-rename kinds until the branch is merged
+        main_profiles = await registry.manager.query(db=db, schema=PROFILE_KIND)
+        assert [profile.id for profile in main_profiles] == [initial_dataset["specific_one_profile"].id]
 
     async def test_step02_update_migrated_node(
         self,
@@ -329,6 +425,39 @@ class TestKindUpdateMigration(TestSchemaLifecycleBase):
         assert len(updated_things_rels) == 1
         assert retrieved_things_rels[0].get_peer_id() == updated_things_rels[0].get_peer_id()
 
+    async def test_step03_generated_kinds_follow_the_merge(
+        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, Node]
+    ) -> None:
+        """After the merge the renamed generated kinds are the ones answering on the default branch."""
+        profiles = await registry.manager.query(db=db, branch=default_branch, schema=PROFILE_KIND_UPDATED)
+        assert [profile.id for profile in profiles] == [initial_dataset["specific_one_profile"].id]
+
+        templates = await registry.manager.query(db=db, branch=default_branch, schema=TEMPLATE_KIND_UPDATED)
+        assert [template.id for template in templates] == [initial_dataset["specific_one_template"].id]
+
+    async def test_step04_template_joins_newly_inherited_generic(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+        initial_dataset: dict[str, Node],
+        schema_step_04: dict[str, Any],
+    ) -> None:
+        """A template created before its kind inherited a generic must join that generic's template kind."""
+        response = await client.schema.load(schemas=[schema_step_04])
+        assert not response.errors
+
+        templates = await registry.manager.query(db=db, branch=default_branch, schema=TEMPLATE_GENERIC_TWO_KIND)
+        assert [template.id for template in templates] == [initial_dataset["specific_one_template"].id]
+
+        # the node itself joins the new generic too, and its profile is unaffected by inheritance
+        specifics = await registry.manager.query(db=db, branch=default_branch, schema=GENERIC_TWO_KIND)
+        assert [specific.id for specific in specifics] == [initial_dataset["specific_one"].id]
+
+        profiles = await registry.manager.query(db=db, branch=default_branch, schema=PROFILE_KIND_UPDATED)
+        assert [profile.id for profile in profiles] == [initial_dataset["specific_one_profile"].id]
+
     async def test_final_validate(self, db: InfrahubDatabase) -> None:
+        await verify_no_duplicate_paths(db=db)
         await verify_no_duplicate_relationships(db=db)
         await verify_no_edges_added_after_node_delete(db=db)

--- a/changelog/+generated-kind-relabelling.fixed.md
+++ b/changelog/+generated-kind-relabelling.fixed.md
@@ -1,0 +1,1 @@
+Fixed existing profiles and object templates becoming unreachable by their kind after the schema they are generated from was renamed or had its inheritance changed.

--- a/changelog/+generated-kind-relabelling.fixed.md
+++ b/changelog/+generated-kind-relabelling.fixed.md
@@ -1,1 +1,1 @@
-Fixed existing profiles and object templates becoming unreachable by their kind after the schema they are generated from was renamed or had its inheritance changed.
+Fixed existing Profiles and Object Templates becoming unreachable by their kind after the schema they are generated from was renamed or had its inheritance changed.


### PR DESCRIPTION
# Why

`SchemaBranch.diff()` reports only nodes and generics, so the `Profile{Kind}` and `Template{Kind}` schemas generated from a node never produce a migration of their own. A kind update relabelled the node's own vertices and left the generated ones untouched, in two ways:

- A template created before its kind gained (or lost) a generic keeps a stale label set, so `MATCH (n:TemplateSomeGeneric)` silently misses it.
- On a **rename**, `TemplateOldKind` / `ProfileOldKind` vertices keep the old kind name entirely, so the renamed generated kinds resolve to nothing.

**Goal:** a kind update carries its generated Profile/Template vertices along with it, for inheritance changes and renames alike.

**Non-goals:**

- Healing installs that are *already* stale. The forward fix only fires on future schema changes; `infrahub db check-inheritance --fix` is the existing vehicle for repair and is node-only today.
- Cleaning up vertices orphaned when a generated kind stops existing (`generate_profile` / `generate_template` turned off). Pre-existing behaviour, unchanged here.

Closes [IFC-3011](https://opsmill.atlassian.net/browse/IFC-3011)

## What changed

**Behavioral changes**

- An `inherit_from`, `name` or `namespace` change on a kind now relabels its `Profile{Kind}` and `Template{Kind}` vertices in the same migration run.
- Subtemplates are covered too. A kind with `generate_template: false` still gets a `Template{Kind}` when it is a component peer of a template-generating kind, and it still joins the template kinds of the generics it inherits.
- A rename of a template-generating kind now produces a slightly larger `schema.check` diff, because the node's `object_template` relationship points at the generated template kind, whose name is derived from the kind being renamed.

**Implementation notes**

`schema_apply_migrations` already holds both the previous and the new `SchemaBranch`, so it resolves the generated schemas for the kind being migrated and passes them to the migration as `derived_schemas`. `NodeKindUpdateMigrationQuery01` folds them into a single `NodeDuplicateQuery` run keyed by kind.

Reading the *real* generated schemas matters. An earlier attempt reconstructed the label sets from the source `NodeSchema`, which cannot be done faithfully: a template's `inherit_from` depends on `need_template_kinds`, schema-wide state accumulated across every node. Reading what the generators produced removes that duplication entirely — and, as a side effect, covers generic kinds, which a `NodeSchema`-based reconstruction had to skip.

`NodeDuplicateQuery` matching moved from a conjunction of the previous label set to a disjunction of the kinds being migrated, with the target looked up per vertex via `$kind_map[node.kind]`:

```cypher
MATCH (node:TestingGadget|ProfileTestingGadget|TemplateTestingGadget)
WITH DISTINCT node, $kind_map[node.kind] AS target
WHERE target IS NOT NULL AND NOT (<labels already match>)
```

Two consequences: a vertex whose label set has already drifted is now repaired rather than skipped, and `target IS NOT NULL` is what keeps a vertex that merely *carries* a matched label (an implementor of a generic) from being rewritten.

A prerequisite fix rides along in the first commit. `TemplateSchema.get_labels()` appended `CoreObjectTemplate` on top of an `inherit_from` that already contained it, returning the label twice, and claimed it for component subtemplates built on `CoreObjectComponentTemplate`; `ProfileSchema.get_labels()` had the same defect with `CoreProfile`. Left alone, the duplicate defeats `NodeDuplicateQuery`'s already-migrated guard, which compares against Neo4j's deduped `labels(n)` — the migration would re-duplicate every vertex on every run.

**What stayed the same**

- No graph migration, no `GRAPH_VERSION` bump, no schema changes.
- The labels written at node creation are unchanged for every schema type. `Node.get_labels()` now delegates to the schema's own `get_labels()`; verified identical across all 114 schemas of a processed core+test schema. The two methods it fixes had **no live callers** before this change — `Node.get_labels()` had its own inline copy, and profile/template schemas never reached a migration.

### Suggested review order

1. `backend/infrahub/core/migrations/query/node_duplicate.py` — the matching change, the highest-risk edit.
2. `backend/infrahub/core/migrations/schema/tasks.py` + `shared.py` — where the generated schemas are resolved and carried.
3. `backend/infrahub/core/migrations/schema/node_kind_update.py` — how they become one query.
4. The `get_labels()` commit (`refactor(schema): derive vertex labels from a single definition`) — small and self-contained.
5. Tests.

## How to review

**Focus on** `node_duplicate.py`. It is shared by four call sites (`node_kind_update`, `m012_convert_account_generic`, `infrahub db check-inheritance`, and a component test), all of which were updated for the new `kind_updates_map` signature. The other backend edits are small.

**Extra scrutiny on** the widened match. Matching by bare kind label rather than the full previous label set is deliberate — it is what lets the migration repair drifted vertices — but it does mean the query now touches vertices it previously skipped. `target IS NOT NULL` and the already-migrated guard are the two things keeping that safe.

**Worth knowing while reviewing:** `Query.__init__` takes `**kwargs: Any`, so a wrong keyword argument at any of those call sites is invisible to mypy and only fails at runtime. That bit me during development.

## Impact & rollout

- **Backward compatibility:** no breaking changes. `NodeDuplicateQuery.__init__` changed signature, but it is internal and all callers are updated in this PR.
- **Performance:** a kind update now relabels up to three vertex populations instead of one. Profile and template instances are few relative to node instances, and the profile pair is skipped outright when its kind and labels are unchanged — which is the common case for an inheritance-only change.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy. No upgrade step; existing stale labels are untouched (see Non-goals).

## Follow-ups

Not addressed here:

1. **Healing existing installs.** `infrahub db check-inheritance --fix` already detects and repairs label drift via `NodeDuplicateQuery`, but only for node kinds. Extending it to the generated kinds is the natural repair path and avoids a new numbered graph migration.
2. **Rename-orphaned vertices.** Vertices left by a *past* rename carry a kind label no longer in the schema, so discovery driven by current schema kinds cannot find them. Needs reverse discovery via the `node__objecttemplate` / `node__profile` edges.
3. **Generated-kind removal.** Turning off `generate_profile` / `generate_template` deletes the generated *schema* but nothing deletes its instances.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relabels generated Profile/Template instances when their source kind is renamed, re-namespaced, or changes inheritance, preventing stale-label instances from becoming unreachable. Previously only node instances were relabelled; now node, profile, and template populations move together, including subtemplates. Relationship edges re-created during relabelling now carry migration-user metadata; tests updated accordingly.

**Review notes**
- `NodeDuplicateQuery` now takes `kind_updates_map` and matches a disjunction of previous kinds; per-node targets resolve via `$kind_map[node.kind]`. The already-migrated guard compares the full label set (including `Node`) to avoid redundant duplication and repairs drifted vertices.
- `schema_apply_migrations` derives Profile/Template pairs from previous/new `SchemaBranch` and passes them to the migration; `NodeKindUpdateMigration` executes one duplication run for all mapped kinds.
- Label computation is centralized: `Node.get_labels()` delegates to schema `get_labels()`; removed inline core-label appends. Added `get_profile_kind`/`get_object_template_kind` and `PROFILE_NAMESPACE`/`TEMPLATE_NAMESPACE`. `schema.check` diffs on renames now also reflect the `object_template` peer rename.

**Migration/rollout**
- Update any direct `NodeDuplicateQuery` uses to pass `kind_updates_map={previous_kind: SchemaNodeInfo(...)}` (updated in `check_inheritance` and `m012_convert_account_generic`).
- No config or graph-version changes; safe to deploy.

<sup>Written for commit f26da9afb543995722fa647ed067fc0c71924df9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





[IFC-3011]: https://opsmill.atlassian.net/browse/IFC-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ