### PR TITLE
test(backend): scope prefect event assertions to their proposed change

### DIFF
--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -85,7 +85,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.approved")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change.approved",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )
 
         # Test the ProposedChangeReview mutation with REJECTED decision
         response = await unprivileged_client.execute_graphql(
@@ -107,7 +111,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert rejected_by_peers == {reviewer["AccountProfile"]["id"]}
 
         # Verify that an event has been logged
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.rejected")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change.rejected",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )
 
     async def test_cancel_approve(
         self,
@@ -168,7 +176,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.approval_revoked")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change.approval_revoked",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )
 
     async def test_cancel_reject(
         self,
@@ -229,7 +241,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.rejection_revoked")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change.rejection_revoked",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )
 
     async def test_missing_permission(
         self,

--- a/backend/tests/functional/proposed_change/test_thread_events.py
+++ b/backend/tests/functional/proposed_change/test_thread_events.py
@@ -47,9 +47,17 @@ class TestProposedChangeThreadEvents(TestInfrahubApp):
         pc_thread_comment = await client.create(kind=THREADCOMMENT, data={"thread": pc_thread.id, "text": "A comment"})
         await pc_thread_comment.save()
 
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change_thread.created")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change_thread.created",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )
 
         pc_thread.resolved.value = True
         await pc_thread.save()
 
-        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change_thread.updated")
+        await self.assert_event(
+            prefect_client=prefect_client,
+            event_name="infrahub.proposed_change_thread.updated",
+            resource_id=f"infrahub.proposed_change.{proposed_change.id}",
+        )

--- a/backend/tests/helpers/events.py
+++ b/backend/tests/helpers/events.py
@@ -2,7 +2,7 @@ import asyncio
 from uuid import UUID
 
 from prefect.client.orchestration import PrefectClient
-from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter
+from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventResourceFilter
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 from pydantic import TypeAdapter
 
@@ -66,8 +66,16 @@ async def query_event(client: PrefectClient, event_id: UUID) -> Event:
     raise Exception(f"No event found for id {event_id}")
 
 
-async def query_events_by_name(client: PrefectClient, event_name: str) -> list[Event]:
-    filters = EventFilter(event=EventNameFilter(name=[event_name]))  # type: ignore[call-arg]
+async def query_events_by_name(client: PrefectClient, event_name: str, resource_id: str | None = None) -> list[Event]:
+    # The Prefect server is shared by every test class running in the same xdist worker, so a
+    # name-only query can match events emitted by other tests; scope by resource where possible.
+    if resource_id:
+        filters = EventFilter(  # type: ignore[call-arg]
+            event=EventNameFilter(name=[event_name]),  # type: ignore[call-arg]
+            resource=EventResourceFilter(id=[resource_id]),  # type: ignore[call-arg]
+        )
+    else:
+        filters = EventFilter(event=EventNameFilter(name=[event_name]))  # type: ignore[call-arg]
     body = {"filter": filters.model_dump(mode="json", exclude_unset=True)}
 
     response = await client._client.post("/events/filter", json=body)

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import AsyncGenerator, Generator
+from typing import TYPE_CHECKING, AsyncGenerator, Generator
 
 import pytest
 from fast_depends import Provider
@@ -8,6 +8,9 @@ from fast_depends import dependency_provider as provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from prefect.client.orchestration import PrefectClient
+
+if TYPE_CHECKING:
+    from prefect.events.schemas.events import Event
 
 from infrahub import config
 from infrahub.core import registry
@@ -288,14 +291,20 @@ class TestInfrahubAppBase(TestInfrahub):
         graphql_registry.clear_cache()
         await initialization(db=db)
 
-    async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:
+    async def assert_event(self, prefect_client: PrefectClient, event_name: str, resource_id: str) -> None:
+        events: list[Event] = []
         for _ in range(PREFECT_EVENT_WAIT_SECONDS):
-            events = await query_events_by_name(client=prefect_client, event_name=event_name)
+            events = await query_events_by_name(client=prefect_client, event_name=event_name, resource_id=resource_id)
             if len(events) == 1:
                 return
+            if len(events) > 1:
+                # Events are append-only, an over-count can never converge back to 1.
+                break
             await asyncio.sleep(1)
 
-        pytest.fail(f"unable to find prefect event '{event_name}'")
+        pytest.fail(
+            f"expected exactly 1 prefect event '{event_name}' for resource '{resource_id}', found {len(events)}"
+        )
 
 
 class TestInfrahubApp(TestInfrahubAppBase):


### PR DESCRIPTION
## Summary

Fixes the recurring `backend-tests-functional` flake where `test_thread_events` fails with `unable to find prefect event 'infrahub.proposed_change_thread.created'` — seen at least three times since early August across `stable`, `develop`, and `release-1.11` (most recently in [this run](https://github.com/opsmill/infrahub/actions/runs/32375496352/job/96446099124)).

## Root cause

The event was never missing — there were **two** of them. `assert_event` polled the Prefect events API filtered by event name only and required exactly one match. The Prefect test server is session-scoped, i.e. shared by every test class running in the same pytest-xdist worker, and its event store is never reset between classes. `test_comment_counts` also creates a change thread, which emits the same `infrahub.proposed_change_thread.created` event. Whenever xdist scheduled it before `test_thread_events` on the same worker, the name query returned two events, `len(events) == 1` never held, and the assertion timed out with a misleading "unable to find" message. All three CI occurrences show `test_comment_counts` passing minutes earlier on the same worker (gw1 / gw3 / gw1).

## Key Changes

- Event assertions are now scoped to the test's own data: `assert_event` requires the event's primary resource id (`infrahub.proposed_change.{id}`) and the query adds an `EventResourceFilter`, so events emitted by other test classes on the shared server can no longer affect the count.
- An over-count now fails immediately instead of polling for 60 seconds (the event store is append-only, so a count above one can never converge back to one).
- The failure message reports the observed event count instead of claiming the event was not found, so the next miscount cannot masquerade as a missing event.
- `test_review.py` (the helper's only other callers) passes the resource id as well; the name-only path of `query_events_by_name` is preserved for its remaining integration-test caller.

## Test Plan

- Reproduced the bad schedule locally (`test_comment_counts` then `test_thread_events` in one process, shared Prefect container): the unfixed helper fails with the exact CI signature, and instrumentation showed the name query returning both proposed changes' events on every poll; with the fix the same schedule passes.
- `pytest backend/tests/functional/proposed_change/` (comment_counts, thread_events, review): 7 passed.
- `ruff format`, `ruff check`, and `mypy` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

