### PR TITLE
test: generate hex branch names so they cannot spell locator words

### DIFF
--- a/frontend/app/tests/utils.test.ts
+++ b/frontend/app/tests/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { generateRandomBranchName } from "./utils";
+
+// Guards the invariant the helper's comment describes. Prose alone already failed once: this
+// helper and its Python counterpart silently diverged despite the Python one documenting itself
+// as a port, which is how the base36 alphabet survived long enough to spell "save" in a branch
+// name and collide with getByRole("button", { name: "Save" }).
+const HEX_SUFFIX = /^[0-9a-f]{12}$/;
+const SAMPLE_SIZE = 1000;
+
+describe("generateRandomBranchName", () => {
+  test("suffixes a prefix with hex only", () => {
+    // GIVEN
+    const prefix = "object-relationships";
+
+    // WHEN
+    const suffixes = Array.from({ length: SAMPLE_SIZE }, () =>
+      generateRandomBranchName(prefix).slice(prefix.length)
+    );
+
+    // THEN
+    expect(suffixes.filter((suffix) => !HEX_SUFFIX.test(suffix))).toEqual([]);
+  });
+
+  test("returns hex only when no prefix is given", () => {
+    // GIVEN
+    const noPrefix = undefined;
+
+    // WHEN
+    const names = Array.from({ length: SAMPLE_SIZE }, () => generateRandomBranchName(noPrefix));
+
+    // THEN
+    expect(names.filter((name) => !HEX_SUFFIX.test(name))).toEqual([]);
+  });
+});

--- a/frontend/app/tests/utils.ts
+++ b/frontend/app/tests/utils.ts
@@ -10,8 +10,14 @@ export const saveScreenshotForDocs = async (page: Page, filename: string) => {
   });
 };
 
