### PR TITLE
test: stop fixtures leaking config overrides and stop retrying a failed Prefect setup

### DIFF
--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -5,17 +5,46 @@ triggers against the per-process Prefect test server. The inputs are static and
 the calls are slow (several seconds of API round-trips), so fixtures should reuse
 a single setup per process instead of repeating it for every test or test class.
 
+A failure is remembered the same way a success is. An unreachable Prefect test
+server does not fail fast — the setup blocks until the pytest timeout fires — so
+retrying it for every later test class costs that timeout each time and buries the
+original cause under a wall of identical errors.
+
 Tests that intentionally corrupt the shared task manager state must restore it
 themselves before yielding back, otherwise later tests will observe the corruption.
 """
 
+from collections.abc import Awaitable, Callable
+
 from infrahub.workflows.initialization import setup_task_manager
 
-_state = {"initialized": False}
+
+class TaskManagerSetup:
+    def __init__(self, setup: Callable[[], Awaitable[None]] = setup_task_manager) -> None:
+        self._setup = setup
+        self._initialized = False
+        self._failure: BaseException | None = None
+
+    async def run_once(self) -> None:
+        if self._failure is not None:
+            raise RuntimeError("Prefect task manager setup already failed in this process") from self._failure
+
+        if self._initialized:
+            return
+
+        try:
+            await self._setup()
+        # The pytest timeout raises Failed, which derives from BaseException, and that is
+        # the failure worth remembering most.
+        except BaseException as exc:
+            self._failure = exc
+            raise
+
+        self._initialized = True
+
+
+_setup = TaskManagerSetup()
 
 
 async def setup_task_manager_once() -> None:
-    if _state["initialized"]:
-        return
-    await setup_task_manager()
-    _state["initialized"] = True
+    await _setup.run_once()

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -96,20 +96,28 @@ class TestInfrahubAppBase(TestInfrahub):
         # Creating another service object to get service correctly initialized is a hack.
         # We should either reuse `service` fixture (leading to circular fixture dependencies issue atm),
         # or ideally properly patch production code responsible for Bus instantiation instead
+        original = config.OVERRIDE.message_bus
         bus = BusSimulator()
         _ = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution(), message_bus=bus)
         config.OVERRIDE.message_bus = bus
-        with dependency_provider.scope(build_message_bus, lambda: bus):
-            yield bus
+        try:
+            with dependency_provider.scope(build_message_bus, lambda: bus):
+                yield bus
+        finally:
+            config.OVERRIDE.message_bus = original
 
     @pytest.fixture(scope="class")
     async def memory_cache(
         self, db: InfrahubDatabase, dependency_provider: Provider
     ) -> AsyncGenerator[MemoryCache, None]:
+        original = config.OVERRIDE.cache
         cache = MemoryCache()
         config.OVERRIDE.cache = cache
-        with dependency_provider.scope(build_cache, lambda: cache):
-            yield cache
+        try:
+            with dependency_provider.scope(build_cache, lambda: cache):
+                yield cache
+        finally:
+            config.OVERRIDE.cache = original
 
     @pytest.fixture(scope="class")
     async def register_internal_schema(self, db: InfrahubDatabase, default_branch: Branch) -> SchemaBranch:

--- a/backend/tests/unit/helpers/test_task_manager.py
+++ b/backend/tests/unit/helpers/test_task_manager.py
@@ -1,0 +1,70 @@
+import pytest
+
+from tests.helpers.task_manager import TaskManagerSetup
+
+
+class TimeoutFailure(BaseException):
+    """Stands in for pytest's Failed, which derives from BaseException rather than Exception."""
+
+
+class RecordingSetup:
+    """Counts how many times the task manager setup was actually run."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self) -> None:
+        self.calls += 1
+
+
+class FailingSetup(RecordingSetup):
+    """Stands in for a Prefect test server that accepts connections but never answers."""
+
+    def __init__(self, error: BaseException) -> None:
+        super().__init__()
+        self.error = error
+
+    async def __call__(self) -> None:
+        await super().__call__()
+        raise self.error
+
+
+async def test_setup_runs_once_across_repeated_calls() -> None:
+    setup = RecordingSetup()
+    once = TaskManagerSetup(setup=setup)
+
+    await once.run_once()
+    await once.run_once()
+    await once.run_once()
+
+    assert setup.calls == 1
+
+
+async def test_failed_setup_is_reported_without_being_rerun() -> None:
+    setup = FailingSetup(TimeoutError("prefect server is unreachable"))
+    once = TaskManagerSetup(setup=setup)
+
+    with pytest.raises(TimeoutError, match=r"^prefect server is unreachable$"):
+        await once.run_once()
+
+    for _ in range(3):
+        with pytest.raises(
+            RuntimeError, match=r"^Prefect task manager setup already failed in this process$"
+        ) as exc_info:
+            await once.run_once()
+        assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+    assert setup.calls == 1
+
+
+async def test_failure_that_bypasses_exception_is_remembered() -> None:
+    setup = FailingSetup(TimeoutFailure("Timeout >300.0s"))
+    once = TaskManagerSetup(setup=setup)
+
+    with pytest.raises(TimeoutFailure, match=r"^Timeout >300\.0s$"):
+        await once.run_once()
+
+    with pytest.raises(RuntimeError, match=r"^Prefect task manager setup already failed in this process$"):
+        await once.run_once()
+
+    assert setup.calls == 1


### PR DESCRIPTION
# Why

Two independent faults in `backend-tests-integration`, both found chasing the CI failure on
[run 32238651760](https://github.com/opsmill/infrahub/actions/runs/32238651760/job/96025466827)
(`1 failed, 445 passed, 46 errors`). Neither is caused by the PR that run belonged to.

## 1. A leaked cache override — the `1 failed`

```
FAILED backend/tests/integration/message_bus/operations/request/test_proposed_change.py::TestProposedChange::test_run_generators_validate_requested_jobs
  - infrahub.exceptions.ResourceNotFoundError: Diff summary for pipeline <uuid> was not found in the cache
```

It is not flaky. It fails exactly when pytest-xdist happens to schedule
`backend/tests/integration/proposed_change/test_artifact_regen_e2e.py` onto the same worker,
earlier in the session:

| run | `test_artifact_regen_e2e.py` | `test_proposed_change.py` | result |
|---|---|---|---|
| [32238651760](https://github.com/opsmill/infrahub/actions/runs/32238651760/job/96025466827) | gw3 @58% | gw3 @92% | **FAILED** |
| [32153198842](https://github.com/opsmill/infrahub/actions/runs/32153198842) | gw3 | gw3 | **FAILED** |
| [32251034448](https://github.com/opsmill/infrahub/actions/runs/32251034448) | gw3 | gw1 | passed |

`memory_cache` sets `config.OVERRIDE.cache` to a `MemoryCache` and never puts it back. The
`dependency_provider.scope(build_cache, ...)` unwinds on teardown, but `build_cache()` consults
`config.OVERRIDE.cache` *first*, so the override outlives the class that installed it and every
later `get_cache()` in that worker returns the dead MemoryCache.

`test_run_generators_validate_requested_jobs` writes the diff summary through a cache it builds
from `config.SETTINGS.cache.driver` (Redis) and `run_generators` reads it back via `get_cache()`.
Once the override leaks, the write goes to Redis and the read goes to the leftover MemoryCache.

`bus_simulator`, immediately above it, leaks `config.OVERRIDE.message_bus` the same way. Nothing
fails from it today — a stale `BusSimulator` silently swallows messages rather than raising —
which is why it is worth closing now. Every *other* override site in the suite
(`component/api/conftest.py`, `component/telemetry/test_tasks.py`, `component/git/test_sync_repository.py`,
`component/api/test_50_internals.py`) already saves and restores; these two fixtures were the outliers.

## 2. A retried Prefect setup — the `46 errors`

On gw0 the worker's Prefect testcontainer answered `wait_for_prefect` and then stopped responding
(`httpx.ReadTimeout`, dead events websocket) for the rest of the session. The container fault is
infrastructure. The 46 errors are ours: `setup_task_manager_once` recorded only success, so every
later test class retried the dead server — and since the setup does not fail fast against an
unreachable server, each retry cost the full 300s pytest timeout.

One broken container became 46 `Failed: Timeout >300.0s` errors across five test files, pushed the
session into its 1800s limit, and buried the original `httpx.ReadTimeout` under 45 identical copies.

# What changed

Three commits, test-only. No production code, so no changelog fragment.

- **`memory_cache` / `bus_simulator`** — save the previous `config.OVERRIDE` value and restore it in
  a `finally`, matching the neighbouring `workflow_local` fixture.
- **`setup_task_manager_once`** — remember the failure alongside the success and re-raise it,
  chained, on every later call. The worker still fails, but once, in seconds, with the cause
  attached to the first error rather than the forty-sixth. `except BaseException` is deliberate:
  the pytest timeout raises `Failed`, which does not derive from `Exception`.
- **`backend/tests/unit/helpers/test_task_manager.py`** — guards the once-on-success,
  no-retry-on-failure and BaseException cases. The once-per-process state moved onto a
  `TaskManagerSetup` object taking the setup callable as a constructor argument, so these drive it
  with recording and failing doubles rather than patching the module.

# Verification

The cache leak, reproduced by running the two files in one process in the poisoning order:

```
INFRAHUB_DB_TYPE=neo4j uv run pytest \
  backend/tests/integration/proposed_change/test_artifact_regen_e2e.py \
  backend/tests/integration/message_bus/operations/request/test_proposed_change.py::TestProposedChange::test_run_generators_validate_requested_jobs \
  --neo4j
```

| | result |
|---|---|
| before | `1 failed, 6 passed` — `ResourceNotFoundError: Diff summary for pipeline ... was not found in the cache` |
| after | `7 passed` |

The retry guard: the three new unit tests pass, and dropping the short-circuit from
`setup_task_manager_once` fails two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
