### PR TITLE
test(webhook): identify the render test's own flow run instead of counting

### DIFF
--- a/backend/tests/functional/webhook/conftest.py
+++ b/backend/tests/functional/webhook/conftest.py
@@ -12,6 +12,9 @@ from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind
 from infrahub.core.node import Node
 from infrahub.events.models import EventBranchContext, EventContext
 from infrahub.task_manager.flow_run.prefect_client import PrefectClientAdapter
+from infrahub.trigger.constants import NAME_SEPARATOR
+from infrahub.trigger.models import TriggerType
+from infrahub.trigger.setup import gather_all_automations
 from infrahub.webhook.tasks import process
 from infrahub.workflows.catalogue import (
     WEBHOOK_CONFIGURE,
@@ -99,6 +102,23 @@ async def initial_dataset(
 async def prefect_client(prefect_test_fixture: None) -> AsyncGenerator[PrefectClient, None]:
     async with get_client(sync_client=False) as client:
         yield client
+
+
+@pytest.fixture(scope="class", autouse=True)
+async def delete_webhook_automations(prefect_client: PrefectClient) -> AsyncGenerator[None, None]:
+    """Delete the webhook automations a test class registered, once the class is done with them.
+
+    The Prefect test server is session-scoped, so an automation outlives the class that created it
+    while the webhook node behind it is dropped with the class database. A surviving all-branches
+    automation then turns every event any later test emits in this session into a scheduled
+    webhook-process run that no worker ever executes, filling the server's database and pushing the
+    run count past the API's 200-row page size.
+    """
+    yield
+    webhook_prefix = f"{TriggerType.WEBHOOK.value}{NAME_SEPARATOR}"
+    for automation in await gather_all_automations(client=prefect_client):
+        if automation.id and automation.name.startswith(webhook_prefix):
+            await prefect_client.delete_automation(automation_id=automation.id)
 
 
 @pytest.fixture(scope="class")

--- a/backend/tests/functional/webhook/test_render.py
+++ b/backend/tests/functional/webhook/test_render.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterId
+from prefect.client.schemas.sorting import FlowRunSort
 from prefect.events.schemas.events import Event, Resource
 from prefect.types import DateTime
 
@@ -19,6 +20,7 @@ from tests.helpers.test_app import TestInfrahubApp
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
     from prefect.client.orchestration import PrefectClient
+    from prefect.client.schemas.objects import FlowRun
 
     from infrahub.database import InfrahubDatabase
 
@@ -63,7 +65,22 @@ class TestWebhookRender(TestInfrahubApp):
 
         deployment = await prefect_client.read_deployment_by_name(f"{WEBHOOK_PROCESS.name}/{WEBHOOK_PROCESS.name}")
         deployment_filter = DeploymentFilter(id=DeploymentFilterId(any_=[deployment.id]))
-        runs_before = len(await prefect_client.read_flow_runs(deployment_filter=deployment_filter))
+
+        async def read_process_runs() -> list[FlowRun]:
+            # Earlier tests leave webhook-process runs behind and a read is capped at the server's
+            # 200-row page size, so run counts saturate and only a run's identity is a usable signal.
+            return await prefect_client.read_flow_runs(
+                deployment_filter=deployment_filter, sort=FlowRunSort.EXPECTED_START_TIME_DESC
+            )
+
+        runs_before = {run.id for run in await read_process_runs()}
+
+        async def read_new_runs() -> list[FlowRun]:
+            return [
+                run
+                for run in await read_process_runs()
+                if run.id not in runs_before and run.parameters.get("webhook_id") == webhook.id
+            ]
 
         # A branch-less event: the resource carries no infrahub.branch.name, the id is a UUID and the
         # occurred time a datetime -- all values the action parameters must render as plain strings.
@@ -76,10 +93,20 @@ class TestWebhookRender(TestInfrahubApp):
         )
         await prefect_client._client.post("/events", json=[event.model_dump(mode="json")])
 
-        runs_after = runs_before
+        new_runs: list[FlowRun] = []
         for _ in range(PREFECT_EVENT_WAIT_SECONDS):
-            runs_after = len(await prefect_client.read_flow_runs(deployment_filter=deployment_filter))
-            if runs_after > runs_before:
+            new_runs = await read_new_runs()
+            if new_runs:
                 break
             await asyncio.sleep(1)
-        assert runs_after > runs_before, "webhook-process deployment was not run; server-side parameter render failed"
+        assert new_runs, "webhook-process deployment was not run; server-side parameter render failed"
+
+        # Every value the deployment receives has to be a plain string, an absent branch included.
+        parameters = new_runs[0].parameters
+        assert parameters["event_id"] == str(event.id)
+        assert parameters["event_type"] == "infrahub.node.created"
+        assert parameters["event_occured_at"] == "2026-01-01 00:00:00+00:00"
+        branch_name = parameters["branch_name"]
+        assert isinstance(branch_name, str)
+        assert not branch_name
+        assert parameters["event_payload"] == {"data": {"node_id": "abc"}, "context": {}}

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -418,6 +418,20 @@ async def test_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
 
 This matches the pattern used in `test_webhook_header.py` and `test_models.py`.
 
+### Prefect Server State Outlives the Test Class
+
+The Prefect test server is session-scoped — one per xdist worker — while the database and the
+fixtures that populate it are class-scoped, so whatever a class registers on that server survives
+it. Two rules follow:
+
+- Delete the automations a class created at its teardown. A surviving all-branches webhook
+  automation turns every event any later test emits into a scheduled flow run — no worker runs in
+  the functional suite, so nothing executes them — filling the server's SQLite database.
+- Never assert on a flow-run count. `read_flow_runs()` returns at most `PREFECT_API_DEFAULT_LIMIT`
+  (200) rows and the API rejects a larger `limit`, so once that page is full a before/after
+  comparison saturates and can never be true again. Read newest-first
+  (`FlowRunSort.EXPECTED_START_TIME_DESC`) and identify the run by its id or parameters instead.
+
 ### Functional Tests with `TestInfrahubApp`
 
 `TestInfrahubApp` provides a `memory_cache` fixture (class-scoped) that injects a `MemoryCache` via `dependency_provider.scope(build_cache, ...)`. Use it in functional tests to pre-fill and assert on cache state:


### PR DESCRIPTION
# Why

`test_render.py::TestWebhookRender::test_branchless_event_triggers_webhook_process` failed on 5
unrelated PRs against `release-1.11` between Aug 13 and Aug 18, always with
`AssertionError: webhook-process deployment was not run; server-side parameter render failed`.
Server-side rendering is fine — the test's own assertion is the bug, and it cannot pass under the
conditions CI now hits.

The test compared flow-run counts before and after posting an event:

```python
runs_before = len(await prefect_client.read_flow_runs(deployment_filter=deployment_filter))
...
assert runs_after > runs_before
```

`read_flow_runs()` returns at most `PREFECT_API_DEFAULT_LIMIT` (200) rows, and the API rejects a
larger `limit` outright (`422 Invalid limit: must be less than or equal to 200`). Once the
webhook-process deployment has >= 200 runs, `runs_before == runs_after == 200` and the comparison
can never be true. Every one of the five failures printed exactly `200`, on four different runners.

Those runs come from the webhook classes: `TestWebhookConfigure::test_configure_all` calls
reconcile-all, and nothing deletes the automations afterwards. A surviving all-branches automation
turns every event any later test class emits into a scheduled webhook-process run (nothing executes
them — the functional suite runs no Prefect worker). Under `--dist loadscope` the test therefore
fails iff a leaking webhook class landed on the same worker before it:

| job | configure | render | result |
|---|---|---|---|
| 94380453769 | gw1 | gw1 | FAILED |
| 94396911944 | gw0 | gw0 | FAILED |
| 94730761717 | gw2 | gw2 | FAILED |
| 95019333463 | gw0 | gw0 | FAILED |
| 95765302237 | gw2 | gw2 | FAILED |
| 94746119281 (green retry of 94730761717) | gw3 | gw1 | PASSED |

Non-goal: no production code changes. Nothing in `infrahub/` is at fault here.

## What changed

- `test_render.py` identifies the run it caused — newest-first read, filtered to run ids not seen
  before the event and to this webhook's `webhook_id` — instead of counting rows, and then asserts
  the rendered parameters are the plain strings the test exists to guard (`event_id`, `event_type`,
  `event_occured_at`, an empty `branch_name` for the branch-less event, and the payload). The
  previous version only proved that *some* run appeared.
- `conftest.py` gains an autouse class-scoped fixture that deletes `webhook::`-prefixed automations
  at class teardown. Automations outlive the class that created them while the webhook node behind
  them is dropped with the class database.
- `dev/knowledge/backend/testing.md` records both traps under a new "Prefect Server State Outlives
  the Test Class" subsection.

## How to review

The interesting question is whether run identity is robust where counting was not: a new
automation-triggered run is the newest by expected start time, so it lands at the top of the page
regardless of how many older runs exist, and the `webhook_id` filter keeps another automation's run
from being mistaken for this one.

## How to test

```bash
# The failing CI ordering, in one process: configure runs before render, same Prefect server
uv run pytest backend/tests/functional/webhook -v
```

29 passed locally in 2m47s, including the co-located ordering that fails in CI.

The 200-row cap was verified directly against a live Prefect test server: with 205 flow runs,
`read_flow_runs()` returns 200, `limit=1000` is a 422, and `offset=200` reveals the remaining 5.

### The teardown makes the suite faster, not slower

Measured over `backend/tests/functional/webhook` followed by one event-heavy class
(`ipam/test_ipam_utilization.py`) in a single process — the CI shape, where webhook classes run
before event-heavy ones on the same worker — two pairs, alternating:

| | pytest duration | webhook-process runs left | leftover `webhook::` automations |
|---|---|---|---|
| with cleanup | 182s / 201s | 1 | 0 |
| without cleanup | 235s / 233s | 243 / 216 | 1 |

The cleanup is worth **33-53s (14-22%)** on that slice, because the leaked automation generates
216-243 scheduled flow runs — each one a trigger evaluation plus rows in the same SQLite database
the tests are waiting on. It also reproduces the failure condition locally: a single event-heavy
class is enough to push the count past 200, and a CI worker runs ~15 of the suite's 62 classes.

The teardown call itself, timed against a live server (gather + deletes per class teardown):

| webhook automations deleted | total automations on server | gather | deletes | teardown |
|---|---|---|---|---|
| 2 | 2 | 5.5ms | 6.9ms | **12.4ms** |
| 4 | 10 | 2.0ms | 11.3ms | **13.3ms** |
| 10 | 50 | 3.8ms | 33.5ms | **37.2ms** |
| 50 | 200 | 12.8ms | 150.1ms | **162.9ms** |
| 200 | 300 | 17.1ms | 12046ms | **12.1s** |

Paging through all automations is cheap and flat (2-17ms even at 300). The cost is entirely in the
`DELETE` calls, and it degrades badly past ~50 — 60ms each at 200, presumably trigger-service
reconfiguration serialized through SQLite. The webhook classes register 1-4 automations each, so
real cost is ~12-13ms per class teardown, ~0.1s across the package. Worth knowing if a future test
ever registers automations in bulk.

## Impact & rollout

- **Backward compatibility:** test-only change, no runtime behavior touched.
- **Deployment notes:** safe to merge; no changelog fragment since nothing user-facing changed.

`develop` and `release-1.11` carry a byte-identical `test_render.py` (same blob hash) and are
vulnerable to the same failure, so they need this via the usual merge-forward. Other functional
suites (computed attributes, action rules) leave their own automations on the shared Prefect server
— same class of leak, different blast radius, deliberately out of scope here.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added — not
      user-facing
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
