### PR TITLE
perf(testcontainers): replace rabbitmq-diagnostics healthcheck with raw TCP probe

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
@@ -34,7 +34,10 @@ services:
       RABBITMQ_DEFAULT_USER: infrahub
       RABBITMQ_DEFAULT_PASS: infrahub
     healthcheck:
-      test: rabbitmq-diagnostics -q check_port_connectivity
+      # raw TCP probe instead of rabbitmq-diagnostics: each diagnostics call
+      # boots a full Erlang VM (~2s CPU), which at a 1s interval pegs two
+      # cores per broker for the life of the stack
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/5672"]
       interval: 1s
       timeout: 1s
       retries: 50

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -17,7 +17,10 @@ services:
       RABBITMQ_DEFAULT_USER: infrahub
       RABBITMQ_DEFAULT_PASS: infrahub
     healthcheck:
-      test: rabbitmq-diagnostics -q check_port_connectivity
+      # raw TCP probe instead of rabbitmq-diagnostics: each diagnostics call
+      # boots a full Erlang VM (~2s CPU), which at a 1s interval pegs two
+      # cores per broker for the life of the stack
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/5672"]
       interval: 1s
       timeout: 1s
       retries: 50


### PR DESCRIPTION
## Summary

The aggressive 1s RabbitMQ healthcheck cadence in `infrahub-testcontainers` silently costs more than two CPU cores per broker container for the entire life of every test stack: each `rabbitmq-diagnostics` invocation boots a full Erlang VM (~2.1s of CPU time measured on `rabbitmq:4.2.1-management`). On CI machines running several stacks in parallel, that CPU is stolen from the tests themselves. This PR keeps the aggressive interval but makes each check effectively free.

## Key Changes

- The `message-queue` healthcheck in both testcontainers compose files (single-node and cluster) now uses a raw TCP probe (`bash -c '</dev/tcp/127.0.0.1/5672'`) instead of `rabbitmq-diagnostics -q check_port_connectivity`, cutting per-check cost from ~2.1s CPU to ~1ms (~2000x).
- The readiness signal is identical: `check_port_connectivity` only verifies that listener ports accept TCP connections, and RabbitMQ opens the AMQP listener at the very end of boot.
- Removes a latent flake: the Erlang CLI's 0.3–1s+ wall time raced against the 1s healthcheck timeout under CPU contention; the TCP probe completes instantly.
- Exec form (`["CMD", "bash", ...]`) is required because the image's `/bin/sh` is dash, which lacks `/dev/tcp`.

## Validation

Verified empirically against `rabbitmq:4.2.1-management`:

- `rabbitmq-diagnostics -q check_port_connectivity`: 2.15s CPU (user+sys) per run; bash TCP probe: ~1ms.
- Repeated bare TCP probes on 5672 produce zero broker log lines (RabbitMQ does not log connections closed before the protocol header).
- A stack booted with the exact new healthcheck block reaches healthy via `docker compose up --wait` in ~2.6s (first probe fails mid-boot, second succeeds).

## Test Plan

- E2E and integration CI suites boot their stacks through these compose files via `docker compose up --wait`; a green run exercises the new healthcheck end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

