### PR TITLE
ci: add infrahub-solution-ai-dc to repository-dispatch targets

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -37,6 +37,7 @@ jobs:
         repo:
           - "opsmill/infrahub-demo-dc"
           - "opsmill/infrahub-demo-sp"
+          - "opsmill/infrahub-solution-ai-dc"
           - "INFRAHUB_PACKER_REPOSITORY"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"


### PR DESCRIPTION
## Summary
- Add `opsmill/infrahub-solution-ai-dc` to the repository-dispatch matrix so it receives `trigger-infrahub-update` events.

## Test plan
- [ ] Verify the workflow triggers a dispatch event to `opsmill/infrahub-solution-ai-dc` on the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

