### PR TITLE
test: stop the webhook traceback fixture from reconfiguring logging process-wide

### DIFF
--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -63,6 +63,10 @@ Skip tests that only exercise library behavior: plain `Enum` value/round-trip ch
 
 If the logic needs only in-memory inputs (a `SchemaBranch`, a dataclass, a pure function), write a unit test without DB fixtures — don't default to a component test because a neighbor uses one. Use the database or containers only when behavior genuinely depends on them.
 
+## Don't leak process-global state
+
+Every test in an xdist worker shares one interpreter. Change `logging` levels/handlers/filters, `structlog` config, module-level registries/singletons, `sys.path`/`sys.modules` or env vars only through a save/restore fixture (change it, `yield`, restore it), or `monkeypatch` where it applies. Never call an application startup routine such as `infrahub.log.configure_logging` from a test — it owns the whole process and undoes nothing, so it reconfigures every later test in the worker. Install only the piece under test and remove it after the `yield`. See `dev/guidelines/backend/testing.md` §"Leave process-global state as you found it".
+
 ## Test file placement
 
 Test files mirror source structure: `infrahub/core/node.py` → `tests/unit/core/test_node.py`

--- a/backend/infrahub/log.py
+++ b/backend/infrahub/log.py
@@ -59,6 +59,22 @@ class TracebackSuppressionFilter(logging.Filter):
         return type(exception) not in self._suppressed_types
 
 
+def install_traceback_suppression_filter() -> TracebackSuppressionFilter:
+    """Install the traceback suppression filter on the Prefect run loggers and return it.
+
+    Prefect ships flow/task run logs to its API; drop tracebacks for failures that are reported as a
+    clean classified reason rather than a crash to debug. The filter reads the shared registry that
+    each expected-failure type opts into via suppress_traceback_in_logs.
+
+    The installed filter is returned so a caller that must leave logging state as it found it can
+    remove it again from every logger in PREFECT_RUN_LOGGERS.
+    """
+    traceback_filter = TracebackSuppressionFilter(_TRACEBACK_SUPPRESSED_TYPES)
+    for prefect_logger_name in PREFECT_RUN_LOGGERS:
+        logging.getLogger(prefect_logger_name).addFilter(traceback_filter)
+    return traceback_filter
+
+
 def clear_log_context() -> None:
     structlog.contextvars.clear_contextvars()
 
@@ -86,13 +102,8 @@ def configure_logging(production: bool, log_level: str) -> None:
     # the infrahub logger
     importlib.import_module("prefect.main")
 
