### PR TITLE
Merge stable into release-1.11

### DIFF
--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -49,9 +49,5 @@ Where IDs *do* belong:
 
 - Comment the *why*, never the *what*: a constraint, an invariant, a workaround, a deliberate deviation from the obvious approach. Never paraphrase the line below it or restate the type signature.
 - Documents the contract of a public function (inputs, outputs, errors raised) when it crosses a module boundary.
-<<<<<<< HEAD
 - Stays silent by default. If code needs a comment to explain *what* it does, rename or extract until it doesn't. A comment that restates the code is worse than none — noise that rots the moment the code changes.
-=======
-- Stays silent by default. A comment that restates the code is worse than no comment — it adds noise and rots the moment the code changes.
 - When a why-comment is warranted, one sentence. If the why needs a paragraph, it belongs in the function's docstring or a `dev/knowledge/` page, not inline. Reviewers repeatedly ask for multi-line inline comments to be condensed.
->>>>>>> origin/stable

--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -50,3 +50,4 @@ Where IDs *do* belong:
 - Explains *why* the code exists when the why is non-obvious (a constraint, an invariant, a workaround for a specific upstream bug).
 - Documents the contract of a public function (inputs, outputs, errors raised) when it crosses a module boundary.
 - Stays silent by default. A comment that restates the code is worse than no comment — it adds noise and rots the moment the code changes.
+- When a why-comment is warranted, one sentence. If the why needs a paragraph, it belongs in the function's docstring or a `dev/knowledge/` page, not inline. Reviewers repeatedly ask for multi-line inline comments to be condensed.

--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -51,7 +51,7 @@ Assert on the exact message with `==`, not substring checks with `in`. Vague che
 
 ## Assert exact expectations
 
-Exact-match is not only for error messages. Assert the exact collection (full set/dict equality, not `in`/`issubset`), never mere non-emptiness (`!= frozenset()`, `len() > 0`), and a positive count where the number matters (so a run that silently measures zero fails). A denial test must also reload the target and assert nothing changed. Full guidance in `dev/guidelines/backend/testing.md` §"Assert exact expectations".
+Exact-match is not only for error messages. Assert the exact collection (full set/dict equality, not `in`/`issubset`), never mere non-emptiness (`!= frozenset()`, `len() > 0`), and a positive count where the number matters (so a run that silently measures zero fails). A denial test must also reload the target and assert nothing changed. Pin literal expected values — never compute the expectation with the same serializer/library the implementation calls. Full guidance in `dev/guidelines/backend/testing.md` §"Assert exact expectations".
 
 ## Don't test the framework
 

--- a/.agents/skills/creating-changelog-entries/SKILL.md
+++ b/.agents/skills/creating-changelog-entries/SKILL.md
@@ -78,6 +78,7 @@ uv run towncrier create -c "Migrated the frontend build to pnpm workspaces" +pnp
 - **Placing it in a sub-package directory** (e.g. `backend/changelog/`) instead of the configured fragments directory.
 - **Describing the implementation.** "Refactored the auth-token cache layer" → instead say what the user sees: "Fixed users being unexpectedly logged out".
 - **Wrong tense or multiple sentences.** One past-tense sentence.
+- **Duplicating an existing fragment.** On a feature branch spanning multiple PRs, list the fragments directory first — numbered (`NNNN.type.md`) and `+`-prefixed fragments all render into the changelog. If a fragment already describes the same user-visible change, extend or reconcile it instead of adding an overlapping one.
 
 ## See Also
 

--- a/.agents/skills/migrate-feature-page/SKILL.md
+++ b/.agents/skills/migrate-feature-page/SKILL.md
@@ -169,7 +169,7 @@ When in doubt, ask: *would this sentence read better with the qualifier removed?
 **Hub + spokes** (Groups / Profiles precedent):
 
 - Hub at `docs/docs/<feature>/index.mdx` — topic content only. **Do NOT add a "Common tasks" or "Deeper concepts" link list** — the spokes already appear in the sidebar when the user is on the hub, so a body link list is redundant clutter. A "Learn by doing" body link to an Academy tutorial is OK because the tutorial lives in a different sidebar section.
-- Spokes at `docs/docs/<feature>/<task>.mdx` — one per task. Each spoke should have a brief "Next" or "Related" section at the bottom pointing to adjacent spokes.
+- Spokes at `docs/docs/<feature>/<task>.mdx` — one per task. Each spoke ends with a brief `## Next` section pointing to adjacent spokes (always `Next`, not `Related` — mixed heading names across a spoke set is a recurring review comment).
 - Optional concept spoke at `docs/docs/<feature>/<concept>.mdx` for substantial deep-dive content (e.g. priority and inheritance) when it's a frequently-referenced topic and would otherwise bloat the hub.
 - Optional Academy tutorial at `docs/docs/academy/tutorials/<feature>.mdx`
 
@@ -299,7 +299,7 @@ Pattern: <single-page merge / hub + spokes / tutorial extraction / split / secti
 
 Most of this PR is preserved content with cross-link updates. The actual NEW prose to review is small:
 
