### PR TITLE
test: generate hex branch names so they cannot spell locator words (backport #10291)

### DIFF
--- a/frontend/app/tests/utils.test.ts
+++ b/frontend/app/tests/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { generateRandomBranchName } from "./utils";
+
+// Guards the invariant the helper's comment describes. Prose alone already failed once: this
+// helper and its Python counterpart silently diverged despite the Python one documenting itself
+// as a port, which is how the base36 alphabet survived long enough to spell "save" in a branch
+// name and collide with getByRole("button", { name: "Save" }).
+const HEX_SUFFIX = /^[0-9a-f]{12}$/;
+const SAMPLE_SIZE = 1000;
+
+describe("generateRandomBranchName", () => {
+  test("suffixes a prefix with hex only", () => {
+    // GIVEN
+    const prefix = "object-relationships";
+
+    // WHEN
+    const suffixes = Array.from({ length: SAMPLE_SIZE }, () =>
+      generateRandomBranchName(prefix).slice(prefix.length)
+    );
+
+    // THEN
+    expect(suffixes.filter((suffix) => !HEX_SUFFIX.test(suffix))).toEqual([]);
+  });
+
+  test("returns hex only when no prefix is given", () => {
+    // GIVEN
+    const noPrefix = undefined;
+
+    // WHEN
+    const names = Array.from({ length: SAMPLE_SIZE }, () => generateRandomBranchName(noPrefix));
+
+    // THEN
+    expect(names.filter((name) => !HEX_SUFFIX.test(name))).toEqual([]);
+  });
+});

--- a/frontend/app/tests/utils.ts
+++ b/frontend/app/tests/utils.ts
@@ -10,8 +10,14 @@ export const saveScreenshotForDocs = async (page: Page, filename: string) => {
   });
 };
 
