### PR TITLE
docs(immutable-history): restructure the hub and add a page for querying historical data

### DIFF
--- a/dev/specs/docs/immutable-history-temporal-queries.md
+++ b/dev/specs/docs/immutable-history-temporal-queries.md
@@ -1,0 +1,360 @@
+# Immutable History: the plan for documenting historical queries
+
+## What this document is
+
+This document records how the Immutable History documentation was planned and written, which facts
+were checked against the source code, and which questions are still unanswered.
+
+It exists so that a person who did not write these pages can understand why they are shaped the way
+they are, and so that a future change to them does not repeat work that has already been done.
+
+The pages it describes are:
+
+- `docs/docs/immutable-history/overview.mdx` — explains the capability. This page already existed
+  and was rewritten.
+- `docs/docs/immutable-history/query-historical-data.mdx` — explains how to query historical data.
+  This page is new.
+- `docs/sidebars.ts` — changed so that Immutable History became a section in the navigation menu,
+  with the overview page as its front page, instead of a single page.
+
+The work was delivered as pull request 10334: <https://github.com/opsmill/infrahub/pull/10334>
+
+The starting point for the work was an assessment of the company blog post about the temporal graph,
+which is recorded in `temporal-graph-blog-assessment.md` in this same folder. The blog post was used
+only to help decide how to frame the explanation. No sentence from the blog post was copied into the
+documentation.
+
+## Decisions that were taken before writing
+
+**A separate page about the "temporal graph" concept was not created.** The vocabulary used in the
+documentation stays as "immutable history" and "temporal queries". Existing pages were not renamed.
+The term "temporal graph" appears once on the overview page, as a definition, because it is a useful
+name for the storage design. It is not used as a heading or a page title.
+
+**The Python SDK does expose the `at` parameter.** This was confirmed in the code, so the overview
+page's claim that four interfaces support historical queries is correct.
+
+**The blog post's performance claim was excluded.** The blog states that Infrahub supports hundreds
+of branches with no performance penalty. Nothing in the repository supports that claim, so it does
+not appear in the documentation.
+
+**Comparing two arbitrary moments in time is a real capability, and it is in scope.** It works
+through the GraphQL interface. It is documented on the new page.
+
+## Where the page sits in the documentation, and why
+
+The Infrahub documentation groups pages into sections. The section called "Branches and Change
+Control" owns anything about branching, proposing changes, and validating changes. Immutable History
+was already the first entry in that section, as a single page.
+
+The Diátaxis model, which this documentation follows, separates pages into four kinds: explanation,
+how-to guides, tutorials, and reference. Before this work, Immutable History had an explanation page
+and nothing else. The missing kind was the how-to guide, which is what the new page provides.
+
+The pattern used is a front page with pages beneath it. The existing overview page became the front
+page, and the new page is the first page beneath it. This pattern is normally reserved for sections
+that will hold several pages. It was justified here because a second page is plausible; see "What was
+deliberately left out" at the end of this document.
+
+No changes were needed in any other repository. The `at` parameter belongs to the platform, so the
+main Infrahub repository is the correct home for the page. The Python SDK's own documentation may
+eventually want a link to it, but that would be a separate change.
+
+## Facts that were verified in the source code
+
+Everything in this section was read from the code in this repository rather than taken from the
+previous version of the page or from the blog post. Each entry gives the file and line so that it can
+be checked again when the code changes.
+
+### How each interface accepts a timestamp
+
+| Interface | How the timestamp is given | Where this is in the code |
+|---|---|---|
+| Web interface | A time selector next to the branch selector. It shows only an icon until a time is chosen; afterwards a bar displays "Current view time" with the chosen value, and a cross clears it. | `frontend/app/src/entities/navigation/ui/time-selector.tsx`, lines 44, 73, 83 |
+| GraphQL | A parameter named `at` in the address of the endpoint, written as `/graphql/<branch>?at=<time>` | `backend/infrahub/graphql/app.py`, line 206 |
+| REST | A parameter named `at`, described in the code itself as accepting "absolute or relative format" | `backend/infrahub/api/dependencies.py`, line 81 |
+| Python SDK | An argument named `at` on the methods `all()`, `get()`, `filters()` and `execute_graphql()` | `python_sdk/infrahub_sdk/client.py`, lines 277, 883, 1184, 2134 |
+
+### Which time formats are accepted
+
+These are read from `python_sdk/infrahub_sdk/timestamp.py`, lines 52 to 101. Infrahub tries them in
+this order:
+
+- A full date and time in ISO 8601 format, with a time zone or an offset.
+- A date and time with no time zone, which is assumed to be UTC.
+- **A date on its own**, such as `2026-03-09`. This resolves to **twelve o'clock midday UTC** on
+  that day, not midnight. This is stated on the page because it surprises people.
+- **A relative offset**, subtracted from the current time. Only three units are supported: seconds,
+  minutes, and hours. They can be combined, for example `2h30m`. **Days and weeks are not
+  supported**: writing `7d` produces an error. The unit definitions are at lines 22 to 26.
+- Anything else produces an error called `TimestampFormatError`, at line 101.
+
+### How far back a query can reach
+
+This is in `backend/infrahub/branch/query_time_validator.py`, lines 24 to 32.
+
+Only the earliest time is checked. The requested time must not be earlier than the effective
+creation time of the branch. For any branch that is not the default branch, the effective creation
+time is the creation time of the **default** branch, not of the branch itself. This is because
+`origin_branch` always refers to the default branch.
+
+The error message the reader will see is:
+
+```text
+Requested time '<time>' is before branch '<name>' was created at '<created_at>'.
+```
+
+**Nothing checks whether the requested time is in the future.** A future time is accepted, and the
+query returns current data with no indication that this happened. The reason is that the filter used
+to select versions is `from <= $at AND (to IS NULL OR to > $at)`, in
+`backend/infrahub/core/timestamp.py`, lines 23 to 24, and every currently valid version satisfies
+that condition for a future time. The web interface is not affected, because its picker only offers
+times in the past (`time-selector.tsx`, lines 56 to 57). This affects GraphQL, REST, and the SDK.
+See open item 2.
+
+### How comparing two moments in time works
+
+Comparing two moments requires two steps, and this was not understood correctly when the page was
+first written.
+
+First, a request called `DiffUpdate` asks Infrahub to calculate the difference and store it. Its
+input accepts `branch`, which is required, plus optional `name`, `from_time` and `to_time`. There is
+also a separate `wait_until_completion` argument, which makes the request return only once the
+calculation has finished instead of starting a background task. This is in
+`backend/infrahub/graphql/mutations/diff.py`, lines 24 to 36.
+
+**If a custom period of time is requested, a name must also be given.** Without a name, Infrahub
+refuses the request with the message "diff with specified time range requires a name". This is at
+line 59 of the same file. This was not documented anywhere before, and it is the real reason why
+asking for an arbitrary period appeared to return nothing on the first attempt.
+
+Second, the stored result is read using either `DiffTree`, which returns the changed objects, or
+`DiffTreeSummary`, which returns only counts. Their arguments are defined in
+`backend/infrahub/graphql/queries/diff/tree.py`, lines 752 to 777:
+
+- `name`, `branch`, `from_time`, `to_time`
+- `filters`, which accepts `ids`, `status`, `kind` and `namespace`. The `status`, `kind` and
+  `namespace` filters each accept lists named `includes` and `excludes`.
+- `limit` and `offset`, for reading results in pages. These are on `DiffTree` only.
+- `proposed_change_id`, which reads the difference belonging to a Proposed Change instead.
+
+When `from_time` is not given, the comparison starts at the point the branch diverged. When
+`to_time` is not given, it runs to the present. These defaults are at lines 463 to 476.
+
+The base of the comparison is always the default branch, at line 551. See open item 1, because a
+reviewer is not certain this is working as intended.
+
+### What happens to history when a branch is merged, rebased, or deleted
+
+**Merging** records the merged changes on the default branch using the timestamp of the merge, not
+the timestamps the changes originally had on the branch. Every merge operation is given one single
+timestamp, in `backend/infrahub/core/diff/merger/merger.py`, lines 94 to 210, which receives it from
+`backend/infrahub/core/merge/branch_merger.py`, line 197.
+
+The practical consequence is worth stating plainly, and it is now on the overview page. If somebody
+creates an object on a branch on Monday and the branch is merged on Friday, the default branch shows
+that object as created on Friday. The history of the default branch therefore contains the final
+result of the branch, but not the sequence of changes that produced it. Those intermediate versions
+stay readable on the branch itself, for as long as the branch exists.
+
+**Rebasing** moves the timestamps of changes made on a branch forward to the time of the rebase, in
+`backend/infrahub/core/branch/models.py`, line 433. A change recorded on the branch before a rebase
+can no longer be read at its original timestamp.
+
+**Deleting a branch** permanently removes the data and history recorded on that branch. The query
+deletes every edge belonging to the branch, and any vertex left with no edges at all, in
+`backend/infrahub/core/query/branch.py`, line 89. This cannot be recovered.
+
+### How the timestamp behaves in the web interface
+
+**The time picker does not use UTC.** The date picker component receives no time zone setting, and
+the applied time is displayed using a local-time format. This is in
+`frontend/app/src/entities/navigation/ui/time-selector.tsx`, lines 42 to 58 and line 75. The
+previous version of the page told readers to choose a time "in UTC", which was wrong and could put a
+reader in Central European Time one or two hours away from the moment they intended.
+
+**The selected time applies to more than object data, and less than the whole interface.** Thirty-
+seven files read the shared value that holds the selected time, which is called `datetimeAtom`.
+Among them are object data, relationships, IPAM, groups, profiles, permissions, search, the schema
+(`entities/schema/ui/queries/load-schema.query.ts`) and the navigation menu
+(`entities/navigation/ui/queries/get-menu.query.ts`). No file belonging to the diff, Proposed
+Change, task or event screens reads it, which means those screens continue to show current data
+while the header still displays "Current view time".
+
+**Editing is not prevented while a past time is applied.** There is no protection anywhere in
+`frontend/app/src/`. A deletion forwards the historical timestamp
+(`entities/nodes/object/ui/queries/delete-object.mutation.ts`, lines 18 and 26) and the backend then
+silently replaces it with the current time (`backend/infrahub/graphql/app.py`, line 223). No error
+is shown. See open item 3.
+
+**The selected time is part of the page address**, as a parameter named `at`
+(`shared/config/qsp.ts`, line 5), and it is preserved as the reader moves around the interface,
+alongside the branch (`shared/api/rest/fetch.ts`, line 83). This means a historical view can be
+saved as a bookmark or shared as a link.
+
+### The schema is also resolved for the requested time
+
+When the requested time is earlier than the moment the branch's schema last changed, Infrahub loads
+the schema as it was at that time and analyses the query against that older schema. This is in
+`backend/infrahub/graphql/app.py`, lines 228 to 231. A query for an earlier time therefore sees the
+attributes that the schema defined then, rather than the ones it defines now.
+
+### A timestamp applies to reading only
+
+If a query document contains a change as well as a read, Infrahub replaces the requested timestamp
+with the current time, in `backend/infrahub/graphql/app.py`, line 223.
+
+### There is a third way to ask about the past
+
+Besides reading one moment and comparing two moments, there is a third operation: asking which
+events happened between two moments. The event query accepts filters named `since` and `until`,
+along with `branches`, `account__ids`, `event_type` and node identifiers. `since` defaults to one
+hundred and eighty days in the past and `until` defaults to the current time. This is in
+`backend/infrahub/graphql/queries/event.py`, lines 48 and 140 to 143.
+
+This is why the new page opens by naming three ways to ask about the past rather than two. See open
+item 4, because these filters are not documented on any page.
+
+## How a comparable product documents this, and what that changed
+
+The equivalent page from Dolt, a database with similar version-control behaviour, was used as a
+benchmark: <https://www.dolthub.com/docs/sql-reference/version-control/querying-history>
+
+Dolt's page leads with the constraint before it shows any syntax. It states that the unit of a
+snapshot is the commit, then works through each interface, then closes with an explicit list of
+limitations.
+
+This changed one thing in the plan. The section describing constraints was moved **above** the
+per-interface syntax rather than being left as a footnote at the end. The reasoning is that a reader
+whose first historical query fails will have failed for one of two reasons — the branch boundary, or
+an unsupported time unit — and both of those belong before the examples rather than after them.
+
+## What changed during the writing, because the code contradicted the plan
+
+**REST has no general way to read an object at a past time.** The `at` parameter is accepted only on
+`/api/query/{query_id}`, `/api/artifact/{artifact_id}`, and the two transformation endpoints
+`/api/transform/python/{transform_id}` and `/api/transform/jinja2/{transform_id}`. This is in
+`backend/infrahub/api/dependencies.py`, lines 77 to 90, and
+`backend/infrahub/api/transformation.py`, lines 35 and 100. The section describing REST therefore
+explains saving a read as a stored query and running that, instead of describing an ad-hoc object
+read that does not exist.
+
+**`DiffTree` reads a stored result rather than calculating one.** This is described above. The page
+was originally written as though `DiffTree` performed the comparison itself.
+
+**The getting-started tutorials are not published.** The folder
+`docs/docs/tutorials/getting-started/` is excluded from the documentation build, in
+`docs/docusaurus.config.ts`, line 83. This was discovered when the build failed after a link was
+added to the existing tutorial about historical data. That whole tutorial series is unpublished. See
+"What was deliberately left out".
+
+**Two structural changes were made.** The four interfaces became four tabs within one section rather
+than four separate sections, following the pattern already used in `docs/docs/groups/create.mdx`.
+And a use case about testing automation against historical data was left out of the introduction
+entirely, rather than written and marked as unconfirmed, because nothing in the repository supported
+it.
+
+**Both pages are written with one paragraph on one line.** They were originally broken across
+several lines at roughly one hundred characters. A reviewer asked for this to change. It is the
+correct choice, because the line-length rule is switched off in `.markdownlint-cli2.yaml`, and
+neighbouring pages such as `docs/docs/branches/overview.mdx` are written as single long lines.
+
+## Open items
+
+These are grouped by who can decide them. None of these are writing problems. Each needs a decision
+or a confirmation from a person.
+
+### Items that need an engineer
+
+**Open item 1. Is the base of the comparison in `DiffTree` working correctly?**
+
+The page states that the base of a comparison is always the default branch, which is what the code
+does at `backend/infrahub/graphql/queries/diff/tree.py`, line 551. However, a reviewer commented
+that he was not certain this is working as intended. Documentation should not describe behaviour that
+nobody is willing to confirm. Please have an engineer confirm it. If the behaviour is wrong, remove
+that sentence from the page and raise a bug report instead.
+
+**Open item 2. Is it intended that a future timestamp is accepted?**
+
+As described above, only the earliest time is checked. A time in the future is accepted and returns
+current data silently.
+
+The page currently documents this as normal behaviour. That may be the wrong choice. If engineering
+would prefer future timestamps to be rejected in the same way that too-early timestamps are
+rejected, then the paragraph describing it should be deleted from the page, and this should become a
+bug report instead.
+
+### An item that needs a product decision
+
+**Open item 3. Should the page warn about editing in a past view, or should the behaviour be fixed?**
+
+As described above, nothing prevents somebody from editing or deleting data while they are viewing a
+past moment, and the change is applied to current data.
+
+There is history here. GitHub issue 2268 asked for exactly this protection in February 2024 and was
+closed in March of that year, but no protection exists in the current code.
+
+The page currently carries a warning box. That was a deliberate choice: it seemed better to warn
+people than to let them discover the problem by losing data. But warning about a problem is not the
+same as fixing it, and this is a product decision rather than a documentation one. If the behaviour
+is fixed, the warning box should be removed.
+
+### Items that need a decision about scope
+
+**Open item 4. The `since` and `until` filters are not documented anywhere.**
+
+The new page opens by naming three ways to ask about the past. The third is the event query with its
+`since` and `until` filters. The table links to the Activity log page, because that is the closest
+existing page, but that page only describes the filters available in the web interface. It does not
+describe the query parameters, and it does not mention that `since` defaults to one hundred and
+eighty days in the past.
+
+There are two reasonable options: extend the Activity log page as a separate change, or add a short
+section to the new page. This was not decided, because either choice changes the scope of this work.
+
+**Open item 5. A reviewer suggested a diagram.**
+
+On the subject of how merging and deleting affect history, a reviewer wrote that a graphic would
+explain the concepts much better. The written explanation now exists. A diagram would probably
+communicate it more clearly, and would need somebody who produces diagrams for the documentation.
+
+### Statements a reviewer asserted that were not confirmed in the code
+
+Both statements are now on the pages. Both came from a maintainer, so they are very likely correct.
+Neither was confirmed by reading the code, so both should be checked before merging.
+
+**Open item 6.** The page says that after a branch is deleted, the Activity log still records the
+operations that were performed on that branch. Events are stored separately from the graph data, so
+this is plausible, but it was not confirmed that the query which deletes a branch's data leaves the
+events untouched.
+
+**Open item 7.** The page describes the creation time of the default branch as the point at which
+Infrahub was first initialised. That phrasing came from the reviewer. The code only states that the
+limit is the creation timestamp of the default branch. The explanation helps the reader, but it
+should be confirmed.
+
+### An item that was in the original plan and is still open
+
+**Open item 8. Is `updated_by` the right way to answer "who changed this"?**
+
+The overview page says that a change can be traced to the account that made it, and links to
+`docs/docs/objects/metadata.mdx`. Reading `updated_by` at a past timestamp gives the account behind
+the change that was current at that time, which is why the claim stands. This should be confirmed as
+the intended way to answer that question.
+
+## What was deliberately left out
+
+These are not oversights. They were considered and excluded on purpose.
+
+**A second page about comparing two points in time.** This would cover `DiffTree` in depth alongside
+the Proposed Change difference. The current page gives it one worked example. A full treatment needs
+somebody to settle the relationship between comparisons based on timestamps and comparisons based on
+branches, which is a larger question than this work.
+
+**Any link to the getting-started tutorials**, because they are not published. Deciding what happens
+to that tutorial series is separate work.
+
+**The blog post's claim about performance**, because nothing in the repository supports it.
+
+**A full review of the writing style across the rest of the overview page.** Only the sections
+touched by this work were revised.

