### PR TITLE
refactor(backend): enable ruff SIM102 and collapse nested if statements

### DIFF
--- a/backend/infrahub/actions/parsers.py
+++ b/backend/infrahub/actions/parsers.py
@@ -34,22 +34,21 @@ class UnresolvedRelationshipError(Exception):
 
 def parse_trigger_rule_response(data: dict[str, Any]) -> list[CoreTriggerRule]:
     rules: list[CoreTriggerRule] = []
-    if kind := data.get(InfrahubKind.TRIGGERRULE):
-        if edges := kind.get("edges"):
-            for edge in edges:
-                node = edge["node"]
-                try:
-                    rule = _parse_graphql_node(node)
-                except UnresolvedRelationshipError as exc:
-                    log.warning(
-                        "Skipping trigger rule with an unresolved relationship",
-                        trigger_rule=node.get("name", {}).get("value"),
-                        trigger_rule_id=node.get("id"),
-                        relationship=exc.relationship_name,
-                    )
-                    continue
-                if rule:
-                    rules.append(rule)
+    if (kind := data.get(InfrahubKind.TRIGGERRULE)) and (edges := kind.get("edges")):
+        for edge in edges:
+            node = edge["node"]
+            try:
+                rule = _parse_graphql_node(node)
+            except UnresolvedRelationshipError as exc:
+                log.warning(
+                    "Skipping trigger rule with an unresolved relationship",
+                    trigger_rule=node.get("name", {}).get("value"),
+                    trigger_rule_id=node.get("id"),
+                    relationship=exc.relationship_name,
+                )
+                continue
+            if rule:
+                rules.append(rule)
 
     return rules
 

--- a/backend/infrahub/auth/auth.py
+++ b/backend/infrahub/auth/auth.py
@@ -589,16 +589,15 @@ async def invalidate_refresh_token(db: InfrahubDatabase, token_id: str) -> bool:
 async def get_groups_from_provider(
     provider: SecurityOAuth2Settings | SecurityOIDCSettings, service: InfrahubServices, payload: dict, user_info: dict
 ) -> list[str]:
