### PR TITLE
fix(backend): annotate COMMAND_MAP so message dispatch type-checks

### DIFF
--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Awaitable, Callable
+
 import ujson
 from prefect import Flow
 
@@ -8,7 +10,11 @@ from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
 
-COMMAND_MAP = {
+# Annotated for the same reason MESSAGE_MAP is: the routing key selects both the message class
+# and its handler, so they always agree at runtime, but that correspondence is not expressible
+# in the type system. Without the annotation the value type infers as a union of the eight
+# concrete handler signatures, and dispatching a base InfrahubMessage fails against every one.
+COMMAND_MAP: dict[str, Callable[..., Awaitable[None]]] = {
     "git.file.get": git.file.get,
     "git.repository.connectivity": git.repository.connectivity,
     "refresh.git.fetch": git.repository.fetch,


### PR DESCRIPTION
# Why

**`stable` has four latent `ty` errors that will block the next PR touching any Python file.** This
PR proposes a fix, but I need a backend opinion on whether it expresses the intent correctly —
see *Questions* below.

`python-lint` runs `uv run ty check .` over the whole repo, and it fails at
`backend/infrahub/message_bus/operations/__init__.py:33`:

```python
await func(message=message)   # Expected `GitFileGet`, found `InfrahubMessage`
```

Four diagnostics, one per handler whose signature it cannot satisfy.

## Why nobody has hit this

The job is path-gated:

```yaml
if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.python == 'true'
```

`python-lint` is **skipped on stable's own runs** — the last four are all `skipped`. The errors only
surface when a PR happens to touch a `.py` file. #10301 (a frontend test backport that adds one
test under `tests/e2e/`) tripped it, which is how this was found.

So this is not a new regression, it is a latent one, and it blocks any Python-touching PR to
`stable` until it is resolved.

## The proposed fix

`COMMAND_MAP` is unannotated, so its value type infers as the union of the eight concrete handler
signatures (`(message: GitFileGet) -> ...` | `Flow[(message: GitRepositoryConnectivity), ...]` | …).
Dispatching a base `InfrahubMessage` matches none of them.

The routing key selects **both** the message class and its handler, so they always agree at
runtime — but that correspondence is not expressible in the type system. `MESSAGE_MAP` immediately
above is already annotated (`dict[str, type[InfrahubMessage]]`) for the same reason; `COMMAND_MAP`
just never was. This applies the symmetric annotation.

Annotation only — no runtime change. The module still imports and the map still has its eight keys.

## Verification, and its limit

**I could not reproduce this locally**, and I want to be explicit about that rather than imply the
fix is confirmed. On unmodified `stable`, `uv run ty check .` passes here with:

- the pinned `ty 0.0.32` from `uv.lock`,
- CI's Python 3.13 (`uv run --python 3.13`),
- the exact `python_sdk` commit `stable` records (mine was 1156 commits ahead; I synced it to check).

So there is an environment gap between a local `uv sync` and CI's `uv sync --all-groups` that I have
not pinned down. **This PR's own `python-lint` run is therefore the verification.** If it goes
green, the annotation is sufficient; if not, the diagnostics will tell us what else is needed.

## Questions for backend

1. Is `dict[str, Callable[..., Awaitable[None]]]` the right expression of intent, or would you
   rather keep the precise per-handler types and `cast` at the call site?
2. `Callable[..., ...]` deliberately drops parameter checking on the handlers. Given the map mixes
   plain coroutines with Prefect `Flow` objects (and line 32 unwraps `.fn`), is there a shape you'd
   prefer that keeps more checking?
3. Should this also go to `develop`? Its copy of the file differs only by a `noqa` comment, yet its
   `python-lint` passes — so the union it infers is presumably different. Worth a look either way.

## How to test

```bash
uv run ty check .
uv run ruff check . --exclude python_sdk
```

Locally both pass with and without this change, which is exactly the problem. Watch CI's
`python-lint` on this PR.

## Impact & rollout

- **Backward compatibility:** none — a variable annotation, no runtime behaviour change.
- **Config/env changes:** none.
- **Deployment notes:** safe.

## Checklist

- [ ] Tests added/updated — n/a, typing-only; `python-lint` is the check
- [ ] Changelog entry — n/a, no user-facing change
- [ ] External docs updated — n/a
- [x] Internal .md docs updated — rationale is a comment at the point of use
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