--- a/dev/specs/docs/immutable-history-temporal-queries.md
+++ b/dev/specs/docs/immutable-history-temporal-queries.md
@@ -264,6 +264,13 @@ neighbouring pages such as `docs/docs/branches/overview.mdx` are written as sing
 These are grouped by who can decide them. None of these are writing problems. Each needs a decision
 or a confirmation from a person.
 
+Each item below states the question and who can answer it. A handover comment on pull request 10334
+covers the same items in more depth. For each one it sets out the available options with their
+trade-offs, how the item could be checked, and what to do with each possible answer. That comment
+stays readable on the pull request after it is merged. Read it alongside this section rather than
+instead of it: this document records why the pages are shaped as they are, and the comment records
+what to do next.
+
 ### Items that need an engineer
 
 **Open item 1. Is the base of the comparison in `DiffTree` working correctly?**

--- a/dev/specs/docs/immutable-history-temporal-queries.md
+++ b/dev/specs/docs/immutable-history-temporal-queries.md
@@ -106,10 +106,11 @@ Requested time '<time>' is before branch '<name>' was created at '<created_at>'.
 
 **Nothing checks whether the requested time is in the future.** A future time is accepted, and the
 query returns current data with no indication that this happened. The reason is that the filter used
-to select versions is `from <= $at AND (to IS NULL OR to > $at)`, in
-`backend/infrahub/core/timestamp.py`, lines 23 to 24, and every currently valid version satisfies
-that condition for a future time. The web interface is not affected, because its picker only offers
-times in the past (`time-selector.tsx`, lines 56 to 57). This affects GraphQL, REST, and the SDK.
+to select versions, in `backend/infrahub/core/timestamp.py` lines 22 to 25, is two clauses joined by
+OR — `(r.from <= $at AND r.to IS NULL)` or `(r.from <= $at AND r.to >= $at)` — and every currently
+valid version satisfies the first of those for a future time. The web interface is not affected,
+because its picker only offers times in the past (`time-selector.tsx`, lines 56 to 57). This affects
+GraphQL, REST, and the SDK.
 See open item 2.
 
 ### How comparing two moments in time works

--- a/dev/specs/docs/temporal-graph-blog-assessment.md
+++ b/dev/specs/docs/temporal-graph-blog-assessment.md
@@ -1,0 +1,153 @@
+# Assessment — "How to Time Travel on Your Network With a Temporal Graph"
+
+Source: <https://opsmill.com/blog/temporal-graph-infrastructure-data/> (Damien Garros, 2026-03-09)
+
+Status: complete. Every recommendation below was either carried out or deliberately rejected, and
+every open question at the end has since been answered. Those answers are recorded in place, so this
+document now serves as the record of why the Immutable History pages are shaped the way they are.
+The work itself is described in `immutable-history-temporal-queries.md` in this same folder.
+
+## Verdict
+
+**Do not add the post as a docs page.** Its conceptual content is already covered in
+three places in the docs, and it carries no technical substance to add. But reading it
+against the docs exposes a real gap that is worth its own pull request: the docs claim
+temporal queries work across four interfaces and never show how to run one.
+
+Recommendation: use the post as **framing source material** for two changes — one new
+how-to page, one edit to an existing concept page. Nothing from the post is imported as
+prose.
+
+## What the post contains
+
+Nine short sections, all conceptual:
+
+- the problem with only storing "now"
+- what a temporal graph is (timestamps on nodes and relationships)
+- temporal graph vs. change log
+- the case for immutability (trustworthy record, cause and effect, safe parallel work)
+- multiple timelines at once (branches share an immutable baseline, record only divergences)
+- why it matters (query any point, test against historical state, precise rollback)
+- how it shows up in Infrahub (attribute-level immutable values, lineage metadata,
+  Git-like workflow at the data layer, diff between two points in time, time picker in the UI)
+
+No API endpoints, no GraphQL parameters, no CLI commands, no schema or Neo4j detail, no
+versions. Audience is prospects; the closing call to action is a demo request.
+
+This is marketing material. It was written for prospective customers, not for engineers, so it was
+used only to help decide how to frame the explanation. No sentence from it was copied into the
+documentation.
+
+## What the docs already cover
+
+| Page | Covers | Quadrant |
+|---|---|---|
+| [`overview/concepts.mdx`](../../../docs/docs/overview/concepts.mdx) §"Immutable graph and historical data" | One paragraph — the engine is immutable, history is queryable | Orientation |
+| [`immutable-history/overview.mdx`](../../../docs/docs/immutable-history/overview.mdx) | Benefits, use cases, timestamps and commits, temporal queries, attribute-level tracking | Concept |
+| [`tutorials/getting-started/historical-data.mdx`](../../../docs/docs/tutorials/getting-started/historical-data.mdx) | Using the UI time selector to see a value before a merge | Tutorial |
+
+Three of the post's nine sections restate what `immutable-history/overview.mdx` already
+says, in some cases almost claim for claim. A fourth conceptual page would give the same
+assertion a fourth place to drift.
+
+## The gap the post exposes
+
+`immutable-history/overview.mdx` states that temporal queries work through the Web UI,
+the GraphQL API, the REST API, and the Python SDK. **The docs never show a temporal query
+in any of them.** The only place the parameter appears is one bullet in an unrelated
+tutorial:
+
+- `learn/tutorials/transformations/build-a-jinja2-transformation.mdx:324` —
+  `?branch=main&at=<time of your choice>`
+
+Verified against the source, not the post:
+
+- `at` is a query-string parameter on both the REST API and the GraphQL endpoint
+  (`backend/infrahub/api/dependencies.py:81`, `backend/infrahub/graphql/app.py:206`).
+- It accepts **absolute or relative** formats — the relative form is documented nowhere
+  in the docs.
+- Requests are validated per branch by `BranchQueryTimeValidator`
+  (`backend/infrahub/api/dependencies.py:88`), so some time/branch combinations are
+  rejected. That constraint is undocumented, and it is the kind of thing a reader hits
+  on their first attempt.
+
+The missing quadrant is how-to. The concept is over-served; the task is unserved.
+
+## Recommended changes
+
+### A. New how-to page — `docs/docs/immutable-history/query-historical-data.mdx`
+
+Title: "Query historical data". Turns Immutable History from a single page into a small
+hub with one spoke, following the hub-and-spokes pattern.
+
+Content, all sourceable from the code and the existing UI:
+
+- selecting a time in the UI (the existing tutorial screenshot can be reused)
+- `at` on the GraphQL endpoint, with a worked query
+- `at` on the REST API
+- absolute vs. relative time formats
+- what happens when a time predates the branch, and why
+
+Sidebar: `sidebars.ts:241` becomes a category with `immutable-history/overview` as its
+hub link.
+
+### B. Edit — `immutable-history/overview.mdx`
+
+Two framings the post articulates better than the current page, and that the page is
+missing rather than duplicating:
+
+1. **Temporal graph vs. change log.** The current page explains that history is kept.
+   It never explains that state at every point in time is directly queryable rather than
+   reconstructed from a log of operations. This is the distinction that tells a reader
+   why the feature is different from an audit trail, and it is the post's strongest section.
+2. **Multiple timelines at once.** Branches share an immutable baseline and record only
+   divergences. The page currently lists "parallel workflows" as a benefit without saying
+   what makes it cheap. This also connects the page to Branches, which it already links to.
+
+Both were conceptual claims that needed confirming with engineering before being written. Both were
+subsequently confirmed against the source code and are now on the page.
+
+### C. Not recommended — a "Temporal graph" concept page
+
+The docs' vocabulary for this is **immutable history** and **temporal queries**. The post
+uses **temporal graph** and **multi-temporal graph**, which are positioning terms aimed at
+a prospect audience. Introducing a third name for the same capability splits search, and
+the reader now has to work out whether the three pages describe three things.
+
+This is a terminology call rather than a docs-mechanics call, so it is yours to make. If
+"temporal graph" is becoming the canonical product term, the right move is to rename
+across the existing pages, not to add a page beside them.
+
+## The open questions, and how each was answered
+
+All four questions below were resolved during the work that followed. They are kept here with their
+answers, because the answers explain decisions that are otherwise invisible in the finished pages.
+
+**Question 1. Is "temporal graph" now the product term, or does it stay marketing vocabulary?**
+
+Answered: it stays marketing vocabulary. The documentation continues to use "immutable history" and
+"temporal queries". Recommendation C was therefore rejected, and no page was renamed. The term
+"temporal graph" appears exactly once on the overview page, as a definition of the storage design,
+because it is a useful name for that design.
+
+**Question 2. Does the Python SDK expose `at`?**
+
+Answered: yes. It is an argument on the methods `all()`, `get()`, `filters()` and
+`execute_graphql()`, in `python_sdk/infrahub_sdk/client.py` at lines 277, 883, 1184 and 2134. The
+overview page's claim that four interfaces support historical queries is therefore correct and
+needed no correction.
+
+**Question 3. Should the claim about hundreds of branches with no performance lag be repeated?**
+
+Answered: no. Nothing in the repository supports it, and no benchmark was found to cite. It was left
+out of both pages.
+
+**Question 4. Is the difference between two arbitrary points in time genuinely available, or is it
+only the Proposed Change difference between two branches?**
+
+Answered: it is genuinely available for two arbitrary timestamps, through the GraphQL interface, and
+it is documented on the new page. However, it works differently from how this document assumed. It
+takes two steps rather than one: a request called `DiffUpdate` calculates the difference and stores
+it, and only then can `DiffTree` or `DiffTreeSummary` read the result. A custom period of time also
+requires a name, or the request is refused. The details are recorded in
+`immutable-history-temporal-queries.md`.

--- a/docs/docs/deploy-manage/run-observe/activity-log.mdx
+++ b/docs/docs/deploy-manage/run-observe/activity-log.mdx
@@ -59,6 +59,54 @@ There are several ways to hone your view in the global activity log:
 ![Activity logs filters - primary](../../media/topics/activity-logs/activity_log_global_filters_primary.png)
 ![Activity logs filters - children](../../media/topics/activity-logs/activity_log_global_filters_children.png)
 
+## Querying the activity log over the API
+
+Use the `InfrahubEvent` GraphQL query to read the activity log from a script: collect every operation in an incident window, or line those operations up against the data as it stood at the time.
+
+```graphql title="Events in a time range"
+query IncidentEvents {
+  InfrahubEvent(
+    since: "2026-03-09T00:00:00Z"
+    until: "2026-03-10T00:00:00Z"
+    branches: ["main"]
+  ) {
+    count
+    edges {
+      node {
+        id
+        event
+        branch
+        occurred_at
+        account_id
+        primary_node { id kind }
+      }
+    }
+  }
+}
+```
+
+`since` defaults to 180 days back and `until` defaults to the current time. A query that omits `since` therefore returns only the last 180 days rather than the full history, and nothing in the response says so. Set `since` explicitly when you need events older than 180 days.
+
+The filters available in the web interface map onto these parameters, and the query accepts several that the interface does not expose:
+
+| Parameter | Selects |
+|---|---|
+| `since`, `until` | Events in a time range |
+| `branches` | Events on specific branches |
+| `account__ids` | Events initiated by specific accounts |
+| `event_type` | Events matching a type, such as `infrahub.node.updated` |
+| `event_type_filter` | Filters specific to one event type |
+| `primary_node__ids` | Events whose primary node is one of these |
+| `related_node__ids` | Events whose related nodes include one of these |
+| `parent__ids` | Events listing one of these as a parent |
+| `has_children` | Events that did or did not trigger child events |
+| `level` | Root events (`0`) or a given depth of child event |
+| `ids` | Specific events by ID |
+| `order` | Sort order, descending by default |
+| `limit`, `offset` | Page through the results |
+
+See [Infrahub Events](../../reference/infrahub-events/overview.mdx) for the event types and the fields each one carries.
+
 ## Viewing event details
 
 If you choose **View more** from the global or object-level list, a separate detail page or popover will show up. Additional details are shown in this view, such as:

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -2,79 +2,95 @@
 title: Immutable history
 ---
 