-    # Prefect ships flow/task run logs to its API; drop tracebacks for failures that
-    # are reported as a clean classified reason rather than a crash to debug. Installed after the
-    # prefect.main import above so it survives Prefect's logging reset; reads the shared registry that
-    # each expected-failure type opts into via suppress_traceback_in_logs.
-    traceback_filter = TracebackSuppressionFilter(_TRACEBACK_SUPPRESSED_TYPES)
-    for prefect_logger_name in PREFECT_RUN_LOGGERS:
-        logging.getLogger(prefect_logger_name).addFilter(traceback_filter)
+    # Installed after the prefect.main import above so it survives Prefect's logging reset.
+    install_traceback_suppression_filter()
 
     shared_processors: list[Processor] = [
         structlog.contextvars.merge_contextvars,

--- a/backend/tests/component/webhook/test_traceback_suppression.py
+++ b/backend/tests/component/webhook/test_traceback_suppression.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 from prefect import flow, task
 
-from infrahub.log import PREFECT_RUN_LOGGERS, install_traceback_suppression_filter
+from infrahub.log import PREFECT_RUN_LOGGERS, TracebackSuppressionFilter, install_traceback_suppression_filter
 from infrahub.webhook.classifier import (
     EXPECTED_DELIVERY_ERRORS,
     ClassifiedFailure,
@@ -17,7 +18,7 @@ from infrahub.webhook.classifier import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterator, Sequence
 
 CLASSIFIED_MESSAGE = "The target responded with HTTP 404."
 
@@ -49,21 +50,29 @@ async def _send_classifying_in_task() -> None:
     await _classify_transport_failure()
 
 
-@pytest.fixture
-def traceback_suppression_installed() -> Generator[None, None, None]:
+@contextmanager
+def _traceback_suppression() -> Iterator[TracebackSuppressionFilter]:
     """Register the traceback filter on the Prefect run loggers, as production startup does, then remove it.
 
     Only the filter is installed, not the whole of configure_logging: that startup routine also raises
     the root log level, replaces the root handler and reconfigures structlog, none of which these
-    assertions need and none of which it undoes. Called from a fixture it would leak that state into
-    every test that follows in the same worker — overriding the WARNING root level the suite pins in
+    assertions need and none of which it undoes. Called per test it would leak that state into every
+    test that follows in the same worker — overriding the WARNING root level the suite pins in
     pytest_configure, so unrelated tests drown in DEBUG records from the database driver and the HTTP
     client.
     """
     traceback_filter = install_traceback_suppression_filter()
-    yield
-    for prefect_logger_name in PREFECT_RUN_LOGGERS:
-        logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)
+    try:
+        yield traceback_filter
+    finally:
+        for prefect_logger_name in PREFECT_RUN_LOGGERS:
+            logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)
+
+
+@pytest.fixture
+def traceback_suppression_installed() -> Generator[None, None, None]:
+    with _traceback_suppression():
+        yield
 
 
 async def test_classified_failure_logs_no_traceback(
@@ -112,3 +121,27 @@ async def test_unclassified_failure_logs_a_traceback(
     logged_exceptions = [record.exc_info[1] for record in caplog.records if record.exc_info]
     assert [type(exc) for exc in logged_exceptions] == [RuntimeError]
     assert str(logged_exceptions[0]) == "boom"
+
+
+def _run_logger_filters() -> dict[str, Sequence[object]]:
+    # Logger.filters is a union of filter forms; the identity of what is attached is all that matters here.
+    return {name: list(logging.getLogger(name).filters) for name in PREFECT_RUN_LOGGERS}
+
+
+def test_traceback_suppression_leaves_logging_state_unchanged() -> None:
+    """The suppression context must hand logging back exactly as it found it.
+
+    The assertions above cannot tell this apart from calling configure_logging, which installs the same
+    filter — only the process-wide state that routine also changes, and never restores, separates them.
+    """
+    root_logger = logging.getLogger()
+    level_before, filters_before = root_logger.level, _run_logger_filters()
+
+    with _traceback_suppression() as traceback_filter:
+        assert _run_logger_filters() == {
+            name: [*filters_before[name], traceback_filter] for name in PREFECT_RUN_LOGGERS
+        }
+        assert root_logger.level == level_before
+
+    assert _run_logger_filters() == filters_before
+    assert root_logger.level == level_before

--- a/backend/tests/component/webhook/test_traceback_suppression.py
+++ b/backend/tests/component/webhook/test_traceback_suppression.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 from prefect import flow, task
 
-from infrahub.log import PREFECT_RUN_LOGGERS, TracebackSuppressionFilter, install_traceback_suppression_filter
 from infrahub.webhook.classifier import (
     EXPECTED_DELIVERY_ERRORS,
     ClassifiedFailure,
@@ -16,9 +14,10 @@ from infrahub.webhook.classifier import (
     WebhookDeliveryError,
     WebhookFailureClassifier,
 )
+from tests.helpers.log import traceback_suppression
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator, Sequence
+    from collections.abc import Generator
 
 CLASSIFIED_MESSAGE = "The target responded with HTTP 404."
 
@@ -50,28 +49,9 @@ async def _send_classifying_in_task() -> None:
     await _classify_transport_failure()
 
 
-@contextmanager
-def _traceback_suppression() -> Iterator[TracebackSuppressionFilter]:
-    """Register the traceback filter on the Prefect run loggers, as production startup does, then remove it.
-
-    Only the filter is installed, not the whole of configure_logging: that startup routine also raises
-    the root log level, replaces the root handler and reconfigures structlog, none of which these
-    assertions need and none of which it undoes. Called per test it would leak that state into every
-    test that follows in the same worker — overriding the WARNING root level the suite pins in
-    pytest_configure, so unrelated tests drown in DEBUG records from the database driver and the HTTP
-    client.
-    """
-    traceback_filter = install_traceback_suppression_filter()
-    try:
-        yield traceback_filter
-    finally:
-        for prefect_logger_name in PREFECT_RUN_LOGGERS:
-            logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)
-
-
 @pytest.fixture
 def traceback_suppression_installed() -> Generator[None, None, None]:
-    with _traceback_suppression():
+    with traceback_suppression():
         yield
 
 
@@ -121,27 +101,3 @@ async def test_unclassified_failure_logs_a_traceback(
     logged_exceptions = [record.exc_info[1] for record in caplog.records if record.exc_info]
     assert [type(exc) for exc in logged_exceptions] == [RuntimeError]
     assert str(logged_exceptions[0]) == "boom"
-
-
-def _run_logger_filters() -> dict[str, Sequence[object]]:
-    # Logger.filters is a union of filter forms; the identity of what is attached is all that matters here.
-    return {name: list(logging.getLogger(name).filters) for name in PREFECT_RUN_LOGGERS}
-
-
-def test_traceback_suppression_leaves_logging_state_unchanged() -> None:
-    """The suppression context must hand logging back exactly as it found it.
-
-    The assertions above cannot tell this apart from calling configure_logging, which installs the same
-    filter — only the process-wide state that routine also changes, and never restores, separates them.
-    """
-    root_logger = logging.getLogger()
-    level_before, filters_before = root_logger.level, _run_logger_filters()
-
-    with _traceback_suppression() as traceback_filter:
-        assert _run_logger_filters() == {
-            name: [*filters_before[name], traceback_filter] for name in PREFECT_RUN_LOGGERS
-        }
-        assert root_logger.level == level_before
-
-    assert _run_logger_filters() == filters_before
-    assert root_logger.level == level_before

--- a/backend/tests/component/webhook/test_traceback_suppression.py
+++ b/backend/tests/component/webhook/test_traceback_suppression.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 from prefect import flow, task
 
-from infrahub.log import configure_logging
+from infrahub.log import PREFECT_RUN_LOGGERS, install_traceback_suppression_filter
 from infrahub.webhook.classifier import (
     EXPECTED_DELIVERY_ERRORS,
     ClassifiedFailure,
@@ -14,6 +15,9 @@ from infrahub.webhook.classifier import (
     WebhookDeliveryError,
     WebhookFailureClassifier,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 CLASSIFIED_MESSAGE = "The target responded with HTTP 404."
 
@@ -46,12 +50,25 @@ async def _send_classifying_in_task() -> None:
 
 
 @pytest.fixture
-def configured_logging() -> None:
-    # Register the traceback filter on the Prefect run loggers, as production startup does.
-    configure_logging(production=False, log_level="DEBUG")
+def traceback_suppression_installed() -> Generator[None, None, None]:
+    """Register the traceback filter on the Prefect run loggers, as production startup does, then remove it.
+
+    Only the filter is installed, not the whole of configure_logging: that startup routine also raises
+    the root log level, replaces the root handler and reconfigures structlog, none of which these
+    assertions need and none of which it undoes. Called from a fixture it would leak that state into
+    every test that follows in the same worker — overriding the WARNING root level the suite pins in
+    pytest_configure, so unrelated tests drown in DEBUG records from the database driver and the HTTP
+    client.
+    """
+    traceback_filter = install_traceback_suppression_filter()
+    yield
+    for prefect_logger_name in PREFECT_RUN_LOGGERS:
+        logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)
 
 
-async def test_classified_failure_logs_no_traceback(configured_logging: None, caplog: pytest.LogCaptureFixture) -> None:
+async def test_classified_failure_logs_no_traceback(
+    traceback_suppression_installed: None, caplog: pytest.LogCaptureFixture
+) -> None:
     with (
         caplog.at_level(logging.INFO, logger="prefect.flow_runs"),
         pytest.raises(WebhookDeliveryError, match=r"^The target responded with HTTP 404\.$"),
@@ -66,7 +83,7 @@ async def test_classified_failure_logs_no_traceback(configured_logging: None, ca
 
 
 async def test_classified_failure_from_task_logs_no_traceback(
-    configured_logging: None, caplog: pytest.LogCaptureFixture
+    traceback_suppression_installed: None, caplog: pytest.LogCaptureFixture
 ) -> None:
     # The transport error is caught and classified inside the task, so the failure the engine records
     # for the task run is a delivery error whose traceback is dropped — not the raw transport stacktrace.
@@ -84,7 +101,7 @@ async def test_classified_failure_from_task_logs_no_traceback(
 
 
 async def test_unclassified_failure_logs_a_traceback(
-    configured_logging: None, caplog: pytest.LogCaptureFixture
+    traceback_suppression_installed: None, caplog: pytest.LogCaptureFixture
 ) -> None:
     with (
         caplog.at_level(logging.INFO, logger="prefect.flow_runs"),

--- a/backend/tests/helpers/log.py
+++ b/backend/tests/helpers/log.py
@@ -1,0 +1,25 @@
+"""Install the infrahub.log traceback suppression filter for a test, then remove it again."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from infrahub.log import PREFECT_RUN_LOGGERS, install_traceback_suppression_filter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from infrahub.log import TracebackSuppressionFilter
+
+
+@contextmanager
+def traceback_suppression() -> Iterator[TracebackSuppressionFilter]:
+    """Register the traceback filter on the Prefect run loggers, as production startup does, then remove it."""
+    traceback_filter = install_traceback_suppression_filter()
+    try:
+        yield traceback_filter
+    finally:
+        for prefect_logger_name in PREFECT_RUN_LOGGERS:
+            logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)

--- a/backend/tests/unit/test_log.py
+++ b/backend/tests/unit/test_log.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from infrahub.log import (
     _TRACEBACK_SUPPRESSED_TYPES,
@@ -9,6 +10,10 @@ from infrahub.log import (
     suppress_traceback_in_logs,
 )
 from infrahub.webhook.classifier import ClassifiedFailure, StatusClass, WebhookDeliveryError
+from tests.helpers.log import traceback_suppression
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _record(exception: BaseException | None) -> logging.LogRecord:
@@ -57,3 +62,23 @@ def test_startup_installs_the_filter_on_the_prefect_run_loggers() -> None:
         if any(isinstance(log_filter, TracebackSuppressionFilter) for log_filter in logging.getLogger(name).filters)
     ]
     assert installed_on == list(PREFECT_RUN_LOGGERS)
+
+
+def _run_logger_filters() -> dict[str, Sequence[object]]:
+    # Logger.filters is a union of filter forms; the identity of what is attached is all that matters here.
+    return {name: list(logging.getLogger(name).filters) for name in PREFECT_RUN_LOGGERS}
+
+
+def test_traceback_suppression_leaves_logging_state_unchanged() -> None:
+    """The suppression context must hand logging back exactly as it found it."""
+    root_logger = logging.getLogger()
+    level_before, filters_before = root_logger.level, _run_logger_filters()
+
+    with traceback_suppression() as traceback_filter:
+        assert _run_logger_filters() == {
+            name: [*filters_before[name], traceback_filter] for name in PREFECT_RUN_LOGGERS
+        }
+        assert root_logger.level == level_before
+
+    assert _run_logger_filters() == filters_before
+    assert root_logger.level == level_before

--- a/backend/tests/unit/test_log.py
+++ b/backend/tests/unit/test_log.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import logging
 
-from infrahub.log import _TRACEBACK_SUPPRESSED_TYPES, TracebackSuppressionFilter, suppress_traceback_in_logs
+from infrahub.log import (
+    _TRACEBACK_SUPPRESSED_TYPES,
+    PREFECT_RUN_LOGGERS,
+    TracebackSuppressionFilter,
+    suppress_traceback_in_logs,
+)
 from infrahub.webhook.classifier import ClassifiedFailure, StatusClass, WebhookDeliveryError
 
 
@@ -42,3 +47,17 @@ def test_decorator_registers_type_in_the_shared_registry() -> None:
 
     # The production filter is wired to this shared registry, so a decorated type is suppressed.
     assert TracebackSuppressionFilter(_TRACEBACK_SUPPRESSED_TYPES).filter(_record(_ExpectedFailureError())) is False
+
+
+def test_startup_installs_the_filter_on_the_prefect_run_loggers() -> None:
+    """Importing infrahub.log configures logging for the process, which is what installs the filter.
+
+    Asserting on that import rather than calling configure_logging again keeps the wiring covered
+    without a test reconfiguring logging for every test that follows it in the worker.
+    """
+    installed_on = [
+        name
+        for name in PREFECT_RUN_LOGGERS
+        if any(isinstance(log_filter, TracebackSuppressionFilter) for log_filter in logging.getLogger(name).filters)
+    ]
+    assert installed_on == list(PREFECT_RUN_LOGGERS)

--- a/backend/tests/unit/test_log.py
+++ b/backend/tests/unit/test_log.py
@@ -50,11 +50,7 @@ def test_decorator_registers_type_in_the_shared_registry() -> None:
 
 
 def test_startup_installs_the_filter_on_the_prefect_run_loggers() -> None:
-    """Importing infrahub.log configures logging for the process, which is what installs the filter.
-
-    Asserting on that import rather than calling configure_logging again keeps the wiring covered
-    without a test reconfiguring logging for every test that follows it in the worker.
-    """
+    """Importing infrahub.log configures logging for the process, which is what installs the filter."""
     installed_on = [
         name
         for name in PREFECT_RUN_LOGGERS

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -111,6 +111,33 @@ The module provides individual node/generic schemas (`CAR`, `DEVICE`, `TAG`, `PE
 
 `config.SETTINGS` is populated from `INFRAHUB_*` environment variables at process start, so values exported in the developer's shell leak into the test process. Any test whose behavior depends on a settings field must pin it in a save/restore fixture (set the value, `yield`, restore the original) — see `import_every_remote_branch` in `backend/tests/integration/git/conftest.py`. Never assume a field holds its default.
 
+## Leave process-global state as you found it
+
+Under `pytest-xdist` every test in a worker shares one interpreter, so whatever a test changes outside
+its own fixtures stays changed for every test that follows it there. Touch global state only through a
+save/restore fixture (change it, `yield`, restore the original). Pinning a setting, above, is one case
+of that rule; it also covers:
+
+- the `logging` module — root and per-logger levels, handlers, filters
+- `structlog` configuration
+- module-level registries, caches and singletons
+- environment variables (prefer `monkeypatch.setenv`, which restores on teardown)
+- `sys.path`, `sys.modules`, warning filters
+
+**Never call an application startup routine from a test.** `infrahub.log.configure_logging` is the
+example to learn from: it runs once at process start and owns the process when it does — setting the
+root log level, replacing the root handler and reconfiguring structlog — so, being startup code, it has
+no counterpart that undoes any of that. Called from a fixture it silently reconfigures every later test
+in the worker. Install only the piece the test needs, extracting it from the startup routine when it is
+not already reusable, and undo it after the `yield` — see `traceback_suppression_installed` in
+`backend/tests/component/webhook/test_traceback_suppression.py`, which installs the traceback
+suppression filter alone rather than calling `configure_logging`.
+
+Such a leak is invisible locally and expensive in CI. A root logger left at `DEBUG` overrides the
+`WARNING` level `pytest_configure` pins, and the Neo4j driver then logs a line per Bolt message for
+every test that follows in that worker: one job produced 185k lines of driver output and pushed three
+unrelated tests past their 300s timeout.
+
 ## Dataclass Test Case Pattern
 
 For parametrized tests with multiple scenarios, use dataclasses to define test cases. This pattern provides type safety, readable test IDs, and clear separation between test data and test logic.

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -129,8 +129,8 @@ example to learn from: it runs once at process start and owns the process when i
 root log level, replacing the root handler and reconfiguring structlog — so, being startup code, it has
 no counterpart that undoes any of that. Called from a fixture it silently reconfigures every later test
 in the worker. Install only the piece the test needs, extracting it from the startup routine when it is
-not already reusable, and undo it after the `yield` — see `traceback_suppression_installed` in
-`backend/tests/component/webhook/test_traceback_suppression.py`, which installs the traceback
+not already reusable, and undo it after the `yield` — see `traceback_suppression` in
+`backend/tests/helpers/log.py`, which the webhook suppression tests use to install the traceback
 suppression filter alone rather than calling `configure_logging`.
 
 Such a leak is invisible locally and expensive in CI. A root logger left at `DEBUG` overrides the


### PR DESCRIPTION
# Why

`backend/tests/component/webhook/test_traceback_suppression.py` installed its Prefect traceback filter by calling application startup code:

```python
@pytest.fixture
def configured_logging() -> None:
    configure_logging(production=False, log_level="DEBUG")
```

`configure_logging` owns the process when it runs — it sets the root log level, swaps the root handler and reconfigures structlog — and, being startup code, undoes none of it. Called from a fixture it left the root logger at `DEBUG` for the rest of the xdist worker, overriding the `WARNING` level `pytest_configure` pins. Every test that ran after it in that worker then logged one line per Bolt message from the Neo4j driver.

The enterprise CI job that surfaced it ([infrahub-private run 32120976740](https://github.com/opsmill/infrahub-private/actions/runs/32120976740/job/95673712574)) produced **185,123 of 193,263 log lines** as `neo4j.io` / `neo4j.pool` DEBUG output, starting at the first test of this file and continuing on that worker for the next 37 minutes. The three tests that failed — all `Failed: Timeout >300.0s`, all on `gw1`, the poisoned worker — ran the suite past its 1800s session timeout.

Goal: the fixture leaves logging exactly as it found it, and the rule is written down so the next fixture doesn't repeat it.

Non-goals: no change to production logging behaviour, and no attempt to pin `neo4j*` / `httpcore` levels in `configure_logging` (see below).

Targets `stable`. The three Python files this touches are byte-identical on `stable` and `develop`, `backend/tests/helpers/log.py` is new on both, and the two docs additions land outside the one region where those files differ between the branches — so the change applies unchanged wherever it flows next.

## What changed

- **`backend/tests/helpers/log.py`** (new) — `traceback_suppression()`, a context manager that installs the filter on the Prefect run loggers and removes it again. One implementation shared by the webhook fixture and the regression guard below, so a future fixture that installs the filter inherits the guard.
- **`backend/tests/component/webhook/test_traceback_suppression.py`** — the fixture now wraps that context manager instead of calling `configure_logging`. Renamed `configured_logging` → `traceback_suppression_installed`, since that is what it does now.
- **`backend/infrahub/log.py`** — the filter installation is extracted from `configure_logging` into `install_traceback_suppression_filter()`, so production startup and the test share one implementation and the test still exercises the real registry (`suppress_traceback_in_logs` opt-in) rather than a hand-built set. Pure extraction — same operations, same order, same call site.
- **`backend/tests/unit/test_log.py`** — two guards: `test_traceback_suppression_leaves_logging_state_unchanged` (the install/remove cycle restores the run loggers' filters and the root level) and `test_startup_installs_the_filter_on_the_prefect_run_loggers` (startup wiring is still in place).
- **`dev/guidelines/backend/testing.md`** — new section "Leave process-global state as you found it": what counts as global state, and never call an application startup routine from a test.
- **`.agents/rules/testing-python.md`** — the same rule in short form for coding agents.

What stayed the same: `configure_logging`'s behaviour, the three suppression tests' assertions, and the traceback suppression contract.

## How to review

Start with the test file — the fixture is the fix. Then `log.py` to confirm the extraction is behaviour-preserving.

The judgement call worth scrutiny: the fixture no longer calls `configure_logging`, so that wiring is covered by the startup assertion in `test_log.py` instead. The alternative — keep calling `configure_logging` and unwind it in teardown — is worse: restoring `root.handlers` wholesale re-attaches pytest's own capture handler (`LogCaptureHandler` subclasses `StreamHandler`, so `configure_logging` removes it too), which would leak records into a stale handler for the rest of the session.

## How to test

```bash
uv run pytest backend/tests/unit/test_log.py backend/tests/component/webhook/ -o addopts="" -q   # 18 passed
```

Two committed guards, both hermetic — no dependence on collection order or on which xdist worker takes the file, and both live in the unit suite because neither needs a database or a Prefect flow run:

- `test_traceback_suppression_leaves_logging_state_unchanged` drives the `traceback_suppression()` context manager the fixture wraps: while it is open the Prefect run loggers carry exactly the filter it installed; once it closes their filter lists and the root log level are back to their previous values. Fails if that cycle reverts to `configure_logging` (verified: the assertion reports the extra filter that routine leaves behind).
- `test_startup_installs_the_filter_on_the_prefect_run_loggers` asserts the wiring `configure_logging` performs at import, so dropping its `install_traceback_suppression_filter()` call fails a test (verified: `[] == ['prefect.flow_runs', 'prefect.task_runs']`). Nothing is reconfigured to check it.

Before/after on the original leak, measured with a throwaway probe module collected after the suppression tests in the same worker:

| | root level | traceback filters | `neo4j.io` DEBUG record |
|---|---|---|---|
| before | `DEBUG` | `[4, 4]` | emitted |
| after | `WARNING` | `[1, 1]` | none |

Also run: `backend/tests/unit/log_forwarding` (4 passed), `ruff format --check backend/`, `ruff check backend/tests/`, `mypy` on the three changed test files, `invoke docs.lint` (0 errors).

## Impact & rollout

- **Backward compatibility:** none affected; `configure_logging`'s public behaviour is unchanged.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Follow-up, not in this PR

`configure_logging` mutes `httpx` explicitly but leaves `neo4j`, `neo4j.io`, `neo4j.pool` and `httpcore` at the root level, which is why a single leaked `DEBUG` was this loud. Worth deciding separately whether those should be pinned. Two smaller things noticed nearby: the handler-removal loop in `configure_logging` mutates `root_logger.handlers` while iterating it (so it can skip a handler), and the enterprise `pyproject.toml`'s `[tool.pytest_env]` omits `INFRAHUB_PRODUCTION = false`, which community sets — that is why the enterprise job renders JSON logs where community renders console.

## Checklist

- [x] Tests added/updated (two regression guards)
- [ ] Changelog entry added (test-only change; no user-visible behaviour)
- [ ] External docs updated (not user-facing)
- [x] Internal .md docs updated
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
