### PR TITLE
fix: initialize git submodules and freeze the lockfile in the web session setup hook

### DIFF
--- a/dev/setup-environment.sh
+++ b/dev/setup-environment.sh
@@ -115,7 +115,7 @@ echo "Installing frontend dependencies with pnpm..."
 if command -v pnpm &> /dev/null; then
     if [ -d "$PROJECT_DIR/frontend/app" ]; then
         cd "$PROJECT_DIR/frontend/app"
-        pnpm install
+        pnpm install --frozen-lockfile || echo "Warning: pnpm install failed (continuing)"
         echo "Frontend dependencies installed"
         cd "$PROJECT_DIR"
     else

--- a/dev/setup-environment.sh
+++ b/dev/setup-environment.sh
@@ -74,6 +74,28 @@ echo "Project directory: $PROJECT_DIR"
 cd "$PROJECT_DIR"
 
 # ------------------------------------------------------------------------------
+# Git Submodules
+# ------------------------------------------------------------------------------
+# Claude Code on the web clones without --recurse-submodules. Both submodules are
+# consumed as local paths, and neither installer errors on an empty directory, so
+# this must run first -- otherwise setup "succeeds" with no infrahub_sdk in the
+# venv and an unresolved schema-visualizer workspace package.
+echo ""
+echo "Initializing git submodules..."
+if ! git -C "$PROJECT_DIR" submodule update --init --recursive; then
+    echo "Error: failed to initialize git submodules" >&2
+    exit 1
+fi
+
+for manifest in "python_sdk/pyproject.toml" "frontend/packages/schema-visualizer/package.json"; do
+    if [ ! -f "$PROJECT_DIR/$manifest" ]; then
+        echo "Error: $manifest is missing after submodule initialization" >&2
+        exit 1
+    fi
+done
+echo "Submodules initialized"
+
+# ------------------------------------------------------------------------------
 # Python Dependencies
 # ------------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
# Why

Two independent defects in `dev/setup-environment.sh`, the `SessionStart` hook for Claude Code on the web. One is new, one is a backport of a fix already on `develop`.

**1. Submodules are never initialized.** The web container clones **without** `--recurse-submodules`, so `python_sdk` and `frontend/packages/schema-visualizer` are empty when the hook runs. Both are consumed as local paths rather than published packages, and neither installer treats an empty directory as an error — so setup reports success while producing a broken environment.

**2. The lockfile churns on every session.** A plain `pnpm install` re-resolves the caret ranges in `package.json` and picks up whatever transitive versions have been published since the lockfile was committed, rewriting `pnpm-lock.yaml`. Observed on a real session: `oxlint` 1.74→1.77, `@oxc-parser` 0.141→0.143, a new `@astrojs/compiler` — a 780-line diff nobody asked for. This was fixed on `develop` in #9972 but never reached `stable`.

**Goal:** every web session starts with both submodules populated and a clean working tree, or setup stops with a clear error.

**Non-goals:** no change to how submodules are pinned or updated, and no change to the Python install command.

## What changed

Two commits against `stable`:

- **`fix: initialize git submodules in the web session setup hook`** (new) — runs `git submodule update --init --recursive` above the Python and frontend installers, then asserts the two expected manifests exist so a partial fetch stops setup instead of silently degrading it. The command is already the canonical one documented in `dev/guidelines/git-workflow.md`.
- **`fix(setup): use --frozen-lockfile in setup hook to stop lockfile churn (#9972)`** — cherry-picked from `develop` (`65efe7bf`, provenance recorded via `cherry-pick -x`). One line, unmodified from the original.

Net: **+23 / -1** in one file. No dependency, lockfile, schema, or CI changes. The script still runs exclusively in the `claude-code-web` environment — the existing `SUPPORTED_ENVIRONMENTS` gate is untouched, so local and CI runs exit early exactly as before. `uv.lock` and `pnpm-lock.yaml` are unmodified.

### Why the submodule failures are silent

`python_sdk/infrahub_sdk` is vendored into the `infrahub-server` distribution via `[tool.hatch.build.targets.wheel.sources]`, not installed as a separate dependency. With the directory empty, `uv sync` succeeds and builds a wheel containing no `infrahub_sdk` — `import infrahub` works while `import infrahub_sdk` raises `ModuleNotFoundError`. 317 backend modules import `infrahub_sdk`, so anything touching the SDK was broken in every web session.

`frontend/packages/schema-visualizer` is a pnpm workspace package; with the directory empty pnpm resolves it to a link with no dependency graph and installs 43 fewer packages.

## How to review

The submodule block is ordering-sensitive — it must stay above the Python section, which is the entire point of that commit. The second commit is a verbatim cherry-pick; reviewing it against #9972 is enough.

## How to test

```bash
# Reproduce the broken state a fresh web session starts in
git submodule deinit -f --all

# Run the hook exactly as SessionStart does
CLAUDE_ENV_FILE=1 bash dev/setup-environment.sh

# Verify
uv run --no-sync python -c "import infrahub_sdk, infrahub, infrahub_testcontainers"
git submodule status   # both at pinned commits, no +/- prefix
git status --porcelain # clean -- no lockfile churn
```

Observed on this branch with both commits applied: exit 0, both submodules checked out at the pinned commits, all three imports succeed, pnpm reports all 5 workspace projects in scope, and the working tree stays clean. Re-running is idempotent. The manifest guard was exercised separately against an empty directory and exits 1 with the expected message.

`shellcheck` on the file reports only a pre-existing `SC2064` at the `gh` install trap, which this PR leaves alone.

## Impact & rollout

- **Backward compatibility:** none affected. CI already checks out with `submodules: true`, so CI behavior is unchanged.
- **Performance:** roughly 4s of submodule cloning per web session; `--frozen-lockfile` makes the frontend install faster by skipping resolution.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy; takes effect on the next web session.

## Checklist

- [ ] Tests added/updated — n/a, this is an environment bootstrap script with no test harness; validated by the reproduction above.
- [ ] Changelog entry added — deliberately skipped: dev tooling only, no user-facing or ops-facing behavior, so it does not belong in release notes.
- [ ] External docs updated — n/a, not user-facing.
- [ ] Internal .md docs updated — no change needed; `dev/guidelines/git-workflow.md` already documents the submodule command, and the change makes the setup script follow it.
- [x] I have reviewed AI generated content