-# Understanding immutable history in Infrahub
+Infrahub keeps every state your infrastructure data has held. Query the graph as it was at any
+point in the past — yesterday's routes, last week's VLAN definitions, the ACL a rollout replaced —
+using the same queries you run against current data.
 
-At its foundation, Infrahub implements data immutability—a principle where information in the database cannot be deleted or modified in place. Instead, every change creates a new version while preserving all previous states. This approach mirrors version control systems like Git, providing a robust history of all infrastructure changes.
+## Why it matters
 
-This architectural decision provides several critical benefits for infrastructure management:
+Debugging a change means comparing what is true now with what was true before it. A data model
+that stores only current values answers the first half and loses the second: once a rollout has
+overwritten the configuration that worked, the comparison you need is gone.
 
-- **Complete audit trail**: Every modification is permanently recorded with who, what, and when, providing full traceability
-- **Time travel queries**: Access the exact state of your infrastructure at any point in history to understand past configurations
-- **Risk-free rollbacks**: Return to any previous state without data loss when issues are detected
-- **Compliance and forensics**: Meet regulatory requirements with immutable change history for audits
-- **Parallel workflows**: Enable multiple teams to work on infrastructure changes simultaneously using branches
-- **Change verification**: Review proposed changes before committing them to production environments
+That gap turns up in ordinary work:
 
-## Use cases
+- A deployment breaks connectivity, and you need the exact configuration it replaced rather than
+  an approximation of it.
+- Something has drifted from design intent, and the useful question is when it diverged.
+- An audit asks which interfaces changed between two dates.
+- A schema change is coming, and you want to know what it does to data that already exists.
+- An automation behaved correctly in testing and incorrectly in production, and you want to run it
+  against the data as it stood at the time.
 
-Immutable history in Infrahub supports several crucial infrastructure management scenarios:
+Because Infrahub records the state of the graph at every point in time, each of these is a query
+rather than an investigation.
 
-- **Historical analysis**: View how your infrastructure looked at a specific point in time to troubleshoot issues or understand past decisions
-- **Compliance auditing**: Extract all changes performed within a specific time frame for regulatory compliance
-- **Change impact assessment**: Compare infrastructure states before and after significant changes
-- **Security investigation**: Trace unauthorized or unexpected changes to their source
-- **Knowledge preservation**: Understand why specific configuration decisions were made, even as team members change
+## How Infrahub stores history
 
-## Core concepts
+Nothing in the database is modified in place. Updating an attribute adds a new value with its own
+timestamp; the previous value stays where it is, still carrying the timestamps that say when it
+was current. The same applies to relationships, so both the objects and the connections between
+them are timestamped.
 
-### Timestamps and commits
+A graph recorded this way is a **temporal graph**: it holds not only how objects relate, but when
+each of those relationships was valid. Naming a time in a query selects the values that were
+current then, which is what makes "the topology before Tuesday's pipeline run" a question the
+database can answer directly.
 
-Every change in Infrahub is organized into commits, each with an immutable timestamp. These commits capture:
+Two properties follow from storing history this way:
 
-- The specific data that changed
-- Who made the change
-- When the change occurred
+- **Change tracking is per attribute, not per object.** An update stores the value that changed
+  rather than a fresh copy of the whole object, and a diff can say which field moved rather than
+  only that the object was touched.
+- **History cannot be rewritten.** Because values are added rather than replaced, a past state
+  cannot be edited after the fact, and the record of who changed what remains attached to it.
 
-This approach ensures a complete and coherent historical record that can never be rewritten or deleted.
+## Temporal history and change logs
 
-### Temporal queries
+A change log records events: what changed, when, and by whom. Reconstructing a past state from one
+means finding an earlier snapshot and replaying the events on top of it, and the result is only as
+complete as the log.
 
-Infrahub's temporal query system allows you to retrieve data from any point in time. When you query the database, you're not just accessing current data—you're accessing a specific moment in the database's history. By default, queries return the latest state, but you can specify any timestamp to see exactly how your infrastructure looked at that moment.
+Infrahub stores the resulting state at every point in time instead of the operations that produced
+it. Reading the past is therefore a query against data that is already there, and it returns
+objects in the same shape as a query against current data — the same fields, the same filters, the
+same client code.
 
-This capability extends across all interfaces:
+Both are useful for different questions. Use the [activity
+log](../deploy-manage/run-observe/activity-log) to see the sequence of operations someone
+performed; query a past time to see the state those operations produced.
 
-- **Web UI**: Time navigation controls in the interface
-- **GraphQL API**: Timestamp parameters for historical queries
-- **REST API**: Temporal query support for retrieving historical data
-- **Python SDK**: Time-aware methods to access past states
+## Branches are parallel timelines
 
-For the syntax each one uses, the time formats they accept, and how far back a branch can be read, see [Query historical data](./query-historical-data.mdx).
+A branch is a second timeline over the same history. Creating one stores a pointer to the moment
+it diverged rather than a copy of the data, so the branch starts with the full history of its
+origin available to it and records only the values you change on it.
 
-### Temporal queries and change logs
+That is why a query names both a branch and a time: together they identify one state out of every
+state the graph has recorded. A branch created last week can be read as it was on Monday, and the
+default branch can be read as it was before that branch merged into it.
 
-A change log records the operations that were applied. Reading a past state from one means replaying those operations in order, and the result is only as complete as the log. Infrahub stores the resulting state at every point in time, so reading the past is a query against data that is already stored rather than a reconstruction from a record of what happened.
+## Where you can use it
 
-### Multiple timelines at once
+| Surface | Access |
+|---|---|
+| Web interface | The time selector beside the branch selector; every object you open reflects the selected time |
+| GraphQL API | `at` on the endpoint — see [Query historical data](./query-historical-data.mdx) |
+| REST API | `at` on stored queries, artifacts, and transformations |
+| Python SDK | `at` on `all()`, `get()`, `filters()`, and `execute_graphql()` |
 
-Branches share the same immutable baseline and record only the values that diverge from it. Creating a branch stores a pointer to a base timestamp rather than a copy of the data, so a branch starts with the full history of its origin available to it and adds only what you change. This is what allows a query to name both a branch and a time: the two together identify one state out of every state the graph has recorded.
-
-### Attribute-level change tracking
-
-Unlike systems that capture entire object snapshots, Infrahub's immutable history operates at the attribute level. This approach offers several advantages:
-
-- **Storage efficiency**: Only changed values are stored, not entire object copies
-- **Change clarity**: Easier identification of exactly what changed in each commit
-- **Performance optimization**: Faster queries and better scalability with large datasets
-
-## Implementation details
-
-There is a timestamp associated with every change in the database. This timestamp is immutable and cannot be changed or deleted. Every query to the database can be associated with a timestamp, allowing you to see the state of the database at that specific point in time.
+To compare two moments rather than read one, query `DiffTree` with a start and end time. A
+[Proposed Change](../proposed-changes/overview.mdx) does the same comparison scoped to a branch,
+which is the right tool when the two states you care about are a branch and its base.
 
 ## Related topics
 
-- [Branches](../branches/overview.mdx) — how branches isolate changes, and what merging does to the timeline
-- [Proposed Changes](../proposed-changes/overview.mdx) — review and validate a set of changes before they merge
+- [Branches](../branches/overview.mdx) — how branches isolate changes, and what merging does to
+  the timeline
+- [Proposed Changes](../proposed-changes/overview.mdx) — review and validate a set of changes
+  before they merge
 
 ## In this section
 
-- [Query historical data](./query-historical-data.mdx) — Read the graph as it stood at any past time, from the web interface, GraphQL, REST, or the Python SDK
+- [Query historical data](./query-historical-data.mdx) — Read the graph as it stood at a past
+  time from any interface, and compare two moments to see what changed

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -2,24 +2,17 @@
 title: Immutable history
 ---
 
-Infrahub preserves previous values and relationships as your infrastructure data changes. Earlier
-versions remain available for queries, so you can inspect what existed at a specific time, compare
-changes across a period, and trace how an object or relationship changed.
+Infrahub preserves previous values and relationships as your infrastructure data changes. Earlier versions remain available for queries, so you can inspect what existed at a specific time, compare changes across a period, and trace how an object or relationship changed.
 
-This is useful for troubleshooting incidents, reviewing the effect of a change, answering audit
-questions, and understanding how topology or dependencies evolved. When you specify a timestamp,
-Infrahub returns the values and relationships that were valid at that time.
+This is useful for troubleshooting incidents, reviewing the effect of a change, answering audit questions, and understanding how topology or dependencies evolved. When you specify a timestamp, Infrahub returns the objects, attribute values, relationships, and schema that were valid at that time.
 
 ## What you can do with immutable history
 
-- Query objects and relationships as they existed at a specific point in time.
+- Query objects, attributes, relationships, and the schema as they existed at a specific point in time.
 - Compare two timestamps to identify which objects, attributes, or relationships changed.
-- Trace a change to the account that made it and the time it happened, through [object
-  metadata](../objects/metadata.mdx).
-- Preserve the history available before a branch was created while recording changes made on that
-  branch.
-- Use previous infrastructure data for troubleshooting, audits, security investigations, and
-  post-incident analysis.
+- Trace a change to the account that made it and the time it happened, through [object metadata](../objects/metadata.mdx).
+- Preserve the history available before a branch was created while recording changes made on that branch.
+- Use previous infrastructure data for troubleshooting, audits, security investigations, and post-incident analysis.
 
 For example, you can answer questions such as:
 
@@ -29,68 +22,45 @@ For example, you can answer questions such as:
 
 ## Historical data and the Activity log answer different questions
 
-The Activity log records operations: which objects were affected, when a change occurred, who made
-it, and the sequence of actions.
+The Activity log records operations: which object was changed, when that change occurred and who made it, and the sequence of actions.
 
-Immutable history preserves the versions of data produced by those changes. If you need to know who
-changed an interface and when, use the [Activity
-log](../deploy-manage/run-observe/activity-log.mdx). If you need to know which interfaces,
-addresses, and relationships existed at 14:00 during an incident, query the data for that timestamp.
+Immutable history preserves the versions of data produced by those changes. If you need to know who changed an interface and when, use the [Activity log](../deploy-manage/run-observe/activity-log.mdx). If you need to know which interfaces, addresses, and relationships existed at 14:00 during an incident, query the data for that timestamp.
 
-When you specify a timestamp, Infrahub returns the values and relationships that were valid then, so
-you query that data directly rather than reconstructing it from a backup and the changes recorded
-after it.
+When you specify a timestamp, Infrahub returns the objects, attribute values, and relationships that were valid then, so you query that data directly rather than reconstructing it from a backup and the changes recorded after it.
 
 ## How Infrahub preserves history
 
-Each change in Infrahub creates a new version instead of modifying the previous value in place.
-Every version is associated with a timestamp, and earlier values remain available for queries that
-specify an earlier time.
+Each change in Infrahub creates a new version instead of modifying the previous value in place. Every version is associated with a timestamp, and earlier values remain available for queries that specify an earlier time.
 
-History is tracked at the attribute level. When one field changes, Infrahub records the new value
-for that field alone. This makes it possible to identify the specific attributes that changed
-between two timestamps.
+History is recorded at four levels: objects, attributes, relationships, and the schema.
 
-Relationships are versioned as well. A query for a specific timestamp therefore returns both the
-attribute values and the object relationships that were valid at that time. This is important for
-topology and dependency questions where the connections between objects are part of the answer.
+An object records the period during which it existed, so a query for an earlier time returns objects that have since been deleted and omits objects that did not yet exist. Attributes are versioned individually — when one field changes, Infrahub records a new value for that field alone, which is what makes it possible to identify the specific fields that changed between two timestamps. Relationships are versioned the same way, so a query for a past time returns the connections between objects as they stood then rather than the current ones. This matters for topology and dependency questions, where the connections are part of the answer.
 
-The schema is versioned the same way. If the schema changed after the timestamp you request,
-Infrahub loads the schema as it was at that point, so the query sees the attributes and
-relationships the schema defined then rather than the ones it defines now.
+The schema is versioned as well. If the schema changed after the timestamp you request, Infrahub loads the schema as it was at that point, so the query sees the attributes and relationships the schema defined then rather than the ones it defines now.
 
-A graph that stores validity times for both its values and its relationships is a **temporal
-graph**. The period during which each value and connection applied is part of the stored data, which
-is why you can answer a question about past topology with a query.
-
-Deleting a branch is the exception. Infrahub removes the data and history recorded on that branch,
-and that history is not recoverable. Versions on the default branch are unaffected.
+A graph that stores validity times for both its values and its relationships is a **temporal graph**. The period during which each value and connection applied is part of the stored data, which is why you can answer a question about past topology with a query.
 
 ## How branches use immutable history
 
-When you create a branch, it starts from the data and history available on the default branch at its
-branch point. Changes made on that branch create new versions there without changing the data on the
-default branch.
+When you create a branch, it starts from the data and history available on the default branch at its branch point. Changes made on that branch create new versions there without changing the data on the default branch, so you can develop and review several changes independently while retaining the history needed to compare and merge them. See [Branches](../branches/overview.mdx) for the branch creation, diff, and merge workflow.
 
-You can therefore develop and review multiple changes independently while retaining the history
-needed to compare and merge them. See [Branches](../branches/overview.mdx) for the branch creation,
-diff, and merge workflow.
+Three branch operations change which history remains available, and each one affects what a historical query can return.
+
+**Merging** records the merged changes on the default branch with the timestamp of the merge, not the timestamps they had on the branch. If someone creates an object on a branch on Monday and the branch merges on Friday, the default branch shows that object as created on Friday. The default branch's history therefore holds the result of the branch rather than the sequence of changes that produced it, and those intermediate versions stay readable on the branch itself for as long as the branch exists.
+
+**Rebasing** moves the timestamps of changes made on a branch up to the rebase time, so a change recorded on the branch before a rebase is no longer readable at its original timestamp.
+
+**Deleting a branch** removes the data and history recorded on it permanently. Versions on the default branch are unaffected, and the [Activity log](../deploy-manage/run-observe/activity-log.mdx) still records the operations that were performed on the branch, but the versions themselves cannot be recovered. If a branch's history matters for an audit or an investigation, read it before the branch is deleted.
 
 ## Query data at a specific time
 