-- **`<file>:<lines>` — <one-line description of new section/prose>.** <Brief rationale or where it came from — e.g. "Sourced from the Confluence net-new content draft" or "Standard spoke 'Related' closer matching Generators/Transformations precedent.">
+- **`<file>:<lines>` — <one-line description of new section/prose>.** <Brief rationale or where it came from — e.g. "Sourced from the Confluence net-new content draft" or "Standard spoke `## Next` closer matching Generators/Transformations precedent.">
 
 Everything else (~XX% of the lines changed) is verbatim from the source legacy files with only cross-link path updates — safe to skim.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -104,6 +104,7 @@ Each entry says *when* to load it — open the doc before working in that area.
 - `dev/knowledge/backend/display-labels-and-hfid.md` - Display-label and human-friendly-id derivation; read when touching either
 - `dev/knowledge/backend/templates.md` - Object template generation and application; read when touching templates
 - `dev/knowledge/backend/code-generation.md` - Generated-file pipeline (protocols, schema, SDK); read before/after changing event, schema, CLI, or config code
+- `dev/knowledge/backend/git-sync.md` - Remote branch import/mapping and git error surfacing; read when touching repository sync or debugging branch-import behavior
 
 ### Guides (How to do X)
 

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -105,6 +105,10 @@ The module provides individual node/generic schemas (`CAR`, `DEVICE`, `TAG`, `PE
 
 4. **Never modify an existing helper schema to satisfy a single test.** Changes to shared schemas affect every test that uses them. If an existing helper almost fits but not quite, use `deepcopy` as shown above.
 
+## Pin settings the test depends on
+
+`config.SETTINGS` is populated from `INFRAHUB_*` environment variables at process start, so values exported in the developer's shell leak into the test process. Any test whose behavior depends on a settings field must pin it in a save/restore fixture (set the value, `yield`, restore the original) — see `import_every_remote_branch` in `backend/tests/integration/git/conftest.py`. Never assume a field holds its default.
+
 ## Dataclass Test Case Pattern
 
 For parametrized tests with multiple scenarios, use dataclasses to define test cases. This pattern provides type safety, readable test IDs, and clear separation between test data and test logic.
@@ -341,6 +345,9 @@ The exact-match principle above is not limited to error messages — it applies 
 - **Assert a positive count where the number matters.** A test that only checks "no failures" can pass while measuring zero of the thing it claims to test — e.g. if a workflow/name string changes so nothing is counted. Assert that the expected count is `> 0` (or the exact number) so a silently-zero run fails.
 - **Make the scenario actually hold.** A "missing row" test must not create the row; a "no second object" test must prove the count is one. Verify the setup produces the state under test.
 - **Denial tests must verify nothing changed.** When asserting an operation is rejected, also reload the target and assert its state is unchanged (or that no row was created/deleted). Asserting only that an error was returned does not prove the write was actually blocked.
+- **Assert persistence from storage, not from the layer the code wrote.** When the contract is that state reaches (or is restored in) the database, reload it from the DB (e.g. `Branch.get_by_name` and check `active_schema_hash`) instead of reading back the in-memory registry/cache the code under test updated — that assertion is self-confirming and cannot detect a failure to persist.
+- **Pin literal expected values — don't derive them with the code's own dependencies.** Computing the expectation with the same serializer/formatter the implementation calls (`ujson.dumps`, `yaml.dump`, the function under test itself) makes the assertion a tautology: it passes even when the library's output changes. Write the raw expected string into the test.
+- **A "does not raise" test still needs an assertion.** When the contract is that an exception is swallowed, also assert a side effect that only the guarded path produces (state set before the raiser was called). With no assertion, a regression that returns early before the guard passes identically.
 
 ## See Also
 

--- a/dev/guidelines/frontend/page-architecture.md
+++ b/dev/guidelines/frontend/page-architecture.md
@@ -2,7 +2,7 @@
 
 > Part of: `dev/guidelines/frontend/`
 
-Rules for structuring page components and the forms / panels they contain. These exist because a recent feature (see PR #9099, path-traversal) shipped a 500+ line page that owned URL sync, clipboard helpers, formatters, mode routing, and rendering simultaneously, and duplicated `useState` between the page and its selector subcomponents.
+Rules for structuring page components and the forms / panels they contain. These exist because a recent feature shipped a 500+ line page that owned URL sync, clipboard helpers, formatters, mode routing, and rendering simultaneously, and duplicated `useState` between the page and its selector subcomponents.
 
 ## State ownership
 
@@ -82,7 +82,7 @@ Move these out of the page component the moment you write them:
 
 ## Component contracts: design for both callers from the start
 
-When two modes/features will share a visualization or panel, design the contract for both *before* shipping the first one. Example from PR #9099: a graph component shipped with `destination` as a required prop; when a second mode arrived without a single destination, the only fix was fabricating a synthetic value — a smell that traces back to the original prop design.
+When two modes/features will share a visualization or panel, design the contract for both *before* shipping the first one. Example: a graph component shipped with `destination` as a required prop; when a second mode arrived without a single destination, the only fix was fabricating a synthetic value — a smell that traces back to the original prop design.
 
 Rule: if a second caller is in the spec at all, the prop API must support it on the first iteration. Make optional what is genuinely optional.
 
@@ -100,9 +100,9 @@ If the client needs to *display* a server-side default, surface it via the API (
 
 | Anti-pattern | Replacement |
 |---|---|
-| 500+ line page mixing URL sync, formatters, clipboard, modes, rendering (PR #9099) | Split into mode components + `utils.ts` + dedicated form |
-| Two selectors each owning a copy of the same `sourceId/maxDepth/...` via `useState` (PR #9099) | Single form (or controlled inputs from page); no `useState` mirror |
-| Mapper fabricating a synthetic destination to satisfy a required prop (PR #9099) | Make the prop optional on the visualization API |
+| 500+ line page mixing URL sync, formatters, clipboard, modes, rendering | Split into mode components + `utils.ts` + dedicated form |
+| Two selectors each owning a copy of the same `sourceId/maxDepth/...` via `useState` | Single form (or controlled inputs from page); no `useState` mirror |
+| Mapper fabricating a synthetic destination to satisfy a required prop | Make the prop optional on the visualization API |
 | Two selectors with ~50% duplicated UI | Extract a `KindMultiSelect` / shared block once both exist |
 | Hand-rolling `gql` + `graphqlClient.query` in a `ui/` file | Use the entity layer (`useGetObject`, `ui/queries/`) |
 | Hardcoding `HIDDEN_NAMESPACES` on the client | Backend-authoritative; surface via schema if needed |

--- a/dev/guidelines/frontend/route-architecture.md
+++ b/dev/guidelines/frontend/route-architecture.md
@@ -319,7 +319,7 @@ itself auth-agnostic (the "authenticated" concern is a distinct component that s
 when logged out). Do **not** rely on placement under `RequireAuth`; do **not** read the auth token
 from a `domain/` use-case (that breaks the FSD layer rule — auth state stays in `ui/`).
 
-This came from PR #9930: `DatePreferencesProvider` first mounted at the app root, then under
+Precedent: `DatePreferencesProvider` first mounted at the app root, then under
 `RequireAuth` — both fired the query for logged-out users and broke E2E. The fix was to gate the
 mount on `isAuthenticated`.
 

--- a/dev/guidelines/markdown.md
+++ b/dev/guidelines/markdown.md
@@ -86,6 +86,7 @@ from infrahub_sdk import InfrahubClient
 - Use descriptive link text
 - Use relative paths for internal documentation links
 - All documentation URLs should be relative (not absolute)
+- When referencing Infrahub source files (models, sample scripts), link the file on GitHub (`https://github.com/opsmill/infrahub/blob/stable/<path>`); never cite a bare repo path — docs readers have no checkout
 
 ```markdown
 <!-- ✅ Good -->
@@ -115,6 +116,7 @@ https://example.com/page
 - **Present tense**: "Infrahub uses branches to isolate changes"
 - **Professional but approachable**: Avoid "simple", "easy", or "just"
 - Use American English for standard text
+- **Literal words**: much of the audience reads English as a second or third language. Avoid figurative phrasing — "carry" (for have), "lives on" (for is stored on), "walk" (for traverse), "reach for" (for use). Say the literal thing.
 
 ### Trailing Commas (Oxford Comma)
 
@@ -191,6 +193,8 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 ````
+
+Only keep imports the page uses — no linter flags unused MDX imports, so check them manually when copying a page skeleton.
 
 ## General Tips
 

--- a/dev/guidelines/repository-organization.md
+++ b/dev/guidelines/repository-organization.md
@@ -61,6 +61,8 @@ Each directory in `dev/` serves a specific purpose and follows a content lifecyc
 
 **Content Lifecycle**: Approved plans. Living during development, then archived or moved to knowledge/guidelines.
 
+Living means kept consistent: when a design decision changes mid-implementation, sweep every artifact in the spec directory (spec, plan, research, data-model, tasks, quickstart, decision records) to the new design in the same pass, and re-verify literal references — test paths, migration numbers, `GRAPH_VERSION` — against the final code. When two artifacts contradict, the code decides which one is stale. Re-running `/speckit-analyze` after a redesign catches drift.
+
 **Primary Target**: Human
 
 **File Size Guidelines**: 200-500 lines

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -248,6 +248,8 @@ Outbound on `n1`, inbound on `n2`.
 - **Same branch**: Set `to` property to deletion time
 - **User branch deleting default branch data**: Add `status="deleted"` edge with `from` = deletion time
 
+These two mechanisms are exclusive. A `status="deleted"` edge is terminal: it always keeps `to: NULL`, never receives a `to` timestamp, and is never re-opened. `to` is only ever set to close a `status="active"` edge.
+
 ### Branch Deletion
 
 Hard-deletes all edges on the branch and the `Branch` vertex.
@@ -355,6 +357,8 @@ CALL (peer, rl) {
 - **DISTINCT first**: When multiple vertices may match, get DISTINCT nodes first, then validate each
 - **Order then filter**: Always `ORDER BY ... LIMIT 1` first, then `WHERE status = "active"` to handle the case where the latest edge is a deletion
 - **No `to` timestamp**: `to IS NULL` ensures the edge is currently valid (not expired)
+
+These filters apply to *any* query whose contract mentions "active" or "current" state — detection/audit queries and test helpers included; an unfiltered edge match silently counts tombstoned rows as live.
 
 ## Transaction Retry
 

--- a/dev/knowledge/backend/git-sync.md
+++ b/dev/knowledge/backend/git-sync.md
@@ -1,0 +1,30 @@
+# Git Sync
+
+> Part of: `dev/knowledge/backend/` | Related: [Architecture](architecture.md)
+
+How Infrahub maps and imports branches from external git repositories, and how git errors surface.
+Read this before reasoning about which remote branches get imported or why a git failure carries
+(or lacks) a message — the logic is split across several methods and is easy to mis-trace.
+
+## Branch import and mapping
+
+- A repository's own `default_branch` is mapped onto Infrahub's default branch by
+  `_get_mapped_target_branch` in `backend/infrahub/git/base.py`: when a commit lands on the
+  repository's default branch, it is recorded against Infrahub's default branch, whatever either
+  is named.
+- Because of that mapping, when the repository's default branch differs from Infrahub's, a remote
+  branch literally named like Infrahub's default branch cannot be imported — it would collide with
+  the mapped default. The skip happens in `validate_remote_branch` (which logs
+  "Ignoring import of mismatched default branch" and returns `False`), *not* in
+  `_get_mapped_target_branch`.
+- `git.import_sync_branch_names` (settings) is a list of names or regex patterns selecting which
+  other remote branches are imported during sync; branches created in Infrahub with
+  `sync_with_git` are imported regardless.
+
+## Git error surfacing
+
+`git merge` writes conflict output to **stdout**, not stderr. GitPython's `GitCommandError.stderr`
+is therefore empty on a merge conflict, and the `RepositoryError` raised from the merge path
+carries only its default message. Keep that in mind when asserting on error messages
+(`pytest.raises(match=...)`) or when tempted to include `exc.stderr` in user-facing output for
+merge failures.

--- a/dev/knowledge/backend/query-pattern.md
+++ b/dev/knowledge/backend/query-pattern.md
@@ -34,6 +34,8 @@ def __init__(self, node_id: str, **kwargs):
 | `add_subquery(str, alias)` | Wrap in `CALL (alias) { }` block |
 | `update_return_labels(list)` | Add labels to RETURN clause |
 
+Constructors take primitives (ids, names, ranges, kinds) — not domain objects like a `Node` subclass. A query that reads fields off a node instance creates a two-way dependency between the query layer and the node layer; compute the primitive values at the call site and pass them in. Some legacy queries (e.g. the number-pool family) still take node objects — follow this rule for new queries rather than the sibling precedent.
+
 ### Execution
 
 ```python
@@ -173,6 +175,12 @@ Each subquery:
 Get `branch_filter` via `self.branch.get_query_filter_path(at=self.at)`. For queries filtering multiple edges with different variable names, use `variable_name="r_custom"` to generate a filter bound to a specific variable.
 
 Example: `NodeGetListByAttributeValueQuery` and `NodeGetByHFIDQuery` chain three such subqueries (`IS_PART_OF`, `HAS_ATTRIBUTE`, `HAS_VALUE`) to resolve the active attribute value for the requested branch/time.
+
+The outer `MATCH` returns one row per matching edge, and the graph keeps one `HAS_ATTRIBUTE` edge per branch that touched the attribute — so an attribute edited on three branches yields three rows, and the `CALL` subquery then runs three times to elect the same winning edge. Add `WITH DISTINCT <keys>` before the `CALL` and group at the natural cardinality: an Attribute has exactly one active AttributeValue per branch/time, so group by `(n, attr)` and re-apply value predicates after the subquery. Keep the outer edge anonymous (`-[:HAS_ATTRIBUTE]->`) while you are there — binding a variable you never read does not change the row count, but it does collide with the subquery's own edge variable (see below). See [Database Schema — Key Points](database-schema.md#key-points).
+
+### Query performance
+
+`AttributeValueIndexed` values are stored natively typed (a number attribute's `av.value` is an integer). Compare `av.value` directly in `WHERE` predicates — wrapping the property in a function (`toInteger(av.value) >= $x`) prevents Neo4j from using the index, so the query scans every row of the kind instead of seeking the matching range.
 
 ### Cypher Variable Shadowing (Neo4j 5+)
 

--- a/dev/knowledge/backend/schema-definitions.md
+++ b/dev/knowledge/backend/schema-definitions.md
@@ -89,7 +89,13 @@ All `AttributeSchema` entries must include a `description` field. This is enforc
 
 ## Constraint Count Test
 
-`backend/tests/component/message_bus/operations/requests/test_proposed_change.py::test_get_proposed_change_schema_integrity_constraints` contains hardcoded constraint counts. These counts change whenever schemas are added or removed because `ConstraintValidatorDeterminer` iterates all schemas in the registry and generates one `SchemaUpdateConstraintInfo` per validatable property. After schema changes, run the test to get actual counts and update the assertions. See `#2592` for planned improvements.
+`backend/tests/component/message_bus/operations/requests/test_proposed_change.py::test_get_proposed_change_schema_integrity_constraints` contains hardcoded constraint counts. These counts change whenever schemas are added or removed because `ConstraintValidatorDeterminer` iterates all schemas in the registry and generates one `SchemaUpdateConstraintInfo` per validatable property. After schema changes, run the test to get actual counts and update the assertions.
+
+## Runtime schema registry cache
+
+Each worker keeps per-branch `SchemaBranch` objects cached in `registry.schema`. The codebase relies on this cache being kept up-to-date, so read the current schema of a branch via `registry.schema.get_schema_branch(name=...)` — do not add defensive `load_schema_from_db` reloads "just in case". One caveat: `get_schema_branch` silently creates an *empty* `SchemaBranch` for a name it has never seen rather than raising, so it is only valid for branches the process has loaded or registered.
+
+In branch merge/rebase tasks, schema loads needed only for migrations (common-ancestor baseline, pre-rebase rollback schema) belong inside the `obj.has_schema_changes` guard so data-only operations skip them.
 
 ## Key Locations
 

--- a/dev/knowledge/backend/templates.md
+++ b/dev/knowledge/backend/templates.md
@@ -23,15 +23,15 @@ Every auto-generated template kind transitively inherits from one of two core ge
 - `CoreObjectTemplate` — for the user-facing template kinds (one per node with `generate_template: true`).
 - `CoreObjectComponentTemplate` — for sub-templates auto-generated for component peers (see [Subtemplates](#subtemplates)).
 
-The kind name is mechanical: a template for `InfraDevice` becomes `TemplateInfraDevice`, computed by `SchemaBranch._get_object_template_kind()` (`schema_branch.py:2532`).
+The kind name is mechanical: a template for `InfraDevice` becomes `TemplateInfraDevice`, computed by `SchemaBranch._get_object_template_kind()`.
 
 ## Schema Generation Flow
 
-Template schemas are generated during schema processing in `process_pre_validation` (`schema_branch.py:633` flow), in this order:
+Template schemas are generated during schema processing in `process_pre_validation` (`schema_branch.py`), in this order:
 
-1. **`manage_object_template_schemas()` (~line 2889)** — for every `NodeSchema` that sets `generate_template: true`, call `generate_object_template_from_node()` to construct a `TemplateSchema` (or a generic template for shared abstractions) and register it under the `Template{kind}` name. Identifies dependent component peers via `identify_required_object_templates()` so they get subtemplates too.
+1. **`manage_object_template_schemas()`** — for every `NodeSchema` that sets `generate_template: true`, call `generate_object_template_from_node()` to construct a `TemplateSchema` (or a generic template for shared abstractions) and register it under the `Template{kind}` name. Identifies dependent component peers via `identify_required_object_templates()` so they get subtemplates too.
 
-2. **`generate_object_template_from_node()` (~line 2759)** — builds the bare `TemplateSchema`: copies attributes that have `support_templates`, sets the `template_name__value` HFID, wires `inherit_from` to `CoreObjectTemplate` (or the auto-generated parent template if the source node inherits from one).
+2. **`generate_object_template_from_node()`** — builds the bare `TemplateSchema`: copies attributes that have `support_templates`, sets the `template_name__value` HFID, wires `inherit_from` to `CoreObjectTemplate` (or the auto-generated parent template if the source node inherits from one).
 
 3. **`add_relationships_to_template()` (~line 2669)** — walks the source node's relationships and copies the propagatable ones onto the template, with adjustments:
    - Filters out `GENERICGROUP` and `PROFILE` peers, and any kind not in `[COMPONENT, PARENT, ATTRIBUTE, GENERIC]`.
@@ -50,7 +50,7 @@ Subtemplates inherit from `CoreObjectComponentTemplate` rather than `CoreObjectT
 
 ## Application Flow
 
-When a user creates an object with `object_template={id: ...}`, `Node._apply_template()` is invoked from `Node.new()` (`core/node/__init__.py:480`). It:
+When a user creates an object with `object_template={id: ...}`, `Node.handle_object_template()` is invoked from `Node.new()` (`core/node/__init__.py`). It:
 
 1. Loads the referenced `CoreObjectTemplate` instance (via the GraphQL `object_template` input).
 2. Constructs a `NodeTemplateApplier` with a `DefaultPoolAllocator` (or `NoOpPoolAllocator` if pool processing is suppressed).
@@ -62,7 +62,7 @@ When a user creates an object with `object_template={id: ...}`, `Node._apply_tem
 4. Merges only previously-absent keys back into `fields`, preserving user input.
 5. Returns the set of `pool_pending_fields` — fields whose pool allocation was deferred (e.g., because the chosen allocator is the no-op variant).
 
-After save, `handle_template_relationships()` (`core/node/create.py:175`) walks the new node's `COMPONENT` relationships and recursively materializes any subtemplate peers as their own real objects, recursing into their components.
+After save, `handle_template_relationships()` (`core/node/create.py`) walks the new node's `COMPONENT` relationships and recursively materializes any subtemplate peers as their own real objects, recursing into their components.
 
 ### Group Propagation
 

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -181,6 +181,12 @@ Two consequences worth remembering:
   releases — scopes are sorted largest-first, so which modules run concurrently can change on an
   upgrade. Tests must not depend on what else is or is not running.
 
+Within a single module or class, however, pytest runs tests in definition order and
+`--dist loadscope` keeps the whole scope on one worker — so the sequential, stateful `test_stepNN`
+pattern used across `backend/tests/integration/` (and in component migration suites) is deliberate
+and safe. Do not rewrite step tests to be order-independent; the rule above is about dependence
+*across* modules, not within one.
+
 ### Base Test Classes
 
 Located in `backend/tests/helpers/test_app.py`:
@@ -301,6 +307,12 @@ Container (session)
 | `car_person_schema_unregistered` | Unregistered version for custom modifications |
 | `car_person_schema_branch_local` | Schema with branch-local support |
 | `register_core_models_schema` | Core Infrahub models only |
+| `register_core_models_schema_scope_class` | Class-scoped variant of the above |
+
+When several tests share an expensive schema/data load, group them in a class and use the
+`_scope_class` variant with `@pytest.fixture(scope="class")` fixtures for the data; methods run in
+definition order and may build on accumulated state. See `TestNumberPoolAllocation` in
+`backend/tests/component/core/resource_manager/test_number_pool.py`.
 
 **When to use existing fixtures:**
 

--- a/dev/knowledge/frontend/design-system.md
+++ b/dev/knowledge/frontend/design-system.md
@@ -47,22 +47,11 @@ This table is a snapshot. Source of truth: `frontend/packages/ui/src/index.ts` â
 
 | Component | Exports | Notes |
 |---|---|---|
-<<<<<<< HEAD
 | `Toolbar` | `Toolbar`, `Toolbar.Divider`, `ToolbarProps`, `ToolbarDividerProps` | Floating toolbar container built on react-aria's `Toolbar` (`aria-label` required): one tab stop, arrow keys move between controls. + vertical divider. |
 | `FloatingPanel` | `FloatingPanel`, `FloatingPanelProps` | Floating overlay built on `Card` + a ghost square `Button`: header (title/description/close) + scroll body; optional `dismissable` (outside-click + Escape). |
 | `ExportMenu` | `ExportMenu`, `ExportFormat`, `ExportMenuProps` | PNG/SVG export popover. |
 | `GraphControls` | `GraphControls`, `GraphControlsProps`, `EdgeStyle`, `LayoutDirection` | Zoom / fit / edge-style / layout controls; uses `useReactFlow` from `@xyflow/react`. |
 | `useDismiss` | `useDismiss` | Hook â€” outside-pointerdown + Escape dismissal. |
-=======
-| `Breadcrumbs` | `Breadcrumbs`, `Breadcrumb`, `BreadcrumbItem`, `BreadcrumbItemLoading`, `BreadcrumbItemError`, `BreadcrumbsProps`, `BreadcrumbProps`, `BreadcrumbItemProps` | Trail of links/buttons with `/` separator, plus loading and error item variants. |
-| `Button` | `Button`, `LinkButton`, `buttonVariants`, `ButtonProps`, `LinkButtonProps` | Replaces ad-hoc `<button>` with Tailwind classes. |
-| `Card` | `Card`, `CardHeader`, `CardContent`, `CardProps`, `CardHeaderProps`, `CardContentProps` | Replaces hand-rolled `<section className="rounded-md border bg-white p-4 shadow-lg">` patterns. |
-| `CheckboxCard` | `CheckboxCard`, `CheckboxCardProps` | Card-style checkbox primitive for selectable card choices. |
-| `Modal` | `Modal`, `ModalOverlay`, `ModalProps`, `ModalOverlayProps` | Use instead of HeadlessUI Dialog for new modals. |
-| `Spinner` | `Spinner`, `SpinnerProps` | Loading indicator. |
-| `Meter` | `Meter`, `MeterProps` | Replaces ad-hoc progress-bar charts. |
-| `ScrollArea` | `ScrollArea`, `ScrollAreaProps` | Replaces `shared/components/ui/scroll-area`. |
->>>>>>> origin/stable
 
 Source of truth: `frontend/packages/graph/src/index.ts`. Adopted by `path-traversal`.
 

--- a/dev/knowledge/frontend/design-system.md
+++ b/dev/knowledge/frontend/design-system.md
@@ -13,13 +13,13 @@ The package is published locally via the workspace and consumed in `frontend/app
 | Component | Exports | Notes |
 |---|---|---|
 | `Breadcrumbs` | `Breadcrumbs`, `Breadcrumb`, `BreadcrumbItem`, `BreadcrumbItemLoading`, `BreadcrumbItemError`, `BreadcrumbsProps`, `BreadcrumbProps`, `BreadcrumbItemProps` | Trail of links/buttons with `/` separator, plus loading and error item variants. |
-| `Button` | `Button`, `LinkButton`, `buttonVariants`, `ButtonProps`, `LinkButtonProps` | Migrated in #9065. Replaces ad-hoc `<button>` with Tailwind classes. |
-| `Card` | `Card`, `CardHeader`, `CardContent`, `CardProps`, `CardHeaderProps`, `CardContentProps` | Migrated in #9048. Replaces hand-rolled `<section className="rounded-md border bg-white p-4 shadow-lg">` patterns. |
+| `Button` | `Button`, `LinkButton`, `buttonVariants`, `ButtonProps`, `LinkButtonProps` | Replaces ad-hoc `<button>` with Tailwind classes. |
+| `Card` | `Card`, `CardHeader`, `CardContent`, `CardProps`, `CardHeaderProps`, `CardContentProps` | Replaces hand-rolled `<section className="rounded-md border bg-white p-4 shadow-lg">` patterns. |
 | `CheckboxCard` | `CheckboxCard`, `CheckboxCardProps` | Card-style checkbox primitive for selectable card choices. |
-| `Modal` | `Modal`, `ModalOverlay`, `ModalProps`, `ModalOverlayProps` | Migrated in #9088. Use instead of HeadlessUI Dialog for new modals. |
+| `Modal` | `Modal`, `ModalOverlay`, `ModalProps`, `ModalOverlayProps` | Use instead of HeadlessUI Dialog for new modals. |
 | `Spinner` | `Spinner`, `SpinnerProps` | Loading indicator. |
-| `Meter` | `Meter`, `MeterProps` | Migrated in #9100. Replaces ad-hoc progress-bar charts. |
-| `ScrollArea` | `ScrollArea`, `ScrollAreaProps` | Migrated in #9101. Replaces `shared/components/ui/scroll-area`. |
+| `Meter` | `Meter`, `MeterProps` | Replaces ad-hoc progress-bar charts. |
+| `ScrollArea` | `ScrollArea`, `ScrollAreaProps` | Replaces `shared/components/ui/scroll-area`. |
 
 Source of truth: `frontend/packages/ui/src/index.ts`.
 
@@ -44,7 +44,7 @@ When you touch one of these and notice it could be a generic primitive, consider
 ## Migration policy
 
 - Net-new generic primitives (no Infrahub-specific data dependencies) should land in `@infrahub/ui` from day one.
-- Existing primitives in `shared/components/ui/` are migrated incrementally — see PRs #9048 (Card), #9065 (Button), #9088 (Modal) as references.
+- Existing primitives in `shared/components/ui/` are migrated incrementally — Card, Button, and Modal are migrated precedents.
 - Migration PRs include: the component, its Storybook story, focus-visible styles, and call-site updates across the app.
 
 ## Storybook

--- a/dev/knowledge/frontend/shared-components.md
+++ b/dev/knowledge/frontend/shared-components.md
@@ -2,7 +2,7 @@
 
 > Part of: `dev/knowledge/frontend/`
 
-A discovery map of reusable building blocks. **Look here before building a new picker, combobox, kind selector, or form input.** Most "new" UI in this codebase already has a shared primitive — see PR #9099 for an example where a 200+ line custom object picker and a hand-rolled `gql` UUID resolver were written because this map didn't exist.
+A discovery map of reusable building blocks. **Look here before building a new picker, combobox, kind selector, or form input.** Most "new" UI in this codebase already has a shared primitive — before this map existed, a 200+ line custom object picker and a hand-rolled `gql` UUID resolver were built for UI that already had one.
 
 The dependency rule still applies: `app → pages → entities → shared`. Cross-entity reuse goes through another entity's `domain/` or `ui/` — never `api/`.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,8 +17,8 @@ Infrahub documentation is organized using the [Diataxis framework](https://diata
 
 | Question | Doc Type | See Guide |
 |----------|----------|-----------|
-| Teaching users to complete a specific task? | **Guide** | [guides/AGENTS.md](docs/guides/AGENTS.md) |
-| Explaining concepts or how something works? | **Topic** | [topics/AGENTS.md](docs/topics/AGENTS.md) |
+| Teaching users to complete a specific task? | **Guide** | [writing-a-guide.md](../dev/guides/docs/writing-a-guide.md) |
+| Explaining concepts or how something works? | **Topic** | [writing-a-topic.md](../dev/guides/docs/writing-a-topic.md) |
 | Providing reference information? | **Reference** | Auto-generated |
 | Walking through a complete learning scenario? | **Tutorial** | Diataxis framework |
 
@@ -26,9 +26,7 @@ Infrahub documentation is organized using the [Diataxis framework](https://diata
 
 - `docs/` – MDX content
   - `guides/` – How-to guides (task-oriented)
-    - `AGENTS.md` – **Specialized instructions for writing guides**
   - `topics/` – Explanations (understanding-oriented)
-    - `AGENTS.md` – **Specialized instructions for writing topics**
   - `reference/` – API/configuration reference
   - `tutorials/` – Learning tutorials
   - `media/` – Images and screenshots
@@ -76,6 +74,7 @@ For the complete style guide including terminology, see `docs/development/style-
 - **Imperative mood** for guides: "Click **New Branch**"
 - **Present tense**: "Infrahub uses branches to isolate changes"
 - **Professional but approachable**: Avoid "simple", "easy", or "just"
+- **Literal words**: much of the audience reads English as a second or third language. Avoid figurative phrasing — "carry" (for have), "lives on" (for is stored on), "walk" (for traverse), "reach for" (for use). Say the literal thing.
 
 ### Infrahub Terminology
 
@@ -95,12 +94,22 @@ Capitalize these Infrahub-specific terms when referring to the feature:
 ## Documentation Workflow
 
 1. **Choose documentation type** using the table above (if not specified)
-2. **Follow specialized guide** (guides/AGENTS.md or topics/AGENTS.md)
+2. **Follow specialized guide** (`dev/guides/docs/writing-a-guide.md` or `dev/guides/docs/writing-a-topic.md`)
 3. **Create the .mdx file** in the appropriate directory
 4. **Add to navigation** by editing `sidebars.ts` in the appropriate section
 5. **Lint before committing**: `uv run invoke docs.lint`
 6. **Build to verify**: `uv run invoke docs.build`
 7. **Serve for human verification**: `uv run invoke docs.serve`
+
+## Restructuring existing docs
+
+When restructuring, merging, or deleting existing pages (on any branch, not only the docs-revamp workflow):
+
+- **Inventory the old content.** Every claim, example, and section from a deleted page gets a home in the new set or an explicit drop decision — including when-to-use guidance and basic CRUD paths, not just the headline topics.
+- **Add redirects.** Every deleted or renamed published URL needs an entry in `docs/redirects-pending/` in the same PR.
+- **Close every spoke.** In hub+spokes feature docs, each spoke ends with a `## Next` section linking to adjacent spokes.
+
+The `migrate-feature-page` skill documents the full workflow.
 
 ## Boundaries
 
@@ -112,6 +121,9 @@ Capitalize these Infrahub-specific terms when referring to the feature:
 - Include language tags on code blocks
 - Choose the appropriate documentation type (guide vs. topic)
 - Define technical terms on first use
+- Verify factual claims (attribute kinds, GraphQL fields, defaults) against the code on the branch the PR targets — docs PRs frequently target a release branch whose features differ from the development branch; this applies doubly before acting on a bot review claim that something "does not exist"
+- When documenting marketplace items, verify each item actually resolves in the live catalog at <https://marketplace.infrahub.app>; if an item is planned but unpublished, get an explicit decision on release timing before referencing it
+- Prefer plain Markdown/MDX over custom React components in doc pages; before adding anything to `docs/src/components/`, check the existing components for reuse, and give a genuinely new component typed props (the docs package typechecks with `tsc`)
 
 ### Ask First
 
@@ -126,3 +138,4 @@ Capitalize these Infrahub-specific terms when referring to the feature:
 - Commit large unoptimized images
 - Skip alt text for images
 - Mix guide and topic content in the same document
+- Delete or rename a published docs page without adding a redirect entry in `docs/redirects-pending/` (see `docs/redirects-pending/README.md`)


### PR DESCRIPTION
Follow-up to #10283. Once this lands, #10275 has nothing left to merge and can be closed.

## Summary

Merges `stable` into `release-1.11`, picking up the one commit that landed on `stable` after #10283 was cut: `bb9801629` (#10259, harvest review lessons).

Docs-only: 19 markdown files under `.agents/`, `dev/` and `docs/AGENTS.md`. No Python, no lockfiles, no generated files.

The merge commit (`57d0a07ae`) intentionally carries the conflict markers so the resolution lands as its own reviewable diff on top of it (`2e27e82`).

## Conflicts resolved

- `.agents/rules/code-doc-style.md` — **combined both sides.** Each had unique content: `release-1.11`'s first bullet is the superset (it adds "if code needs a comment to explain *what* it does, rename or extract until it doesn't"), while `stable`'s second bullet on keeping why-comments to one sentence exists only there. Picking either side alone would have dropped real guidance.
- `dev/knowledge/frontend/design-system.md` — **kept `release-1.11`'s rows.** Worth a careful look, because the mechanical resolution here is wrong: git aligned `stable`'s `@infrahub/ui` component inventory against `release-1.11`'s `@infrahub/graph` table, since both are markdown tables with an identical `|---|---|---|` separator. Taking `stable`'s side would have filed `Button`, `Card`, `Modal`, `Spinner`, `Meter` and `ScrollArea` under the "Sibling package: `@infrahub/graph`" heading — the wrong package.

  `stable`'s rows are not lost: `release-1.11` had already rewritten that ui inventory into a wider 19-row "compact inventory, `*Props` omitted" format, and all 8 of `stable`'s components are present there (verified per-component: Breadcrumbs, Button, Card, CheckboxCard, Modal, Spinner, Meter, ScrollArea). Its only unique content was the `Exports` column, which `release-1.11` dropped deliberately as noise.

## Validation

| Check | Result |
|---|---|
| `invoke docs.lint` | 0 errors (184 files) |
| Markdown-only confirmed | no non-`.md` file in the diff |
| Conflict-marker sweep | clean across all 19 changed files |

Python lint, type-check, tests and generated-file validation are not applicable — no code, lockfile or generator input changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

