### PR TITLE
chore: update base Python to 3.14.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3
+FROM python:3.14.7
 
 RUN apt-get remove -yq docker.io docker-doc docker-compose podman-docker containerd runc 2>&1 || true
 
@@ -36,7 +36,7 @@ USER vscode
 
 RUN pip install invoke
 
-ARG UV_VER=0.9.9
+ARG UV_VER=0.11.8
 RUN curl -sSL https://astral.sh/uv/$UV_VER/install.sh | sh - \
     && echo "export PATH=\"$HOME/.local/bin:$PATH\"" >> $HOME/.bashrc
 

--- a/.github/workflows/define-versions.yml
+++ b/.github/workflows/define-versions.yml
@@ -7,7 +7,7 @@ on:
       UV_VERSION:
         value: "0.11.8"
       PYTHON_VERSION:
-        value: "3.14.3"
+        value: "3.14.7"
 
 jobs:
   prepare:

--- a/changelog/+base-python-3-14-7.housekeeping.md
+++ b/changelog/+base-python-3-14-7.housekeeping.md
@@ -1,0 +1,1 @@
+Updated the base Python version of the Infrahub container image and the development environment from 3.14.3 to 3.14.7.

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -2,7 +2,7 @@
 # ****************************************************************
 # STAGE : Base Python Image (build-time toolchain)
 # ****************************************************************
-ARG PYTHON_VER=3.14.3
+ARG PYTHON_VER=3.14.7
 ARG NODE_VER=24.15.0
 ARG UV_VER
 FROM docker.io/python:${PYTHON_VER}-slim AS base

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       context: ../
       args:
         CI_ARG: ${CI:-0}
-        UV_VER: ${UV_VERSION:-0.9.9}
+        UV_VER: ${UV_VERSION:-0.11.8}
       dockerfile: development/Dockerfile
       target: backend
     image: "${IMAGE_NAME}:${IMAGE_VER}"
@@ -230,7 +230,7 @@ services:
       context: ../
       args:
         CI_ARG: ${CI:-0}
-        UV_VER: ${UV_VERSION:-0.9.9}
+        UV_VER: ${UV_VERSION:-0.11.8}
       dockerfile: development/Dockerfile
       target: backend
     image: "${IMAGE_NAME}:${IMAGE_VER}"

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -54,7 +54,7 @@ CACHE_DOCKER_IMAGE = os.getenv(
 here = Path(__file__).parent.resolve()
 TOP_DIRECTORY_NAME = here.parent.name
 BUILD_NAME = os.getenv("INFRAHUB_BUILD_NAME", re.sub(r"[^a-zA-Z0-9_/.]", "", str(TOP_DIRECTORY_NAME)))
-PYTHON_VER = os.getenv("PYTHON_VER", "3.13")
+PYTHON_VER = os.getenv("PYTHON_VER", "3.14.7")
 
 PWD = Path.cwd()
 


### PR DESCRIPTION
## What changed

Bumps the base Python version of the Infrahub container image and the development environment from **3.14.3 → 3.14.7** — the latest 3.14 patch release (3.14.8 does not exist on python.org or Docker Hub).

| File | Change |
|---|---|
| `development/Dockerfile` | `ARG PYTHON_VER` `3.14.3` → `3.14.7` (feeds both the `base` and `backend` stages) |
| `.devcontainer/Dockerfile` | `FROM python:3.14.3` → `3.14.7` |
| `.github/workflows/define-versions.yml` | `PYTHON_VERSION` `3.14.3` → `3.14.7` |
| `tasks/shared.py` | `PYTHON_VER` default `3.13` → `3.14.7` |
| `.devcontainer/Dockerfile` | `ARG UV_VER` `0.9.9` → `0.11.8` |
| `development/docker-compose.yml` | `UV_VER: ${UV_VERSION:-0.9.9}` → `:-0.11.8` (both build sites) |

## Notable details

Beyond the version bump itself, two local build defaults had drifted away from what CI already uses. Both were invisible in CI and only affected local/devcontainer builds:

- **`tasks/shared.py` defaulted `PYTHON_VER` to `3.13`**, and it *wins over* the Dockerfile `ARG` because `tasks/container_ops.py` passes it as `--build-arg PYTHON_VER=`. So every local `invoke dev.build` was building on `python:3.13-slim` while CI built on 3.14.x — local and CI images were on different Python **minor** versions.
- **`UV_VER` defaulted to `0.9.9`** in the compose file and devcontainer. CI exports `UV_VERSION` as a job-level env (`ci.yml`, `ci-docker-image.yml`, `version-upgrade.yml`), so the fallback never fired there — but local and devcontainer builds silently installed uv 0.9.9 instead of the pinned 0.11.8.

uv is aligned to the repo's canonical `0.11.8` from `define-versions.yml` rather than bumped. Worth noting for a follow-up: uv's latest is `0.12.5`, so `0.11.8` is itself a few minors behind.

Deliberately left alone: the CI test matrices (`3.12`/`3.13`/`3.14`) and `requires-python = ">=3.12,<3.15"` express the *supported* range, not the base version; `[tool.ty.environment] python-version = "3.12"` type-checks against the minimum supported version.

## Testing performed

- `python:3.14.7-slim` pulls and reports `Python 3.14.7 (main, Aug 5 2026) [GCC 14.2.0]`.
- Full `builder` stage builds clean with `PYTHON_VER=3.14.7 UV_VER=0.11.8`; the resulting venv runs 3.14.7 with 170 distributions and `import infrahub` succeeds.
- `docker compose config` across the full dev file set with `UV_VERSION` unset (the previously-broken local case): both build sites now resolve `UV_VER: 0.11.8`.
- `https://astral.sh/uv/0.11.8/install.sh` resolves and pins `APP_VERSION="0.11.8"`.
- `uv lock --check` passes unchanged — 3.14.7 sits inside `requires-python`, and a patch bump cannot shift resolution (wheels are `cp314`-tagged).
- `uv run invoke format`, `main.lint`, `ruff check . --exclude python_sdk`, `yamllint -s .github/ development/`, `invoke docs.lint`, and `invoke docs.validate` all pass; `docs.validate` regenerated nothing, confirming no generated file is stale.

Backend unit tests were not run: the diff touches no backend source (only Dockerfiles, compose/workflow YAML, and `tasks/shared.py`, which the unit suite does not cover).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