-By default, queries return the latest data on the selected branch. Set a time when you need the
-values and relationships that were valid at an earlier timestamp. You can specify a time through the
-web interface, GraphQL API, REST API, and Python SDK.
+By default, queries return the latest data on the selected branch. Set a time when you need the state of the data at an earlier time. You can specify a time through the web interface, GraphQL API, REST API, and Python SDK.
 
-See [Query historical data](./query-historical-data.mdx) for the available interfaces, comparing two
-timestamps, supported time formats, and branch history limits.
+See [Query historical data](./query-historical-data.mdx) for the available interfaces, comparing two timestamps, supported time formats, and branch history limits.
 
 ## Related
 
-- [Query historical data](./query-historical-data.mdx) — read the graph at an earlier timestamp,
-  and compare two timestamps to see what changed
+- [Query historical data](./query-historical-data.mdx) — read the graph at an earlier timestamp, and compare two timestamps to see what changed
 - [Branches](../branches/overview.mdx) — how branches diverge, share history, and merge
-- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base, with
-  review, validation, and checks
-- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when,
-  and by whom
+- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base, with review, validation, and checks
+- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when, and by whom

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -2,95 +2,89 @@
 title: Immutable history
 ---
 
-Infrahub keeps every state your infrastructure data has held. Query the graph as it was at any
-point in the past — yesterday's routes, last week's VLAN definitions, the ACL a rollout replaced —
-using the same queries you run against current data.
+Infrahub preserves previous values and relationships as your infrastructure data changes. Earlier
+versions remain available for queries, so you can inspect what existed at a specific time, compare
+changes across a period, and trace how an object or relationship changed.
 
-## Why it matters
+This is useful for troubleshooting incidents, reviewing the effect of a change, answering audit
+questions, and understanding how topology or dependencies evolved. When you specify a timestamp,
+Infrahub returns the values and relationships that were valid at that time.
 
-Debugging a change means comparing what is true now with what was true before it. A data model
-that stores only current values answers the first half and loses the second: once a rollout has
-overwritten the configuration that worked, the comparison you need is gone.
+## What you can do with immutable history
 
-That gap turns up in ordinary work:
+- Query objects and relationships as they existed at a specific point in time.
+- Compare two timestamps to identify which objects, attributes, or relationships changed.
+- Trace each change to the account that made it and the time it happened.
+- Preserve the history available before a branch was created while recording changes made on that
+  branch.
+- Use previous infrastructure data for troubleshooting, audits, security investigations, and
+  post-incident analysis.
 
-- A deployment breaks connectivity, and you need the exact configuration it replaced rather than
-  an approximation of it.
-- Something has drifted from design intent, and the useful question is when it diverged.
-- An audit asks which interfaces changed between two dates.
-- A schema change is coming, and you want to know what it does to data that already exists.
-- An automation behaved correctly in testing and incorrectly in production, and you want to run it
-  against the data as it stood at the time.
+For example, you can answer questions such as:
 
-Because Infrahub records the state of the graph at every point in time, each of these is a query
-rather than an investigation.
+- Which devices, interfaces, and relationships existed for this site during last night's incident?
+- Which interface attributes changed between the last known-good timestamp and now?
+- Which services and circuits were related before this topology change?
 
-## How Infrahub stores history
+## Historical data and the Activity log answer different questions
 
-Nothing in the database is modified in place. Updating an attribute adds a new value with its own
-timestamp; the previous value stays where it is, still carrying the timestamps that say when it
-was current. The same applies to relationships, so both the objects and the connections between
-them are timestamped.
+The Activity log records operations: which objects were affected, when a change occurred, who made
+it, and the sequence of actions.
 
-A graph recorded this way is a **temporal graph**: it holds not only how objects relate, but when
-each of those relationships was valid. Naming a time in a query selects the values that were
-current then, which is what makes "the topology before Tuesday's pipeline run" a question the
-database can answer directly.
+Immutable history preserves the versions of data produced by those changes. If you need to know who
+changed an interface and when, use the [Activity
+log](../deploy-manage/run-observe/activity-log.mdx). If you need to know which interfaces,
+addresses, and relationships existed at 14:00 during an incident, query the data for that timestamp.
 
-Two properties follow from storing history this way:
+Infrahub returns the relevant values and relationships for the time you specify, so you query that
+data directly rather than reconstructing it from a backup and the changes recorded after it.
 
-- **Change tracking is per attribute, not per object.** An update stores the value that changed
-  rather than a fresh copy of the whole object, and a diff can say which field moved rather than
-  only that the object was touched.
-- **History cannot be rewritten.** Because values are added rather than replaced, a past state
-  cannot be edited after the fact, and the record of who changed what remains attached to it.
+## How Infrahub preserves history
 
-## Temporal history and change logs
+Each change in Infrahub creates a new version instead of modifying the previous value in place.
+Every version is associated with a timestamp, and earlier values remain available for queries that
+specify an earlier time.
 
-A change log records events: what changed, when, and by whom. Reconstructing a past state from one
-means finding an earlier snapshot and replaying the events on top of it, and the result is only as
-complete as the log.
+History is tracked at the attribute level. When one field changes, Infrahub records the new value
+for that field alone. This makes it possible to identify the specific attributes that changed
+between two timestamps.
 
-Infrahub stores the resulting state at every point in time instead of the operations that produced
-it. Reading the past is therefore a query against data that is already there, and it returns
-objects in the same shape as a query against current data — the same fields, the same filters, the
-same client code.
+Relationships are versioned as well. A query for a specific timestamp therefore returns both the
+attribute values and the object relationships that were valid at that time. This is important for
+topology and dependency questions where the connections between objects are part of the answer.
 
-Both are useful for different questions. Use the [activity
-log](../deploy-manage/run-observe/activity-log) to see the sequence of operations someone
-performed; query a past time to see the state those operations produced.
+A graph that stores validity times for both its values and its relationships is a **temporal
+graph**. The period during which each value and connection applied is part of the stored data, which
+is why you can answer a question about past topology with a query.
 
-## Branches are parallel timelines
+Deleting a branch is the exception. Infrahub removes the data and history recorded on that branch,
+and that history is not recoverable. Versions on the default branch are unaffected.
 
-A branch is a second timeline over the same history. Creating one stores a pointer to the moment
-it diverged rather than a copy of the data, so the branch starts with the full history of its
-origin available to it and records only the values you change on it.
+## How branches use immutable history
 
-That is why a query names both a branch and a time: together they identify one state out of every
-state the graph has recorded. A branch created last week can be read as it was on Monday, and the
-default branch can be read as it was before that branch merged into it.
+When you create a branch, it starts from the data and history available on the default branch at its
+branch point. Changes made on that branch create new versions there without changing the data on the
+default branch.
 
-## Where you can use it
+You can therefore develop and review multiple changes independently while retaining the history
+needed to compare and merge them. See [Branches](../branches/overview.mdx) for the branch creation,
+diff, and merge workflow.
 
-| Surface | Access |
-|---|---|
-| Web interface | The time selector beside the branch selector; every object you open reflects the selected time |
-| GraphQL API | `at` on the endpoint — see [Query historical data](./query-historical-data.mdx) |
-| REST API | `at` on stored queries, artifacts, and transformations |
-| Python SDK | `at` on `all()`, `get()`, `filters()`, and `execute_graphql()` |
+## Query data at a specific time
 
-To compare two moments rather than read one, query `DiffTree` with a start and end time. A
-[Proposed Change](../proposed-changes/overview.mdx) does the same comparison scoped to a branch,
-which is the right tool when the two states you care about are a branch and its base.
+By default, queries return the latest data on the selected branch. Set a time when you need the
+values and relationships that were valid at an earlier timestamp. You can specify a time through the
+web interface, GraphQL API, REST API, and Python SDK.
 
-## Related topics
+See [Query historical data](./query-historical-data.mdx) for the available interfaces, comparing two
+timestamps, supported time formats, and branch history limits.
 
-- [Branches](../branches/overview.mdx) — how branches isolate changes, and what merging does to
-  the timeline
-- [Proposed Changes](../proposed-changes/overview.mdx) — review and validate a set of changes
-  before they merge
+## Related
 
-## In this section
-
-- [Query historical data](./query-historical-data.mdx) — Read the graph as it stood at a past
-  time from any interface, and compare two moments to see what changed
+- [Query historical data](./query-historical-data.mdx) — read the graph at an earlier timestamp,
+  and compare two timestamps to see what changed
+- [Branches](../branches/overview.mdx) — how branches diverge, share history, and merge
+- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base, with
+  review, validation, and checks
+- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when,
+  and by whom

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -14,7 +14,8 @@ Infrahub returns the values and relationships that were valid at that time.
 
 - Query objects and relationships as they existed at a specific point in time.
 - Compare two timestamps to identify which objects, attributes, or relationships changed.
-- Trace each change to the account that made it and the time it happened.
+- Trace a change to the account that made it and the time it happened, through [object
+  metadata](../objects/metadata.mdx).
 - Preserve the history available before a branch was created while recording changes made on that
   branch.
 - Use previous infrastructure data for troubleshooting, audits, security investigations, and
@@ -52,6 +53,10 @@ between two timestamps.
 Relationships are versioned as well. A query for a specific timestamp therefore returns both the
 attribute values and the object relationships that were valid at that time. This is important for
 topology and dependency questions where the connections between objects are part of the answer.
+
+The schema is versioned the same way. If the schema changed after the timestamp you request,
+Infrahub loads the schema as it was at that point, so the query sees the attributes and
+relationships the schema defined then rather than the ones it defines now.
 
 A graph that stores validity times for both its values and its relationships is a **temporal
 graph**. The period during which each value and connection applied is part of the stored data, which

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -48,6 +48,16 @@ This capability extends across all interfaces:
 - **REST API**: Temporal query support for retrieving historical data
 - **Python SDK**: Time-aware methods to access past states
 
+For the syntax each one uses, the time formats they accept, and how far back a branch can be read, see [Query historical data](./query-historical-data.mdx).
+
+### Temporal queries and change logs
+
+A change log records the operations that were applied. Reading a past state from one means replaying those operations in order, and the result is only as complete as the log. Infrahub stores the resulting state at every point in time, so reading the past is a query against data that is already stored rather than a reconstruction from a record of what happened.
+
+### Multiple timelines at once
+
+Branches share the same immutable baseline and record only the values that diverge from it. Creating a branch stores a pointer to a base timestamp rather than a copy of the data, so a branch starts with the full history of its origin available to it and adds only what you change. This is what allows a query to name both a branch and a time: the two together identify one state out of every state the graph has recorded.
+
 ### Attribute-level change tracking
 
 Unlike systems that capture entire object snapshots, Infrahub's immutable history operates at the attribute level. This approach offers several advantages:
@@ -62,5 +72,9 @@ There is a timestamp associated with every change in the database. This timestam
 
 ## Related topics
 
-- [Proposed Changes](../proposed-changes/overview.mdx)
-- [Branches](../branches/overview.mdx)
+- [Branches](../branches/overview.mdx) — how branches isolate changes, and what merging does to the timeline
+- [Proposed Changes](../proposed-changes/overview.mdx) — review and validate a set of changes before they merge
+
+## In this section
+
+- [Query historical data](./query-historical-data.mdx) — Read the graph as it stood at any past time, from the web interface, GraphQL, REST, or the Python SDK

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -37,8 +37,9 @@ changed an interface and when, use the [Activity
 log](../deploy-manage/run-observe/activity-log.mdx). If you need to know which interfaces,
 addresses, and relationships existed at 14:00 during an incident, query the data for that timestamp.
 
-Infrahub returns the relevant values and relationships for the time you specify, so you query that
-data directly rather than reconstructing it from a backup and the changes recorded after it.
+When you specify a timestamp, Infrahub returns the values and relationships that were valid then, so
+you query that data directly rather than reconstructing it from a backup and the changes recorded
+after it.
 
 ## How Infrahub preserves history
 

--- a/docs/docs/immutable-history/overview.mdx
+++ b/docs/docs/immutable-history/overview.mdx
@@ -10,7 +10,7 @@ This is useful for troubleshooting incidents, reviewing the effect of a change, 
 
 - Query objects, attributes, relationships, and the schema as they existed at a specific point in time.
 - Compare two timestamps to identify which objects, attributes, or relationships changed.
-- Trace a change to the account that made it and the time it happened, through [object metadata](../objects/metadata.mdx).
+- Trace who performed an operation and when, through the [Activity log](../deploy-manage/run-observe/activity-log.mdx), and see where a value came from through [object metadata](../objects/metadata.mdx).
 - Preserve the history available before a branch was created while recording changes made on that branch.
 - Use previous infrastructure data for troubleshooting, audits, security investigations, and post-incident analysis.
 

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -5,19 +5,25 @@ title: Query historical data
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Query historical data
+Attach a time to any read and Infrahub returns the data as it stood then. The query is the one you
+already use — same fields, same filters, same client code — with a point in time added to it.
 
-Every read in Infrahub happens at a point in time. By default that point is now. Add the `at` parameter to a read and Infrahub returns the data as it was at the time you name, on whichever branch you are querying.
+This is the tool for questions that current state cannot answer: which interfaces changed between
+two dates, what the topology looked like before a pipeline ran, or what a device's configuration
+was at the moment an alert fired. [Immutable history](./overview.mdx) covers why those states are
+still available to query; this guide covers how to ask for them.
 
-Use `at` when the current state cannot explain the present: a change was merged overnight and a device stopped forwarding traffic, an auditor asks which prefixes were assigned to a site on a given date, or you need to compare a configuration against the one it replaced.
+Three things carry most of the work: choosing the point in time, knowing how far back the branch
+you are querying can be read, and picking the interface that fits what you are doing.
 
-## Before you start
+## Choose a point in time
 
-Two things determine whether a first attempt returns data: the format of the time you pass, and how far back the branch can be read.
+Two kinds of question need two kinds of timestamp, and `at` accepts both.
 
-### Time formats
-
-`at` accepts an absolute time or an offset from now.
+While you are working backwards from a problem, the useful reference is now — "what did this look
+like an hour ago" — and a relative offset says that without arithmetic. An audit question, a
+post-incident writeup, or anything two people need to agree on requires a fixed moment that still
+means the same thing next week, which is an absolute time.
 
 | Form | Example | Resolves to |
 |---|---|---|
@@ -26,32 +32,53 @@ Two things determine whether a first attempt returns data: the format of the tim
 | Date only | `2026-03-09` | 12:00 UTC on that day |
 | Offset from now | `30s`, `45m`, `6h`, `2h30m` | That much time before now |
 