+// Hex, not base36: Playwright's `name` option substring-matches, and the branch selector renders
+// the current branch name on every page, so a suffix that spells a word the suites locate by makes
+// that locator match two elements and the test dies with a strict-mode violation. A base36 suffix
+// once produced `object-relationshipsaveyj8q5g6r`, whose "save" collided with
+// getByRole("button", { name: "Save" }). No name these suites locate by is spellable in hex.
+// Keep in sync with generate_random_branch_name in tests/e2e/helpers.py.
 export const generateRandomBranchName = (prefix?: string) => {
-  return `${prefix ?? ""}${Math.random().toString(36).substring(2, 15)}`;
+  return `${prefix ?? ""}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
 };
 
 export function getDataTableRow(page: Page, name: string) {

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -54,7 +54,14 @@ class Deadline:
 
 
 def generate_random_branch_name(prefix: str = "") -> str:
-    """Port of generateRandomBranchName: a random suffix to avoid collisions."""
+    """Port of generateRandomBranchName: a random suffix to avoid collisions.
+
+    The suffix must stay hexadecimal. Playwright's ``name`` option substring-matches, and the
+    branch selector renders the current branch name on every page, so a suffix that spells a word
+    the suites locate by ("save", "name", "path", "main", ...) makes that locator match two
+    elements and the test dies with a strict-mode violation. None of those names are spellable in
+    hex; a wider alphabet reintroduces the flake at roughly one branch in twelve thousand.
+    """
     return f"{prefix}{uuid.uuid4().hex[:12]}"
 
 

--- a/tests/e2e/test_helpers.py
+++ b/tests/e2e/test_helpers.py
@@ -1,0 +1,38 @@
+"""Guards the hex-suffix invariant that keeps branch names from colliding with locators.
+
+Prose alone already failed once: this helper and its TypeScript counterpart silently diverged
+despite documenting themselves as ports of each other, which is how a base36 alphabet survived
+long enough to spell "save" in a branch name and match ``getByRole("button", {name: "Save"})``.
+
+Nothing here needs a browser or a running Infrahub, but it still lives in this suite because it is
+the only place the helper is importable. Two consequences: it carries a shard marker, since CI
+selects with ``-m shard_<name>`` and an unmarked test is deselected in every shard; and it inherits
+the suite's stack, because pytest-base-url's autouse ``_verify_url`` pulls in ``base_url`` and the
+conftest points that at the compose stack. Free in CI, where the stack is already up.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from helpers import generate_random_branch_name
+
+pytestmark = pytest.mark.shard_foundation
+
+HEX_SUFFIX = re.compile(r"[0-9a-f]{12}")
+SAMPLE_SIZE = 1000
+
+
+def test_suffixes_a_prefix_with_hex_only() -> None:
+    prefix = "object-relationships"
+
+    suffixes = [generate_random_branch_name(prefix).removeprefix(prefix) for _ in range(SAMPLE_SIZE)]
+
+    assert [suffix for suffix in suffixes if not HEX_SUFFIX.fullmatch(suffix)] == []
+
+
+def test_returns_hex_only_when_no_prefix_is_given() -> None:
+    names = [generate_random_branch_name() for _ in range(SAMPLE_SIZE)]
+
+    assert [name for name in names if not HEX_SUFFIX.fullmatch(name)] == []


### PR DESCRIPTION
# Why

Backport of #10291 to `stable`. The bug is present here unchanged: `generateRandomBranchName` still
uses a base36 suffix, so a random branch name can spell a word the E2E suites locate by.

Playwright's `name` option **substring-matches** by default, and the branch selector renders the
current branch name on every page. On develop this produced the branch
`object-relationshipsaveyj8q5g6r` — prefix ending in `s`, suffix starting `ave`, spelling
**"save"** — which made `getByRole("button", { name: "Save" })` match both the real Save button and
the branch-selector trigger, killing the test with a strict-mode violation.

It presents as an unrelated test failing for no reason and passing on re-run, so it gets written
off as runner noise.

## What changed

Cherry-picked with `-x` from develop, unmodified:

- `17fb4d644` ← `4cf2b301f` — switch the TypeScript generator to hex, matching the pytest helper
  (`generate_random_branch_name`), which already used `uuid4().hex[:12]`. The two had silently
  diverged despite the Python one documenting itself as a port.
- `e4c2fb283` ← `ecb56d0d4` — assert the `[0-9a-f]{12}` invariant on both sides, so the constraint
  is machine-checked rather than living only in a comment.

Measured on develop over 2M generations: base36 produced **168** collisions (~1 in 12,000), hex
**0**. It was never only "save" — the sample also threw up `branchesmainzvsrjh8`,
`...u6vl6xpathb` and `...t6nname02n`, hitting the `main`, `path` and `name` locators.

## Verified against `stable`, not assumed from develop

`stable`'s frontend differs structurally (no pnpm workspace, `file:` deps, no `@infrahub/graph`),
so the sweep was re-run here rather than carried over:

- **415 distinct locator names** across both E2E suites on `stable` — **none** is spellable in hex.
- 113 unscoped `name: "Save"` sites in the TypeScript suite, 111 in the pytest suite.

So the fix closes the class on this branch too, not just the one instance.

## Merge-conflict risk: none

Every line touched is byte-identical to develop. Blob hashes:

| file | stable backport | develop |
|---|---|---|
| `frontend/app/tests/utils.ts` | `619b2d9e` | `619b2d9e` |
| `frontend/app/tests/utils.test.ts` | `01f8a092` | `01f8a092` |
| `tests/e2e/test_helpers.py` | `8d00a125` | `8d00a125` |

`tests/e2e/helpers.py` differs between the branches, but only by 12 lines of **pre-existing**
drift — the `generate_random_branch_name` function and its docstring are byte-identical on both
sides (same md5). This backport adds no conflict surface.

## How to test

```bash
cd frontend/app && pnpm test    # includes tests/utils.test.ts
uv run pytest -c tests/e2e/pytest.ini tests/e2e/test_helpers.py -m shard_foundation
```

Run on this branch: the invariant tests pass (2 + 2), the full app suite is 129 files / 841 tests
green, betterer unchanged, biome and ruff clean.

The Python test needs its shard marker because CI selects with `-m shard_<name>`, so an unmarked
test would be deselected in every shard and silently never run.

## Impact & rollout

- **Backward compatibility:** test-only. No product code, no runtime behaviour.
- **Config/env changes:** none.
- **Deployment notes:** safe to merge independently.

## Checklist

- [x] Tests added/updated — the invariant tests come with the backport
- [ ] Changelog entry — n/a, test-only with no user-facing effect
- [ ] External docs updated — n/a
- [x] Internal .md docs updated — the constraint is documented in both helpers
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

