### PR TITLE
fix: flush stale PENDING flow runs alongside RUNNING ones

### DIFF
--- a/backend/infrahub/cli/tasks.py
+++ b/backend/infrahub/cli/tasks.py
@@ -15,6 +15,10 @@ from infrahub.workflows.models import WorkerPoolDefinition
 
 app = AsyncTyper()
 
+# States a flow run can be stuck in: RUNNING for a worker that died mid-flow, PENDING for one
+# that was picked up but never got to start.
+STALE_FLOW_RUN_STATES = [StateType.RUNNING, StateType.PENDING]
+
 
 @app.command()
 async def init(
@@ -87,7 +91,7 @@ async def stale_runs(
     days_to_keep: int = 2,
     batch_size: int = 100,
 ) -> None:
-    """Flush stale task runs."""
+    """Flush stale task runs, marking long RUNNING or PENDING flow runs as crashed."""
     logging.getLogger("infrahub").setLevel(logging.WARNING)
     logging.getLogger("neo4j").setLevel(logging.ERROR)
     logging.getLogger("prefect").setLevel(logging.ERROR)
@@ -95,5 +99,5 @@ async def stale_runs(
     config.load_and_exit(config_file_name=config_file)
 
     await PrefectTask.delete_flow_runs(
-        states=[StateType.RUNNING], delete=False, days_to_keep=days_to_keep, batch_size=batch_size
+        states=STALE_FLOW_RUN_STATES, delete=False, days_to_keep=days_to_keep, batch_size=batch_size
     )


### PR DESCRIPTION
# Why

`infrahub tasks flush stale-runs` is the escape hatch for flow runs that a dead worker
left behind, but it only ever reset runs stuck in `RUNNING`. A worker that dies after
moving a run `SCHEDULED → PENDING` but before it reaches `RUNNING` leaves the run
`PENDING` forever, and the flush command walks straight past it — the operator has to
find and delete the run by hand in the Prefect UI.

Goal: make the command clear those runs too, so the documented recovery step actually
recovers the stuck deployment.

Non-goals: this does not fix the root cause behind #9856 (in-memory concurrency lease
storage leaking the deployment slot across a task-manager restart). It only makes the
manual escape hatch work on `PENDING` runs.

Refs #9856

## What changed

Behavioral changes:

- `infrahub tasks flush stale-runs` now marks stale `PENDING` flow runs as crashed, in
  addition to stale `RUNNING` ones. Crashing the run releases its deployment
  concurrency slot, which unwedges `concurrency_limit=1` deployments such as
  `clean-up-deadlocks`.

Implementation notes:

- The states are now a named `STALE_FLOW_RUN_STATES` constant so the reason both states
  count as stale is documented next to the list.
- No change was needed to the age cutoff. A `PENDING` run has no `start_time` (Prefect
  only sets it on the `RUNNING` transition), but Prefect's `start_time` filter is
  `coalesce(start_time, expected_start_time)` server-side
  (`prefect/server/schemas/filters.py`), so `days_to_keep` already ages never-started
  runs correctly off `expected_start_time`.

What stayed the same:

- `flush flow-runs` (the delete-old-runs command) is untouched.
- `SCHEDULED` and terminal states are still left alone.
- `PrefectTask.delete_flow_runs` itself is unchanged — only its caller.

## How to review

The whole diff is `backend/infrahub/cli/tasks.py`, +6/-2.

The one non-obvious claim worth checking is the `coalesce` behaviour above — it is what
makes the one-line state-list change sufficient rather than needing a separate
`expected_start_time` filter for `PENDING`.

## How to test

Verified locally against the Prefect test harness with a throwaway component test
(created four runs — `PENDING`, `RUNNING`, `SCHEDULED`, `COMPLETED`):

- `days_to_keep=0` → `PENDING` and `RUNNING` become `CRASHED`; `SCHEDULED` and
  `COMPLETED` are untouched.
- `days_to_keep=1` → nothing is touched.
- Removing `PENDING` from the state list makes the first case fail, confirming the
  change is what does the work.

That test is **not** part of this PR — it was dropped at the author's request. Reviewers
who want it in the tree, say so and I'll add it back.

Manual check against a running stack:

```bash
# with a flow run stranded in PENDING older than the cutoff
invoke backend.cli -- tasks flush stale-runs --days-to-keep 0
```

## Impact & rollout

- **Backward compatibility:** no interface change — same command, same flags. Only the
  set of runs it acts on widens.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy. The command is operator-invoked, not on any
  automatic path.

## Checklist

- [ ] Tests added/updated — written and passing locally, removed from the branch at the author's request
- [ ] Changelog entry — written, then removed at the author's request
- [x] External docs updated (if user-facing or ops-facing change) — n/a, the `tasks` CLI is not in the generated CLI reference (`tasks/docs.py`) and is not referenced in `docs/`
- [x] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

