### PR TITLE
refactor(frontend): add a selected token for list box selection

### DIFF
--- a/frontend/packages/ui/src/components/list-box/list-box.tsx
+++ b/frontend/packages/ui/src/components/list-box/list-box.tsx
@@ -84,7 +84,9 @@ const listBoxItemStyles = tv({
     "data-disabled:pointer-events-none data-disabled:opacity-50",
   ],
   variants: {
-    isFocused: { true: "bg-stone-700/10 text-foreground" },
+    isFocused: {
+      true: "bg-highlight text-highlight-foreground",
+    },
   },
 });
 
@@ -107,7 +109,9 @@ export function ListBoxItem<T extends object>({
       className={composeAriaClassName(className, ({ isFocused, isSelected }) =>
         cn(
           listBoxItemStyles({ isFocused }),
-          isSelected && selectionIndicator === "highlight" && "bg-stone-700/10 text-foreground",
+          isSelected &&
+            selectionIndicator === "highlight" &&
+            "bg-selected text-selected-foreground shadow-selected",
         ),
       )}
       {...props}

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -23,6 +23,10 @@
   --highlight: --alpha(var(--color-stone-600) / 10%);
   --highlight-foreground: var(--foreground);
 
+  --selected: linear-gradient(var(--highlight), var(--highlight));
+  --selected-foreground: var(--foreground);
+  --selected-shadow: 0 0 #0000;
+
   --card: linear-gradient(to bottom, var(--color-stone-50) 0%, var(--color-white) 10%);
   --card-shadow:
     inset 0 2px 0 rgb(255 255 255), inset 0 -1px 2px 1px rgb(0 0 0 / 0.03),
@@ -64,6 +68,14 @@
 
   --highlight: --alpha(var(--color-stone-700) / 70%);
   --highlight-foreground: var(--foreground);
+
+  --selected: linear-gradient(
+    180deg,
+    --alpha(var(--color-stone-600) / 75%) 0%,
+    --alpha(var(--color-stone-700) / 75%) 100%
+  );
+  --selected-foreground: var(--color-white);
+  --selected-shadow: inset 0 1px 0 rgb(255 255 255 / 0.12), 0 1px 3px rgb(0 0 0 / 0.6);
 
   --card: linear-gradient(180deg, #201d1c 0%, #191716 55%, #141312 100%);
   --card-shadow: inset 0 2px 2px 1px rgb(32 28 26 / 0.2), 0 1px 2px rgb(0 0 0 / 0.5);
@@ -108,6 +120,10 @@
 
   --color-highlight: var(--highlight);
   --color-highlight-foreground: var(--highlight-foreground);
+
+  --background-image-selected: var(--selected);
+  --color-selected-foreground: var(--selected-foreground);
+  --shadow-selected: var(--selected-shadow);
 
   --background-image-card: var(--card);
   --background-image-card-header: var(--card-header);


### PR DESCRIPTION
# Why

List box selection reused the hover treatment (`bg-stone-700/10`), so in dark
mode a selected option was indistinguishable from a merely focused one. The
dark palette work so far tokenized hover/focus (`--highlight`) but left
selection with no token of its own.

## What changed

- Selected list box items now read as selected in both themes: a distinct
  filled surface in dark mode, unchanged subtle tint in light mode.
- Focused items use the existing `--highlight` token instead of a hardcoded
  stone tint.
- New `--selected` / `--selected-foreground` / `--selected-shadow` tokens in
  `theme.css`, exposed as `bg-selected`, `text-selected-foreground`,
  `shadow-selected`. Light mode maps `--selected` to `--highlight` with no
  shadow, so its appearance is unchanged.

## How to test

Storybook / any Select or ListBox: toggle dark mode, keyboard-navigate the
options and confirm the focused item and the selected item are visually
distinct, and that light mode looks as before.

## Impact & rollout

- **Backward compatibility:** additive tokens only; no API changes.
- **Deployment notes:** safe to deploy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

