### PR TITLE
refactor(frontend): tokenize hover and focus surfaces for dark mode

### DIFF
--- a/frontend/app/src/entities/branches/ui/branch-list-item/branch-list-item.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-list-item/branch-list-item.tsx
@@ -28,7 +28,7 @@ export function BranchListItem({ branch, className, ...props }: BranchListItemPr
         "grid grid-cols-[minmax(200px,1fr)_auto_1fr] items-center gap-4 px-6 py-4",
         "border border-transparent not-last:border-b-border",
         "first:rounded-t-lg last:rounded-b-lg",
-        "hover:bg-neutral-100",
+        "hover:bg-highlight",
         className
       )}
       {...props}

--- a/frontend/app/src/entities/homepage/ui/git-repository.tsx
+++ b/frontend/app/src/entities/homepage/ui/git-repository.tsx
@@ -24,7 +24,7 @@ export const GitRepositoryItem = ({ repository }: { repository: GitRepositoryDat
         focusVisibleStyle,
         "flex items-center justify-between p-4 text-sm",
         "border border-transparent",
-        "hover:bg-neutral-100"
+        "hover:bg-highlight"
       )}
       textValue={display_label ?? id}
     >

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu-section-object.tsx
@@ -47,9 +47,8 @@ const RecursiveObjectMenuItem: React.FC<{
       <DropdownMenuAccordionTrigger
         className={classNames(
           menuNavigationItemStyle,
-          "py-1 font-bold data-[state=open]:data-highlighted:bg-neutral-100 data-[state=open]:bg-transparent data-[state=open]:text-inherit"
+          "py-1 font-bold data-[state=open]:data-highlighted:bg-highlight data-[state=open]:bg-transparent data-[state=open]:text-inherit"
         )}
-        iconClassName="hover:bg-neutral-200"
       >
         <Icon icon={item.icon} className="inline-flex w-5 shrink-0 items-center justify-center" />
         {item.path ? (
@@ -61,7 +60,10 @@ const RecursiveObjectMenuItem: React.FC<{
         )}
       </DropdownMenuAccordionTrigger>
 
-      <DropdownMenuAccordionContent style={{ marginLeft: (level + 1) * 18 }} className="border-l">
+      <DropdownMenuAccordionContent
+        style={{ marginLeft: (level + 1) * 18 }}
+        className="border-border-strong border-l"
+      >
         {item.children.map((child) => (
           <RecursiveObjectMenuItem key={child.identifier} item={child} level={level + 1} />
         ))}

--- a/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
+++ b/frontend/app/src/entities/navigation/ui/sidebar/styles.ts
@@ -1,2 +1,2 @@
 export const menuNavigationItemStyle =
-  "flex items-center outline-hidden gap-2 px-2.5 py-2 rounded-lg font-medium text-subtle hover:bg-neutral-100 focus:bg-neutral-100 group/menu-item data-[state=open]:bg-indigo-50 data-[state=open]:text-indigo-700";
+  "flex items-center outline-hidden gap-2 px-2.5 py-2 rounded-lg font-medium text-subtle hover:bg-highlight focus:bg-highlight group/menu-item data-[state=open]:bg-indigo-500/10 data-[state=open]:text-indigo-500";

--- a/frontend/app/src/shared/components/ui/dropdown-menu.tsx
+++ b/frontend/app/src/shared/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ export const DropdownMenuItem = ({ className, ref, ...props }: DropdownMenuItemP
       "rounded-lg px-2 py-1.5",
       "text-sm text-subtle",
       "relative flex items-center gap-1.5",
-      "cursor-pointer outline-hidden focus:bg-neutral-100",
+      "cursor-pointer outline-hidden focus:bg-highlight focus:text-highlight-foreground",
       "data-disabled:pointer-events-none data-disabled:opacity-40",
       className
     )}
@@ -69,7 +69,7 @@ export const DropdownMenuSubTrigger = ({
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={classNames(
-      "flex cursor-default select-none items-center gap-1.5 rounded-lg p-2 text-sm outline-hidden focus:bg-neutral-100 data-[state=open]:bg-neutral-100",
+      "flex cursor-default select-none items-center gap-1.5 rounded-lg p-2 text-sm outline-hidden focus:bg-highlight data-[state=open]:bg-highlight",
       className
     )}
     {...props}
@@ -87,17 +87,19 @@ export const DropdownMenuSubContent = ({
   ref,
   ...props
 }: DropdownMenuSubContentProps) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={classNames(
-      "min-w-32 space-y-1 overflow-hidden rounded-xl bg-popover p-2 shadow-lg backdrop-blur-lg",
-      "data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in",
-      "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out",
-      "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={classNames(
+        "z-50 min-w-32 space-y-1 overflow-hidden rounded-xl bg-popover p-2 shadow-lg backdrop-blur-lg",
+        "data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 );
 
 interface DropdownMenuAccordionProps extends React.ComponentProps<typeof AccordionItem> {

--- a/frontend/packages/ui/src/components/menu/menu.stories.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.stories.tsx
@@ -31,7 +31,7 @@ function ColumnLabel({ children }: { children: React.ReactNode }) {
 // The menu lives inside a Popover in real usage; this mimics that surface so the  items render against the expected background.
 function MenuSurface({ children }: { children: React.ReactNode }) {
   return (
-    <div className="w-56 rounded-xl border border-border-strong bg-stone-100/70 shadow-md">
+    <div className="w-56 rounded-xl border border-border-strong bg-popover shadow-md backdrop-blur-lg">
       {children}
     </div>
   );

--- a/frontend/packages/ui/src/components/menu/menu.tsx
+++ b/frontend/packages/ui/src/components/menu/menu.tsx
@@ -31,10 +31,12 @@ const menuItemStyles = tv({
   variants: {
     variant: {
       action: [
-        "bg-white shadow-sm transition-colors [&:not(:last-child)]:mb-0.5",
+        "shadow-sm transition-colors [&:not(:last-child)]:mb-0.5",
+        "bg-white dark:bg-stone-800",
         "data-focused:border-sky-200 data-focused:bg-sky-50 data-focused:text-sky-700",
+        "dark:data-focused:border-sky-300/25 dark:data-focused:bg-sky-300/10 dark:data-focused:text-sky-300",
       ],
-      picker: ["rounded-lg", "data-focused:bg-stone-700/10 data-focused:text-foreground"],
+      picker: ["rounded-lg", "data-focused:bg-highlight data-focused:text-highlight-foreground"],
     },
   },
   defaultVariants: { variant: "action" },
@@ -139,7 +141,7 @@ export function MenuSection<T extends object>({
 }: MenuSectionProps<T>) {
   return (
     <AriaMenuSection className={cn("flex flex-col", className)} {...props}>
-      {title && <AriaHeader className="mb-0.5 px-1 text-xs text-subtle-muted">{title}</AriaHeader>}
+      {title && <AriaHeader className="mb-0.5 px-1 text-xs text-subtle/80">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>
   );

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -20,6 +20,9 @@
 
   --popover: --alpha(var(--color-stone-100) / 70%);
 
+  --highlight: --alpha(var(--color-stone-600) / 10%);
+  --highlight-foreground: var(--foreground);
+
   --card: linear-gradient(to bottom, var(--color-stone-50) 0%, var(--color-white) 10%);
   --card-shadow:
     inset 0 2px 0 rgb(255 255 255), inset 0 -1px 2px 1px rgb(0 0 0 / 0.03),
@@ -58,6 +61,9 @@
   --input-shadow: 0 2px 4px rgb(0 0 0 / 0.35);
 
   --popover: --alpha(var(--color-stone-900) / 70%);
+
+  --highlight: --alpha(var(--color-stone-700) / 70%);
+  --highlight-foreground: var(--foreground);
 
   --card: linear-gradient(180deg, #201d1c 0%, #191716 55%, #141312 100%);
   --card-shadow: inset 0 2px 2px 1px rgb(32 28 26 / 0.2), 0 1px 2px rgb(0 0 0 / 0.5);
@@ -99,6 +105,9 @@
   --shadow-input: var(--input-shadow);
 
   --color-popover: var(--popover);
+
+  --color-highlight: var(--highlight);
+  --color-highlight-foreground: var(--highlight-foreground);
 
   --background-image-card: var(--card);
   --background-image-card-header: var(--card-header);


### PR DESCRIPTION
# Why

Hover and focus states across menus, dropdowns and the sidebar were still hardcoded to `neutral-*` / `stone-*` utilities, so in dark mode they either disappeared or flashed a light-grey block. Continues the dark-theme tokenization started in #10272-#10276.

Non-goals: no new components, no behavioral change in light mode beyond the equivalent token value.

## What changed

- Hover/focus highlights now follow the active theme everywhere they appear: branch list items, homepage repository rows, sidebar navigation and accordion triggers, dropdown menu items and submenu triggers, and the `@infrahub/ui` menu picker variant.
- Adds `--highlight` / `--highlight-foreground` to both palettes, exposed as `bg-highlight` / `text-highlight-foreground`.
- The `@infrahub/ui` action menu variant gets explicit dark surface and focus colors; section headers use `text-subtle/80` instead of the removed de-emphasized token.
- Sidebar accordion content borders use `border-border-strong`, and the active nav item uses `indigo-500/10` + `indigo-500` so it reads on both backgrounds.
- Fixes `DropdownMenuSubContent` rendering below its trigger: it is now portalled with `z-50`, like the other Radix content surfaces.

## How to review

Focus on `frontend/packages/ui/src/styles/theme.css` — the two token values are the only judgement calls; everything else is a mechanical swap to them.

## How to test

```bash
cd frontend/app && pnpm dev
```

Toggle light/dark and hover the sidebar items, branch list, homepage repository list, and open a dropdown with a submenu.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