-    if isinstance(provider, (SecurityOAuth2Google, SecurityOIDCGoogle)):
-        # Poor man's workaround to fetch user groups from Google
-        if provider.fetch_groups:
-            groups_response = await service.http.get(
-                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
-                headers={"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"},
-            )
-            group_memberships = groups_response.json()
-            if "memberships" in group_memberships:
-                return [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
+    # Poor man's workaround to fetch user groups from Google
+    if isinstance(provider, (SecurityOAuth2Google, SecurityOIDCGoogle)) and provider.fetch_groups:
+        groups_response = await service.http.get(
+            f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
+            headers={"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"},
+        )
+        group_memberships = groups_response.json()
+        if "memberships" in group_memberships:
+            return [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
 
     return []
 

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -299,13 +299,11 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
                 if not is_valid:
                     raise ValidationError({name: f"{validation_value} must conform with the regex: {regex!r}"})
 
-        if min_length := schema.get_min_length():
-            if len(value) < min_length:
-                raise ValidationError({name: f"{value} must have a minimum length of {min_length!r}"})
+        if (min_length := schema.get_min_length()) and len(value) < min_length:
+            raise ValidationError({name: f"{value} must have a minimum length of {min_length!r}"})
 
-        if max_length := schema.get_max_length():
-            if len(value) > max_length:
-                raise ValidationError({name: f"{value} must have a maximum length of {max_length!r}"})
+        if (max_length := schema.get_max_length()) and len(value) > max_length:
+            raise ValidationError({name: f"{value} must have a maximum length of {max_length!r}"})
 
         # Some invalid values may exist due to https://github.com/opsmill/infrahub/issues/6714.
         if config.SETTINGS.main.schema_strict_mode and isinstance(schema.parameters, NumberAttributeParameters):

--- a/backend/infrahub/core/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/core/diff/enricher/cardinality_one.py
@@ -70,9 +70,12 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
                 elif diff_property.changed_at < current_earliest.changed_at:
                     earliest_property_map[prop_type] = diff_property
                 # special handling for a REMOVE and ADD with the same timestamp to treat them as an update
-                elif diff_property.changed_at == current_earliest.changed_at:
-                    if diff_property.action is DiffAction.REMOVED and current_earliest.action is DiffAction.ADDED:
-                        earliest_property_map[prop_type] = diff_property
+                elif (
+                    diff_property.changed_at == current_earliest.changed_at
+                    and diff_property.action is DiffAction.REMOVED
+                    and current_earliest.action is DiffAction.ADDED
+                ):
+                    earliest_property_map[prop_type] = diff_property
 
                 current_latest = latest_property_map.get(prop_type)
                 if not current_latest:
@@ -80,9 +83,12 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
                 elif diff_property.changed_at > current_latest.changed_at:
                     latest_property_map[prop_type] = diff_property
                 # special handling for a REMOVE and ADD with the same timestamp to treat them as an update
-                elif diff_property.changed_at == current_latest.changed_at:
-                    if diff_property.action is DiffAction.ADDED and current_latest.action is DiffAction.REMOVED:
-                        latest_property_map[prop_type] = diff_property
+                elif (
+                    diff_property.changed_at == current_latest.changed_at
+                    and diff_property.action is DiffAction.ADDED
+                    and current_latest.action is DiffAction.REMOVED
+                ):
+                    latest_property_map[prop_type] = diff_property
         return (earliest_property_map, latest_property_map)
 
     def consolidate_cardinality_one_diff_elements(self, diff_relationship: EnrichedDiffRelationship) -> None:

--- a/backend/infrahub/core/diff/model/diff.py
+++ b/backend/infrahub/core/diff/model/diff.py
@@ -163,13 +163,15 @@ class ModifiedPath(BaseModel):
         if self.modification_type != other.modification_type:
             return False
 
-        if self.modification_type == "node":
-            if self.action == other.action and self.action in [DiffAction.REMOVED, DiffAction.UPDATED]:
-                return False
+        if (
+            self.modification_type == "node"
+            and self.action == other.action
+            and self.action in [DiffAction.REMOVED, DiffAction.UPDATED]
+        ):
+            return False
 
-        if self.modification_type == "element":
-            if self.action == other.action and self.action == DiffAction.REMOVED:
-                return False
+        if self.modification_type == "element" and self.action == other.action and self.action == DiffAction.REMOVED:
+            return False
 
         return self.type == other.type and self.node_id == other.node_id
 

--- a/backend/infrahub/core/graphql_query/node_id_query.py
+++ b/backend/infrahub/core/graphql_query/node_id_query.py
@@ -34,9 +34,8 @@ class NodeIDQuery(BaseModel):
         result: list[str] = []
         if kind_payload := response.get(self.kind):
             for edge in kind_payload.get("edges", []):
-                if node := edge.get("node"):
-                    if node_id := node.get("id"):
-                        result.append(node_id)
+                if (node := edge.get("node")) and (node_id := node.get("id")):
+                    result.append(node_id)
         return result
 
     async def fetch_all_paginated(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -421,16 +421,15 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         """
         number_pool_id: str | None = None
         # Templates must use _from_resource_pool relationships, not from_pool
-        if isinstance(self._schema, TemplateSchema):
-            if attribute.from_pool:
-                pool_rel_name = f"{attribute.name}{RESOURCE_POOL_REL_SUFFIX}"
-                raise ValidationError(
-                    {
-                        f"{attribute.name}.from_pool": (
-                            f"'from_pool' is not supported on template attributes. Set the '{pool_rel_name}' relationship on this template instead."
-                        )
-                    }
-                )
+        if isinstance(self._schema, TemplateSchema) and attribute.from_pool:
+            pool_rel_name = f"{attribute.name}{RESOURCE_POOL_REL_SUFFIX}"
+            raise ValidationError(
+                {
+                    f"{attribute.name}.from_pool": (
+                        f"'from_pool' is not supported on template attributes. Set the '{pool_rel_name}' relationship on this template instead."
+                    )
+                }
+            )
 
         # Case 1: Schema-defined NumberPool attribute
         if (
@@ -984,10 +983,15 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
     async def process_label(self, db: InfrahubDatabase | None = None) -> None:  # noqa: ARG002
         # If there label and name are both defined for this node
         #  if label is not define, we'll automatically populate it with a human friendy vesion of name
-        if not self._existing and hasattr(self, "label") and hasattr(self, "name"):
-            if self.label.value is None and self.name.value:
-                self.label.value = " ".join([word.title() for word in self.name.value.split("_")])
-                self.label.is_default = False
+        if (
+            not self._existing
+            and hasattr(self, "label")
+            and hasattr(self, "name")
+            and self.label.value is None
+            and self.name.value
+        ):
+            self.label.value = " ".join([word.title() for word in self.name.value.split("_")])
+            self.label.is_default = False
 
     async def new(self, db: InfrahubDatabase, id: str | None = None, process_pools: bool = True, **kwargs: Any) -> Self:
         if id and not is_valid_uuid(id):
@@ -1022,17 +1026,20 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         # If we are creating a new node, we need to resolve extra filters from Display Labels or HFIDs, if we don't do
         # this the fields might be blank.
         # We could also need it when we need to recompute the Display Labels or HFIDs
-        if (not self._existing) or self._human_friendly_id:
-            if hfid := schema_branch.hfids.get_template_nodes().get(self._schema.kind):
-                definitions.append(hfid)
-        if (not self._existing) or self._display_label:
-            if display_labels := schema_branch.display_labels.get_template_nodes().get(self._schema.kind):
-                definitions.append(display_labels)
+        if ((not self._existing) or self._human_friendly_id) and (
+            hfid := schema_branch.hfids.get_template_nodes().get(self._schema.kind)
+        ):
+            definitions.append(hfid)
+        if ((not self._existing) or self._display_label) and (
+            display_labels := schema_branch.display_labels.get_template_nodes().get(self._schema.kind)
+        ):
+            definitions.append(display_labels)
 
         # For existing nodes (updates), also include peer attributes needed by Jinja2 computed attribute templates
-        if self._existing:
-            if computed := schema_branch.computed_attributes.get_registered_jinja2_node(self._schema.kind):
-                definitions.append(computed)
+        if self._existing and (
+            computed := schema_branch.computed_attributes.get_registered_jinja2_node(self._schema.kind)
+        ):
+            definitions.append(computed)
 
         return self._merge_relationship_fields(definitions)
 
@@ -1146,13 +1153,15 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 updated_relationship = await rel.save(db=db, user_id=user_id, at=update_at)
                 node_changelog.add_relationship(relationship_changelog=updated_relationship)
 
-        if len(processed_relationships) != len(self._relationships):
-            # Analyze if the node has a parent and add it to the changelog if missing
-            if parent_relationship := self._get_parent_relationship_name():
-                if parent_relationship not in processed_relationships:
-                    rel = self.get_relationship(name=parent_relationship)
-                    if parent := await rel.get_parent(db=db):
-                        node_changelog.add_parent_from_relationship(parent=parent)
+        # Analyze if the node has a parent and add it to the changelog if missing
+        if (
+            len(processed_relationships) != len(self._relationships)
+            and (parent_relationship := self._get_parent_relationship_name())
+            and parent_relationship not in processed_relationships
+        ):
+            rel = self.get_relationship(name=parent_relationship)
+            if parent := await rel.get_parent(db=db):
+                node_changelog.add_parent_from_relationship(parent=parent)
 
         # Recompute Jinja2 computed attributes affected by the updated fields
         await self._recompute_local_jinja2(
@@ -1218,17 +1227,19 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 node_changelog.add_attribute(attribute=deleted_attribute)
 
         if self._human_friendly_id:
-            if deleted_attribute := await self._human_friendly_id.get_node_attribute(node=self, at=delete_at).delete(
+            deleted_attribute = await self._human_friendly_id.get_node_attribute(node=self, at=delete_at).delete(
                 db=db,
                 user_id=user_id,
                 at=delete_at,
-            ):
+            )
+            if deleted_attribute:
                 node_changelog.add_attribute(attribute=deleted_attribute)
 
         if self._display_label:
-            if deleted_attribute := await self._display_label.get_node_attribute(node=self, at=delete_at).delete(
+            deleted_attribute = await self._display_label.get_node_attribute(node=self, at=delete_at).delete(
                 db=db, at=delete_at, user_id=user_id
-            ):
+            )
+            if deleted_attribute:
                 node_changelog.add_attribute(attribute=deleted_attribute)
 
         branch = self.get_branch_based_on_support_type()

--- a/backend/infrahub/core/node/delete_validator.py
+++ b/backend/infrahub/core/node/delete_validator.py
@@ -163,9 +163,8 @@ class NodeDeleteValidator:
                     src_kind=peer_data.source_kind, relationship_identifier=peer_data.identifier
                 )
                 peer_id = str(peer_data.destination_id)
-                if DeleteRelationshipType.CASCADE_DELETE in relationship_types:
-                    if peer_id not in node_ids_to_delete:
-                        node_ids_to_check.add(peer_id)
+                if DeleteRelationshipType.CASCADE_DELETE in relationship_types and peer_id not in node_ids_to_delete:
+                    node_ids_to_check.add(peer_id)
                 if DeleteRelationshipType.DEPENDENT_NODE in relationship_types:
                     if peer_id not in dependent_node_details_map:
                         dependent_node_details_map[peer_id] = []

--- a/backend/infrahub/core/node/proposed_change.py
+++ b/backend/infrahub/core/node/proposed_change.py
@@ -28,18 +28,17 @@ class CoreProposedChange(Node):
             include_properties=include_properties,
         )
 
-        if fields:
-            if "total_comments" in fields:
-                total_comments = 0
-                proposed_change = cast("CoreProposedChangeProtocol", self)
-                change_comments = await proposed_change.comments.get_relationships(db=db)
-                total_comments += len(change_comments)
+        if fields and "total_comments" in fields:
+            total_comments = 0
+            proposed_change = cast("CoreProposedChangeProtocol", self)
+            change_comments = await proposed_change.comments.get_relationships(db=db)
+            total_comments += len(change_comments)
 
-                threads = await proposed_change.threads.get_peers(db=db)
-                thread_comments = await NodeManager.query(
-                    db=db, schema=THREADCOMMENT, filters={"thread__ids": list(threads.keys())}
-                )
-                total_comments += len(thread_comments)
-                response["total_comments"] = {"value": total_comments}
+            threads = await proposed_change.threads.get_peers(db=db)
+            thread_comments = await NodeManager.query(
+                db=db, schema=THREADCOMMENT, filters={"thread__ids": list(threads.keys())}
+            )
+            total_comments += len(thread_comments)
+            response["total_comments"] = {"value": total_comments}
 
         return response

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -89,11 +89,11 @@ class TextAttributeParameters(AttributeParameters):
             and config.SETTINGS.main.schema_strict_mode
             and self.min_length is not None
             and self.max_length is not None
+            and self.min_length > self.max_length
         ):
-            if self.min_length > self.max_length:
-                raise ValueError(
-                    "`max_length` can't be less than `min_length` when the schema is configured with strict mode"
-                )
+            raise ValueError(
+                "`max_length` can't be less than `min_length` when the schema is configured with strict mode"
+            )
 
         return self
 
@@ -137,11 +137,11 @@ class NumberAttributeParameters(AttributeParameters):
             and config.SETTINGS.main.schema_strict_mode
             and self.min_value is not None
             and self.max_value is not None
+            and self.min_value > self.max_value
         ):
-            if self.min_value > self.max_value:
-                raise ValueError(
-                    "`max_value` can't be less than `min_value` when the schema is configured with strict mode"
-                )
+            raise ValueError(
+                "`max_value` can't be less than `min_value` when the schema is configured with strict mode"
+            )
 
         return self
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2862,11 +2862,12 @@ class SchemaBranch:
             for kind in node.inherit_from
             if self.has(name=kind)
         )
-        if getattr(node, "generate_profile", False) or parent_generates_profile:
-            if PROFILES_RELATIONSHIP_NAME not in [r.name for r in template_schema.relationships]:
-                settings = dict(profiles_rel_settings)
-                settings["identifier"] = PROFILE_TEMPLATE_RELATIONSHIP_IDENTIFIER
-                template_schema.relationships.append(RelationshipSchema(**settings))
+        if (
+            getattr(node, "generate_profile", False) or parent_generates_profile
+        ) and PROFILES_RELATIONSHIP_NAME not in [r.name for r in template_schema.relationships]:
+            settings = dict(profiles_rel_settings)
+            settings["identifier"] = PROFILE_TEMPLATE_RELATIONSHIP_IDENTIFIER
+            template_schema.relationships.append(RelationshipSchema(**settings))
 
         self.set(name=template_schema.kind, schema=template_schema)
 
@@ -2987,14 +2988,18 @@ class SchemaBranch:
                 continue
             # In a context of a generic, we won't be able to create objects out of it, so any kind of nodes implementing the generic is a valid
             # option, we therefore need to have a template for each of those nodes
-            if isinstance(peer_schema, GenericSchema) and peer_schema.used_by:
-                if relationship.kind != RelationshipKind.PARENT or not any(
-                    u in [i.kind for i in identified] for u in peer_schema.used_by
-                ):
-                    for used_by in peer_schema.used_by:
-                        identified |= self.identify_required_object_templates(
-                            node_schema=self.get_node(name=used_by, duplicate=False), identified=identified
-                        )
+            if (
+                isinstance(peer_schema, GenericSchema)
+                and peer_schema.used_by
+                and (
+                    relationship.kind != RelationshipKind.PARENT
+                    or not any(u in [i.kind for i in identified] for u in peer_schema.used_by)
+                )
+            ):
+                for used_by in peer_schema.used_by:
+                    identified |= self.identify_required_object_templates(
+                        node_schema=self.get_node(name=used_by, duplicate=False), identified=identified
+                    )
 
             identified |= self.identify_required_object_templates(node_schema=peer_schema, identified=identified)
 

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -708,24 +708,22 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
         context_type = query_node.context_type
         infrahub_model = None
         infrahub_node_models: list[MainSchemaTypes] = []
-        if query_node.in_property_level:
-            if model := query_node.context_model():
-                if node.name.value in model.attribute_names:
-                    query_node.append_attribute(attribute=node.name.value)
-                elif node_property := NODE_PROPERTY_BY_QUERY_FIELD.get(node.name.value):
-                    query_node.append_attribute(attribute=node_property)
-                elif node.name.value in model.relationship_names:
-                    rel = model.get_relationship_or_none(name=node.name.value)
-                    if rel:
-                        infrahub_model = self.schema_branch.get(name=rel.peer, duplicate=False)
-                        if isinstance(infrahub_model, GenericSchema):
-                            infrahub_node_models = [
-                                self.schema_branch.get(name=used_by, duplicate=False)
-                                for used_by in infrahub_model.used_by
-                            ]
+        if query_node.in_property_level and (model := query_node.context_model()):
+            if node.name.value in model.attribute_names:
+                query_node.append_attribute(attribute=node.name.value)
+            elif node_property := NODE_PROPERTY_BY_QUERY_FIELD.get(node.name.value):
+                query_node.append_attribute(attribute=node_property)
+            elif node.name.value in model.relationship_names:
+                rel = model.get_relationship_or_none(name=node.name.value)
+                if rel:
+                    infrahub_model = self.schema_branch.get(name=rel.peer, duplicate=False)
+                    if isinstance(infrahub_model, GenericSchema):
+                        infrahub_node_models = [
+                            self.schema_branch.get(name=used_by, duplicate=False) for used_by in infrahub_model.used_by
+                        ]
 
-                        context_type = ContextType.from_relationship_cardinality(cardinality=rel.cardinality)
-                    query_node.append_relationship(relationship=node.name.value)
+                    context_type = ContextType.from_relationship_cardinality(cardinality=rel.cardinality)
+                query_node.append_relationship(relationship=node.name.value)
 
         current_node = GraphQLQueryNode(
             parent=query_node,

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -437,10 +437,9 @@ class InfrahubGraphQLApp:
                 websocket=websocket,
                 subscriptions=subscriptions,
             )
-        elif message_type == GQL_STOP:
-            if operation_id in subscriptions:
-                await subscriptions[operation_id].aclose()
-                del subscriptions[operation_id]
+        elif message_type == GQL_STOP and operation_id in subscriptions:
+            await subscriptions[operation_id].aclose()
+            del subscriptions[operation_id]
 
     async def _ws_on_start(
         self,

--- a/backend/infrahub/graphql/field_extractor.py
+++ b/backend/infrahub/graphql/field_extractor.py
@@ -56,9 +56,10 @@ class GraphQLFieldExtractor:
                     elif isinstance(fields[sub_node_name_value], dict) and isinstance(value, dict):
                         fields[sub_node_name_value].update(value)
             elif isinstance(node, FragmentSpreadNode):
-                if node.name.value in self.info.fragments:
-                    if fragment_fields := self._extract_fields(self.info.fragments[node.name.value].selection_set):
-                        fields.update(fragment_fields)
+                if node.name.value in self.info.fragments and (
+                    fragment_fields := self._extract_fields(self.info.fragments[node.name.value].selection_set)
+                ):
+                    fields.update(fragment_fields)
 
         return fields
 

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -603,10 +603,11 @@ class GraphQLSchemaManager:
                 generic = self.get_type(name=generic_name)
                 interfaces.add(generic)
 
-        if isinstance(schema, NodeSchema):
-            if not schema.inherit_from or InfrahubKind.GENERICGROUP not in schema.inherit_from:
-                node_interface = self.get_type(name=InfrahubKind.NODE)
-                interfaces.add(node_interface)
+        if isinstance(schema, NodeSchema) and (
+            not schema.inherit_from or InfrahubKind.GENERICGROUP not in schema.inherit_from
+        ):
+            node_interface = self.get_type(name=InfrahubKind.NODE)
+            interfaces.add(node_interface)
 
         meta_attrs = {
             "schema": schema,

--- a/backend/infrahub/graphql/mutations/action.py
+++ b/backend/infrahub/graphql/mutations/action.py
@@ -160,19 +160,17 @@ def _validate_node_kind_field(data: InputObjectType, node_schema: NodeSchema) ->
     input_data = cast("dict[str, dict[str, Any]]", data)
     if attribute_name := input_data.get("attribute_name"):
         value = attribute_name.get("value")
-        if isinstance(value, str):
-            if value not in node_schema.attribute_names:
-                raise ValidationError(
-                    input_value={
-                        "attribute_name": f"The attribute {value} doesn't exist on related node trigger using {node_schema.kind}"
-                    }
-                )
+        if isinstance(value, str) and value not in node_schema.attribute_names:
+            raise ValidationError(
+                input_value={
+                    "attribute_name": f"The attribute {value} doesn't exist on related node trigger using {node_schema.kind}"
+                }
+            )
     if relationship_name := input_data.get("relationship_name"):
         value = relationship_name.get("value")
-        if isinstance(value, str):
-            if value not in node_schema.relationship_names:
-                raise ValidationError(
-                    input_value={
-                        "relationship_name": f"The relationship {value} doesn't exist on related node trigger using {node_schema.kind}"
-                    }
-                )
+        if isinstance(value, str) and value not in node_schema.relationship_names:
+            raise ValidationError(
+                input_value={
+                    "relationship_name": f"The relationship {value} doesn't exist on related node trigger using {node_schema.kind}"
+                }
+            )

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -489,11 +489,10 @@ async def _validate_peer_types(
             and peer_relationships[0].cardinality == RelationshipCardinality.ONE
         ):
             peer_relationship: RelationshipManager = getattr(node, peer_relationships[0].name)
-            if peer := await peer_relationship.get_peer(db=graphql_context.db):
-                if peer.id != input_id:
-                    raise ValidationError(
-                        f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
-                    )
+            if (peer := await peer_relationship.get_peer(db=graphql_context.db)) and peer.id != input_id:
+                raise ValidationError(
+                    f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
+                )
 
 
 async def _validate_peer_parents(

--- a/backend/infrahub/graphql/mutations/webhook.py
+++ b/backend/infrahub/graphql/mutations/webhook.py
@@ -131,10 +131,9 @@ def _validate_input(graphql_context: GraphqlContext, branch: Branch, input_data:
         # Validate that the requested node_kind exists, will raise an error if not
         graphql_context.db.schema.get(name=input_data.node_kind.value, branch=branch, duplicate=False)
 
-        if input_data.event_type:
-            # If the event type is not set then all events are applicable, this will mean that some events
-            # would be filtered out, as they won't match the node.
-            if input_data.event_type.value not in get_all_infrahub_node_kind_events():
-                raise ValidationError(
-                    input_value=f"Defining a node_kind is not valid for {input_data.event_type.value} events"
-                )
+        # If the event type is not set then all events are applicable, this will mean that some events
+        # would be filtered out, as they won't match the node.
+        if input_data.event_type and input_data.event_type.value not in get_all_infrahub_node_kind_events():
+            raise ValidationError(
+                input_value=f"Defining a node_kind is not valid for {input_data.event_type.value} events"
+            )

--- a/backend/infrahub/graphql/parser.py
+++ b/backend/infrahub/graphql/parser.py
@@ -51,11 +51,10 @@ class GraphQLExtractor:
     def _process_expand_directive(self, path: str, directive: DirectiveNode) -> None:
         excluded_fields = []
         for argument in directive.arguments:
-            if argument.name.value == "exclude":
-                if isinstance(argument.value, ListValueNode):
-                    excluded_fields.extend(
-                        [value.value for value in argument.value.values if isinstance(value, StringValueNode)]
-                    )
+            if argument.name.value == "exclude" and isinstance(argument.value, ListValueNode):
+                excluded_fields.extend(
+                    [value.value for value in argument.value.values if isinstance(value, StringValueNode)]
+                )
 
         if path not in self.typename_paths:
             self.typename_paths[path] = []

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -147,19 +147,18 @@ async def _resolve_available_address_nodes(
     # Look for gaps between existing addresses
     for existing in sorted_nodes:
         current = existing.address.obj.ip
-        if previous_address:
-            if int(current) - int(previous_address) > 1:
-                with_available_ranges.append(
-                    await _build_ip_range_node(
-                        db=db,
-                        branch=branch,
-                        schema=ip_range_schema,
-                        address=previous_address + 1,
-                        last_address=current - 1,
-                        ip_namespace=ip_namespace,
-                        ip_prefix=prefix,
-                    )
+        if previous_address and int(current) - int(previous_address) > 1:
+            with_available_ranges.append(
+                await _build_ip_range_node(
+                    db=db,
+                    branch=branch,
+                    schema=ip_range_schema,
+                    address=previous_address + 1,
+                    last_address=current - 1,
+                    ip_namespace=ip_namespace,
+                    ip_prefix=prefix,
                 )
+            )
 
         with_available_ranges.append(existing)
         previous_address = existing.address.obj.ip

--- a/backend/infrahub/groups/parsers.py
+++ b/backend/infrahub/groups/parsers.py
@@ -35,22 +35,22 @@ class GroupNodeMutationParser:
     def _get_applicable_events(self, events: list[NodeMutatedEvent]) -> list[ApplicableEvent]:
         applicable: list[ApplicableEvent] = []
         for event in events:
-            if event_kind := self._get_schema(kind=event.kind):
-                if (
-                    InfrahubKind.GENERICGROUP in event_kind.inherit_from
-                    and "members" in event.changelog.relationships
-                    and isinstance(
-                        event.changelog.relationships["members"],
-                        RelationshipCardinalityManyChangelog,
+            if (
+                (event_kind := self._get_schema(kind=event.kind))
+                and InfrahubKind.GENERICGROUP in event_kind.inherit_from
+                and "members" in event.changelog.relationships
+                and isinstance(
+                    event.changelog.relationships["members"],
+                    RelationshipCardinalityManyChangelog,
+                )
+            ):
+                applicable.append(
+                    ApplicableEvent(
+                        event=event,
+                        node_schema=event_kind,
+                        relationship=event.changelog.relationships["members"],
                     )
-                ):
-                    applicable.append(
-                        ApplicableEvent(
-                            event=event,
-                            node_schema=event_kind,
-                            relationship=event.changelog.relationships["members"],
-                        )
-                    )
+                )
         return applicable
 
     async def group_events_from_node_actions(self, events: list[NodeMutatedEvent]) -> list[InfrahubEvent]:

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
@@ -31,9 +31,12 @@ class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
 
                         if endpoint_node["connected_endpoint"]:
                             connected_endpoint_node = endpoint_node["connected_endpoint"]["node"]
-                            if connected_endpoint_node:
-                                if connected_endpoint_node["enabled"]["value"] and circuit_status == "active":
-                                    backbone_links_per_site[site_name]["operational"] += 1
+                            if (
+                                connected_endpoint_node
+                                and connected_endpoint_node["enabled"]["value"]
+                                and circuit_status == "active"
+                            ):
+                                backbone_links_per_site[site_name]["operational"] += 1
 
             for site_name, site in backbone_links_per_site.items():
                 if site.get("operational", 0) / site["total"] < 0.6:

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/checks/check_backbone_link_redundancy.py
@@ -31,9 +31,12 @@ class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
 
                         if endpoint_node["connected_endpoint"]:
                             connected_endpoint_node = endpoint_node["connected_endpoint"]["node"]
-                            if connected_endpoint_node:
-                                if connected_endpoint_node["enabled"]["value"] and circuit_status == "active":
-                                    backbone_links_per_site[site_name]["operational"] += 1
+                            if (
+                                connected_endpoint_node
+                                and connected_endpoint_node["enabled"]["value"]
+                                and circuit_status == "active"
+                            ):
+                                backbone_links_per_site[site_name]["operational"] += 1
 
             for site_name, site in backbone_links_per_site.items():
                 if site.get("operational", 0) / site["total"] < 0.6:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -589,7 +589,6 @@ allow-dunder-method-names = [
     "S101",     # Use of `assert` detected
     "S105",     # Possible hardcoded password
     "S311",     # Standard pseudo-random generators are not suitable for crypto
-    "SIM102",   # Use a single `if` statement instead of nested `if` statements
     "SIM103",   # Return the condition directly
     "SIM108",   # Use ternary operator instead of `if`-`else`-block
     "SIM110",   # Use `return any(...)` instead of `for` loop
@@ -820,7 +819,6 @@ allow-dunder-method-names = [
     "INP001",   # File is part of an implicit namespace package
     "PLR2004",  # Magic value used in comparison
     "RUF010",   # Use explicit conversion flag
-    "SIM102",   # Use a single `if` statement instead of nested `if` statements
 ]
 
 "backend/tests/functional/**.py" = [


### PR DESCRIPTION
# Why

`SIM102` (collapsible-if) was suppressed in two places in `pyproject.toml`: the global `ignore`
list, and a `backend/tests/fixtures/**.py` per-file entry sitting under a "Refactor code and remove
the ignore rule" header. Both suppressions are now gone and the rule is fully enforced.

Goal: enable the rule with zero behavioral change.

Non-goals: no logic changes, no restructuring beyond what the rule requires, no changes to the
other rules still listed in either ignore block.

## What changed

**Behavioral changes:** none. Every edit is structural.

- Removed `"SIM102"` from the global `ignore` list and from the
  `backend/tests/fixtures/**.py` per-file ignores. `grep -c SIM102 pyproject.toml` is now 0.
- Fixed the 38 violations that surfaced (36 in `backend/infrahub/`, 2 in fixtures) across 23 files.
  Nested `if A: if B:` becomes `if A and B:`, which short-circuits identically.
- Two sites in `core/node/__init__.py` where the collapsed form wrapped a multi-line `await` in a
  walrus inside an `and` were instead destructured into an assignment plus a plain `if`. That also
  satisfies the rule (the outer body then holds two statements) and matches the idiom already used
  a few lines above.
- Flattened redundant parenthesization the autofix left behind - `(A and B and C) and D` - in
  `attribute_parameters.py` and `groups/parsers.py`. No `and`-within-`and` or `or`-within-`or`
  nesting remains anywhere in the diff.

**What stayed the same:** no schema changes, no API changes, no dependency changes. Three comments
moved from inside an outer `if` to just above the merged condition; no comment was added, removed,
or reworded.

## How to review

Most of the diff is mechanical and was produced by `ruff check --fix`. Worth actual attention:

1. `backend/infrahub/core/node/__init__.py` - the two destructured `await` blocks in `delete()`,
   and the multi-term guard chains in `_collect_extra_filters` / `process_label`.
2. `backend/infrahub/core/schema/schema_branch.py` - `identify_required_object_templates`, the one
   condition mixing `or` inside `and`.
3. Four sites where an `elif` was collapsed (`graphql/app.py`, `graphql/field_extractor.py`,
   `core/diff/enricher/cardinality_one.py` x2). Collapsing an `elif` is only sound when it is the
   terminal branch; each was verified to have no trailing `else`.

Two things reviewers should weigh in on:

- **New idiom.** Before this PR the backend had 110 walrus operators and **zero** used as a boolean
  operand. This PR introduces 14 across 8 files, 8 of which put the walrus in a *later* operand
  (`if guard and (x := f()):`), where the binding is conditional. It is correct - the name is only
  read inside the body, and the binding condition is unchanged from the nested original - but it is
  a convention arriving via a lint sweep. The alternative is destructuring those 8 the way the
  `delete()` blocks were. Happy to do that if preferred.
- **Fixture drift.** The two fixture edits live in local copies of `infrahub-demo-edge`. If that
  fixture is ever re-synced from upstream the violation returns, and because the per-file ignore is
  gone, CI will fail until it is re-applied. That is the intended tripwire rather than an
  oversight; a follow-up cleanup issue on `opsmill/infrahub-demo-edge` could remove the friction.

## How to test

```bash
uv run ruff check .            # clean
uv run ruff format --check .   # clean
uv run mypy backend/infrahub/  # clean on changed files
uv run pytest backend/tests/unit -q
```

Beyond the standard checks, equivalence was proven mechanically rather than by eye. Both versions
of every changed file were canonicalised to a maximally-nested normal form (explode `and`-chains
into nested ifs; de-sugar sole-test walruses into assignment plus test; flatten same-operator
boolean nesting - all three behaviour-preserving), then compared as ASTs. All 23 files are
identical to their base version under that normal form, and comment token streams match exactly.

The canonicaliser was itself validated against 26 control cases, confirming it rejects `and`→`or`,
flipped comparisons, reordered operands, dropped negations, swallowed `else` branches, non-terminal
`elif` collapses, dropped sibling statements, `and`/`or` regrouping, and - specifically for the
destructured blocks - an assignment hoisted outside its guard.

The edited fixture check was additionally differential-tested: old and new `validate()` driven
through 122 enumerated input combinations, comparing recorded `log_error` calls. Zero mismatches,
with 112 cases producing non-empty output.

## Impact & rollout

- **Backward compatibility:** no behavioral change; nothing to migrate.
- **Performance:** unaffected.
- **Config/env changes:** none at runtime; `pyproject.toml` lint config only.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated - n/a, no behavior change; existing suite covers the touched paths
- [x] Changelog entry - n/a, not user-facing
- [x] External docs updated - n/a
- [x] Internal .md docs updated - n/a
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

