### PR TITLE
fix: emit group.member_added only for the group named in the mutation (closes #10314)

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -591,7 +591,7 @@ class RelationshipChangelogGetter:
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
         secondaries: list[NodeChangelog] = []
-        peer_relation = peer_schema.get_relationship_by_identifier(id=str(rel_schema.identifier), raise_on_error=False)
+        peer_relation = peer_schema.get_reverse_relationship(relationship=rel_schema)
         if peer_relation:
             node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
             if peer_relation.cardinality == RelationshipCardinality.ONE:
@@ -625,7 +625,7 @@ class RelationshipChangelogGetter:
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
         secondaries: list[NodeChangelog] = []
-        peer_relation = peer_schema.get_relationship_by_identifier(id=str(rel_schema.identifier), raise_on_error=False)
+        peer_relation = peer_schema.get_reverse_relationship(relationship=rel_schema)
         if peer_relation:
             node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
             if peer_relation.cardinality == RelationshipCardinality.ONE:

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -395,9 +395,14 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
         expected_direction = relationship.direction.neighbor_direction
 
         for candidate in self.get_relationships_by_identifier(id=relationship.get_identifier()):
-            if candidate.direction != expected_direction:
-                continue
-            if candidate.direction == RelationshipDirection.BIDIR and candidate.name == relationship.name:
+            # A peer has to point the opposite way, which rules out every candidate on the same side.
+            # Both sides of a bidirectional pair share BIDIR, so there the name is the only thing that
+            # separates a real peer from the relationship we started on: an identical name means two
+            # kinds inherited the same relationship from a common generic (CoreGroup.members on both
+            # CoreStandardGroup and CoreGeneratorGroup), not two sides of one relationship.
+            if candidate.direction != expected_direction or (
+                candidate.direction == RelationshipDirection.BIDIR and candidate.name == relationship.name
+            ):
                 continue
             return candidate
 

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -11,7 +11,12 @@ from infrahub_sdk.utils import compare_lists, intersection
 from pydantic import ConfigDict, ValidationError, field_validator
 
 from infrahub.computed_attribute.jinja2 import InfrahubJinja2Template
-from infrahub.core.constants import HashableModelState, RelationshipCardinality, RelationshipKind
+from infrahub.core.constants import (
+    HashableModelState,
+    RelationshipCardinality,
+    RelationshipDirection,
+    RelationshipKind,
+)
 from infrahub.core.models import HashableModel, HashableModelDiff
 
 from .attribute_schema import AttributeSchema, get_attribute_schema_class_for_kind
@@ -377,6 +382,26 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
                 rels.append(item)
 
         return rels
+
+    def get_reverse_relationship(self, relationship: RelationshipSchema) -> RelationshipSchema | None:
+        """Return the relationship on this schema that traverses back along the provided relationship.
+
+        Sharing an identifier is not enough: two kinds can both declare the same identifier on the same
+        side, and a single kind can declare both sides of it. The peer must point the opposite way, and a
+        bidirectional relationship is never its own reverse because both sides are stored asymmetrically.
+
+        Returns None when this schema declares no relationship pointing back.
+        """
+        expected_direction = relationship.direction.neighbor_direction
+
+        for candidate in self.get_relationships_by_identifier(id=relationship.get_identifier()):
+            if candidate.direction != expected_direction:
+                continue
+            if candidate.direction == RelationshipDirection.BIDIR and candidate.name == relationship.name:
+                continue
+            return candidate
+
+        return None
 
     def get_relationships_of_kind(self, relationship_kinds: Iterable[RelationshipKind]) -> list[RelationshipSchema]:
         return [r for r in self.relationships if r.kind in relationship_kinds]

--- a/backend/tests/component/graphql/mutations/test_group_event_collection.py
+++ b/backend/tests/component/graphql/mutations/test_group_event_collection.py
@@ -184,3 +184,62 @@ async def test_node_mutation_to_group_event(
     assert len(orphan_group_event.members) == 1
     assert EventNode(id=person_id, kind="TestPerson") in orphan_group_event.members
     assert len(orphan_group_event.ancestors) == 0
+
+
+async def test_group_enrolled_into_group_only_emits_event_for_enclosing_group(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    node_group_schema: None,
+    standard_group_schema: None,
+    session_first_account: AccountSession,
+) -> None:
+    """Enrolling a group into another group reports the enclosing group as the one that gained a member.
+
+    The enrolled group gains nothing, so it must not be reported as having gained a member itself.
+    """
+    enclosing_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await enclosing_group.new(db=db, name="enclosing_group")
+    await enclosing_group.save(db=db)
+    enrolled_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await enrolled_group.new(db=db, name="enrolled_group")
+    await enrolled_group.save(db=db)
+
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, service=service, account_session=session_first_account
+    )
+
+    update_query = """
+    mutation($group: String!, $member: String!) {
+        CoreStandardGroupUpdate(data:
+            {
+                id: $group,
+                members: [{id: $member}]
+            }
+        ) {
+            ok
+        }
+    }
+    """
+    result = await graphql(
+        schema=gql_params.schema,
+        source=update_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group": enclosing_group.get_id(), "member": enrolled_group.get_id()},
+    )
+
+    assert not result.errors
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    member_added_events = [event for event in memory_event.events if isinstance(event, GroupMemberAddedEvent)]
+    assert [event.node_id for event in member_added_events] == [enclosing_group.get_id()]
+    assert member_added_events[0].members == [EventNode(id=enrolled_group.get_id(), kind="CoreStandardGroup")]
+
+    assert len(memory_event.events) == 2
+    group_updated = memory_event.events[0]
+    assert isinstance(group_updated, NodeUpdatedEvent)
+    assert group_updated.node_id == enclosing_group.get_id()

--- a/backend/tests/component/graphql/mutations/test_group_event_collection.py
+++ b/backend/tests/component/graphql/mutations/test_group_event_collection.py
@@ -1,7 +1,12 @@
+import pytest
+
 from infrahub.auth.session import AccountSession
+from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
@@ -187,18 +192,36 @@ async def test_node_mutation_to_group_event(
     assert len(orphan_group_event.ancestors) == 0
 
 
+@pytest.fixture
+async def tracking_group_schema(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, standard_group_schema: None
+) -> None:
+    """Register a second group kind, so group-to-group enrolment can be exercised across two kinds."""
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="TrackingGroup",
+                namespace="Test",
+                inherit_from=[InfrahubKind.GENERICGROUP],
+                attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+            )
+        ]
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+
 async def test_group_enrolled_into_group_only_emits_event_for_enclosing_group(
     db: InfrahubDatabase,
     default_branch: Branch,
-    node_group_schema: None,
-    standard_group_schema: None,
+    tracking_group_schema: None,
     session_first_account: AccountSession,
 ) -> None:
     """Enrolling a group into another group reports the enclosing group as the one that gained a member.
 
-    The enrolled group gains nothing, so it must not be reported as having gained a member itself.
+    The enrolled group gains nothing, so it must not be reported as having gained a member itself. The two
+    groups are of different kinds, which is how a repository import enrols one group into another.
     """