-A date on its own resolves to midday, not midnight. Write the time out when the distinction matters.
+Two limits are worth knowing before they surprise you. A date on its own resolves to midday rather
+than midnight, so an audit question about "the 9th" is not the same request as `2026-03-09` — write
+the time out when the boundary of a day matters. And offsets stop at hours: seconds, minutes, and
+hours combine in one string, but there is no day or week form, so `7d` returns a
+`TimestampFormatError`. For anything further back than a few hours, pass an absolute time.
 
-Offsets are limited to seconds, minutes, and hours — `s`, `sec`, `second`, `seconds`, `m`, `min`, `minute`, `minutes`, `h`, `hour`, `hours` — and combine in one string. Days and weeks have no offset form, so `7d` returns a `TimestampFormatError`. For anything beyond a few hours back, pass an absolute time.
+## How far back a branch can be read
 
-### How far back you can read
+A branch's history starts where the branch does. Creating a branch stores a pointer to the moment
+it diverged rather than a copy of the data, so what a branch can be read from is the history it
+inherited, plus the changes you have made on it since.
 
-A branch cannot be read from before it existed. On the default branch and the global branch, the earliest readable time is that branch's own creation time. On any other branch, the boundary is the creation time of the branch it came from, because the history before the branch point belongs to the origin branch.
+That inheritance is what puts the boundary where it is. On the default branch and the global
+branch, the earliest readable time is that branch's own creation. On any other branch, the boundary
+is the creation time of the branch it came from, because everything before the divergence point is
+the origin branch's history and that is where the branch reads it from.
 
-Ask for something earlier and Infrahub rejects the query:
+Ask for anything earlier and Infrahub rejects the query rather than returning a partial answer:
 
 ```text
 Requested time '2026-01-05T00:00:00Z' is before branch 'main' was created at '2026-02-01T09:14:22.481000Z'.
 ```
 
+If you need history from before a branch existed, query the branch it came from.
+
 ## Read data at a past time
 
-Pass `at` alongside the branch you are reading. The examples below all return the state of `ord1-edge1` at the same moment.
+Each interface suits a different moment. Use the web interface while you are still working out
+what changed, when moving the time and re-reading objects is the fastest way to find it. Use
+GraphQL for a specific question you can express as a query. Use the REST API when something
+scheduled or external needs the answer. Use the Python SDK when you are comparing states in code
+rather than reading them.
+
+The examples below all return the state of `ord1-edge1` at the same moment.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
-Select the time selector — the calendar and clock icon beside the branch selector — and choose a date and time in UTC. The control has no text label until you set a time, at which point the bar beside it reads **Current view time** with your selection.
+Select the time selector — the calendar and clock icon beside the branch selector — and choose a
+date and time in UTC. The control carries no text label until you set a time, at which point the
+bar beside it reads **Current view time** with your selection.
 
-Every object you open while a time is set shows its state at that time. Select the **×** beside the displayed time to return to the present.
+The selected time then applies to everything you open, so you can move through related objects
+without setting it again. Select the **×** beside the displayed time to return to the present.
 
-The picker offers past times only.
+Because the picker offers past times only, it is the one interface that cannot be pointed at a
+future timestamp.
 
 ![The time selector, with a past time applied](../media/tutorial_2_historical.png)
 
@@ -59,7 +86,7 @@ The picker offers past times only.
 
   <TabItem value="graphql" label="GraphQL">
 
-`at` is a query-string parameter on the GraphQL endpoint, so the query itself is unchanged:
+`at` is a query-string parameter on the endpoint, so the query itself is unchanged:
 
 ```graphql # Read a device at a past time
 # Endpoint : http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
@@ -76,26 +103,34 @@ query DeviceAtTime {
 }
 ```
 
-Because `at` is part of the endpoint rather than the query, the same stored query returns current or historical data depending on the URL you send it to.
+Keeping the time out of the query body means a query you have already written and saved works
+against any point in time — the endpoint you send it to decides which one. That is what makes a
+stored query reusable for both monitoring current state and answering a question about the past.
 
 </TabItem>
 
   <TabItem value="rest" label="REST API">
 
-The REST API applies `at` to stored GraphQL queries, artifacts, and transformations rather than to ad-hoc object reads. To read objects at a past time over REST, save the query as a `CoreGraphQLQuery` object and run it by name:
+The REST API applies `at` to stored GraphQL queries, artifacts, and transformations rather than to
+ad-hoc object reads. To read objects at a past time over REST, save the query as a
+`CoreGraphQLQuery` object and run it by name:
 
 ```bash
 curl "http://localhost:8000/api/query/device-status?branch=main&at=2026-03-09T14:00:00Z" \
   -H "X-INFRAHUB-KEY: $INFRAHUB_API_TOKEN"
 ```
 
-The same parameter works on `/api/artifact/{artifact_id}` and on the transformation endpoints, so you can render an artifact from the data as it was rather than from current data.
+The same parameter works on `/api/artifact/{artifact_id}` and on the transformation endpoints,
+which renders an artifact from the data as it stood rather than from current data — useful for
+producing the configuration a device was given at a particular time and comparing it with what is
+on the device now.
 
 </TabItem>
 
   <TabItem value="sdk" label="Python SDK">
 
-`all()`, `get()`, `filters()`, and `execute_graphql()` each take an `at` argument:
+`all()`, `get()`, `filters()`, and `execute_graphql()` each take an `at` argument, so a script can
+read two moments and compare them:
 
 ```python
 from infrahub_sdk import InfrahubClientSync
@@ -103,23 +138,29 @@ from infrahub_sdk.timestamp import Timestamp
 
 client = InfrahubClientSync(address="http://localhost:8000")
 
-device = client.get(
+before = client.get(
     kind="InfraDevice",
     name__value="ord1-edge1",
     at=Timestamp("2026-03-09T14:00:00Z"),
 )
+now = client.get(kind="InfraDevice", name__value="ord1-edge1")
 
-print(device.description.value)
+print(before.description.value, "->", now.description.value)
 ```
 
 `Timestamp` accepts every form in the table above, so `Timestamp("6h")` reads six hours back.
+Pointing a script at a past state is also how you test an automation against the data it ran on,
+rather than against data that has moved on since.
 
 </TabItem>
 </Tabs>
 
 ## Compare two points in time
 
-To see what changed between two moments rather than the state at one of them, query `DiffTree` with `from_time` and `to_time`. Both take a timestamp, and the two times can be arbitrary — they do not have to correspond to a branch point or a proposed change.
+Reading one state answers "what was it then". To answer "what changed between these two moments",
+query `DiffTree` with `from_time` and `to_time`. The two times are yours to choose — they do not
+have to line up with a branch point or a proposed change, which is what makes this usable for a
+window like "the four hours around the incident".
 
 ```graphql # What changed on main between two timestamps
 # Endpoint : http://localhost:8000/graphql/main
@@ -145,12 +186,26 @@ query ChangesBetween {
 }
 ```
 
-Omit `from_time` and the comparison starts at the branch's creation; omit `to_time` and it ends at the current time. Add `filters` to restrict the result by kind, namespace, or status, and `limit` and `offset` to page through a large result. For a count without the node detail, query `DiffTreeSummary` with the same arguments.
+Omit `from_time` and the comparison starts at the branch's creation; omit `to_time` and it ends at
+the current time. Add `filters` to restrict the result by kind, namespace, or status, and `limit`
+and `offset` to page through a large result. For counts without the node detail, query
+`DiffTreeSummary` with the same arguments.
 
-Two things to expect from the result. The base of the comparison is always the default branch, so naming a feature branch compares that branch against the default branch across the window, while naming the default branch compares it against itself. And where no diff covering the requested window is available, `DiffTree` returns `null` rather than an empty result.
+Two things to expect from the result. The base of the comparison is always the default branch, so
+naming a feature branch compares that branch against the default branch across the window, while
+naming the default branch compares it against itself over time. And where no diff covering the
+requested window is available, `DiffTree` returns `null` rather than an empty result — so treat a
+null as "not calculated", not as "nothing changed".
+
+When the two states you want to compare are a branch and its base, a
+[Proposed Change](../proposed-changes/overview.mdx) gives you the same comparison with review and
+validation attached.
 
 ## Related
 
-- [Immutable history](./overview.mdx) — how Infrahub stores every past state, and why a historical read is a query rather than a reconstruction
-- [Branches](../branches/overview.mdx) — how branch creation and merging place the timestamps you query against
-- [Proposed Changes](../proposed-changes/overview.mdx) — review a diff scoped to a branch, rather than to two times you choose
+- [Immutable history](./overview.mdx) — how Infrahub stores every past state, and why reading one
+  is a query rather than a reconstruction
+- [Branches](../branches/overview.mdx) — how branch creation and merging place the timestamps you
+  query against
+- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — the sequence of operations
+  someone performed, where a past state tells you what those operations produced

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -5,80 +5,64 @@ title: Query historical data
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Attach a time to any read and Infrahub returns the data as it stood then. The query is the one you
-already use — same fields, same filters, same client code — with a point in time added to it.
+Infrahub lets you query infrastructure data at previous points in time and compare how it changed
+between them. Use queries with a timestamp to investigate incidents, verify changes during a period,
+answer audit questions, and inspect how objects and relationships differed at an earlier time.
 
-This is the tool for questions that current state cannot answer: which interfaces changed between
-two dates, what the topology looked like before a pipeline ran, or what a device's configuration
-was at the moment an alert fired. [Immutable history](./overview.mdx) covers why those states are
-still available to query; this guide covers how to ask for them.
+To query a specific point, specify a branch and timestamp. Infrahub returns the values and
+relationships that were valid at that time through the same interfaces you use for current data. To
+compare changes, specify two timestamps.
 
-Three things carry most of the work: choosing the point in time, knowing how far back the branch
-you are querying can be read, and picking the interface that fits what you are doing.
+## Specify a branch and a time
 
-## Choose a point in time
+Each query is evaluated for a branch and a point in time. Infrahub uses those two inputs to select
+which versions of objects and relationships it returns. If you do not set either one, Infrahub
+returns the current data from the default branch.
 
-Two kinds of question need two kinds of timestamp, and `at` accepts both.
-
-While you are working backwards from a problem, the useful reference is now — "what did this look
-like an hour ago" — and a relative offset says that without arithmetic. An audit question, a
-post-incident writeup, or anything two people need to agree on requires a fixed moment that still
-means the same thing next week, which is an absolute time.
-
-| Form | Example | Resolves to |
+| State to read | Branch | Time |
 |---|---|---|
-| ISO 8601 with a zone or offset | `2026-03-09T14:00:00Z`, `2026-03-09T15:00:00+01:00` | The instant you name |
-| ISO 8601 without a zone | `2026-03-09T14:00:00` | The same wall-clock time, read as UTC |
-| Date only | `2026-03-09` | 12:00 UTC on that day |
-| Offset from now | `30s`, `45m`, `6h`, `2h30m` | That much time before now |
+| Production as it stands | default | now |
+| Production during last night's incident | default | a time within the incident |
+| The change someone is proposing | their branch | now |
+| The default branch just before that change merged | default | a time before the merge |
 
-Two limits are worth knowing before they surprise you. A date on its own resolves to midday rather
-than midnight, so an audit question about "the 9th" is not the same request as `2026-03-09` — write
-the time out when the boundary of a day matters. And offsets stop at hours: seconds, minutes, and
-hours combine in one string, but there is no day or week form, so `7d` returns a
-`TimestampFormatError`. For anything further back than a few hours, pass an absolute time.
+Queries for earlier data therefore use the same read interfaces as current queries. The difference
+is that you specify the time to evaluate the data.
 
-## How far back a branch can be read
+## How historical queries work
 
-A branch's history starts where the branch does. Creating a branch stores a pointer to the moment
-it diverged rather than a copy of the data, so what a branch can be read from is the history it
-inherited, plus the changes you have made on it since.
+When you add a timestamp to a query, Infrahub evaluates each requested object using the attribute
+values and relationships that were valid at that time. You use the same query structure as you do
+for current data; the timestamp changes which versions Infrahub returns.
 
-That inheritance is what puts the boundary where it is. On the default branch and the global
-branch, the earliest readable time is that branch's own creation. On any other branch, the boundary
-is the creation time of the branch it came from, because everything before the divergence point is
-the origin branch's history and that is where the branch reads it from.
+Infrahub can return those versions because changes create new attribute values and relationship
+versions instead of replacing the previous ones. History is tracked per attribute and relationship,
+so a comparison can identify the specific fields or connections that changed, including the previous
+values.
 
-Ask for anything earlier and Infrahub rejects the query rather than returning a partial answer:
+Later changes do not modify versions that were already recorded. See [Immutable
+history](./overview.mdx) for more detail on how Infrahub preserves those versions and how immutable
+history relates to branches and the Activity log.
 
-```text
-Requested time '2026-01-05T00:00:00Z' is before branch 'main' was created at '2026-02-01T09:14:22.481000Z'.
-```
+## Query data at a specific time
 
-If you need history from before a branch existed, query the branch it came from.
+Use a timestamp when you need the values and relationships that existed at a known point — for
+example, during an incident or before a change.
 
-## Read data at a past time
-
-Each interface suits a different moment. Use the web interface while you are still working out
-what changed, when moving the time and re-reading objects is the fastest way to find it. Use
-GraphQL for a specific question you can express as a query. Use the REST API when something
-scheduled or external needs the answer. Use the Python SDK when you are comparing states in code
-rather than reading them.
-
-The examples below all return the state of `ord1-edge1` at the same moment.
+You can specify a time when viewing or querying Infrahub data through the web interface, GraphQL,
+REST API, or Python SDK. Use the web interface for interactive investigation and the APIs or SDK
+when you need a repeatable or programmatic query.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
 Select the time selector — the calendar and clock icon beside the branch selector — and choose a
-date and time in UTC. The control carries no text label until you set a time, at which point the
-bar beside it reads **Current view time** with your selection.
+date and time in UTC. Until you set a time, the selector displays only the icon; once you set one,
+the bar beside it displays **Current view time** with your selection.
 
-The selected time then applies to everything you open, so you can move through related objects
-without setting it again. Select the **×** beside the displayed time to return to the present.
-
-Because the picker offers past times only, it is the one interface that cannot be pointed at a
-future timestamp.
+The selected time remains applied as you navigate, so objects and relationships are displayed using
+the values valid at that timestamp. Select the × beside the displayed time to return to the current
+time.
 
 ![The time selector, with a past time applied](../media/tutorial_2_historical.png)
 
@@ -86,9 +70,12 @@ future timestamp.
 
   <TabItem value="graphql" label="GraphQL">
 
-`at` is a query-string parameter on the endpoint, so the query itself is unchanged:
+Apply the historical time to the same GraphQL query you use for current data. Use this when you can
+already state the data you need and want a repeatable query.
 
