### PR TITLE
refactor(frontend): add dark theme for data table surfaces

### DIFF
--- a/frontend/app/src/entities/branches/ui/branches-table/branches-table.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/branches-table.tsx
@@ -30,7 +30,12 @@ export function BranchesTable() {
   const isLoading = isPending || isFetchingNextPage;
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <BranchesDataTable
         columns={columns}
         data={flatData}

--- a/frontend/app/src/entities/branches/ui/branches-table/cells/branch-identifier-header.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/cells/branch-identifier-header.tsx
@@ -14,9 +14,7 @@ export function BranchIdentifierHeader({ className, ...props }: BranchIdentifier
   const { isAuthenticated } = useAuth();
 
   return (
-    <div
-      className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10 hover:bg-white", className)}
-    >
+    <div className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10", className)}>
       {isAuthenticated && (
         <Checkbox aria-label="Select all branches" {...props} data-testid="select-all-rows" />
       )}

--- a/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
@@ -40,7 +40,7 @@ export function BranchNameCell({ branch, isSelected, onClickCheckbox }: BranchNa
             variant="ghost"
             size="sm"
             href={getBranchDetailsUrl(branch.name)}
-            className="truncate rounded-full px-2.5 text-custom-blue-700 data-hovered:bg-custom-blue-700/10 data-hovered:underline"
+            className="truncate rounded-full px-2.5 text-accent data-hovered:bg-accent/10 data-hovered:underline"
           >
             {branch.name}
           </LinkButton>

--- a/frontend/app/src/entities/branches/ui/branches-table/cells/branch-status-header.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/cells/branch-status-header.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 
 import { Icon } from "@/shared/components/display/icon";
-import { cellHeaderStyle, cellsStyle } from "@/shared/components/table/style";
+import {
+  cellHeaderInteractiveStyle,
+  cellHeaderStyle,
+  cellsStyle,
+} from "@/shared/components/table/style";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import { classNames } from "@/shared/utils/common";
 
@@ -22,7 +26,9 @@ export function BranchStatusHeader() {
 
   return (
     <Popover open={showFilters} onOpenChange={setShowFilters}>
-      <PopoverTrigger className={classNames(cellsStyle, cellHeaderStyle)}>
+      <PopoverTrigger
+        className={classNames(cellsStyle, cellHeaderStyle, cellHeaderInteractiveStyle)}
+      >
         <FieldSchemaIcon fieldSchema={fieldSchema} />
 
         <span className="mr-2 truncate">{fieldSchema.label ?? fieldSchema.name}</span>
@@ -36,7 +42,7 @@ export function BranchStatusHeader() {
       </PopoverTrigger>
 
       <PopoverContent className="relative rounded-tl-none p-0" align="start">
-        <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-b-0 bg-white px-2 py-1 font-semibold">
+        <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-b-0 bg-table-cell-pinned px-2 py-1 font-semibold">
           Filter by {fieldSchema.label ?? fieldSchema.name}
         </div>
         <BranchStatusFilterForm onSuccess={closePopover} />

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/actions-header-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/actions-header-cell.tsx
@@ -4,11 +4,7 @@ import { classNames } from "@/shared/utils/common";
 export function ActionsHeaderCell() {
   return (
     <div
-      className={classNames(
-        cellsStyle,
-        cellHeaderStyle,
-        "right-0 z-10 -ml-px size-10 border-l hover:bg-white"
-      )}
+      className={classNames(cellsStyle, cellHeaderStyle, "right-0 z-10 -ml-px size-10 border-l")}
     />
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/generics/kind-header-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/generics/kind-header-cell.tsx
@@ -13,7 +13,7 @@ export interface KindHeaderCellProps extends React.HTMLAttributes<HTMLDivElement
 export function KindHeaderCell({ schema, className, ...props }: KindHeaderCellProps) {
   return (
     <div
-      className={classNames(cellsStyle, cellHeaderStyle, "hover:bg-white", className)}
+      className={classNames(cellsStyle, cellHeaderStyle, className)}
       data-testid="kind-header-cell"
       {...props}
     >

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/object-actions-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/object-actions-cell.tsx
@@ -1,9 +1,8 @@
 import { Button, Menu, MenuItem, MenuTrigger, Popover, Sheet } from "@infrahub/ui";
-import { PencilLineIcon, Trash2Icon } from "lucide-react";
+import { EllipsisVerticalIcon, Maximize2Icon, PencilLineIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
 
 import { queryClient } from "@/shared/api/rest/client";
-import { Icon } from "@/shared/components/display/icon";
 import { SlideOverTitle } from "@/shared/components/display/slide-over";
 
 import { DeleteObjectModal } from "@/entities/nodes/object/ui/delete-object-modal";
@@ -50,13 +49,13 @@ export function ObjectActionsCell({
             variant="ghost"
             data-testid={`actions-cell-${objectLabel}`}
           >
-            <Icon icon="mdi:dots-vertical" className="text-subtle-muted" />
+            <EllipsisVerticalIcon className="text-foreground-muted" />
           </Button>
 
           <Popover placement="bottom end">
             <Menu aria-label="Object actions">
               <MenuItem href={getObjectDetailsUrl(objectKind, objectId)}>
-                <Icon icon="mdi:arrow-expand" />
+                <Maximize2Icon />
                 <span>View details</span>
               </MenuItem>
 

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
@@ -1,3 +1,4 @@
+import { StickyCellShadow } from "@/shared/components/table/sticky-cell-shadow";
 import { cellMutedStyle } from "@/shared/components/table/style";
 import { TableCell, type TableCellProps } from "@/shared/components/table/table-cell";
 import { classNames } from "@/shared/utils/common";
@@ -16,13 +17,13 @@ export function StickyLeftCell({
     <TableCell
       className={classNames(
         "sticky left-0 z-1 font-medium",
-        isMuted ? cellMutedStyle : "bg-white",
+        isMuted ? cellMutedStyle : "bg-table-cell-pinned",
         className
       )}
       {...props}
     >
       {children}
-      <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-gradient-to-r from-gray-500/10" />
+      <StickyCellShadow side="left" />
     </TableCell>
   );
 }
@@ -32,12 +33,12 @@ export function StickyRightCell({ className, isMuted, children, ...props }: Stic
     <TableCell
       className={classNames(
         "sticky right-0 -ml-px size-10 items-center justify-center border-l",
-        isMuted ? cellMutedStyle : "bg-white",
+        isMuted ? cellMutedStyle : "bg-table-cell-pinned",
         className
       )}
       {...props}
     >
-      <div className="pointer-events-none absolute top-0 bottom-0 -left-4 w-4 bg-gradient-to-r from-transparent to-gray-300/30" />
+      <StickyCellShadow side="right" />
       {children}
     </TableCell>
   );

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header-simple.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header-simple.tsx
@@ -20,7 +20,7 @@ export function TableColumnHeaderSimple({ columnSchema, className }: TableColumn
     : (columnSchema.label ?? columnSchema.name);
 
   return (
-    <div className={classNames(cellsStyle, cellHeaderStyle, "hover:bg-white", className)}>
+    <div className={classNames(cellsStyle, cellHeaderStyle, className)}>
       <FieldSchemaIcon fieldSchema={columnSchema} />
       <span className="mr-2 truncate">{label}</span>
     </div>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-column-header.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { Button } from "react-aria-components";
 
 import { Row } from "@/shared/components/container";
-import { cellHeaderStyle, cellsStyle } from "@/shared/components/table/style";
+import {
+  cellHeaderInteractiveStyle,
+  cellHeaderStyle,
+  cellsStyle,
+} from "@/shared/components/table/style";
 import { classNames, sortByOrderWeight } from "@/shared/utils/common";
 
 import { isFieldFiltered } from "@/entities/nodes/filters/domain/rules/is-field-filtered";
@@ -225,7 +229,10 @@ function ColumnHeaderMenu({
   return (
     <>
       <MenuTrigger>
-        <Button ref={triggerRef} className={classNames(cellsStyle, cellHeaderStyle, className)}>
+        <Button
+          ref={triggerRef}
+          className={classNames(cellsStyle, cellHeaderStyle, cellHeaderInteractiveStyle, className)}
+        >
           <FieldSchemaIcon fieldSchema={columnSchema} />
 
           <span className="mr-2 truncate">{label}</span>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
@@ -34,7 +34,7 @@ export function TableIdentifierCell({
         variant="ghost"
         size="sm"
         href={getObjectDetailsUrl(objectKind, objectId, overrideParams)}
-        className="-mx-1 truncate rounded-xl px-2 text-custom-blue-700 hover:underline"
+        className="-mx-1 truncate rounded-xl px-2 text-accent hover:underline"
       >
         {label}
       </LinkButton>

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-header.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-header.tsx
@@ -17,9 +17,7 @@ export function TableIdentifierHeader({ schema, className, ...props }: TableIden
   const { isAuthenticated } = useAuth();
 
   return (
-    <div
-      className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10 hover:bg-white", className)}
-    >
+    <div className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10", className)}>
       {isAuthenticated && <Checkbox {...props} data-testid="select-all-rows" />}
 
       <Row className="mx-2 gap-1.5">

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
@@ -47,12 +47,12 @@ export function RelationshipNodeDisplay({ node }: { node: NodeCore }) {
 
   return (
     <LinkButton
-      variant="outline"
+      variant="input"
       size="sm"
       href={getObjectDetailsUrl(node.__typename, node.id)}
-      className="truncate rounded-full pr-2.5 hover:border-custom-blue-700 hover:underline"
+      className="truncate rounded-full border-border pr-2.5 hover:border-ring hover:underline dark:border-white/10 dark:bg-white/5 dark:shadow-none dark:hover:border-ring"
     >
-      <Icon icon={getSchemaIcon(schema)} className="text-custom-blue-800" />
+      <Icon icon={getSchemaIcon(schema)} className="text-accent" />
       {getNodeLabel(node)}
     </LinkButton>
   );

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table-skeleton.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table-skeleton.tsx
@@ -17,7 +17,7 @@ export function ObjectTableSkeleton({ headerCount }: ObjectsTableSkeletonProps) 
           return (
             <TableCell
               key={`skeleton-${rowIndex}-${colIndex}`}
-              className={classNames(colIndex === 0 && "sticky left-0 z-1 bg-white")}
+              className={classNames(colIndex === 0 && "sticky left-0 z-1 bg-table-cell-pinned")}
             >
               {colIndex === 0 && <Checkbox isDisabled className={"mr-4"} />}
               <Skeleton className="h-4 w-full" />

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table.tsx
@@ -33,7 +33,12 @@ export const ObjectTable = () => {
   const flatData = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+      className="dark:bg-table-frame"
+    >
       <DataTable
         columns={columns}
         count={count}

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-actions-cell.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-actions-cell.tsx
@@ -1,15 +1,15 @@
 import { Popover as AriaPopover, Button, Menu, MenuItem, MenuTrigger, Sheet } from "@infrahub/ui";
-import { PencilLineIcon } from "lucide-react";
+import { EllipsisVerticalIcon, PencilLineIcon } from "lucide-react";
 import { useState } from "react";
 
 import { queryClient } from "@/shared/api/rest/client";
 import { Icon } from "@/shared/components/display/icon";
 import { SlideOverTitle } from "@/shared/components/display/slide-over";
 import ErrorScreen from "@/shared/components/errors/error-screen";
-import { TableCell } from "@/shared/components/table/table-cell";
 import { Popover, PopoverAnchor, PopoverContent } from "@/shared/components/ui/popover";
 
 import ObjectEdit from "@/entities/nodes/object/ui/object-edit/object-item-edit-paginated";
+import { StickyRightCell } from "@/entities/nodes/object/ui/object-table/cells/style";
 import { objectQueryKeys } from "@/entities/nodes/object/ui/queries/object.query-keys";
 import { canDissociateRelationship } from "@/entities/nodes/relationships/domain/rules/can-dissociate-relationship";
 import { DissociateRelationshipsModal } from "@/entities/nodes/relationships/ui/dissociate-relationships-modal";
@@ -57,8 +57,7 @@ export function RelationshipActionsCell({
 
   return (
     <Popover open={showPropertiesModal} onOpenChange={setShowPropertiesModal}>
-      <TableCell className="sticky right-0 -ml-px size-10 items-center justify-center border-l bg-white">
-        <div className="pointer-events-none absolute top-0 bottom-0 -left-4 w-4 bg-linear-to-r from-transparent to-gray-300/30" />
+      <StickyRightCell>
         <MenuTrigger>
           <PopoverAnchor>
             <Button
@@ -67,7 +66,7 @@ export function RelationshipActionsCell({
               variant="ghost"
               data-testid={`actions-cell-${relationshipLabel}`}
             >
-              <Icon icon={"mdi:dots-vertical"} className="text-subtle-muted" />
+              <EllipsisVerticalIcon className="text-foreground-muted" />
             </Button>
           </PopoverAnchor>
 
@@ -100,7 +99,7 @@ export function RelationshipActionsCell({
             </Menu>
           </AriaPopover>
         </MenuTrigger>
-      </TableCell>
+      </StickyRightCell>
 
       <PopoverContent>
         <RelationshipProperties

--- a/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
+++ b/frontend/app/src/entities/nodes/relationships/ui/relationship-table/relationship-table.tsx
@@ -83,7 +83,12 @@ export function RelationshipTable({
     });
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         count={count}

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter-link.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter-link.tsx
@@ -17,7 +17,7 @@ export function ProposedChangeTableFilterLink({
       className={classNames(
         cellsStyle,
         cellHeaderStyle,
-        "rounded-sm border-0 font-normal text-foreground-muted transition-all data-hovered:bg-transparent data-hovered:text-foreground",
+        "rounded-sm border-0 font-normal text-foreground-muted transition-all data-hovered:text-foreground",
         isActive && "font-semibold",
         className
       )}

--- a/frontend/app/src/entities/role-manager/ui/account-table.tsx
+++ b/frontend/app/src/entities/role-manager/ui/account-table.tsx
@@ -41,7 +41,12 @@ export function AccountTable() {
   const rows = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         data={rows}

--- a/frontend/app/src/entities/role-manager/ui/decision-column-header.tsx
+++ b/frontend/app/src/entities/role-manager/ui/decision-column-header.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 
 import { Icon } from "@/shared/components/display/icon";
-import { cellHeaderStyle, cellsStyle } from "@/shared/components/table/style";
+import {
+  cellHeaderInteractiveStyle,
+  cellHeaderStyle,
+  cellsStyle,
+} from "@/shared/components/table/style";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/components/ui/popover";
 import { classNames } from "@/shared/utils/common";
 
@@ -24,7 +28,9 @@ export function DecisionColumnHeader({
 
   return (
     <Popover open={showFilters} onOpenChange={setShowFilters}>
-      <PopoverTrigger className={classNames(cellsStyle, cellHeaderStyle)}>
+      <PopoverTrigger
+        className={classNames(cellsStyle, cellHeaderStyle, cellHeaderInteractiveStyle)}
+      >
         <FieldSchemaIcon fieldSchema={attributeSchema} />
 
         <span className="mr-2 truncate">{attributeSchema.label ?? attributeSchema.name}</span>
@@ -35,7 +41,7 @@ export function DecisionColumnHeader({
       </PopoverTrigger>
 
       <PopoverContent className="relative rounded-tl-none p-0" align="start">
-        <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-b-0 bg-white px-2 py-1 font-semibold">
+        <div className="absolute -top-[1.8rem] -left-px rounded-t-md border border-b-0 bg-table-cell-pinned px-2 py-1 font-semibold">
           Filter by {attributeSchema.label ?? attributeSchema.name}
         </div>
 

--- a/frontend/app/src/entities/role-manager/ui/global-permissions-table.tsx
+++ b/frontend/app/src/entities/role-manager/ui/global-permissions-table.tsx
@@ -54,7 +54,12 @@ export function GlobalPermissionsTable() {
   const rows = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         data={rows}

--- a/frontend/app/src/entities/role-manager/ui/group-table.tsx
+++ b/frontend/app/src/entities/role-manager/ui/group-table.tsx
@@ -38,7 +38,12 @@ export function GroupTable() {
   const rows = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         data={rows}

--- a/frontend/app/src/entities/role-manager/ui/object-permission-table.tsx
+++ b/frontend/app/src/entities/role-manager/ui/object-permission-table.tsx
@@ -54,7 +54,12 @@ export function ObjectPermissionTable() {
   const rows = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         data={rows}

--- a/frontend/app/src/entities/role-manager/ui/role-table.tsx
+++ b/frontend/app/src/entities/role-manager/ui/role-table.tsx
@@ -38,7 +38,12 @@ export function RoleTable() {
   const rows = data?.pages.flat() ?? [];
 
   return (
-    <InfiniteScroll scrollX hasNextPage={hasNextPage} onLoadMore={fetchNextPage}>
+    <InfiniteScroll
+      scrollX
+      className="dark:bg-table-frame"
+      hasNextPage={hasNextPage}
+      onLoadMore={fetchNextPage}
+    >
       <DataTable
         columns={columns}
         data={rows}

--- a/frontend/app/src/shared/components/loading/infrahub-loading.tsx
+++ b/frontend/app/src/shared/components/loading/infrahub-loading.tsx
@@ -6,7 +6,7 @@ export const InfrahubLoading = ({ children }: { children?: React.ReactNode }) =>
   return (
     <div className="flex h-screen w-screen flex-col items-center justify-center bg-background">
       <img src={infrahubLogo} alt="Infrahub logo" className="h-14 animate-bounce" />
-      <span className="font-medium text-foreground">{children}</span>
+      <span className="font-medium text-foreground-muted">{children}</span>
     </div>
   );
 };

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -9,6 +9,7 @@ import {
 import React from "react";
 
 import { Row } from "@/shared/components/container";
+import { StickyCellShadow } from "@/shared/components/table/sticky-cell-shadow";
 import { cellFooterStyle, cellsStyle } from "@/shared/components/table/style";
 import { classNames } from "@/shared/utils/common";
 import { formatNumberDisplay } from "@/shared/utils/number";
@@ -90,7 +91,7 @@ export function DataTable<T extends NodeCore>({
 
       {allRows.map((row) => {
         return (
-          <div key={row.id} className="contents" data-testid="data-table-row">
+          <div key={row.id} className="group contents" data-testid="data-table-row">
             {row.getVisibleCells().map((cell) => {
               return flexRender(cell.column.columnDef.cell, {
                 ...cell.getContext(),
@@ -117,7 +118,7 @@ export function DataTable<T extends NodeCore>({
                   <span className="font-medium">{formatNumberDisplay(count)}</span>
                   <span className="text-foreground-muted">count{count > 1 && "s"}</span>
                 </Row>
-                <div className="pointer-events-none absolute top-0 -right-4 bottom-0 w-4 bg-linear-to-r from-gray-500/10" />
+                <StickyCellShadow side="left" />
               </>
             )}
           </div>

--- a/frontend/app/src/shared/components/table/sticky-cell-shadow.tsx
+++ b/frontend/app/src/shared/components/table/sticky-cell-shadow.tsx
@@ -1,0 +1,21 @@
+import { cva } from "class-variance-authority";
+
+const stickyCellShadowVariants = cva(
+  "pointer-events-none absolute top-0 bottom-0 w-4 bg-linear-to-r",
+  {
+    variants: {
+      side: {
+        left: "-right-4 from-gray-500/10 to-transparent dark:from-black/40",
+        right: "-left-4 from-transparent to-gray-500/10 dark:to-black/40",
+      },
+    },
+  }
+);
+
+export interface StickyCellShadowProps {
+  side: "left" | "right";
+}
+
+export function StickyCellShadow({ side }: StickyCellShadowProps) {
+  return <div className={stickyCellShadowVariants({ side })} />;
+}

--- a/frontend/app/src/shared/components/table/style.tsx
+++ b/frontend/app/src/shared/components/table/style.tsx
@@ -1,9 +1,13 @@
-export const cellsStyle = "flex items-center gap-1.5 p-2 text-sm h-10 bg-white disabled:bg-white";
+export const cellsStyle = "flex items-center gap-1.5 p-2 text-sm h-10";
 
-export const cellHeaderStyle = "z-1 sticky top-0 border-r border-y hover:bg-gray-100 font-medium";
+export const cellHeaderStyle =
+  "z-1 sticky top-0 border-r border-y bg-table-cell-pinned disabled:bg-table-cell-pinned font-medium dark:backdrop-blur-md";
 
-export const cellBodyStyle = "bg-gray-50 border-r border-b";
+export const cellHeaderInteractiveStyle = "hover:bg-highlight";
 
-export const cellFooterStyle = "sticky bottom-0 -mt-px h-9 px-2.5 border-t border-r";
+export const cellBodyStyle = "bg-table-cell border-r border-b dark:group-hover:bg-stone-900";
 
-export const cellMutedStyle = "bg-gray-50 text-subtle-muted";
+export const cellFooterStyle =
+  "sticky bottom-0 -mt-px h-9 px-2.5 border-t border-r bg-table-cell-pinned";
+
+export const cellMutedStyle = "bg-table-cell text-subtle-muted";

--- a/frontend/packages/ui/src/components/button/button.tsx
+++ b/frontend/packages/ui/src/components/button/button.tsx
@@ -57,8 +57,8 @@ const buttonVariants = tv({
       ],
       outline: [
         "bg-gradient-to-b from-stone-100 to-white text-foreground inset-shadow-[0_1px_0_rgba(255,255,255,0.9)]",
-        "dark:border-stone-700 dark:from-stone-700 dark:to-stone-800/70 dark:inset-shadow-[0_1px_0_rgba(255,255,255,0.15)]",
-        "data-hovered:from-neutral-100 dark:data-hovered:from-stone-600",
+        "dark:border-stone-700 dark:from-stone-700/70 dark:to-stone-900 dark:inset-shadow-[0_1px_0_rgba(255,255,255,0.07)]",
+        "data-hovered:from-neutral-100 dark:data-hovered:from-stone-700",
       ],
       ghost: [
         "border-transparent text-foreground shadow-none",

--- a/frontend/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/frontend/packages/ui/src/components/checkbox/checkbox.tsx
@@ -18,7 +18,7 @@ const checkboxVariants = tv({
 
 const checkboxIndicatorVariants = tv({
   base: [
-    "flex size-4.5 shrink-0 items-center justify-center rounded-md border border-border-strong bg-white text-white transition-all duration-200",
+    "flex size-4.5 shrink-0 items-center justify-center rounded-md border border-border-strong bg-input text-white transition-all duration-200",
     "group-data-pressed/checkbox:scale-90",
     "group-data-focus-visible/checkbox:border-ring group-data-focus-visible/checkbox:ring-2 group-data-focus-visible/checkbox:ring-ring-halo group-data-focus-visible/checkbox:outline-hidden",
   ],

--- a/frontend/packages/ui/src/components/modal/modal.tsx
+++ b/frontend/packages/ui/src/components/modal/modal.tsx
@@ -21,7 +21,7 @@ export function ModalOverlay({ className, ...props }: ModalOverlayProps) {
     <AriaModalOverlay
       isDismissable
       className={cn(
-        "absolute inset-0 z-50 overflow-hidden bg-gray-600/25",
+        "absolute inset-0 z-50 overflow-hidden bg-black/25",
         "data-entering:animate-in data-entering:duration-200 data-entering:fade-in-0",
         "data-exiting:animate-out data-exiting:duration-150 data-exiting:fade-out-0",
         className,

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -14,6 +14,8 @@
   --ring: var(--color-cyan-700);
   --ring-halo: --alpha(var(--ring) / 25%);
 
+  --accent: #087895;
+
   --input: var(--color-white);
   --input-border: var(--border);
   --input-shadow: 0 2px 4px rgb(0 0 0 / 0.04);
@@ -49,6 +51,10 @@
   --sheet-frame: --alpha(var(--color-white) / 25%);
   --sheet-frame-border: var(--border);
   --sheet-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+
+  --table-cell: var(--color-stone-50);
+  --table-cell-pinned: var(--color-white);
+  --table-frame: none;
 }
 
 .dark {
@@ -63,6 +69,8 @@
 
   --ring: var(--color-cyan-700);
   --ring-halo: --alpha(var(--ring) / 25%);
+
+  --accent: #a7d9e6;
 
   --input: var(--color-stone-900);
   --input-border: var(--border-strong);
@@ -101,6 +109,13 @@
   --sheet-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.12), 0 28px 70px rgb(0 0 0 / 0.75),
     0 6px 20px rgb(0 0 0 / 0.5);
+
+  --table-cell: rgb(255 255 255 / 0.02);
+  --table-cell-pinned: rgb(18 18 18 / 0.94);
+  --table-frame:
+    radial-gradient(85% 60% at 10% 0%, rgb(255 244 230 / 0.11), transparent 55%),
+    linear-gradient(0deg, rgb(255 244 230 / 0.09), transparent 160px),
+    linear-gradient(var(--color-black), var(--color-black));
 }
 
 @theme inline {
@@ -115,6 +130,8 @@
 
   --color-ring: var(--ring);
   --color-ring-halo: var(--ring-halo);
+
+  --color-accent: var(--accent);
 
   --color-input: var(--input);
   --color-input-border: var(--input-border);
@@ -146,6 +163,10 @@
   --color-sheet-frame: var(--sheet-frame);
   --color-sheet-frame-border: var(--sheet-frame-border);
   --shadow-sheet: var(--sheet-shadow);
+
+  --color-table-cell: var(--table-cell);
+  --color-table-cell-pinned: var(--table-cell-pinned);
+  --background-image-table-frame: var(--table-frame);
 }
 
 @layer base {
@@ -158,7 +179,6 @@
   }
 
   body {
-    background: var(--background);
     color: var(--foreground);
   }
 


### PR DESCRIPTION
# Why

The data table was the last major surface still hardcoded to light colors (`bg-white`, `bg-gray-50`, `bg-gray-100`). With the dark palette in place from the earlier PRs in this series, every table in the app — objects, branches, IPAM, role manager, proposed changes — stayed white in dark mode.

Non-goals: the legacy `<table>` component in `shared/components/table/table.tsx` still has hardcoded light colors; it's untouched here.

## What changed

**Behavioral**

- Data tables now follow the active theme instead of rendering white in dark mode.

**Implementation notes**

- Two new tokens replace the hardcoded colors: `--table-cell` for regular body cells, `--table-cell-pinned` for the sticky header row, sticky footer, and frozen first/last columns. Dark values are warm stone tints in the same family as the existing `--card` gradient, preserving light's raised-header / recessed-row relationship rather than inverting it.
- Header hover is now **opt-in** via `cellHeaderInteractiveStyle` (`hover:bg-highlight`), applied to the four headers that actually open something. Previously the shared header style always carried a hover that the five non-interactive headers cancelled with a competing `bg-*` utility — two `background-color` utilities on one element, where the winner is decided by Tailwind's emit order, not authoring order.
- For the same reason `cellsStyle` no longer sets a background at all; each role (body / header / footer) owns its own, so no element declares a background twice.
- The sticky-column edge shadow is extracted into `StickyCellShadow` with a `side` variant, replacing three duplicated gradient strings across `StickyLeftCell`, `StickyRightCell`, and the footer.
- Drive-by tokenization of surfaces that sit on or next to tables: relationship-cell pill (`variant="input"`, `border-ring`), checkbox indicator (`bg-input`), modal overlay (`bg-black/25`).

**What stayed the same:** light theme is visually unchanged — same `gray-50` rows, `white` pinned cells, `gray-500/10` shadow.

## How to review

Start with `frontend/packages/ui/src/styles/theme.css` (token definitions) and `frontend/app/src/shared/components/table/style.tsx` (how roles consume them); the rest is mechanical class swaps.

Worth extra scrutiny: the sticky body cells add `bg-table-cell-pinned` over `TableCell`'s `bg-table-cell`, which is the one remaining place two background utilities land on one element. Verified computed values rather than assuming — pinned wins in both themes.

## How to test

```bash
cd frontend/app && pnpm exec biome ci . && pnpm knip && pnpm exec betterer ci && pnpm test
```

Manually: run `pnpm dev`, open any object list, and toggle `.dark` on `<html>`. Check the header row, the pinned first/last columns and their edge shadows, the count footer, and hovering a sortable column header.

## Impact & rollout

- **Backward compatibility:** none — CSS only, no API or schema changes.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] Tests added/updated — n/a, styling-only; existing 1190 tests pass
- [ ] Changelog entry — n/a, `ci/skip-changelog` (matches the rest of this series)
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