-    enclosing_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    enclosing_group = await Node.init(db=db, schema="TestTrackingGroup", branch=default_branch)
     await enclosing_group.new(db=db, name="enclosing_group")
     await enclosing_group.save(db=db)
     enrolled_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
@@ -214,7 +237,7 @@ async def test_group_enrolled_into_group_only_emits_event_for_enclosing_group(
 
     update_query = """
     mutation($group: String!, $member: String!) {
-        CoreStandardGroupUpdate(data:
+        TestTrackingGroupUpdate(data:
             {
                 id: $group,
                 members: [{id: $member}]
@@ -239,6 +262,7 @@ async def test_group_enrolled_into_group_only_emits_event_for_enclosing_group(
     member_added_events = [event for event in memory_event.events if isinstance(event, GroupMemberAddedEvent)]
     assert [event.node_id for event in member_added_events] == [enclosing_group.get_id()]
     assert member_added_events[0].members == [EventNode(id=enrolled_group.get_id(), kind="CoreStandardGroup")]
+    assert member_added_events[0].kind == "TestTrackingGroup"
 
     node_updated_events = [event for event in memory_event.events if isinstance(event, NodeUpdatedEvent)]
     assert [event.node_id for event in node_updated_events] == [enclosing_group.get_id()]

--- a/backend/tests/component/graphql/mutations/test_group_event_collection.py
+++ b/backend/tests/component/graphql/mutations/test_group_event_collection.py
@@ -1,5 +1,6 @@
 from infrahub.auth.session import AccountSession
 from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -239,7 +240,14 @@ async def test_group_enrolled_into_group_only_emits_event_for_enclosing_group(
     assert [event.node_id for event in member_added_events] == [enclosing_group.get_id()]
     assert member_added_events[0].members == [EventNode(id=enrolled_group.get_id(), kind="CoreStandardGroup")]
 
+    node_updated_events = [event for event in memory_event.events if isinstance(event, NodeUpdatedEvent)]
+    assert [event.node_id for event in node_updated_events] == [enclosing_group.get_id()]
+
     assert len(memory_event.events) == 2
-    group_updated = memory_event.events[0]
-    assert isinstance(group_updated, NodeUpdatedEvent)
-    assert group_updated.node_id == enclosing_group.get_id()
+
+    reloaded_enclosing = await NodeManager.get_one(db=db, id=enclosing_group.get_id(), prefetch_relationships=True)
+    reloaded_enrolled = await NodeManager.get_one(db=db, id=enrolled_group.get_id(), prefetch_relationships=True)
+    assert list(await reloaded_enclosing.members.get_peers(db=db)) == [enrolled_group.get_id()]
+    # Both group kinds read the one stored membership through the same relationship, so it is visible
+    # from either side and cannot say which group gained a member: only the mutation says that.
+    assert list(await reloaded_enrolled.members.get_peers(db=db)) == [enclosing_group.get_id()]

--- a/changelog/10314.fixed.md
+++ b/changelog/10314.fixed.md
@@ -1,1 +1,1 @@
-Adding a group as a member of another group no longer reports the added group as the one that gained a member, which previously made every repository import start a generator run that failed.
+Adding a group as a member of another group no longer reports the added group as the one that gained a member, which previously made every repository import start a Generator run that failed.

--- a/changelog/10314.fixed.md
+++ b/changelog/10314.fixed.md
@@ -1,0 +1,1 @@
+Adding a group as a member of another group no longer reports the added group as the one that gained a member, which previously made every repository import start a generator run that failed.


### PR DESCRIPTION
# Why

Adding a group as a member of another group emitted a second `infrahub.group.member_added` event naming the *enrolled* group as the one that gained a member, with the enclosing group as the member. Every repository import hits this, because object import wraps each pass in a `CoreRepositoryGroup` tracking group and enrols every group defined in `objects/*.yml` into it. A `CoreGroupTriggerRule` watching one of those groups matched the spurious event and ran its `CoreGeneratorAction` against the tracking group, which then failed with `ValueError: Target <id> is not part of the group <id>`.

Goal: one membership change produces one `member_added` event, for the group named in the mutation.

Non-goals: this PR does not change the import path, the tracking group, or which peers it collects (#6886, #9248), the import ordering for repository-defined trigger rules (#10063 / #10196), or the fact that a group-to-group membership is readable from both groups (see *Risky or uncertain parts*).

Closes #10314

## What changed

Behavioral changes:

- Enrolling group B into group A now emits a single `member_added` event, for A with B as the member. Previously a second event fired for B, claiming it had gained A.
- The peer-side `NodeUpdatedEvent` that accompanied that spurious event is gone too, so a `CoreNodeTriggerRule` watching `members` on B no longer fires either.
- Secondary changelogs now pick the correct side of a hierarchical relationship. `parent` and `children` share one identifier on hierarchical kinds, and the previous lookup returned whichever appeared first in the schema's relationship list.

Implementation notes:

- Root cause was in `RelationshipChangelogGetter`: it resolved the peer's "reverse" relationship with `get_relationship_by_identifier`, which matches on identifier alone. Group kinds never receive `member_of_groups` (`add_groups()` skips anything inheriting `CoreGroup`), so a group peer's only `group_member` relationship is its own inherited `members` — the same side that was just changed, not the reverse.
- Added `BaseNodeSchema.get_reverse_relationship()`, which requires the candidate to point the opposite way (`RelationshipDirection.neighbor_direction`) and never accepts a bidirectional relationship as its own reverse. It reuses the existing `get_relationships_by_identifier` rather than introducing new machinery.
- Both `_process_added_peers` and `_process_removed_peers` now call it. The existing `if peer_relation:` guard already handles "no reverse relationship", so no control flow changed.

What stayed the same:

- No schema changes, no migration, no GraphQL contract change. `add_groups()` was deliberately **not** changed to inject `member_of_groups` onto group kinds: that would add a field to every group in the public API and still leave two bidirectional `group_member` relationships on one kind to disambiguate.
- `get_relationship_by_identifier` is untouched and keeps its eight other callers.
- No data repair is needed. The fix changes only which events are derived, never what is written.

## How to review

Focus on `backend/infrahub/core/schema/basenode_schema.py` — specifically whether the two rejection rules in `get_reverse_relationship` are the right ones. Everything else follows from it; the changelog change is a two-line call-site swap.

The second rule compares relationship *names*, which deliberately also rejects two different kinds that share a name: the reported failure is exactly that shape, `CoreRepositoryGroup.members` and `CoreGeneratorGroup.members`, both inherited from `CoreGroup`. Restricting the rule to a self-referential relationship instead does not fix the report, and there is no identity token to compare on — inherited relationships get `id = None` and carry no `source_*_id`. The replication test therefore enrols a group into a group of a *different* kind; it fails again if the rule is narrowed to an identity comparison.

Risky or uncertain parts:

- **Worth a maintainer's opinion:** while adding the persistence assertions requested in review, the test showed that a group-to-group membership is readable from *both* groups — after adding B to A's `members`, reloading B also lists A. Both kinds read the one stored link through the same `members` relationship, so the graph genuinely cannot say which group gained a member; only the mutation can. This makes the issue's statement that "nothing in the graph changed" inaccurate, and it means suppressing the second event is a decision about event semantics (report the intent of the mutation) rather than a correction of a claim the graph contradicts. The test pins the current storage behavior so a future change to the group data model surfaces here. If you would rather group-to-group membership were asymmetric, that is a separate modelling change, adjacent to #9248.
- The direction filter would stop emitting a secondary changelog for a pair whose two sides declare mismatched directions (e.g. one `OUTBOUND`, one `BIDIR`). Core schemas contain no such pair: the only explicit directions are the properly inverse hierarchy pair and the resource-pool relationship, whose identifier exists on one side only and already resolved to nothing. A user-defined mismatched pair cannot be traversed from the peer's side anyway.

Alternatives considered: guarding in `GroupNodeMutationParser` or in `CoreGroupTriggerRule`, and tolerating an empty intersection in `_run_generators`. All three leave the fabricated changelog in place and only hide its effects; the last one would also mask genuine misconfiguration, which is what that error exists to report. Gating on `infrahub.node.action` does not work: it is `CREATED` for every `GroupMemberAddedEvent`.

## How to test

```bash
# Replication test (fails on stable, passes here) plus the regression canary in the same file
uv run pytest backend/tests/component/graphql/mutations/test_group_event_collection.py -v --neo4j

# Blast radius: both call sites of RelationshipChangelogGetter, and the action/trigger path
uv run pytest -n 4 --neo4j \
  backend/tests/component/core/changelog/ \
  backend/tests/component/graphql/mutations/ \
  backend/tests/component/graphql/test_mutation_relationship.py \
  backend/tests/component/actions/

uv run invoke backend.test-unit
```

Results locally: 2 passed in the test file (it failed as `assert [enclosing] == [enclosing, enrolled]` before the fix), 158 passed across the blast-radius suites, 1435 unit tests passed. `uv run invoke format`, `main.lint` and `backend.lint` (ruff, ty, mypy) clean. `backend.generate`, `schema.generate-graphqlschema`, `schema.generate-jsonschema` and `docs.generate` produce no diff, so frontend codegen cannot be affected either. `docs.lint` / `docs.format` could not run locally (`markdownlint-cli2` not installed); no markdown other than the changelog fragment changed.

## Impact & rollout

- **Backward compatibility:** no breaking change to any API or schema. Automation that relied on the spurious second event will stop receiving it — that is the point of the fix.
- **Performance:** unchanged. The new lookup walks the same relationship list as before.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy; no migration, no coordinated release.

## Checklist

- [x] Tests added/updated
- [x] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change) — N/A, no documented behavior changes
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) — N/A for the fix; the group-to-group symmetry noted above may deserve a line in `dev/knowledge/backend/events.md` once maintainers decide whether it is intended
- [x] I have reviewed AI generated content

<!-- AGENT_TEST_COMPLETE -->
<!-- AGENT_FIX_COMPLETE -->
