### PR TITLE
docs: cover branch rebase in the upgrade docs

### DIFF
--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/community.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/community.mdx
@@ -92,7 +92,7 @@ invoke demo.start
 
 ## Verify the upgrade
 
-After the `infrahub upgrade` command exits with `Upgrade complete SUCCESS`, run `infrahub db showmigrations` against the same database to confirm every migration shows `[X]` and that the database version matches the target version reported in the header. If any migrations are still pending, re-run `infrahub upgrade`.
+After the `infrahub upgrade` command exits with `Upgrade complete SUCCESS`, run `infrahub db showmigrations` against the same database to confirm every migration shows `[X]` and that the database version matches the target version reported in the header. Then run `infrahub upgrade --check`, which reports pending migrations, core schema differences and branches that still need rebase, so all three parts of the upgrade are covered rather than the migrations alone. Re-run `infrahub upgrade` until it reports nothing outstanding.
 
 If you skipped `--rebase-branches` and the upgrade reported open branches that need rebase, they are left in the `needs-rebase` state. You can rebase them manually later, or re-run with `infrahub upgrade --rebase-branches` (optionally combined with `--interactive` to confirm each branch).
 

--- a/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
+++ b/docs/docs/deploy-manage/maintain-upgrade/upgrade/overview.mdx
@@ -12,6 +12,8 @@ Upgrading Infrahub involves pulling the latest container images, running databas
 
 **Backup first**: Even though a smooth migration is anticipated, we strongly recommend creating a backup before upgrading. See [Backup and restore](../database-backup/backup-and-restore.mdx).
 
+**Open branches**: Run `infrahub upgrade --check` before you start. It reports the branches the upgrade will rebase, so a branch that needs attention first can be resolved or deleted instead of failing during the upgrade.
+
 **Release notes**: Review the [release notes](../../../release-notes/infrahub/) for any version-specific upgrade instructions. In Infrahub 1.2 and later, the upgrade process was streamlined with a unified upgrade command. For earlier versions, refer to the release notes for specific instructions.
 
 ## What the upgrade does
@@ -176,11 +178,11 @@ Select the guide for your edition and deployment:
 
 ### Migration failing because of transaction memory limit reached in Neo4j
 
-For large database/schema migrations, you may encounter a `Transaction memory limit reached` error in Neo4j.
+For large database/schema migrations, you may encounter a `Transaction memory limit reached` error in Neo4j. The branch rebase in Step 6/6 can reach the same limit, because the memory it needs grows with the number of changes on the branch being rebased.
 
 :::info
 
-To work around this, you can disable the transaction memory limit by setting the `dbms.memory.transaction.total.max` to `0` in your Neo4j configuration.
+To work around this, you can disable the transaction memory limit by setting the `dbms.memory.transaction.total.max` to `0` in your Neo4j configuration. The memory is still allocated from the JVM heap, so `server.memory.heap.max_size` also has to be large enough for the operation.
 
 :::
 


### PR DESCRIPTION
## Why

Three gaps in the upgrade docs, each of which an operator hits in practice. Kept deliberately minimal — one addition per gap, no restructuring.

## What changed, and why each line is there

**`overview.mdx` — "Before you upgrade" gains an "Open branches" line**

The section covers upgrade path, backups and release notes, but says nothing about branches, even though Step 6/6 rebases every open branch. A branch that cannot be rebased is therefore discovered mid-upgrade. The line points at `infrahub upgrade --check`, which already reports the branches the upgrade will rebase, so they can be dealt with beforehand.

**`overview.mdx` — the transaction memory known issue gains two sentences**

1. The section is scoped to "large database/schema migrations", but the branch rebase in Step 6/6 can reach the same limit, and its requirement grows with the number of changes on the branch rather than with the size of the database. An operator reading the current text does not expect a rebase failure.
2. Setting `dbms.memory.transaction.total.max` to `0` removes the ceiling, but the memory is still allocated from the JVM heap, so `server.memory.heap.max_size` has to be large enough as well. Without this, the documented workaround can be applied and still fail.

**`community.mdx` — "Verify the upgrade" also uses `--check`**

Verification stopped at `infrahub db showmigrations`, which passes even when the core schema or a branch rebase is still outstanding, so an upgrade can look verified while it is not. `infrahub upgrade --check` reports all three areas.

## Related issues

Reported separately, against 1.10.6:

- #10307 — `validate_database` does not retry `TransientError`, so a command can abort with `DatabaseUnavailable` while Neo4j is still recovering
- #10308 — `infrahub upgrade` prints `Upgrade complete SUCCESS` and exits 0 when branch rebases failed
- #10309 — the per-branch rebase loop only catches `ValidationError` and `MigrationFailureError`, so any other error aborts the remaining branches
- #10310 — branch rebase memory use scales with the branch diff size

The two paragraphs about the memory limit are interim guidance; if #10310 lands they should be revisited.

## Verification

- `uv run invoke docs.lint` — 0 markdownlint errors; vale reports 0 warnings on the changed files (the 25 warnings in the run are pre-existing in other pages)
- `cd docs && npm run build` — succeeds, no broken links or anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)