### PR TITLE
fix(backend): apply transaction retry to relationship-remove schema migration

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -122,6 +122,7 @@ Each entry says *when* to load it — open the doc before working in that area.
 - `dev/guides/backend/creating-events.md` - Creating new events
 - `dev/guides/backend/creating-async-tasks.md` - How to create an async task, with a pre-submit checklist. Load when adding a `@task`/`@flow`.
 - `dev/guides/backend/creating-messages.md` - Creating message bus messages
+- `dev/guides/backend/creating-migrations.md` - Choosing a migration base class, `GRAPH_VERSION` bookkeeping, batching, and transaction retry. Load when adding a graph or schema migration.
 
 ### ADRs (Why we decided)
 

--- a/backend/infrahub/core/migrations/schema/node_relationship_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_relationship_remove.py
@@ -7,6 +7,7 @@ from infrahub.core.constants import RelationshipStatus
 from infrahub.core.query import QueryType
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.database import retry_db_transaction
 
 from ..query import MigrationBaseQuery
 from ..shared import MigrationResult, RelationshipSchemaMigration
@@ -256,6 +257,7 @@ class NodeRelationshipRemoveMigration(RelationshipSchemaMigration):
             rel_identifiers=rel_identifiers,
         )
 
+    @retry_db_transaction(name="relationship_remove_schema_migration")
     async def execute(
         self,
         migration_input: MigrationInput,

--- a/dev/guides/backend/creating-migrations.md
+++ b/dev/guides/backend/creating-migrations.md
@@ -24,6 +24,8 @@ Choose the right base class in `backend/infrahub/core/migrations/shared.py`:
 - **`ArbitraryMigration`** — Implements a custom `execute()` method. Use when you need Python logic (e.g., JSON parsing, conditional branching, batching decisions driven by fetched data).
 - **`InternalSchemaMigration`** — Modifies internal schema definitions. Rarely used directly.
 
+`SchemaMigration` is a separate family under `backend/infrahub/core/migrations/schema/`, registered in `MIGRATION_MAP` and selected by the schema diff rather than by `GRAPH_VERSION`. Steps 1-3 below do not apply to it, but the retry rule does.
+
 ## Steps
 
 ### Step 1: Create the Migration File
@@ -67,6 +69,8 @@ class Migration070(ArbitraryMigration):
 Set `minimum_version` to the current `GRAPH_VERSION` (the migration runs when upgrading from that version).
 
 **Transient database errors.** `SchemaMigration` and `GraphMigration` own their transaction and carry `retry_db_transaction`, so a transient error (a deadlock, or an entity a concurrent migration removed) is replayed on a fresh transaction with backoff and jitter instead of failing the migration; their inner query loops let those errors propagate to the transaction owner. This matters when migrations of the same kind run concurrently (schema path migrations execute as a batch). The catch-all `except` shown above belongs to `ArbitraryMigration`/`execute` overrides that run serially during upgrade and record every error as a failed `MigrationResult`; if you override `execute` to own a transaction on a concurrent path, add `retry_db_transaction` and do not catch retriable errors inside the transaction. See [Database Schema — Transaction Retry](../../knowledge/backend/database-schema.md#transaction-retry).
+
+**Overriding `execute` discards the decorator.** A `SchemaMigration` subclass that overrides `execute` to open its own transaction must reapply `@retry_db_transaction(name="schema_migration")` — `node_relationship_remove.py` is the worked example. A subclass that only guards a condition and then delegates to `super().execute(...)` is already covered by the base and must not add it again, or the two retries nest.
 
 ### Step 2: Bump `GRAPH_VERSION`
 

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -376,6 +376,8 @@ Backoff is configured under the `database` settings (`INFRAHUB_DB_RETRY_*` envir
 
 **The retry must run at the transaction owner.** A method decorated with `retry_db_transaction` opens the transaction it retries. Code running *inside* that transaction (a query loop, a nested helper) must let a retriable error propagate to the owner rather than catching it and returning a failed result: a caught error still leaves the transaction poisoned, so the commit fails with a non-retryable `TransactionError` and the replay never happens. Only paths that run outside any transaction (they skip the transaction wrapper and have no owner to replay them) record the error as a failure instead. Gate that choice on `db.is_transaction`.
 
+The corollary for subclasses: the decorator is applied to a specific method, so overriding a decorated method discards it. A subclass that overrides the base's transaction-owning method and opens its own transaction has to reapply the decorator; one that delegates back to `super()` inherits the retry and must not.
+
 This transaction-layer retry is distinct from Prefect task retry (see [Async Tasks — Failure handling](async-tasks.md#failure-handling)): a task retry re-runs the failed task with no delay between attempts, so a batch of concurrent tasks that deadlock on the same nodes retry at the same time and deadlock again. Transient database errors belong to the transaction-layer retry, which spaces replays with backoff and jitter so contending writers separate.
 
 ## See Also


### PR DESCRIPTION
`NodeRelationshipRemoveMigration` overrides `SchemaMigration.execute` to open its own transaction rather than delegating to the base, which discarded the `retry_db_transaction` decorator applied to the base method. A transient error inside that transaction failed the migration instead of being replayed.

Document the rule where migrations are authored, since an override silently dropping an inherited decorator is easy to repeat.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