-```graphql # Read a device at a past time
+`at` is a query-string parameter on the endpoint, so the query document itself is unchanged:
+
+```graphql # Read a device as it existed at an earlier time
 # Endpoint : http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
 query DeviceAtTime {
   InfraDevice(name__value: "ord1-edge1") {
@@ -103,64 +90,49 @@ query DeviceAtTime {
 }
 ```
 
-Keeping the time out of the query body means a query you have already written and saved works
-against any point in time — the endpoint you send it to decides which one. That is what makes a
-stored query reusable for both monitoring current state and answering a question about the past.
-
 </TabItem>
 
   <TabItem value="rest" label="REST API">
 
-The REST API applies `at` to stored GraphQL queries, artifacts, and transformations rather than to
-ad-hoc object reads. To read objects at a past time over REST, save the query as a
-`CoreGraphQLQuery` object and run it by name:
+Use the REST API when an external tool, scheduled process, or integration needs data for a specific
+timestamp. `at` applies to stored GraphQL queries, artifacts, and Transformations rather than to
+ad-hoc object reads, so save the query as a `CoreGraphQLQuery` and execute it by name:
 
 ```bash
 curl "http://localhost:8000/api/query/device-status?branch=main&at=2026-03-09T14:00:00Z" \
   -H "X-INFRAHUB-KEY: $INFRAHUB_API_TOKEN"
 ```
 
-The same parameter works on `/api/artifact/{artifact_id}` and on the transformation endpoints,
-which renders an artifact from the data as it stood rather than from current data — useful for
-producing the configuration a device was given at a particular time and comparing it with what is
-on the device now.
+The same parameter applies to `/api/artifact/{artifact_id}` and the transformation endpoints, where
+Infrahub renders the artifact from the data that was valid at that timestamp.
 
 </TabItem>
 
   <TabItem value="sdk" label="Python SDK">
 
-`all()`, `get()`, `filters()`, and `execute_graphql()` each take an `at` argument, so a script can
-read two moments and compare them:
+Pass the `at` argument to the SDK query methods when you need a node or set of nodes as they existed
+at a specific time. `all()`, `get()`, and `filters()` take a `Timestamp`; `execute_graphql()` also
+accepts a string.
 
 ```python
-from infrahub_sdk import InfrahubClientSync
 from infrahub_sdk.timestamp import Timestamp
 
-client = InfrahubClientSync(address="http://localhost:8000")
-
-before = client.get(
+device = await client.get(
     kind="InfraDevice",
     name__value="ord1-edge1",
     at=Timestamp("2026-03-09T14:00:00Z"),
 )
-now = client.get(kind="InfraDevice", name__value="ord1-edge1")
-
-print(before.description.value, "->", now.description.value)
 ```
-
-`Timestamp` accepts every form in the table above, so `Timestamp("6h")` reads six hours back.
-Pointing a script at a past state is also how you test an automation against the data it ran on,
-rather than against data that has moved on since.
 
 </TabItem>
 </Tabs>
 
-## Compare two points in time
+## Compare changes between two timestamps
 
-Reading one state answers "what was it then". To answer "what changed between these two moments",
-query `DiffTree` with `from_time` and `to_time`. The two times are yours to choose — they do not
-have to line up with a branch point or a proposed change, which is what makes this usable for a
-window like "the four hours around the incident".
+Use a diff when you need to identify which objects or attributes changed between two timestamps.
+`DiffTree` compares the data at `from_time` with the data at `to_time`. The timestamps do not need
+to align with a branch point or Proposed Change, so you can compare any useful period, such as the
+four hours around an incident.
 
 ```graphql # What changed on main between two timestamps
 # Endpoint : http://localhost:8000/graphql/main
@@ -186,26 +158,72 @@ query ChangesBetween {
 }
 ```
 
-Omit `from_time` and the comparison starts at the branch's creation; omit `to_time` and it ends at
-the current time. Add `filters` to restrict the result by kind, namespace, or status, and `limit`
-and `offset` to page through a large result. For counts without the node detail, query
-`DiffTreeSummary` with the same arguments.
+Behavior to expect:
 
-Two things to expect from the result. The base of the comparison is always the default branch, so
-naming a feature branch compares that branch against the default branch across the window, while
-naming the default branch compares it against itself over time. And where no diff covering the
-requested window is available, `DiffTree` returns `null` rather than an empty result — so treat a
-null as "not calculated", not as "nothing changed".
+- Omit `from_time` and the comparison starts at the branch's `branched_from` timestamp.
+- Omit `to_time` and the comparison runs to the present.
+- Use `filters` to narrow the result by kind, namespace, or status.
+- Use `limit` and `offset` to page through results.
+- Use `DiffTreeSummary` when you only need counts rather than the full set of changed nodes.
+- The base of the comparison is the default branch. Name a feature branch to compare it with the
+  default branch across the requested period, or name the default branch to compare it with itself
+  over time.
+- If no diff covering the requested period is available, the query returns `null` rather than an
+  empty result. Treat `null` as "not calculated," not "nothing changed."
 
-When the two states you want to compare are a branch and its base, a
-[Proposed Change](../proposed-changes/overview.mdx) gives you the same comparison with review and
-validation attached.
+`DiffTree` retrieves a diff that has already been calculated. To calculate one for a period, send
+the `DiffUpdate` mutation first with the `branch` and, when you need a period other than the
+default, `from_time` and `to_time`. This is why a request for an arbitrary period can return `null`
+on the first attempt.
+
+In the web interface, a branch's Branch view shows its diff and lets you refresh it, whether or not
+a Proposed Change exists for that branch. When you are comparing a branch with its base and also
+need review, validation, and checks, use a [Proposed Change](../proposed-changes/overview.mdx).
+
+## Choose an absolute timestamp or relative offset
+
+Use a relative offset when you are investigating from the current time. Use an absolute timestamp
+when the query needs to resolve to the same time each time it runs — for example, for an audit
+answer, post-incident report, or reproducible analysis.
+
+| Form | Example | Resolves to |
+|---|---|---|
+| ISO 8601 with a zone or offset | `2026-03-09T14:00:00Z` or `2026-03-09T15:00:00+01:00` | The specified instant |
+| ISO 8601 without a zone | `2026-03-09T14:00:00` | The same wall-clock time, interpreted as UTC |
+| Date only | `2026-03-09` | 12:00 UTC on that day |
+| Offset from now | `30s`, `45m`, `6h`, `2h30m` | That interval before the current time |
+
+A date without a time resolves to midday rather than midnight, so include an explicit time when a
+day boundary matters. Relative offsets support seconds, minutes, and hours, including combined
+values such as `2h30m`. They do not support day or week units; use an absolute timestamp for those
+intervals.
+
+## Understand branch history limits
+
+Each branch has an earliest timestamp you can query. If the requested time is earlier than the
+history available to that branch, Infrahub rejects the query rather than returning partial data.
+
+When you create a branch, Infrahub records where it diverged rather than copying the entire dataset.
+You can query the history available through the default branch, plus the changes recorded on the
+branch after it diverged.
+
+On the default branch and the global branch, the earliest available time is that branch's creation.
+On any other branch, the boundary is the creation time of the default branch.
+
+```text
+Requested time '2026-01-05T00:00:00Z' is before branch 'main' was created at '2026-02-01T09:14:22.481000Z'.
+```
+
+If you need data from an earlier timestamp than the branch allows, query the default branch instead.
+
+Rebasing a branch moves the timestamps of changes made on it up to the rebase time, so a change
+recorded on the branch before a rebase is no longer readable at its original timestamp.
 
 ## Related
 
-- [Immutable history](./overview.mdx) — how Infrahub stores every past state, and why reading one
-  is a query rather than a reconstruction
-- [Branches](../branches/overview.mdx) — how branch creation and merging place the timestamps you
-  query against
-- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — the sequence of operations
-  someone performed, where a past state tells you what those operations produced
+- [Immutable history](./overview.mdx) — how Infrahub preserves previous values and relationships
+- [Branches](../branches/overview.mdx) — how branches diverge, share history, and merge
+- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when,
+  and by whom
+- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base with review,
+  validation, and checks

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -210,8 +210,8 @@ intervals.
 
 ## Understand branch history limits
 
-Each branch has an earliest timestamp you can query. If the requested time is earlier than the
-history available to that branch, Infrahub rejects the query rather than returning partial data.
+You can query a branch back to the point where its history begins. If you request a time earlier
+than that, Infrahub rejects the query rather than returning partial data.
 
 When you create a branch, Infrahub records where it diverged rather than copying the entire dataset.
 You can query the history available through the default branch, plus the changes recorded on the

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -5,19 +5,21 @@ title: Query historical data
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-You can query infrastructure data at previous points in time and compare how it changed between
-them. Use queries with a timestamp to investigate incidents, verify changes during a period, answer
-audit questions, and inspect how objects and relationships differed at an earlier time.
+You can read infrastructure data as it existed at previous points in time, and compare how it changed between them. A timestamped query answers what current data cannot: which devices and interfaces existed for a site during last night's incident, which interface attributes changed between the last known-good time and now, or which prefixes were assigned to a site on a given date.
 
-To query a specific point, specify a branch and timestamp. Infrahub returns the values and
-relationships that were valid at that time through the same interfaces you use for current data. To
-compare changes, specify two timestamps.
+Infrahub offers three ways to ask about the past, and they answer different questions:
+
+| What you need | How to ask | Where it is covered |
+|---|---|---|
+| The state of the data at one point in time | `at` and `branch` on a read | [Query data at a specific time](#query-data-at-a-specific-time) |
+| Which objects and attributes changed between two points | `DiffUpdate`, then `DiffTree` | [Compare changes between two timestamps](#compare-changes-between-two-timestamps) |
+| Which operations were performed between two points, and by whom | `since` and `until` on an event query | [Activity log](../deploy-manage/run-observe/activity-log.mdx) |
+
+The first two read the data itself. The third reads the record of operations that produced it — see [Immutable history](./overview.mdx) for which question each one answers.
 
 ## Specify a branch and a time
 
-Each query is evaluated for a branch and a point in time. Infrahub uses those two inputs to select
-which versions of objects and relationships it returns. If you do not set either one, Infrahub
-returns the current data from the default branch.
+To read the state of the data at a specific point in time, specify a branch and a timestamp. Infrahub returns the objects, attribute values, and related objects that were valid at that time. If you do not set either one, Infrahub returns the current data from the default branch.
 
 | State to read | Branch | Time |
 |---|---|---|
@@ -26,50 +28,38 @@ returns the current data from the default branch.
 | The change someone is proposing | their branch | now |
 | The default branch just before that change merged | default | a time before the merge |
 
-Queries for earlier data therefore use the same read interfaces as current queries. The difference
-is that you specify the time to evaluate the data.
-
 ## How historical queries work
 
-When you add a timestamp to a query, Infrahub evaluates each requested object using the attribute
-values and relationships that were valid at that time. You use the same query structure as you do
-for current data; the timestamp changes which versions Infrahub returns.
+When you add a timestamp to a query, Infrahub evaluates each requested object using the attribute values and relationships that were valid at that time. You use the same query structure as you do for current data; the timestamp changes which versions Infrahub returns.
 
-Infrahub can return those versions because changes create new attribute values and relationship
-versions instead of replacing the previous ones. History is tracked per attribute and relationship,
-so a comparison can identify the specific fields or connections that changed, including the previous
-values.
+Infrahub can return those versions because a change records a new value alongside the previous one rather than replacing it. History is recorded per object, per attribute, and per relationship, which is what lets a comparison identify the specific fields or connections that changed and what they held before. See [How Infrahub preserves history](./overview.mdx) for the storage model.
 
-The schema is evaluated for the same point in time. If the schema changed after the timestamp you
-request, Infrahub loads the schema as it was then, so the query sees the attributes and relationships
-that existed at that point rather than the current ones.
+The schema is evaluated for the same point in time. If the schema changed after the timestamp you request, Infrahub loads the schema as it was then, so the query sees the objects, attributes, and relationships that existed at that point rather than the current ones.
 
-A timestamp applies to reads only. If a query document contains a mutation, Infrahub ignores the
-timestamp and applies the mutation at the current time.
+A timestamp applies to read operations only — queries, in GraphQL terms. If a query document contains a mutation, Infrahub ignores the timestamp and applies the mutation at the current time.
 
-Once Infrahub records a version, a change made after it does not alter that version. See [Immutable
-history](./overview.mdx) for more detail on how Infrahub preserves those versions and how immutable
-history relates to branches and the Activity log.
+Once Infrahub records a version, a change made after it does not alter that version. See [Immutable history](./overview.mdx) for more detail on how Infrahub preserves those versions and how immutable history relates to branches and the Activity log.
 
 ## Query data at a specific time
 
-Use a timestamp when you need the values and relationships that existed at a known point — for
-example, during an incident or before a change.
+Use a timestamp when you need the objects, attributes, and relationships that existed at a known point — for example, during an incident or before a change.
 
-You can specify a time when viewing or querying Infrahub data through the web interface, GraphQL,
-REST API, or Python SDK. Use the web interface for interactive investigation and the APIs or SDK
-when you need a repeatable or programmatic query.
+You can specify a time when viewing or querying Infrahub data through the web interface, GraphQL, REST API, or Python SDK. Use the web interface for interactive investigation and the APIs or SDK when you need a repeatable or programmatic query.
 
 <Tabs groupId="method" queryString>
   <TabItem value="web" label="Web interface" default>
 
-Select the time selector — the calendar and clock icon beside the branch selector — and choose a
-date and time in UTC. Until you set a time, the selector displays only the icon; once you set one,
-the bar beside it displays **Current view time** with your selection.
+Select the time selector — the calendar and clock icon beside the branch selector — and choose a date and time. The picker uses your browser's time zone rather than UTC, and offers past dates and times only. Until you set a time, the selector displays only the icon; once you set one, the bar beside it displays **Current view time** with your selection. Select the × beside the displayed time to return to the current time.
 
-The selected time remains applied as you navigate, so objects and relationships are displayed using
-the values valid at that timestamp. Select the × beside the displayed time to return to the current
-time.
+The selected time stays applied as you navigate, and it covers more than object data. Attribute values, relationships, the schema, and the navigation menu are all loaded for that timestamp, so an object's fields and the navigation tree can differ from what the current schema defines. Diffs, Proposed Changes, tasks, and events have no time-aware query, so those screens show current data even while **Current view time** is displayed.
+
+The selected time is part of the page URL as the `at` parameter, and it is preserved as you navigate, so you can bookmark a historical view or share it as a link.
+
+:::warning
+
+Infrahub does not prevent editing while a past time is applied, and it does not warn you. A change you save — including a deletion — applies to the current data at the current time, not to the time you are viewing. Treat a view with **Current view time** set as read-only.
+
+:::
 
 ![The time selector, with a past time applied](../media/tutorial_2_historical.png)
 
@@ -77,13 +67,13 @@ time.
 
   <TabItem value="graphql" label="GraphQL">
 
-Apply the historical time to the same GraphQL query you use for current data. Use this when you can
-already state the data you need and want a repeatable query.
+Use the `at` URL parameter to specify the timestamp for a GraphQL query. `at` goes on the endpoint, not in the query document, so the document itself is unchanged from the one you use for current data:
 
-`at` is a query-string parameter on the endpoint, so the query document itself is unchanged:
+```text
+http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
+```
 
 ```graphql # Read a device as it existed at an earlier time
-# Endpoint : http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
 query DeviceAtTime {
   InfraDevice(name__value: "ord1-edge1") {
     edges {
@@ -101,25 +91,27 @@ query DeviceAtTime {
 
   <TabItem value="rest" label="REST API">
 
-Use the REST API when an external tool, scheduled process, or integration needs data for a specific
-timestamp. `at` applies to stored GraphQL queries, artifacts, and Transformations rather than to
-ad-hoc object reads, so save the query as a `CoreGraphQLQuery` and execute it by name:
+The REST API accepts `at` on the endpoints that run stored objects, not on ad-hoc object reads:
+
+| Endpoint | Returns |
+|---|---|
+| `/api/query/{query_id}` | The result of a stored `CoreGraphQLQuery` at that time |
+| `/api/artifact/{artifact_id}` | An artifact rendered from the data valid at that time |
+| `/api/transform/python/{transform_id}` | A Python transform run against that data |
+| `/api/transform/jinja2/{transform_id}` | A Jinja2 transform rendered from that data |
+
+To read objects at a past time over REST, save the read as a `CoreGraphQLQuery` and execute it by name:
 
 ```bash
 curl "http://localhost:8000/api/query/device-status?branch=main&at=2026-03-09T14:00:00Z" \
   -H "X-INFRAHUB-KEY: $INFRAHUB_API_TOKEN"
 ```
 
-The same parameter applies to `/api/artifact/{artifact_id}` and the transformation endpoints, where
-Infrahub renders the artifact from the data that was valid at that timestamp.
-
 </TabItem>
 
   <TabItem value="sdk" label="Python SDK">
 
-Pass the `at` argument to the SDK query methods when you need a node or set of nodes as they existed
-at a specific time. `all()`, `get()`, and `filters()` take a `Timestamp`; `execute_graphql()` also
-accepts a string.
+Pass the `at` argument to the SDK query methods when you need a node or set of nodes as they existed at a specific time. `all()`, `get()`, and `filters()` take a `Timestamp`; `execute_graphql()` also accepts a string.
 
 ```python
 from infrahub_sdk import InfrahubClient
@@ -139,19 +131,33 @@ device = await client.get(
 
 ## Compare changes between two timestamps
 
-Use a diff when you need to identify which objects or attributes changed between two timestamps.
-`DiffTree` compares the data at `from_time` with the data at `to_time`. The timestamps do not need
-to align with a branch point or Proposed Change, so you can compare any useful period, such as the
-four hours around an incident.
+Comparing two timestamps takes two steps: Infrahub calculates the diff, then you retrieve it. A diff is stored rather than computed when you ask for it, which is why a query for a period that has never been calculated returns `null` instead of a result.
 
-```graphql # What changed on main between two timestamps
-# Endpoint : http://localhost:8000/graphql/main
-query ChangesBetween {
-  DiffTree(
-    branch: "main"
-    from_time: "2026-03-09T00:00:00Z"
-    to_time: "2026-03-10T00:00:00Z"
+Send the `DiffUpdate` mutation to calculate the diff. A custom period requires both the time range and a `name` to store it under — without a name, Infrahub rejects the request. Pass `wait_until_completion: true` when the mutation should return only once the calculation has finished, rather than starting a background task.
+
+```graphql # Calculate a diff for a period
+# Endpoint: http://localhost:8000/graphql/main
+mutation CalculateIncidentDiff {
+  DiffUpdate(
+    data: {
+      branch: "main"
+      name: "incident-2026-03-09"
+      from_time: "2026-03-09T00:00:00Z"
+      to_time: "2026-03-10T00:00:00Z"
+    }
+    wait_until_completion: true
   ) {
+    ok
+  }
+}
+```
+
+Then retrieve it by the name you calculated it under, using `DiffTree` for the changed nodes or `DiffTreeSummary` when you only need counts. The timestamps do not need to align with a branch point or a Proposed Change, so you can compare any useful period, such as the hours around an incident.
+
+```graphql # Retrieve the calculated diff
+# Endpoint: http://localhost:8000/graphql/main
+query IncidentChanges {
+  DiffTree(branch: "main", name: "incident-2026-03-09") {
     num_added
     num_updated
     num_removed
@@ -172,29 +178,17 @@ Behavior to expect:
 
 - Omit `from_time` and the comparison starts at the branch's `branched_from` timestamp.
 - Omit `to_time` and the comparison runs to the present.
-- Use `filters` to narrow the result by kind, namespace, or status.
-- Use `limit` and `offset` to page through results.
-- Use `DiffTreeSummary` when you only need counts rather than the full set of changed nodes.
-- The base of the comparison is the default branch. Name a feature branch to compare it with the
-  default branch across the requested period, or name the default branch to compare it with itself
-  over time.
-- If no diff covering the requested period is available, the query returns `null` rather than an
-  empty result. Treat `null` as "not calculated," not "nothing changed."
+- Narrow the result with `filters`, which accepts `ids`, `kind`, `namespace`, and `status`. The `kind`, `namespace`, and `status` filters each take `includes` and `excludes` lists.
+- Page through results with `limit` and `offset`.
+- The base of the comparison is the default branch. Name a feature branch to compare it with the default branch across the requested period, or name the default branch to compare it with itself over time.
+- Pass `proposed_change_id` instead of a branch and period to retrieve the diff for a Proposed Change.
+- A `null` result means that no diff covering the requested period has been calculated, not that nothing changed.
 
-`DiffTree` retrieves a diff that has already been calculated. To calculate one for a period, send
-the `DiffUpdate` mutation first with the `branch` and, when you need a period other than the
-default, `from_time` and `to_time`. This is why a request for an arbitrary period can return `null`
-on the first attempt.
-
-In the web interface, a branch's Branch view shows its diff and lets you refresh it, whether or not
-a Proposed Change exists for that branch. When you are comparing a branch with its base and also
-need review, validation, and checks, use a [Proposed Change](../proposed-changes/overview.mdx).
+In the web interface, a branch's Branch view shows its diff and lets you refresh it, whether or not a Proposed Change exists for that branch, and a Proposed Change shows the diff between its source and target branches. When you need review, validation, and checks alongside the comparison, use a [Proposed Change](../proposed-changes/overview.mdx).
 
 ## Choose an absolute timestamp or relative offset
 
-Use a relative offset when you are investigating from the current time. Use an absolute timestamp
-when the query needs to resolve to the same time each time it runs — for example, for an audit
-answer, post-incident report, or reproducible analysis.
+Use a relative offset when you are investigating from the current time. Use an absolute timestamp when the query needs to resolve to the same time each time it runs — for example, for an audit answer, post-incident report, or reproducible analysis.
 
 | Form | Example | Resolves to |
 |---|---|---|
@@ -203,37 +197,23 @@ answer, post-incident report, or reproducible analysis.
 | Date only | `2026-03-09` | 12:00 UTC on that day |
 | Offset from now | `30s`, `45m`, `6h`, `2h30m` | That interval before the current time |
 
-A date without a time resolves to midday rather than midnight, so include an explicit time when a
-day boundary matters. Relative offsets support seconds, minutes, and hours, including combined
-values such as `2h30m`. They do not support day or week units; use an absolute timestamp for those
-intervals.
+A date without a time resolves to midday rather than midnight, so include an explicit time when a day boundary matters. Relative offsets support seconds, minutes, and hours, including combined values such as `2h30m`. They do not support day or week units; use an absolute timestamp for those intervals.
 
 ## Understand branch history limits
 
-You can query a branch back to the point where its history begins. If you request a time earlier
-than that, Infrahub rejects the query rather than returning partial data.
+Every branch reads history through the default branch, so the earliest time you can query is the default branch's creation time — the point at which Infrahub was first initialized. That floor is the same on a feature branch as on the default branch, because creating a branch records where it diverged rather than copying the dataset. A branch created this morning can still be read back to the default branch's creation, with the changes recorded on the branch since it diverged added to that history.
 
-When you create a branch, Infrahub records where it diverged rather than copying the entire dataset.
-You can query the history available through the default branch, plus the changes recorded on the
-branch after it diverged.
-
-On the default branch and the global branch, the earliest available time is that branch's creation.
-On any other branch, the boundary is the creation time of the default branch.
+If you request an earlier time than that, Infrahub rejects the query rather than returning partial data:
 
 ```text
 Requested time '2026-01-05T00:00:00Z' is before branch 'main' was created at '2026-02-01T09:14:22.481000Z'.
 ```
 
-If you need data from an earlier timestamp than the branch allows, query the default branch instead.
-
-Rebasing a branch moves the timestamps of changes made on it up to the rebase time, so a change
-recorded on the branch before a rebase is no longer readable at its original timestamp.
+Infrahub validates the earliest time only. If you request a time later than the current time, Infrahub accepts it and returns the current data, because every attribute value and relationship that is valid now is also valid at a later time. In the web interface, the time selector offers past dates and times; through GraphQL, the REST API, and the Python SDK, you can request a future time. If you build the timestamp from a variable or a calculation, confirm it resolves to a past time — nothing in the response indicates that a future timestamp was used.
 
 ## Related
 
 - [Immutable history](./overview.mdx) — how Infrahub preserves previous values and relationships
 - [Branches](../branches/overview.mdx) — how branches diverge, share history, and merge
-- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when,
-  and by whom
-- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base with review,
-  validation, and checks
+- [Activity log](../deploy-manage/run-observe/activity-log.mdx) — which operations occurred, when, and by whom
+- [Proposed Changes](../proposed-changes/overview.mdx) — compare a branch with its base with review, validation, and checks

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -1,0 +1,156 @@
+---
+title: Query historical data
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Query historical data
+
+Every read in Infrahub happens at a point in time. By default that point is now. Add the `at` parameter to a read and Infrahub returns the data as it was at the time you name, on whichever branch you are querying.
+
+Use `at` when the current state cannot explain the present: a change was merged overnight and a device stopped forwarding traffic, an auditor asks which prefixes were assigned to a site on a given date, or you need to compare a configuration against the one it replaced.
+
+## Before you start
+
+Two things determine whether a first attempt returns data: the format of the time you pass, and how far back the branch can be read.
+
+### Time formats
+
+`at` accepts an absolute time or an offset from now.
+
+| Form | Example | Resolves to |
+|---|---|---|
+| ISO 8601 with a zone or offset | `2026-03-09T14:00:00Z`, `2026-03-09T15:00:00+01:00` | The instant you name |
+| ISO 8601 without a zone | `2026-03-09T14:00:00` | The same wall-clock time, read as UTC |
+| Date only | `2026-03-09` | 12:00 UTC on that day |
+| Offset from now | `30s`, `45m`, `6h`, `2h30m` | That much time before now |
+
+A date on its own resolves to midday, not midnight. Write the time out when the distinction matters.
+
+Offsets are limited to seconds, minutes, and hours — `s`, `sec`, `second`, `seconds`, `m`, `min`, `minute`, `minutes`, `h`, `hour`, `hours` — and combine in one string. Days and weeks have no offset form, so `7d` returns a `TimestampFormatError`. For anything beyond a few hours back, pass an absolute time.
+
+### How far back you can read
+
+A branch cannot be read from before it existed. On the default branch and the global branch, the earliest readable time is that branch's own creation time. On any other branch, the boundary is the creation time of the branch it came from, because the history before the branch point belongs to the origin branch.
+
+Ask for something earlier and Infrahub rejects the query:
+
+```text
+Requested time '2026-01-05T00:00:00Z' is before branch 'main' was created at '2026-02-01T09:14:22.481000Z'.
+```
+
+## Read data at a past time
+
+Pass `at` alongside the branch you are reading. The examples below all return the state of `ord1-edge1` at the same moment.
+
+<Tabs groupId="method" queryString>
+  <TabItem value="web" label="Web interface" default>
+
+Select the time selector — the calendar and clock icon beside the branch selector — and choose a date and time in UTC. The control has no text label until you set a time, at which point the bar beside it reads **Current view time** with your selection.
+
+Every object you open while a time is set shows its state at that time. Select the **×** beside the displayed time to return to the present.
+
+The picker offers past times only.
+
+![The time selector, with a past time applied](../media/tutorial_2_historical.png)
+
+</TabItem>
+
+  <TabItem value="graphql" label="GraphQL">
+
+`at` is a query-string parameter on the GraphQL endpoint, so the query itself is unchanged:
+
+```graphql # Read a device at a past time
+# Endpoint : http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
+query DeviceAtTime {
+  InfraDevice(name__value: "ord1-edge1") {
+    edges {
+      node {
+        name { value }
+        description { value }
+        status { value }
+      }
+    }
+  }
+}
+```
+
+Because `at` is part of the endpoint rather than the query, the same stored query returns current or historical data depending on the URL you send it to.
+
+</TabItem>
+
+  <TabItem value="rest" label="REST API">
+
+The REST API applies `at` to stored GraphQL queries, artifacts, and transformations rather than to ad-hoc object reads. To read objects at a past time over REST, save the query as a `CoreGraphQLQuery` object and run it by name:
+
+```bash
+curl "http://localhost:8000/api/query/device-status?branch=main&at=2026-03-09T14:00:00Z" \
+  -H "X-INFRAHUB-KEY: $INFRAHUB_API_TOKEN"
+```
+
+The same parameter works on `/api/artifact/{artifact_id}` and on the transformation endpoints, so you can render an artifact from the data as it was rather than from current data.
+
+</TabItem>
+
+  <TabItem value="sdk" label="Python SDK">
+
+`all()`, `get()`, `filters()`, and `execute_graphql()` each take an `at` argument:
+
+```python
+from infrahub_sdk import InfrahubClientSync
+from infrahub_sdk.timestamp import Timestamp
+
+client = InfrahubClientSync(address="http://localhost:8000")
+
+device = client.get(
+    kind="InfraDevice",
+    name__value="ord1-edge1",
+    at=Timestamp("2026-03-09T14:00:00Z"),
+)
+
+print(device.description.value)
+```
+
+`Timestamp` accepts every form in the table above, so `Timestamp("6h")` reads six hours back.
+
+</TabItem>
+</Tabs>
+
+## Compare two points in time
+
+To see what changed between two moments rather than the state at one of them, query `DiffTree` with `from_time` and `to_time`. Both take a timestamp, and the two times can be arbitrary — they do not have to correspond to a branch point or a proposed change.
+
+```graphql # What changed on main between two timestamps
+# Endpoint : http://localhost:8000/graphql/main
+query ChangesBetween {
+  DiffTree(
+    branch: "main"
+    from_time: "2026-03-09T00:00:00Z"
+    to_time: "2026-03-10T00:00:00Z"
+  ) {
+    num_added
+    num_updated
+    num_removed
+    nodes {
+      kind
+      label
+      status
+      attributes {
+        name
+        action
+      }
+    }
+  }
+}
+```
+
+Omit `from_time` and the comparison starts at the branch's creation; omit `to_time` and it ends at the current time. Add `filters` to restrict the result by kind, namespace, or status, and `limit` and `offset` to page through a large result. For a count without the node detail, query `DiffTreeSummary` with the same arguments.
+
+Two things to expect from the result. The base of the comparison is always the default branch, so naming a feature branch compares that branch against the default branch across the window, while naming the default branch compares it against itself. And where no diff covering the requested window is available, `DiffTree` returns `null` rather than an empty result.
+
+## Related
+
+- [Immutable history](./overview.mdx) — how Infrahub stores every past state, and why a historical read is a query rather than a reconstruction
+- [Branches](../branches/overview.mdx) — how branch creation and merging place the timestamps you query against
+- [Proposed Changes](../proposed-changes/overview.mdx) — review a diff scoped to a branch, rather than to two times you choose

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -5,9 +5,9 @@ title: Query historical data
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Infrahub lets you query infrastructure data at previous points in time and compare how it changed
-between them. Use queries with a timestamp to investigate incidents, verify changes during a period,
-answer audit questions, and inspect how objects and relationships differed at an earlier time.
+You can query infrastructure data at previous points in time and compare how it changed between
+them. Use queries with a timestamp to investigate incidents, verify changes during a period, answer
+audit questions, and inspect how objects and relationships differed at an earlier time.
 
 To query a specific point, specify a branch and timestamp. Infrahub returns the values and
 relationships that were valid at that time through the same interfaces you use for current data. To
@@ -39,6 +39,13 @@ Infrahub can return those versions because changes create new attribute values a
 versions instead of replacing the previous ones. History is tracked per attribute and relationship,
 so a comparison can identify the specific fields or connections that changed, including the previous
 values.
+
+The schema is evaluated for the same point in time. If the schema changed after the timestamp you
+request, Infrahub loads the schema as it was then, so the query sees the attributes and relationships
+that existed at that point rather than the current ones.
+
+A timestamp applies to reads only. If a query document contains a mutation, Infrahub ignores the
+timestamp and applies the mutation at the current time.
 
 Later changes do not modify versions that were already recorded. See [Immutable
 history](./overview.mdx) for more detail on how Infrahub preserves those versions and how immutable
@@ -115,7 +122,10 @@ at a specific time. `all()`, `get()`, and `filters()` take a `Timestamp`; `execu
 accepts a string.
 
 ```python
+from infrahub_sdk import InfrahubClient
 from infrahub_sdk.timestamp import Timestamp
+
+client = InfrahubClient(address="http://localhost:8000")
 
 device = await client.get(
     kind="InfraDevice",

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -47,7 +47,7 @@ that existed at that point rather than the current ones.
 A timestamp applies to reads only. If a query document contains a mutation, Infrahub ignores the
 timestamp and applies the mutation at the current time.
 
-Later changes do not modify versions that were already recorded. See [Immutable
+Once Infrahub records a version, a change made after it does not alter that version. See [Immutable
 history](./overview.mdx) for more detail on how Infrahub preserves those versions and how immutable
 history relates to branches and the Activity log.
 

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -153,7 +153,7 @@ mutation CalculateIncidentDiff {
 
 Then retrieve it with the same branch and time range you calculated it for, using `DiffTree` for the changed nodes or `DiffTreeSummary` when you only need counts. The timestamps do not need to align with a branch point or a Proposed Change, so you can compare any useful period, such as the hours around an incident.
 
-Infrahub stores the diff under that name but retrieves it by time range. Both queries accept a `name` argument, and passing it does not retrieve the diff: `DiffTree` returns `null` and `DiffTreeSummary` returns an error. Retrieve with the time range instead.
+Retrieve a custom period by that period rather than by its name. `DiffTree` looks for a diff covering the range it computes by default, from the branch point to the present, so it does not find one stored for a different range and returns `null`. `DiffTreeSummary` does not accept `name` at all and returns an error. A name is still worth setting, because `DiffUpdate` requires one for a custom period.
 
 ```graphql title="Retrieve the calculated diff"
 query IncidentChanges {

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -73,7 +73,7 @@ Use the `at` URL parameter to specify the timestamp for a GraphQL query. `at` go
 http://localhost:8000/graphql/main?at=2026-03-09T14:00:00Z
 ```
 
-```graphql # Read a device as it existed at an earlier time
+```graphql title="Read a device as it existed at an earlier time"
 query DeviceAtTime {
   InfraDevice(name__value: "ord1-edge1") {
     edges {
@@ -135,8 +135,7 @@ Comparing two timestamps takes two steps: Infrahub calculates the diff, then you
 
 Send the `DiffUpdate` mutation to calculate the diff. A custom period requires both the time range and a `name` to store it under — without a name, Infrahub rejects the request. Pass `wait_until_completion: true` when the mutation should return only once the calculation has finished, rather than starting a background task.
 
-```graphql # Calculate a diff for a period
-# Endpoint: http://localhost:8000/graphql/main
+```graphql title="Calculate a diff for a period"
 mutation CalculateIncidentDiff {
   DiffUpdate(
     data: {
@@ -152,12 +151,17 @@ mutation CalculateIncidentDiff {
 }
 ```
 
-Then retrieve it by the name you calculated it under, using `DiffTree` for the changed nodes or `DiffTreeSummary` when you only need counts. The timestamps do not need to align with a branch point or a Proposed Change, so you can compare any useful period, such as the hours around an incident.
+Then retrieve it with the same branch and time range you calculated it for, using `DiffTree` for the changed nodes or `DiffTreeSummary` when you only need counts. The timestamps do not need to align with a branch point or a Proposed Change, so you can compare any useful period, such as the hours around an incident.
 
-```graphql # Retrieve the calculated diff
-# Endpoint: http://localhost:8000/graphql/main
+Infrahub stores the diff under that name but retrieves it by time range. Both queries accept a `name` argument, and passing it does not retrieve the diff: `DiffTree` returns `null` and `DiffTreeSummary` returns an error. Retrieve with the time range instead.
+
+```graphql title="Retrieve the calculated diff"
 query IncidentChanges {
-  DiffTree(branch: "main", name: "incident-2026-03-09") {
+  DiffTree(
+    branch: "main"
+    from_time: "2026-03-09T00:00:00Z"
+    to_time: "2026-03-10T00:00:00Z"
+  ) {
     num_added
     num_updated
     num_removed
@@ -167,7 +171,7 @@ query IncidentChanges {
       status
       attributes {
         name
-        action
+        status
       }
     }
   }

--- a/docs/docs/immutable-history/query-historical-data.mdx
+++ b/docs/docs/immutable-history/query-historical-data.mdx
@@ -13,7 +13,7 @@ Infrahub offers three ways to ask about the past, and they answer different ques
 |---|---|---|
 | The state of the data at one point in time | `at` and `branch` on a read | [Query data at a specific time](#query-data-at-a-specific-time) |
 | Which objects and attributes changed between two points | `DiffUpdate`, then `DiffTree` | [Compare changes between two timestamps](#compare-changes-between-two-timestamps) |
-| Which operations were performed between two points, and by whom | `since` and `until` on an event query | [Activity log](../deploy-manage/run-observe/activity-log.mdx) |
+| Which operations were performed between two points, and by whom | `since` and `until` on an event query | [Querying the activity log over the API](../deploy-manage/run-observe/activity-log.mdx#querying-the-activity-log-over-the-api) |
 
 The first two read the data itself. The third reads the record of operations that produced it — see [Immutable history](./overview.mdx) for which question each one answers.
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -233,7 +233,12 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       link: { type: 'generated-index', slug: 'branches-and-change-control' },
       items: [
-        { type: 'doc', id: 'immutable-history/overview', label: 'Immutable History' },
+        {
+          type: 'category',
+          label: 'Immutable History',
+          link: { type: 'doc', id: 'immutable-history/overview' }, // hub
+          items: ['immutable-history/query-historical-data'],
+        },
         {
           type: 'category',
           label: 'Branches',


### PR DESCRIPTION
## What changed

Immutable History had a concept page but no task page. The only mention of `at` in the published
docs was a bullet reading "GraphQL API: Timestamp parameters for historical queries". The syntax,
the accepted time formats, and the limits were not documented anywhere.

- New page: `immutable-history/query-historical-data.mdx`. Covers how a branch and a time select the
  state, how a historical query is resolved, reading a past state from each interface, comparing two
  timestamps, time formats, and branch history limits.
- Rewritten: `immutable-history/overview.mdx`. Reordered to lead with the capability instead of the
  storage model.
- Changed: `docs/sidebars.ts`. Immutable History is now a category with the overview as its hub, so
  the category label is clickable.

## Why the hub was reordered

The old order was: architecture, then a benefits list, then use cases, then commits, then temporal
queries, then attribute storage, then an Implementation details section that repeated the temporal
queries section.

The new order is: what the capability does and when you need it, what you can do with it, how
historical data differs from the Activity log, how history is preserved, how branches use it, and
where to query it.

Two things were removed. "Risk-free rollbacks" overstated the guarantee, because immutable storage
by itself does not establish an operational rollback path. The Implementation details section
repeated content already covered under temporal queries.

## Source material

The starting point was the [temporal graph blog
post](https://opsmill.com/blog/temporal-graph-infrastructure-data/). Three ideas from it are on
these pages because they help explain how the product behaves:

- Historical state answers a different question than an operations log.
- Relationships carry history, not only attributes.
- A branch builds on the history that already existed at its branch point.

The blog's claim about hundreds of branches with no performance lag is not included, because there
is nothing in the repository to support it.

## Facts verified against the implementation

Every behavioural claim on both pages was read from the source rather than from the old page or the
blog. These were not documented before:

- A date with no time resolves to 12:00 UTC, not midnight
  (`python_sdk/infrahub_sdk/timestamp.py:74`).
- Relative offsets support seconds, minutes and hours only. `7d` raises `TimestampFormatError`
  (`timestamp.py:22-26`).
- `at` applies to reads only. If a query document contains a mutation, Infrahub replaces the
  timestamp with the current time (`backend/infrahub/graphql/app.py:223`).
- Schema is resolved for the requested time. When `at` is earlier than the branch's
  `schema_changed_at`, Infrahub calls `load_schema_from_db(at=at_ts)` and analyzes the query against
  that schema (`app.py:228-231`). A query for an earlier time therefore sees the attributes the
  schema defined then.
- REST has no generic historical object read. `at` is accepted on `/api/query/{query_id}`,
  `/api/artifact/{artifact_id}` and the transformation endpoints
  (`backend/infrahub/api/dependencies.py:77`). The REST tab documents running a stored
  `CoreGraphQLQuery`.
- SDK argument types: `at` takes a `Timestamp` on `all()`, `get()` and `filters()`, and also accepts
  a string on `execute_graphql()`. There is no `DateTime` form. A `datetime` passed to
  `Timestamp.__init__` falls through to the default branch and resolves to the current time, so a
  reader following the wrong type would get current data and believe it was historical.

## Review feedback from @ajtmccarty

All five points were correct. Each was checked against the code before it was written up.

- Deleting a branch removes the data and history recorded on it, and that history cannot be
  recovered. `DeleteBranchEdgesQuery` deletes every edge where `r.branch = $branch_name` and any
  vertex left with no edges (`backend/infrahub/core/query/branch.py:89`). The hub no longer implies
  that history is always kept.
- A branch's origin is always the default branch. `Branch.origin_branch` defaults to `main`
  (`backend/infrahub/core/branch/models.py:33`). The boundary rule and the workaround now both name
  the default branch, so nothing suggests branching from a branch.
- `DiffTree` returns a diff that has already been calculated. `DiffUpdate` calculates one for a
  period (`backend/infrahub/graphql/mutations/diff.py:32`). This is documented next to the `null`
  behaviour, because it explains why a request for an arbitrary period can return `null` the first
  time.
- A branch's Branch view shows its diff and allows a refresh whether or not a Proposed Change
  exists.
- Rebasing moves the timestamps of changes made on a branch up to the rebase time. `rebase_graph`
  updates relationships to start from the rebase point and deletes those that ended before it
  (`backend/infrahub/core/branch/models.py:433`). This is noted in the history limits section, where
  it affects what can be queried.

Aaron also raised schema temporal support twice. It was open in an earlier revision of this
description and is now resolved and documented, with the file reference above.

## Open questions for the reviewer

1. **Immutability and rebase read as a contradiction.** "How historical queries work" says that once
   a version is recorded, a later change does not alter it. "Understand branch history limits" then
   says a rebase moves the timestamps of changes made on a branch. Both statements are correct, but
   they are four sections apart and the reader has to connect them. Should the first sentence name
   rebase as the exception and link down to it, or is the current separation acceptable?

2. **Wording of the schema paragraph.** @ajtmccarty, the mechanism is verified, but please confirm
   the description reads correctly: "If the schema changed after the timestamp you request, Infrahub
   loads the schema as it was then, so the query sees the attributes and relationships that existed
   at that point rather than the current ones."

3. **`DiffTree` filters.** The page documents `kind`, `namespace` and `status`. `DiffTreeQueryFilters`
   also accepts `ids` (`backend/infrahub/graphql/queries/diff/tree.py:746`). Worth adding, or is a
   summary of the common three enough for this page?

4. **`updated_by` is the last account to modify an object, not a per-change record.** The hub says a
   change can be traced to the account that made it, and links to `objects/metadata.mdx`. Reading
   `updated_by` at a past timestamp gives the account behind the change that was current then, which
   is why the claim stands. Confirm that is the intended way to answer "who changed this".

## Out of scope

`tutorials/getting-started/**` is excluded from the Docusaurus build
(`docs/docusaurus.config.ts:83`). That series, including
`tutorials/getting-started/historical-data.mdx`, is not published. The build failed when the new
page linked to it, which is how this surfaced. There is currently no published tutorial for
historical data. Deciding what happens to that series belongs in its own change.

A full voice pass over the rest of `overview.mdx` is also out of scope for this PR.

## Verification

- `cd docs && npm run build` passes with no broken links.
- `npx markdownlint-cli2 "docs/docs/immutable-history/**/*.mdx"` reports 0 issues.
- Vale is not installed locally, so CI will be its first run. Both pages were checked by hand against
  `swap.yml`, `simple-easy.yml`, `oxford-comma.yml` and the sentence-case heading rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
