### PR TITLE
docs(deploy): lower the medium sizing preset DB heap to 16G

### DIFF
--- a/docs/archive/guides/installation.mdx
+++ b/docs/archive/guides/installation.mdx
@@ -371,8 +371,8 @@ You can also specify a sizing preset in the URL. This will automatically configu
 | Size   | Total required memory | API workers | Task workers | Task manager API workers | Task manager background workers | DB heap size | DB page cache size |
 | ----------- | ----- | - | - | - | - | --- | --- |
 | small       | 16 GB  | 4 | 2 | 1 | 1 | 8G  | 1G  |
-| medium      | 32 GB | 4 | 4 | 2 | 2 | 24G | 4G  |
-| medium-data | 32 GB | 4 | 2 | 1 | 1 | 24G | 4G  |
+| medium      | 32 GB | 4 | 4 | 2 | 2 | 16G | 4G  |
+| medium-data | 32 GB | 4 | 2 | 1 | 1 | 16G | 4G  |
 | large       | 64 GB | 4 | 8 | 4 | 2 | 31G | 16G |
 | large-data  | 64 GB | 4 | 2 | 1 | 1 | 31G | 16G |
 

--- a/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
+++ b/docs/docs/deploy-manage/install-configure/install/enterprise.mdx
@@ -38,8 +38,8 @@ You can also specify a sizing preset in the URL. This will automatically configu
 | Size        | Total required memory | API workers | Task workers | Task manager API workers | Task manager background workers | DB heap size | DB page cache size |
 |-------------|-----------------------|-------------|--------------|--------------------------|--------------------------------|--------------|--------------------|
 | small       | 16 GB                 | 4           | 2            | 1                        | 1                              | 8G           | 1G                 |
-| medium      | 32 GB                 | 4           | 4            | 2                        | 2                              | 24G          | 4G                 |
-| medium-data | 32 GB                 | 4           | 2            | 1                        | 1                              | 24G          | 4G                 |
+| medium      | 32 GB                 | 4           | 4            | 2                        | 2                              | 16G          | 4G                 |
+| medium-data | 32 GB                 | 4           | 2            | 1                        | 1                              | 16G          | 4G                 |
 | large       | 64 GB                 | 4           | 8            | 4                        | 2                              | 31G          | 16G                |
 | large-data  | 64 GB                 | 4           | 2            | 1                        | 1                              | 31G          | 16G                |
 


### PR DESCRIPTION
## Summary

The `medium` and `medium-data` sizing presets in the Enterprise install docs both listed a **24G** Neo4j heap against a **32 GB** total memory budget — that leaves nothing for the 4G page cache, the API/task workers, and the rest of the stack. Both rows now read **16G**.

## Changes

- `docs/docs/deploy-manage/install-configure/install/enterprise.mdx` — sizing table
- `docs/archive/guides/installation.mdx` — same table in the archived install guide, kept in sync

Only the DB heap column changed; worker counts, page cache, and the small/large rows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