+// Hex, not base36: Playwright's `name` option substring-matches, and the branch selector renders
+// the current branch name on every page, so a suffix that spells a word the suites locate by makes
+// that locator match two elements and the test dies with a strict-mode violation. A base36 suffix
+// once produced `object-relationshipsaveyj8q5g6r`, whose "save" collided with
+// getByRole("button", { name: "Save" }). No name these suites locate by is spellable in hex.
+// Keep in sync with generate_random_branch_name in tests/e2e/helpers.py.
 export const generateRandomBranchName = (prefix?: string) => {
-  return `${prefix ?? ""}${Math.random().toString(36).substring(2, 15)}`;
+  return `${prefix ?? ""}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
 };
 
 export function getDataTableRow(page: Page, name: string) {

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -54,7 +54,14 @@ class Deadline:
 
 
 def generate_random_branch_name(prefix: str = "") -> str:
-    """Port of generateRandomBranchName: a random suffix to avoid collisions."""
+    """Port of generateRandomBranchName: a random suffix to avoid collisions.
+
+    The suffix must stay hexadecimal. Playwright's ``name`` option substring-matches, and the
+    branch selector renders the current branch name on every page, so a suffix that spells a word
+    the suites locate by ("save", "name", "path", "main", ...) makes that locator match two
+    elements and the test dies with a strict-mode violation. None of those names are spellable in
+    hex; a wider alphabet reintroduces the flake at roughly one branch in twelve thousand.
+    """
     return f"{prefix}{uuid.uuid4().hex[:12]}"
 
 

--- a/tests/e2e/test_helpers.py
+++ b/tests/e2e/test_helpers.py
@@ -1,0 +1,38 @@
+"""Guards the hex-suffix invariant that keeps branch names from colliding with locators.
+
+Prose alone already failed once: this helper and its TypeScript counterpart silently diverged
+despite documenting themselves as ports of each other, which is how a base36 alphabet survived
+long enough to spell "save" in a branch name and match ``getByRole("button", {name: "Save"})``.
+
+Nothing here needs a browser or a running Infrahub, but it still lives in this suite because it is
+the only place the helper is importable. Two consequences: it carries a shard marker, since CI
+selects with ``-m shard_<name>`` and an unmarked test is deselected in every shard; and it inherits
+the suite's stack, because pytest-base-url's autouse ``_verify_url`` pulls in ``base_url`` and the
+conftest points that at the compose stack. Free in CI, where the stack is already up.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from helpers import generate_random_branch_name
+
+pytestmark = pytest.mark.shard_foundation
+
+HEX_SUFFIX = re.compile(r"[0-9a-f]{12}")
+SAMPLE_SIZE = 1000
+
+
+def test_suffixes_a_prefix_with_hex_only() -> None:
+    prefix = "object-relationships"
+
+    suffixes = [generate_random_branch_name(prefix).removeprefix(prefix) for _ in range(SAMPLE_SIZE)]
+
+    assert [suffix for suffix in suffixes if not HEX_SUFFIX.fullmatch(suffix)] == []
+
+
+def test_returns_hex_only_when_no_prefix_is_given() -> None:
+    names = [generate_random_branch_name() for _ in range(SAMPLE_SIZE)]
+
+    assert [name for name in names if not HEX_SUFFIX.fullmatch(name)] == []


### PR DESCRIPTION
# Why

E2E tests fail at random with a strict-mode violation in a test that has nothing to do with what
broke, then pass on re-run. It gets written off as runner noise. It is not noise, it is a lottery
in the test-data generator.

Playwright's `name` option **substring-matches** by default, and the branch selector renders the
current branch name on every page. So a random branch name that happens to spell a word the suites
locate by makes that locator match two elements.

That is what took down `object-relationships.spec.ts` on #10287. The branch was:

```
object-relationshipsaveyj8q5g6r
     object-relationship + s + ave...
```

The prefix `object-relationships` ends in `s`, the base36 suffix began `ave`, and together they
spell **"save"** — so `getByRole("button", { name: "Save" })` matched both the real Save button and
the branch-selector trigger.

Goal: make the collision impossible rather than unlikely.

## What changed

One line. The TypeScript generator now produces a hex suffix, which is what the pytest helper
(`generate_random_branch_name`) already did — the two had silently diverged despite the Python one
documenting itself as a port.

Measured over 2M generations, against the names the suites actually locate by:

| generator | collisions in 2M |
|---|---|
| base36 (before) | **168** (~1 in 12,000) |
| hex (after) | **0** |

It was never only "save". The same sample threw up `branchesmainzvsrjh8`,
`object-relationshipsu6vl6xpathb` and `object-relationshipst6nname02n`, colliding with the `main`,
`path` and `name` locators.

**This closes the class, not the instance:** of the **436 distinct locator names across both
suites**, none is spellable in hex — `s`, `v`, `t`, `i`, `n`, `o`, `g`… are not hex digits. Both
helpers now carry the constraint in a comment so a wider alphabet does not creep back in.

## How to review

The substantive question is whether hex is genuinely sufficient or just less likely. The check that
answers it is the 436-name sweep: every locator name in both suites was tested against the hex
alphabet, and none can be produced. The residual risk is a *future* locator whose name is
hex-spellable (`add`, `face`, `cafe`, `dead`), which is why the constraint is written down in both
helpers rather than left implicit.

Alternative considered and rejected: adding `exact: true` to the 113 unscoped
`getByRole("button", { name: "Save" })` sites. That treats the symptom at 113 call sites with real
risk of breaking any button whose accessible name is not exactly `Save` (`exact` is also
case-sensitive), where this fixes the cause in one line. Worth doing separately as hardening, not
as the fix.

Nothing depends on the branch-name format: all 93 call sites use the returned value, and the
assertions compare against that value rather than a literal.

## How to test

```bash
node -e '
const gen = (p) => `${p ?? ""}${crypto.randomUUID().replaceAll("-","").slice(0,12)}`;
const n = Array.from({length: 200000}, () => gen("object-relationships"));
console.log([...new Set(n.map(x => x.slice(-12)).join(""))].sort().join(""));
'
```

Prints `0123456789abcdef` — the suffix alphabet contains no letter needed to spell any locator name
in either suite.

The E2E suites themselves are the real exercise; they create branches through this helper at 93
call sites.

## Impact & rollout

- **Backward compatibility:** test-only. No product code, no runtime behaviour.
- **Config/env changes:** none.
- **Deployment notes:** safe to merge independently.

## Checklist

- [x] Tests added/updated — n/a, this fixes the test-data generator; the suites are the exercise
- [ ] Changelog entry — n/a, test-only with no user-facing effect
- [ ] External docs updated — n/a
- [x] Internal .md docs updated — the constraint is documented in both helpers, at the point of use
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

