### PR TITLE
Tag coalesced recompute jobs with their branch

### DIFF
--- a/backend/infrahub/core/merge/recompute_coalescing.py
+++ b/backend/infrahub/core/merge/recompute_coalescing.py
@@ -15,6 +15,7 @@ from infrahub.workflows.catalogue import (
     DISPLAY_LABELS_PROCESS_JINJA2,
     HFID_PROCESS,
 )
+from infrahub.workflows.constants import WorkflowTag
 
 log = get_logger()
 
@@ -436,7 +437,12 @@ class CoalescedRecomputeSubmitter:
             )
             try:
                 await self.workflow.submit_workflow(
-                    workflow=workflow_definition, context=context, parameters=parameters
+                    workflow=workflow_definition,
+                    context=context,
+                    parameters=parameters,
+                    # Must be a creation tag: tags added from inside a run do not reach the filter,
+                    # so without this the run is invisible to every branch-scoped task query.
+                    tags=[WorkflowTag.BRANCH.render(identifier=submission.branch)],
                 )
             except Exception:
                 log.exception(

--- a/backend/tests/unit/core/merge/test_submit_coalesced_recompute.py
+++ b/backend/tests/unit/core/merge/test_submit_coalesced_recompute.py
@@ -20,6 +20,7 @@ from infrahub.workflows.catalogue import (
     DISPLAY_LABELS_PROCESS_JINJA2,
     HFID_PROCESS,
 )
+from infrahub.workflows.constants import WorkflowTag
 from tests.adapters.workflow import WorkflowRecorder
 
 if TYPE_CHECKING:
@@ -150,3 +151,19 @@ async def test_submit_skips_a_failing_submission_and_keeps_the_rest() -> None:
     # The first submission failed; the other two were still dispatched and returned.
     assert len(recorder.submit_calls) == 2
     assert len(submitted) == 2
+
+
+async def test_every_submission_carries_the_branch_tag() -> None:
+    """Without it the run is invisible to every branch-scoped task query.
+
+    A tag added from inside a run does not reach the filter, so it has to be set at creation.
+    An untagged recompute still does its work, which is why this went unnoticed until a
+    branch-filtered count came back zero while the values had plainly been refreshed.
+    """
+    recorder = WorkflowRecorder()
+
+    await CoalescedRecomputeSubmitter(workflow=recorder).submit(coalesced=_coalesced(), context=_event_context())
+
+    assert recorder.submit_calls, "expected the coalesced pass to submit something"
+    for call in recorder.submit_calls:
+        assert call["tags"] == [WorkflowTag.BRANCH.render(identifier="main")], call["workflow"].name


### PR DESCRIPTION
# Why

A merge or a rebase refreshes computed attributes, display labels and human-friendly ids through one coalesced pass. The jobs that pass submits were never tagged with a branch, so they do not show up when tasks are filtered by branch, including in the UI task views.

The recompute itself is correct. Only its visibility is wrong, which is why this went unnoticed: a count filtered on the branch comes back zero while the values have plainly been updated.

## What changed

- The coalesced submitter sets the branch tag when it creates a flow run. All three families go through that submitter, so all three are fixed.
- A unit test asserts every submission carries the tag.

A tag has to be set at creation. Tags added from inside a running flow do not reach the filter, which is why `trigger_update_python_computed_attributes` already sets one this way; the coalesced path simply did not.

No schema change, no API change, no config change.

## How to review

Two lines of behaviour in `backend/infrahub/core/merge/recompute_coalescing.py`. The rest is the test.

## How to test

```bash
uv run pytest backend/tests/unit/core/merge -q
```

To see the bug itself, merge a branch that changes nodes feeding a computed attribute, then compare these two on the destination branch:

```graphql
query {
  all: InfrahubTask(workflow: ["computed_attribute_process_jinja2"]) { count }
  tagged: InfrahubTask(workflow: ["computed_attribute_process_jinja2"], branch: "main") { count }
}
```

Before this change the second count is zero while the first is not.

## Impact & rollout

- **Backward compatibility:** no breaking change. Only adds a tag to newly created flow runs.
- **Deployment notes:** safe to deploy. Runs created before this change stay untagged.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry: not needed, the coalesced pass this fixes has not been released
- [ ] External docs updated (not user-facing beyond the task view)
- [x] I have reviewed AI generated content