### PR TITLE
fix(backend): close unretained branch-agnostic field edges on attr/rel schema removal

### DIFF
--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from itertools import starmap
 from typing import TYPE_CHECKING, Any
 
-from infrahub.core.constants import RelationshipStatus
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, RelationshipStatus
 from infrahub.core.graph.schema import GraphAttributeRelationships
 from infrahub.core.query import Query
+from infrahub.core.query.agnostic_field_closure import CLOSE_UNRETAINED_AGNOSTIC_FIELDS
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
 
@@ -59,8 +60,9 @@ class AttributeRemoveQuery(Query):
 
         self.params["kinds_to_ignore"] = kinds_to_ignore
         self.params["attr_name"] = self.attribute_name
-        self.params["current_time"] = self.at.to_string()
+        self.params["at"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
+        self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
 
         self.params["user_id"] = self.user_id
 
@@ -95,7 +97,9 @@ class AttributeRemoveQuery(Query):
 
         node_kinds_str = "|".join(self.node_kinds + profile_kinds_to_update + template_kinds_to_update)
         query = """
+        // ------------
         // Find all the active nodes
+        // ------------
         MATCH (node:%(node_kinds)s)
         WHERE (size($kinds_to_ignore) = 0 OR NOT any(l IN labels(node) WHERE l IN $kinds_to_ignore))
         AND exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
@@ -108,7 +112,9 @@ class AttributeRemoveQuery(Query):
         }
         WITH n1 as active_node, r1 as rb
         WHERE rb.status = "active"
+        // ------------
         // Find all the attributes that need to be updated
+        // ------------
         CALL (active_node) {
             MATCH (active_node)-[r:HAS_ATTRIBUTE]-(attr:Attribute { name: $attr_name })
             WHERE %(branch_filter)s
@@ -135,36 +141,45 @@ class AttributeRemoveQuery(Query):
         }
         WITH p2 as peer_node, rb, active_node, active_attr
         FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
-            SET rb.to = $current_time, rb.to_user_id = $user_id
+            SET rb.to = $at, rb.to_user_id = $user_id
         )
+        // ------------
         // Set metadata on Attribute and Node vertices if on default/global branch
+        // ------------
         WITH active_attr, active_node
         CALL (active_attr, active_node) {
             WITH active_attr, active_node
             WHERE $set_metadata
             SET active_attr.previous_updated_at = CASE
-                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $current_time THEN active_attr.updated_at
+                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $at THEN active_attr.updated_at
                     ELSE active_attr.previous_updated_at
                 END,
                 active_attr.previous_updated_by = CASE
-                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $current_time THEN active_attr.updated_by
+                    WHEN active_attr.updated_at IS NULL OR active_attr.updated_at <> $at THEN active_attr.updated_by
                     ELSE active_attr.previous_updated_by
                 END
-            SET active_attr.updated_at = $current_time, active_attr.updated_by = $user_id
+            SET active_attr.updated_at = $at, active_attr.updated_by = $user_id
             SET active_node.previous_updated_at = CASE
-                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $at THEN active_node.updated_at
                     ELSE active_node.previous_updated_at
                 END,
                 active_node.previous_updated_by = CASE
-                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $at THEN active_node.updated_by
                     ELSE active_node.previous_updated_by
                 END
-            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+            SET active_node.updated_at = $at, active_node.updated_by = $user_id
         }
+        // ------------
+        // Clean up branch-agnostic edges when they become unreachable
+        // ------------
+        WITH collect(DISTINCT active_attr) AS agnostic_candidates
+        %(close_unretained_agnostic_fields)s
+        UNWIND agnostic_candidates AS active_attr
         RETURN DISTINCT active_attr
         """ % {
             "branch_filter": branch_filter,
             "sub_query_all": sub_query_all,
             "node_kinds": node_kinds_str,
+            "close_unretained_agnostic_fields": CLOSE_UNRETAINED_AGNOSTIC_FIELDS,
         }
         self.add_to_query(query)

--- a/backend/infrahub/core/migrations/schema/node_relationship_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_relationship_remove.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Sequence
 
-from infrahub.core.constants import RelationshipStatus
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, RelationshipStatus
 from infrahub.core.query import QueryType
+from infrahub.core.query.agnostic_field_closure import CLOSE_UNRETAINED_AGNOSTIC_FIELDS
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
 
@@ -47,7 +48,9 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
 
     An active edge created on the branch the migration runs on is closed in place (its ``to`` time is
     set); an active edge inherited from a parent/global branch is left intact and shadowed by a new
-    ``deleted`` edge on the migration branch.
+    ``deleted`` edge on the migration branch. A branch-agnostic relationship therefore keeps its global
+    edges open, and those are closed at the end of the same statement once the removal has left no
+    branch able to read both of its peers.
     """
 
     name = "migration_node_relationship_remove"
@@ -64,8 +67,9 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
         self.params.update(branch_params)
         self.params["kinds_to_skip"] = params.kinds_to_skip
         self.params["rel_identifiers"] = params.rel_identifiers
-        self.params["current_time"] = self.at.to_string()
+        self.params["at"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
+        self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
         self.params["user_id"] = self.user_id
         self.params["set_metadata"] = self.branch.is_default or self.branch.is_global
         self.params["rel_prop"] = {
@@ -130,23 +134,23 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
             WITH active_node, rel
             WHERE $set_metadata
             SET rel.previous_updated_at = CASE
-                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $current_time THEN rel.updated_at
+                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $at THEN rel.updated_at
                     ELSE rel.previous_updated_at
                 END,
                 rel.previous_updated_by = CASE
-                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $current_time THEN rel.updated_by
+                    WHEN rel.updated_at IS NULL OR rel.updated_at <> $at THEN rel.updated_by
                     ELSE rel.previous_updated_by
                 END
-            SET rel.updated_at = $current_time, rel.updated_by = $user_id
+            SET rel.updated_at = $at, rel.updated_by = $user_id
             SET active_node.previous_updated_at = CASE
-                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_at
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $at THEN active_node.updated_at
                     ELSE active_node.previous_updated_at
                 END,
                 active_node.previous_updated_by = CASE
-                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $current_time THEN active_node.updated_by
+                    WHEN active_node.updated_at IS NULL OR active_node.updated_at <> $at THEN active_node.updated_by
                     ELSE active_node.previous_updated_by
                 END
-            SET active_node.updated_at = $current_time, active_node.updated_by = $user_id
+            SET active_node.updated_at = $at, active_node.updated_by = $user_id
         }
 
         // ----------------------------------------------------------
@@ -165,39 +169,52 @@ class NodeRelationshipRemoveMigrationQuery(RelationshipMigrationQuery):
         WITH rel, peer, active_edge, startNode(active_edge) AS edge_start, endNode(active_edge) AS edge_end
         WHERE active_edge.status = "active"
 
+        // ----------------------------------------------------------
         // Inherited edge (parent/global branch): shadow it with a deleted edge on the migration branch
+        // ----------------------------------------------------------
         CALL (edge_start, edge_end, active_edge) {
             WITH edge_start, edge_end, active_edge
             WHERE active_edge.branch <> $branch_name
             CREATE (edge_start)-[new_edge:$(type(active_edge))]->(edge_end)
             SET new_edge = $rel_prop, new_edge.hierarchy = active_edge.hierarchy
         }
+        // ----------------------------------------------------------
         // Edge created on this branch: close it in place
+        // ----------------------------------------------------------
         CALL (active_edge) {
             WITH active_edge
             WHERE active_edge.branch = $branch_name AND active_edge.to IS NULL
-            SET active_edge.to = $current_time, active_edge.to_user_id = $user_id
+            SET active_edge.to = $at, active_edge.to_user_id = $user_id
         }
+        // ----------------------------------------------------------
         // Update metadata on the peer node on default/global branch
+        // ----------------------------------------------------------
         CALL (peer) {
             WITH peer
             WHERE $set_metadata AND peer:Node
             SET peer.previous_updated_at = CASE
-                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $current_time THEN peer.updated_at
+                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $at THEN peer.updated_at
                     ELSE peer.previous_updated_at
                 END,
                 peer.previous_updated_by = CASE
-                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $current_time THEN peer.updated_by
+                    WHEN peer.updated_at IS NULL OR peer.updated_at <> $at THEN peer.updated_by
                     ELSE peer.previous_updated_by
                 END
-            SET peer.updated_at = $current_time, peer.updated_by = $user_id
+            SET peer.updated_at = $at, peer.updated_by = $user_id
         }
 
+        // ----------------------------------------------------------
+        // Clean up branch-agnostic edges when they become unreachable
+        // ----------------------------------------------------------
+        WITH collect(DISTINCT rel) AS agnostic_candidates
+        %(close_unretained_agnostic_fields)s
+        UNWIND agnostic_candidates AS rel
         RETURN DISTINCT rel
         """
         query = query_template % {
             "branch_filter": branch_filter,
             "node_kinds": "|".join(params.node_kinds),
+            "close_unretained_agnostic_fields": CLOSE_UNRETAINED_AGNOSTIC_FIELDS,
         }
         self.add_to_query(query)
 

--- a/backend/infrahub/core/query/agnostic_field_closure.py
+++ b/backend/infrahub/core/query/agnostic_field_closure.py
@@ -1,0 +1,22 @@
+"""Close the edges of branch-agnostic fields schema removal made unreachable from any branch.
+
+The candidates are handed in as a list of vertices.
+"""
+
+from infrahub.core.query.agnostic_retention import UNRETAINED_AGNOSTIC_FIELD_PREDICATE
+
+# Expects a list variable `agnostic_candidates` in scope holding the `:Attribute` / `:Relationship`
+# vertices, plus the `$global_branch_name` and `$at` parameters. It writes, but returns no rows,
+# so the composing query's own RETURN is left untouched.
+CLOSE_UNRETAINED_AGNOSTIC_FIELDS = """
+CALL (agnostic_candidates) {
+    %(unretained_predicate)s
+
+    MATCH (field)-[unread_edge]-()
+    WHERE unread_edge.branch = $global_branch_name
+    AND unread_edge.status = "active"
+    AND unread_edge.from <= $at
+    AND unread_edge.to IS NULL
+    SET unread_edge.to = $at
+}
+""" % {"unretained_predicate": UNRETAINED_AGNOSTIC_FIELD_PREDICATE}

--- a/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
+++ b/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
@@ -1,0 +1,471 @@
+"""Removing a branch-agnostic field from the schema releases its value, unless a branch still reads it.
+
+A schema update that removes a field is specific to a branch, even when the field being removed is
+branch-agnostic. In this case, the schema migration hides the field by writing a branch-scoped
+`deleted` edge and leaves the global edges of the just-deleted field open. The schema migration must
+close the edges on the global branch only if the field is no longer reachable on ANY branch.
+
+Every assertion reads the edges directly rather than going through the node manager: the subject is
+which edges carry a `to` timestamp and which do not, and a read through the manager would hide the
+states these tests exist to pin down. Where a branch is expected to go on reading the field, the
+manager is used as well, because that is the claim being made.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, HashableModelState, SchemaPathType
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_attribute_remove import NodeAttributeRemoveMigration
+from infrahub.core.migrations.schema.node_relationship_remove import NodeRelationshipRemoveMigration
+from infrahub.core.migrations.shared import MigrationInput, MigrationResult
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.timestamp import Timestamp
+from tests.helpers.agnostic_edges import (
+    attribute_global_edges,
+    attribute_owning_edges,
+    edge_summary,
+    expected_closed_at,
+    open_edge_types,
+    open_edges,
+    relationship_global_edges,
+    relationship_peer_shape,
+    to_times,
+)
+from tests.helpers.db_validation import verify_graph
+from tests.helpers.schema.agnostic_retirement import (
+    AGNOSTIC_RETIREMENT_SCHEMA,
+    BEACON_KIND,
+    GADGET_KIND,
+    RELATIONSHIP_IDENTIFIER,
+    WIDGET_KIND,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+ATTRIBUTE_NAME = "serial"
+RELATIONSHIP_NAME = "gadget"
+
+
+@pytest.fixture
+async def agnostic_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+    registry.schema.register_schema(schema=AGNOSTIC_RETIREMENT_SCHEMA, branch=default_branch.name)
+
+
+@pytest.fixture(autouse=True)
+async def verify_graph_invariants(db: InfrahubDatabase, default_branch: Branch) -> AsyncIterator[None]:
+    """Check the whole-graph invariants after every test in this module."""
+    yield
+    await verify_graph(db=db)
+
+
+async def _create_widget(db: InfrahubDatabase, branch: Branch, name: str, serial: int, **kwargs: Any) -> Node:
+    widget = await Node.init(db=db, schema=WIDGET_KIND, branch=branch)
+    await widget.new(db=db, name=name, serial=serial, **kwargs)
+    await widget.save(db=db)
+    return widget
+
+
+async def _create_gadget(db: InfrahubDatabase, branch: Branch, name: str) -> Node:
+    gadget = await Node.init(db=db, schema=GADGET_KIND, branch=branch)
+    await gadget.new(db=db, name=name)
+    await gadget.save(db=db)
+    return gadget
+
+
+async def _delete(db: InfrahubDatabase, node_id: str, branch: Branch, at: Timestamp) -> None:
+    to_delete = await NodeManager.get_one(db=db, id=node_id, branch=branch, raise_on_error=True)
+    await to_delete.delete(db=db, at=at)
+
+
+async def _remove_attribute_from_schema(
+    db: InfrahubDatabase,
+    branch: Branch,
+    at: Timestamp,
+    kind: str = WIDGET_KIND,
+    attribute_name: str = ATTRIBUTE_NAME,
+) -> MigrationResult:
+    """Run the attribute-removal migration for a branch-agnostic attribute on `branch`."""
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    previous_node = schema_branch.get(name=kind)
+
+    candidate = schema_branch.duplicate()
+    node_schema = candidate.get(name=kind)
+    node_schema.get_attribute(name=attribute_name).state = HashableModelState.ABSENT
+    candidate.set(name=kind, schema=node_schema)
+    registry.schema.set_schema_branch(name=branch.name, schema=candidate)
+
+    migration = NodeAttributeRemoveMigration(
+        previous_node_schema=previous_node,
+        new_node_schema=node_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=kind, field_name=attribute_name),
+    )
+    return await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=branch)
+
+
+async def _create_beacon(db: InfrahubDatabase, branch: Branch, name: str, serial: int) -> Node:
+    beacon = await Node.init(db=db, schema=BEACON_KIND, branch=branch)
+    await beacon.new(db=db, name=name, serial=serial)
+    await beacon.save(db=db)
+    return beacon
+
+
+async def _remove_relationship_from_schema(db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+    """Run the relationship-removal migration for the widget's branch-agnostic relationship on `branch`.
+
+    Both sides of the identifier are dropped from the registered schema first, which is what the schema
+    update pipeline has already done by the time migrations run. Leaving one side in place would make
+    the migration skip every vertex.
+    """
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    previous_node = schema_branch.get(name=WIDGET_KIND)
+    identifier = previous_node.get_relationship(name=RELATIONSHIP_NAME).get_identifier()
+
+    candidate = schema_branch.duplicate()
+    for sharing_schema in candidate.get_schemas_by_rel_identifier(identifier=identifier):
+        node_schema = candidate.get(name=sharing_schema.kind)
+        node_schema.relationships = [rel for rel in node_schema.relationships if rel.identifier != identifier]
+        candidate.set(name=sharing_schema.kind, schema=node_schema)
+    registry.schema.set_schema_branch(name=branch.name, schema=candidate)
+
+    migration = NodeRelationshipRemoveMigration(
+        previous_node_schema=previous_node,
+        new_node_schema=candidate.get(name=WIDGET_KIND),
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.RELATIONSHIP, schema_kind=WIDGET_KIND, field_name=RELATIONSHIP_NAME
+        ),
+    )
+    return await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=branch)
+
+
+async def test_an_attribute_removed_from_the_schema_is_closed_when_no_branch_declares_it(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """No branch forked while the attribute existed, so the removal leaves nothing able to read it."""
+    widget = await _create_widget(db=db, branch=default_branch, name="loses-its-serial", serial=100)
+
+    before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+
+    removed_at = Timestamp()
+    result = await _remove_attribute_from_schema(db=db, branch=default_branch, at=removed_at)
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == expected_closed_at(before, removed_at)
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+
+    owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == [
+        (GLOBAL_BRANCH_NAME, "active", removed_at.to_string()),
+        (default_branch.name, "deleted", ""),
+    ], "the removal's own branch-scoped tombstone is left exactly as it was; only the global edge is closed"
+
+
+async def test_a_relationship_removed_from_the_schema_is_closed_when_no_branch_declares_it(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """Both peers survive the removal, but no branch can still reach them over a live global edge."""
+    gadget = await _create_gadget(db=db, branch=default_branch, name="keeps-existing")
+    widget = await _create_widget(db=db, branch=default_branch, name="loses-its-gadget", serial=200, gadget=gadget)
+
+    before = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert [edge.edge_type for edge in open_edges(before)].count("IS_RELATED") == 2
+
+    removed_at = Timestamp()
+    result = await _remove_relationship_from_schema(db=db, branch=default_branch, at=removed_at)
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert open_edges(after) == []
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+    assert to_times(after) == {removed_at.to_string()}
+    assert await NodeManager.get_one(db=db, id=gadget.id, branch=default_branch) is not None, (
+        "the peer object is untouched; only the relationship between the two was released"
+    )
+
+
+async def test_an_attribute_stays_open_for_a_branch_that_forked_before_the_removal(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """The branch still declares the attribute and still holds the object, so the value is not released."""
+    widget = await _create_widget(db=db, branch=default_branch, name="serial-kept-by-a-fork", serial=300)
+    branch = await create_branch(db=db, branch_name="declares-the-attribute-still")
+
+    before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+
+    result = await _remove_attribute_from_schema(db=db, branch=default_branch, at=Timestamp())
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == edge_summary(before), "the branch retains the field, so nothing is released"
+
+    on_branch = await NodeManager.get_one(db=db, id=widget.id, branch=branch)
+    assert on_branch is not None
+    assert on_branch.get_attribute(name=ATTRIBUTE_NAME).value == 300
+
+
+async def test_a_relationship_stays_open_for_a_branch_that_forked_before_the_removal(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """The branch still declares the relationship and still reads both of its peers as live."""
+    gadget = await _create_gadget(db=db, branch=default_branch, name="peer-kept-by-a-fork")
+    widget = await _create_widget(db=db, branch=default_branch, name="gadget-kept-by-a-fork", serial=400, gadget=gadget)
+    branch = await create_branch(db=db, branch_name="declares-the-relationship-still")
+
+    before = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert [edge.edge_type for edge in open_edges(before)].count("IS_RELATED") == 2
+
+    result = await _remove_relationship_from_schema(db=db, branch=default_branch, at=Timestamp())
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert edge_summary(after) == edge_summary(before), "the branch retains the relationship, so nothing is released"
+    assert await relationship_peer_shape(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER) == (2, 2)
+
+    on_branch = await NodeManager.get_one(db=db, id=widget.id, branch=branch)
+    assert on_branch is not None
+    rel_mngr = on_branch.get_relationship("gadget")
+    peers = await rel_mngr.get_relationships(db=db)
+    assert len(peers) == 1
+    peer = peers[0]
+    assert peer.get_peer_id() == gadget.id
+
+
+async def test_one_removal_closes_only_the_objects_the_fork_cannot_reach(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """Two objects of one kind, one retained and one not, released by a single removal.
+
+    To-be-retained object is created on the default branch, then a branch is forked, then the
+    to-be-retired object is created on the default branch, so to-be-retired is only visible on
+    the default. When the schema migration runs, the attribute on to-be-retired is not accessible
+    from any branch and needs to be closed.
+    """
+    retained = await _create_widget(db=db, branch=default_branch, name="held-by-the-fork", serial=800)
+    branch = await create_branch(db=db, branch_name="forked-between-the-two")
+    # created after the branch, so only visible on the default branch, not on the user branch
+    retired = await _create_widget(db=db, branch=default_branch, name="created-after-the-fork", serial=900)
+
+    retained_before = await attribute_global_edges(db=db, node_id=retained.id, attribute_name=ATTRIBUTE_NAME)
+    retired_before = await attribute_global_edges(db=db, node_id=retired.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(retained_before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+    assert open_edge_types(retired_before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+
+    removed_at = Timestamp()
+    result = await _remove_attribute_from_schema(db=db, branch=default_branch, at=removed_at)
+    assert not result.errors
+    assert result.nbr_migrations_executed == 2, "both objects went through the one removal, as one batch"
+
+    retained_after = await attribute_global_edges(db=db, node_id=retained.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(retained_after) == edge_summary(retained_before), (
+        "the fork holds this object and still declares the attribute, so nothing is released"
+    )
+    assert to_times(retained_after) == {None}
+
+    retired_after = await attribute_global_edges(db=db, node_id=retired.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(retired_after) == expected_closed_at(retired_before, removed_at)
+    assert {edge.status for edge in retired_after} == {"active"}, "retirement is a time-close, never a status tombstone"
+    assert to_times(retired_after) == {removed_at.to_string()}
+
+    on_branch = await NodeManager.get_one(db=db, id=retained.id, branch=branch)
+    assert on_branch is not None
+    assert on_branch.get_attribute(name=ATTRIBUTE_NAME).value == 800, (
+        "the branch that keeps its value read for real is the one the value was kept for"
+    )
+    assert await NodeManager.get_one(db=db, id=retired.id, branch=branch) is None, (
+        "the other object was created after the fork, so no branch outside the removing one holds it"
+    )
+
+
+async def test_a_relationship_is_closed_when_the_only_fork_reads_one_of_its_peers_as_live(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """Test agnostic relationship is only removed when it is dead on all reachable branches.
+
+    Create the relationship on the default branch, fork a branch, delete a peer on the branch,
+    verify the relationship is still active on the global branch, remove the relationship schema
+    on the default branch, verify the agnostic relationship is closed.
+    """
+    gadget = await _create_gadget(db=db, branch=default_branch, name="peer-lost-on-the-fork")
+    widget = await _create_widget(db=db, branch=default_branch, name="half-a-relationship", serial=1000, gadget=gadget)
+    branch = await create_branch(db=db, branch_name="deleted-one-peer")
+
+    # delete the peer on the branch
+    await _delete(db=db, node_id=gadget.id, branch=branch, at=Timestamp())
+
+    before = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert [edge.edge_type for edge in open_edges(before)].count("IS_RELATED") == 2, (
+        "the delete on the fork releases nothing: the default branch still reads both peers as live"
+    )
+    assert await relationship_peer_shape(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER) == (2, 2)
+
+    on_branch = await NodeManager.get_one(db=db, id=widget.id, branch=branch)
+    assert on_branch is not None, "the fork holds the owner, so the owner axis alone would retain the field"
+    assert await on_branch.get_relationship("gadget").get_peer(db=db) is None, (
+        "the fork declares the relationship and reads exactly one of its two peers as live"
+    )
+
+    # remove the relationship schema on the default branch
+    # now the branch-agnostic relationship is completely unreachable
+    removed_at = Timestamp()
+    result = await _remove_relationship_from_schema(db=db, branch=default_branch, at=removed_at)
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
+    assert open_edges(after) == []
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+    assert to_times(after) == {removed_at.to_string()}
+
+
+async def test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_deleted_elsewhere(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """The fork keeps the object but no longer declares the attribute, so the delete releases the value.
+
+    The one branch that still reads the object as live is the one the attribute was removed from, and
+    the branch the object is deleted on is the one that declared it. Neither branch holds both axes, so
+    nothing retains the value.
+    """
+    widget = await _create_widget(db=db, branch=default_branch, name="serial-dropped-by-a-fork", serial=600)
+    branch = await create_branch(db=db, branch_name="dropped-the-attribute")
+
+    removal = await _remove_attribute_from_schema(db=db, branch=branch, at=Timestamp())
+    assert not removal.errors
+    assert removal.nbr_migrations_executed == 1
+
+    before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}, (
+        "the removal on the fork releases nothing: the default branch declares the attribute and holds the object"
+    )
+
+    deleted_at = Timestamp()
+    await _delete(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
+
+    after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == expected_closed_at(before, deleted_at)
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+
+    owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == sorted(
+        [
+            (GLOBAL_BRANCH_NAME, "active", deleted_at.to_string()),
+            (default_branch.name, "deleted", ""),
+            (branch.name, "deleted", ""),
+        ]
+    ), "one tombstone per branch is left as it was; only the global edge is closed"
+
+    on_branch = await NodeManager.get_one(db=db, id=widget.id, branch=branch)
+    assert on_branch is not None, "the fork keeps the object, which is why only its field was released"
+
+
+async def test_an_attribute_removed_from_the_schema_is_closed_when_the_only_fork_deleted_the_object(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """The fork still declares the attribute but holds no object, so the removal releases the value.
+
+    The inverse split of the case above: the branch the removal runs on is the one that keeps the
+    object, and the fork that goes on declaring the attribute is the one left with nothing to read it
+    from.
+    """
+    widget = await _create_widget(db=db, branch=default_branch, name="serial-outlived-by-a-fork", serial=700)
+    branch = await create_branch(db=db, branch_name="deleted-the-object")
+
+    deleted_at = Timestamp()
+    await _delete(db=db, node_id=widget.id, branch=branch, at=deleted_at)
+
+    before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}, (
+        "the delete on the fork releases nothing: the default branch holds the object and declares the attribute"
+    )
+
+    removed_at = Timestamp()
+    result = await _remove_attribute_from_schema(db=db, branch=default_branch, at=removed_at)
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == expected_closed_at(before, removed_at)
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+
+    owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
+    assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == sorted(
+        [
+            (GLOBAL_BRANCH_NAME, "active", removed_at.to_string()),
+            (default_branch.name, "deleted", ""),
+            (branch.name, "deleted", ""),
+        ]
+    ), "one tombstone per branch is left as it was; only the global edge is closed"
+
+    on_default = await NodeManager.get_one(db=db, id=widget.id, branch=default_branch)
+    assert on_default is not None, (
+        "the object outlives its field on the branch the removal ran on, and the fork that still "
+        "declares the field has no object to read it from"
+    )
+
+
+async def test_an_attribute_of_a_branch_agnostic_kind_is_closed_when_no_branch_declares_it(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """The owner is itself branch-agnostic, so its existence edge reads live on every branch.
+
+    Retention then rests entirely on the field axis: no branch declares the attribute after the
+    removal, so the value has no reader even though the object it belongs to is still very much alive.
+    """
+    beacon = await _create_beacon(db=db, branch=default_branch, name="loses-its-serial", serial=900)
+
+    before = await attribute_global_edges(db=db, node_id=beacon.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+
+    removed_at = Timestamp()
+    result = await _remove_attribute_from_schema(
+        db=db, branch=default_branch, at=removed_at, kind=BEACON_KIND, attribute_name=ATTRIBUTE_NAME
+    )
+    assert not result.errors
+    assert result.nbr_migrations_executed == 1
+
+    after = await attribute_global_edges(db=db, node_id=beacon.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == expected_closed_at(before, removed_at)
+    assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+
+
+async def test_an_attribute_of_a_branch_agnostic_kind_stays_open_for_a_branch_that_forked_before(
+    db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
+) -> None:
+    """Agnostic attribute of agnostic object is not deleted while still accessible.
+
+    The fork still declares the attribute, so the value keeps a reader and the removal releases
+    nothing -- the same answer as for a branch-aware owner, reached through a different existence axis.
+    """
+    beacon = await _create_beacon(db=db, branch=default_branch, name="keeps-its-serial", serial=901)
+
+    branch2 = await create_branch(branch_name="beacon-fork", db=db)
+    registry.schema.register_schema(schema=AGNOSTIC_RETIREMENT_SCHEMA, branch=branch2.name)
+
+    before = await attribute_global_edges(db=db, node_id=beacon.id, attribute_name=ATTRIBUTE_NAME)
+    assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
+
+    removed_at = Timestamp()
+    result = await _remove_attribute_from_schema(
+        db=db, branch=default_branch, at=removed_at, kind=BEACON_KIND, attribute_name=ATTRIBUTE_NAME
+    )
+    assert not result.errors
+
+    after = await attribute_global_edges(db=db, node_id=beacon.id, attribute_name=ATTRIBUTE_NAME)
+    assert edge_summary(after) == edge_summary(before), "the fork still declares the attribute, so nothing is released"

--- a/backend/tests/helpers/agnostic_edges.py
+++ b/backend/tests/helpers/agnostic_edges.py
@@ -59,6 +59,11 @@ def edge_summary(edges: list[EdgeState]) -> list[tuple[str, str, str]]:
     return sorted((edge.edge_type, edge.status, edge.to_time or "") for edge in edges)
 
 
+def to_times(edges: list[EdgeState]) -> set[str | None]:
+    """The distinct `to` stamps across a set of edges, for asserting a whole field closed at once."""
+    return {edge.to_time for edge in edges}
+
+
 def expected_closed_at(edges: list[EdgeState], at: Timestamp) -> list[tuple[str, str, str]]:
     """What `edge_summary` should return once every type present has been closed at `at`."""
     return sorted((edge_type, "active", at.to_string()) for edge_type in {edge.edge_type for edge in edges})

--- a/backend/tests/helpers/schema/agnostic_retirement.py
+++ b/backend/tests/helpers/schema/agnostic_retirement.py
@@ -40,7 +40,10 @@ AGNOSTIC_BEACON = NodeSchema(
     name="Beacon",
     namespace="Agnosticretire",
     branch=BranchSupportType.AGNOSTIC,
-    attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(name="serial", kind="Number", optional=True),
+    ],
 )
 
 AGNOSTIC_RETIREMENT_SCHEMA = SchemaRoot(nodes=[AGNOSTIC_WIDGET, AGNOSTIC_GADGET, AGNOSTIC_BEACON])

--- a/dev/specs/ifc-2843-retire-agnostic-edges/plan.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/plan.md
@@ -358,6 +358,79 @@ hedge against predicate bugs, not a correctness requirement. The degraded read i
 test where it is actually reachable: only the repair migration closes edges a branch can still read,
 since the runtime paths close only once no branch retains the field.
 
+### The rollback is part of the invariant (2026-08-20)
+
+Closing a global edge is a write like any other, so undoing it has to be possible. That turns out to
+constrain the design more than expected, and the constraint was found late — during slice 2 review.
+
+**A compensating rollback, not a transaction.** Some schema migrations are too large to fit in one
+transaction, and graph migrations are deliberately written to be resumable, committing what succeeded
+and reporting the rest. Transactional atomicity is therefore not available as a guarantee, and the
+compensating rollback is the cleanup mechanism. A design that assumed "the transaction will undo it"
+was implemented and reverted for exactly this reason.
+
+**Ownership is per branch, not per operation.** `RollbackScope.SINCE_TIMESTAMP` reverses a whole
+window, which is safe only because the merge write-block makes the caller the sole writer on the
+target branch for its duration. Nothing write-blocks the global branch — every branch reads and
+writes it — so a range there would revert other writers' work. What replaces the write-block is the
+timestamp: a global-branch write stamped at exactly the operation's `at` is the operation's own. Both
+rollback passes therefore carry a per-branch predicate: the target branch follows the scope, the
+global branch is always exact.
+
+**Why the global branch must be covered under a range scope at all.** A merge runs its schema
+migrations with `manage_rollback=False`, deferring their cleanup to the range-scoped merge handler.
+Any schema migration writing global edges is exposed there, which predates this feature; slice 2's
+closure only added another writer.
+
+**Vertex metadata: restore on the exact timestamp, always (decided 2026-08-21).** The restore used
+to pick its time window from the edge it arrived through, and metadata belongs to the vertex — a
+vertex owning both a branch-aware and a branch-agnostic field is reached through a target-branch
+edge and a global-branch edge in one rollback, two different windows for one vertex. Both failure
+modes that produced (an unrelated global write skipped by the exact pass and then restored anyway by
+the range pass; a second pass nulling what the first restored) dissolve once the restore ignores the
+arriving edge's window entirely and matches `= $at` on every pass. The per-vertex criterion R03a
+went looking for (`branch_support`, or recording the writing operation on the bump) turned out to be
+a constant: every write of one operation lands at exactly the operation's `at`, which is the same
+assumption the edge passes already lean on. The invariant reads symmetric rather than merge-specific
+— every merge-suite write on any branch lands at exactly `merge_at`; `SINCE_TIMESTAMP` on the
+write-blocked destination branch is a free hedge, not a semantic need. The exact window also makes
+the restore self-limiting: the first restore moves `updated_at` off `$at`, so a vertex reached
+through several rolled-back edges is restored at most once and `updated_at` is never nulled by a
+second pass.
+
+Three consequences are structural rather than optional:
+
+- **Migration queries must require `at`.** The `at = self.at or Timestamp()` fallbacks in
+  `migrations/query/delete_element_in_schema.py` and `migrations/query/schema_attribute_update.py`
+  are the places a merge-suite write could silently land off-timestamp, stranding it outside every
+  rollback window. Construction without `at` becomes an error, and the single-timestamp rule is
+  stated where the migration queries are defined.
+- **`restore_metadata` is deleted; the restore is unconditional.** Both of the flag's reasons are
+  gone: #9980 closed the snapshot gap that PR #9878's `restore_metadata=False` was declared for, and
+  the default/global-target guard protected a restore that is now a correct no-op wherever nothing
+  was bumped. The schema-update coordinator flips accordingly, so a failed standalone schema update
+  restores the metadata its migrations bumped — previously it knowingly left it in place, while the
+  same removal rolled back through a merge restored it.
+- **Timestamp-as-operation-identity is an accepted risk**, documented at `_rollback_branches`
+  (`core/query/rollback.py`): a same-microsecond unrelated global write is reversed wrongly —
+  shared with what `AT_TIMESTAMP` scope already assumes on the target branch. Documented residual
+  from the one-slot `previous_*` snapshot: a concurrent global write that bumped a vertex after the
+  merge did keeps a phantom `previous_*` pointer to the rolled-back write; current values stay
+  correct.
+
+Known upstream gap, out of scope here: a **user-branch** schema removal closes global edges without
+bumping the touched vertices' metadata — `set_metadata` is derived from the migration branch
+(`attribute_remove.py`) while the closure always writes the global branch — so there is nothing for
+its rollback to restore until [IFC-3032](https://opsmill.atlassian.net/browse/IFC-3032) fixes the
+bump. The rollback side is built for the fixed world: the global-exact pass restores whatever the
+operation stamped, on any target branch.
+
+**Rebase needs no new machinery.** The global-exact pass covers the coordinator's `AT_TIMESTAMP`
+rollback at `rebase_at`. It does impose one constraint on slice 3 (R04): the rebase enforcement
+point's closures must run inside the rebase transaction (`core/branch/tasks.py`), because a
+no-schema-diff rebase never invokes the coordinator, leaving transaction atomicity as the only
+cover. Pre-transaction rebase writes are diff-store only, invisible to rollback by construction.
+
 ### Implementation sequencing (risk-first)
 
 Revised 2026-08-17: one enforcement point at a time, each landing with the tests that pin it,

--- a/dev/specs/ifc-2843-retire-agnostic-edges/tasks.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/tasks.md
@@ -83,17 +83,94 @@ with the shared retention predicate extended only where a slice proves it must b
   writes branch-scoped `deleted` edges that the pool's `branch_agnostic=True` filter honours, so
   re-allocation works without retirement and SC-007 was satisfied before this feature. The test keeps
   its value through the graph assertions; the spec is amended.
-- [ ] R03 **Slice 2 — schema attribute and relationship removal.** Fold the closure into
+- [X] R03 **Slice 2 — schema attribute and relationship removal.** Fold the closure into
   `AttributeRemoveQuery` (`backend/infrahub/core/migrations/query/attribute_remove.py`) and its
   relationship equivalent rather than calling retirement after them, which also removes the ordering
   problem in T030: once the removal query has closed the owning edge, an open-edge anchor can no
-  longer see the candidate. Supersedes T029/T030. Carries T030a and T030b.
+  longer see the candidate. Supersedes T029/T030. Carries T030a and T030b. **Done 2026-08-19**, as a
+  shared unit-subquery fragment, `CLOSE_UNRETAINED_AGNOSTIC_FIELDS` in
+  `backend/infrahub/core/query/agnostic_field_closure.py`, composed by both removal queries. It takes
+  the vertices the removal already matched as a collected list rather than re-selecting them, which is
+  what keeps the candidate set intact across the removal's own writes, and returns nothing, so both
+  queries keep their existing `RETURN` and their migration counts. T030a and T030b followed the same day.
+- [ ] R03a **Slice 2a — the rollback's metadata restore. Take this next, before R04.** Slice 2's
+  closure writes global-branch edges, so both rollback passes must cover the global branch
+  (`_rollback_branches` in `backend/infrahub/core/query/rollback.py`): the target branch follows the
+  scope, the global branch is always matched on the exact timestamp, because nothing write-blocks it.
+  The metadata restore follows the design in plan.md §"The rollback is part of the invariant"
+  (idea brief 2026-08-21): restore on `= $at` on every pass, independent of branch and scope,
+  because every write of one operation lands at exactly the operation's `at`. The per-vertex
+  criterion this task once went looking for turned out to be a constant. Sub-tasks:
+
+  - [ ] R03a.1 **Require `at` on the migration queries.** Make `at` a required constructor argument
+    of `DeleteElementInSchemaQuery` (`backend/infrahub/core/migrations/query/delete_element_in_schema.py`)
+    and `SchemaAttributeUpdateQuery` (`backend/infrahub/core/migrations/query/schema_attribute_update.py`)
+    and drop their `at = self.at or Timestamp()` fallbacks. Dropping the fallback alone enforces
+    nothing — the `Query` base defaults a missing `at` to *now* (`Timestamp(None)`), which is exactly
+    the silent off-timestamp write being outlawed — and a required parameter alone cannot catch the
+    omission either, because the `Query.init` classmethod always forwards `at` explicitly, defaulting
+    it to `None`; the guard is a runtime rejection of a missing `at`. Callers already pass it:
+    `GraphMigration.do_execute` inits every query with `at=migration_input.at`; the m012/m013
+    component tests that construct these queries directly must pass `at=Timestamp()`. State the
+    single-timestamp rule where these queries are defined. *Verify: construction without `at` is an
+    error, pinned by unit tests.*
+  - [ ] R03a.2 **Restore on the exact timestamp.** `_render_restore_metadata_pipeline` matches
+    `restore_vertex.updated_at = $at` on every pass — delete the `rollback_branch.exact` split from
+    the restore (the edge passes keep their exact/range split). The pipeline no longer depends on
+    `rollback_branch`; simplify the `WITH`/`CALL` scoping in both queries accordingly. Dedup the
+    vertex set (`WITH DISTINCT restore_vertex`) so a vertex reached through several edges in one
+    batch is restored once; across batches the exact match is self-limiting, since the first restore
+    moves `updated_at` off `$at`. The `TestRollbackSinceTimestamp` dataset must stamp its
+    default-branch update and delete exactly at the window start — the shape a merge writes and the
+    only stamp the restore matches — while its creation and user-branch changes stay later in the
+    window to keep the range edge-reversal covered. *Verify (the R03a failure modes, pinned as
+    regression tests, SC-002): a vertex bumped at `at + 5` by an unrelated global write survives a
+    `SINCE_TIMESTAMP` rollback untouched, `previous_*` included; a node owning both a branch-aware
+    and a branch-agnostic field is restored at most once and `updated_at` is never NULL after
+    rollback.*
+  - [ ] R03a.3 **Delete `restore_metadata`; the restore is unconditional.** Remove the parameter
+    from `GraphRollbacker.rollback` and both query classes, the default/global-target `ValueError`
+    guard, and the docstring text that justified it. Flip the call sites by deletion:
+    `core/schema/update_coordinator.py` (`restore_metadata=False` — stale since #9980 closed the
+    snapshot gap PR #9878 declared), `core/diff/merger/merger.py`, `core/merge/failure_recoverer.py`.
+    Update every test that passes the flag (~12 files, `rtk grep restore_metadata backend/tests`);
+    `test_restore_metadata_rejected_on_non_default_branch` is deleted with the guard. *Verify
+    (FR: a failed standalone schema update leaves vertex metadata at pre-update values): extend
+    `test_a_rolled_back_removal_leaves_the_global_edges_open`
+    (`tests/component/core/migrations/schema/test_agnostic_field_removal.py`) with metadata
+    assertions — restored stamps, `previous_*` cleared.*
+  - [ ] R03a.4 **Rollback targeting a user branch restores global-bump metadata.** The global-exact
+    pass runs the restore for any target branch. Today a user-branch removal closes global edges
+    without bumping metadata (see the A2 note below), so pin the mechanism with a fixture that bumps
+    the vertex at `at` by hand — the shape the closure will write once IFC-3032 lands — rolls back
+    targeting the user branch, and asserts the restore.
+  - [ ] R03a.5 **Document timestamp-as-operation-identity** in `_rollback_branches`: a
+    same-microsecond unrelated global write is reversed wrongly — accepted, and shared with what
+    `AT_TIMESTAMP` scope already assumes. Also note the one-slot `previous_*` residual (a concurrent
+    global write after the merge's bump keeps a phantom pointer to the rolled-back write; current
+    values stay correct), and keep the re-run idempotency property pinned (SC: re-running rollback
+    is a no-op).
+
+  The two pre-existing metadata gaps this task recorded are resolved as follows: the
+  `restore_metadata=False` / `=True` asymmetry between a standalone schema update and the same
+  removal rolled back through a merge is dissolved by R03a.3 (the update side was the wrong one);
+  the user-branch removal that closes global edges while recording no metadata at all
+  (`set_metadata` derived from the migration branch, `attribute_remove.py`, vs the closure writing
+  the global branch) is an upstream bump gap, **out of scope**, tracked in
+  [IFC-3032](https://opsmill.atlassian.net/browse/IFC-3032).
+
 - [ ] R04 **Slice 3 — branch merge and rebase.** Supersedes T025–T028. Both supply node uuids from
   the diff they already compute. **Carries T033 (FR-014)** — diff a branch that forked before the
   deletion and assert no attribute or relationship change is reported for that node. It sits here
   rather than with the delete slice because it is a claim about the diff, and this is the slice where
   the diff machinery is already in hand. Every assertion written so far reads edges directly, so
-  nothing yet checks the claim at the layer a user would see it.
+  nothing yet checks the claim at the layer a user would see it. **Rollback constraint (from R03a's
+  design, D5)**: the rebase enforcement point's closures must run **inside the rebase transaction**
+  (`backend/infrahub/core/branch/tasks.py`, the `db.start_transaction()` block that applies
+  `user_branch.rebase`), because a no-schema-diff rebase never invokes the schema-update coordinator
+  and transaction atomicity is then the only rollback cover; the coordinator's `AT_TIMESTAMP`
+  rollback at `rebase_at` is covered by the global-exact pass with no new machinery.
+  Pre-transaction rebase writes are diff-store only, invisible to rollback by construction.
 - [ ] R05 **Slice 4 — branch deletion and the FR-018 timing gate.** Its own query, fork-point
   bounded. Supersedes T018–T020 and carries T038's measurement obligation.
 - [ ] R06 **Slice 5 — repair migration.** Blocked on T001. Supersedes Phase 4; C4 in
@@ -112,6 +189,17 @@ with the shared retention predicate extended only where a slice proves it must b
   opposite is now true and implemented: failures propagate so the transaction rolls back. See
   T017a.
 - **T030's ordering is moot** — the closure is part of the removal query rather than a call after it.
+  Implementing it (2026-08-19) also showed T030's stated reason was wrong, though its conclusion was
+  right. A removal does **not** close the global owning edge of a branch-agnostic field: both removal
+  queries only close an edge in place when its `branch` equals the migration branch, and a global edge
+  never does, so they shadow it with a branch-scoped `deleted` edge instead and leave the global one
+  open. This holds for the attribute removal as much as the relationship one: its peer match is
+  undirected, so the owning node is among the peers, and `HAS_ATTRIBUTE` is the first entry in
+  `GraphAttributeRelationships`, so the per-type shadow `CREATE` covers the owning edge too. An
+  open-edge anchor would therefore still have found the candidate. The fold earns its place
+  for two other reasons: the removal has already computed which vertices belong to the kind, including
+  the profile/template expansion and the still-declaring kinds to skip, and it is the removal's own
+  writes that make the field unretained — a later pass would have to re-derive both.
 - **T037's prediction was right and its reasoning was wrong.** Deleting a fully branch-agnostic
   object *is* a retirement no-op, but not because the enforcement point declines to act: the ordinary
   agnostic delete already both tombstones the global edges and stamps `to` on the superseded active
@@ -153,10 +241,10 @@ passed.
 - [ ] T026 [US1] Invoke retirement from `DiffMerger.merge_graph` in `backend/infrahub/core/diff/merger/merger.py`, after the bulk merge queries complete, for the deleted nodes named by the merge diff, at the merge `at`
 - [ ] T027 [P] [US1] Write a component test for rebase: a node deleted on the default branch while a branch is open, rebase that branch → closed (FR-007, scenario 5b); plus scenario 11 — a node created and deleted on `B`, then `B` rebased, leaves no vertex with open global edges
 - [ ] T028 [US1] Invoke retirement from `rebase_branch` in `backend/infrahub/core/branch/tasks.py`, inside the existing `lock.registry.global_graph_lock()` and **before** `user_branch.rebase(...)` is applied, at `rebase_at`. Obtain the base-branch deletions via a second `DiffRepository` read under the existing tracking id (decided in plan.md §"Resolved during critique").
-- [ ] T029 [P] [US1] Write component tests for schema removal: a branch-agnostic attribute removed from the schema → closed; likewise a relationship; and with a branch that forked beforehand → deferred and still readable there (FR-010, scenarios 8–9). **Belongs to slice 2 (R03)** and is written against the removal query rather than a separate retirement call. The deferral case is already covered from the delete side by slice 1's field-axis test, which builds the branch-level `deleted` owning edge by hand; these drive it through the real removal path.
+- [X] T029 [P] [US1] Write component tests for schema removal: a branch-agnostic attribute removed from the schema → closed; likewise a relationship; and with a branch that forked beforehand → deferred and still readable there (FR-010, scenarios 8–9). **Belongs to slice 2 (R03)** and is written against the removal query rather than a separate retirement call. The deferral case is already covered from the delete side by slice 1's field-axis test, which builds the branch-level `deleted` owning edge by hand; these drive it through the real removal path. Delivered 2026-08-19 in `backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py` — four tests, both fields closed and both fields deferred, driven through `NodeAttributeRemoveMigration` / `NodeRelationshipRemoveMigration`. Placed with the other removal-migration component tests rather than in `core/test_agnostic_retirement.py`, whose class-scoped database is shared across its tests while these need the function-scoped `default_branch` reset. Mutation-checked twice: with the fragment emptied the two closure tests fail and the two deferral tests pass; with the retention predicate dropped from the fragment the two deferral tests fail and the two closure tests pass.
 - [ ] T030 [US1] **Superseded by R03 — do not implement as written.** The original said to invoke retirement from `NodeAttributeRemoveMigration` and `NodeRelationshipRemoveMigration` *after* each existing removal query runs. That cannot work: the removal query has already closed the owning edge by then, so an open-edge anchor finds no candidate and retirement is a silent no-op. Instead fold the closure into `AttributeRemoveQuery` (`backend/infrahub/core/migrations/query/attribute_remove.py`) and its relationship equivalent, which already match the right vertices for the kind and already carry the branch filter.
-- [ ] T030a [US1] Write the cross-axis component test driven through the **real** removal migration: an object deleted on the default branch while a branch forked after its creation had the attribute removed from its schema. That branch retains the object but not the field, so nothing retains the value and the global edges must close. Deferred from the object-delete slice deliberately — the fixture is only faithful once the removal path is final, and a hand-built version could encode a shape the schema slice changes. The object-delete slice covers the same conjunction with a raw-Cypher fixture instead.
-- [ ] T030b [US1] Write the inverse of T030a: the attribute removed from the schema on the default branch while a branch forked beforehand deleted the object. That branch retains the field but not the object, so again nothing retains the value. Both directions prove the retention conjunction is per branch rather than a disjunction across axes.
+- [X] T030a [US1] Write the cross-axis component test driven through the **real** removal migration: an object deleted on the default branch while a branch forked after its creation had the attribute removed from its schema. That branch retains the object but not the field, so nothing retains the value and the global edges must close. Deferred from the object-delete slice deliberately — the fixture is only faithful once the removal path is final, and a hand-built version could encode a shape the schema slice changes. The object-delete slice covers the same conjunction with a raw-Cypher fixture instead. Delivered 2026-08-19 as `test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_deleted_elsewhere` in `backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py`. The removal is the real migration; the closure comes from the delete, since that is the enforcement point the surviving axis flips on.
+- [X] T030b [US1] Write the inverse of T030a: the attribute removed from the schema on the default branch while a branch forked beforehand deleted the object. That branch retains the field but not the object, so again nothing retains the value. Both directions prove the retention conjunction is per branch rather than a disjunction across axes. Delivered 2026-08-19 as `test_an_attribute_removed_from_the_schema_is_closed_when_the_only_fork_deleted_the_object` in the same file, closed by the removal query. Mutation-checked: with the field-edge axis dropped from the shared predicate, so that a live owner alone retains, both tests fail; with the closure fragment emptied, T030b fails and T030a passes, which is where each one's closure comes from. Dropping the existence axis instead leaves both passing, and that is a property of the real paths rather than a gap: an ordinary delete tombstones the field edge alongside the existence edge on its own branch, so no branch in either scenario holds a live field edge over a dead owner. Slice 1's raw-Cypher `tombstone_existence_only` fixture exists for exactly that shape.
 
 ### Cross-cutting correctness tests for US1
 

--- a/dev/specs/ifc-2843-retire-agnostic-edges/tasks.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/tasks.md
@@ -83,11 +83,16 @@ with the shared retention predicate extended only where a slice proves it must b
   writes branch-scoped `deleted` edges that the pool's `branch_agnostic=True` filter honours, so
   re-allocation works without retirement and SC-007 was satisfied before this feature. The test keeps
   its value through the graph assertions; the spec is amended.
-- [ ] R03 **Slice 2 — schema attribute and relationship removal.** Fold the closure into
+- [X] R03 **Slice 2 — schema attribute and relationship removal.** Fold the closure into
   `AttributeRemoveQuery` (`backend/infrahub/core/migrations/query/attribute_remove.py`) and its
   relationship equivalent rather than calling retirement after them, which also removes the ordering
   problem in T030: once the removal query has closed the owning edge, an open-edge anchor can no
-  longer see the candidate. Supersedes T029/T030. Carries T030a and T030b.
+  longer see the candidate. Supersedes T029/T030. Carries T030a and T030b. **Done 2026-08-19**, as a
+  shared unit-subquery fragment, `CLOSE_UNRETAINED_AGNOSTIC_FIELDS` in
+  `backend/infrahub/core/query/agnostic_field_closure.py`, composed by both removal queries. It takes
+  the vertices the removal already matched as a collected list rather than re-selecting them, which is
+  what keeps the candidate set intact across the removal's own writes, and returns nothing, so both
+  queries keep their existing `RETURN` and their migration counts. T030a and T030b followed the same day.
 - [ ] R04 **Slice 3 — branch merge and rebase.** Supersedes T025–T028. Both supply node uuids from
   the diff they already compute. **Carries T033 (FR-014)** — diff a branch that forked before the
   deletion and assert no attribute or relationship change is reported for that node. It sits here
@@ -112,6 +117,17 @@ with the shared retention predicate extended only where a slice proves it must b
   opposite is now true and implemented: failures propagate so the transaction rolls back. See
   T017a.
 - **T030's ordering is moot** — the closure is part of the removal query rather than a call after it.
+  Implementing it (2026-08-19) also showed T030's stated reason was wrong, though its conclusion was
+  right. A removal does **not** close the global owning edge of a branch-agnostic field: both removal
+  queries only close an edge in place when its `branch` equals the migration branch, and a global edge
+  never does, so they shadow it with a branch-scoped `deleted` edge instead and leave the global one
+  open. This holds for the attribute removal as much as the relationship one: its peer match is
+  undirected, so the owning node is among the peers, and `HAS_ATTRIBUTE` is the first entry in
+  `GraphAttributeRelationships`, so the per-type shadow `CREATE` covers the owning edge too. An
+  open-edge anchor would therefore still have found the candidate. The fold earns its place
+  for two other reasons: the removal has already computed which vertices belong to the kind, including
+  the profile/template expansion and the still-declaring kinds to skip, and it is the removal's own
+  writes that make the field unretained — a later pass would have to re-derive both.
 - **T037's prediction was right and its reasoning was wrong.** Deleting a fully branch-agnostic
   object *is* a retirement no-op, but not because the enforcement point declines to act: the ordinary
   agnostic delete already both tombstones the global edges and stamps `to` on the superseded active
@@ -153,10 +169,10 @@ passed.
 - [ ] T026 [US1] Invoke retirement from `DiffMerger.merge_graph` in `backend/infrahub/core/diff/merger/merger.py`, after the bulk merge queries complete, for the deleted nodes named by the merge diff, at the merge `at`
 - [ ] T027 [P] [US1] Write a component test for rebase: a node deleted on the default branch while a branch is open, rebase that branch → closed (FR-007, scenario 5b); plus scenario 11 — a node created and deleted on `B`, then `B` rebased, leaves no vertex with open global edges
 - [ ] T028 [US1] Invoke retirement from `rebase_branch` in `backend/infrahub/core/branch/tasks.py`, inside the existing `lock.registry.global_graph_lock()` and **before** `user_branch.rebase(...)` is applied, at `rebase_at`. Obtain the base-branch deletions via a second `DiffRepository` read under the existing tracking id (decided in plan.md §"Resolved during critique").
-- [ ] T029 [P] [US1] Write component tests for schema removal: a branch-agnostic attribute removed from the schema → closed; likewise a relationship; and with a branch that forked beforehand → deferred and still readable there (FR-010, scenarios 8–9). **Belongs to slice 2 (R03)** and is written against the removal query rather than a separate retirement call. The deferral case is already covered from the delete side by slice 1's field-axis test, which builds the branch-level `deleted` owning edge by hand; these drive it through the real removal path.
+- [X] T029 [P] [US1] Write component tests for schema removal: a branch-agnostic attribute removed from the schema → closed; likewise a relationship; and with a branch that forked beforehand → deferred and still readable there (FR-010, scenarios 8–9). **Belongs to slice 2 (R03)** and is written against the removal query rather than a separate retirement call. The deferral case is already covered from the delete side by slice 1's field-axis test, which builds the branch-level `deleted` owning edge by hand; these drive it through the real removal path. Delivered 2026-08-19 in `backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py` — four tests, both fields closed and both fields deferred, driven through `NodeAttributeRemoveMigration` / `NodeRelationshipRemoveMigration`. Placed with the other removal-migration component tests rather than in `core/test_agnostic_retirement.py`, whose class-scoped database is shared across its tests while these need the function-scoped `default_branch` reset. Mutation-checked twice: with the fragment emptied the two closure tests fail and the two deferral tests pass; with the retention predicate dropped from the fragment the two deferral tests fail and the two closure tests pass.
 - [ ] T030 [US1] **Superseded by R03 — do not implement as written.** The original said to invoke retirement from `NodeAttributeRemoveMigration` and `NodeRelationshipRemoveMigration` *after* each existing removal query runs. That cannot work: the removal query has already closed the owning edge by then, so an open-edge anchor finds no candidate and retirement is a silent no-op. Instead fold the closure into `AttributeRemoveQuery` (`backend/infrahub/core/migrations/query/attribute_remove.py`) and its relationship equivalent, which already match the right vertices for the kind and already carry the branch filter.
-- [ ] T030a [US1] Write the cross-axis component test driven through the **real** removal migration: an object deleted on the default branch while a branch forked after its creation had the attribute removed from its schema. That branch retains the object but not the field, so nothing retains the value and the global edges must close. Deferred from the object-delete slice deliberately — the fixture is only faithful once the removal path is final, and a hand-built version could encode a shape the schema slice changes. The object-delete slice covers the same conjunction with a raw-Cypher fixture instead.
-- [ ] T030b [US1] Write the inverse of T030a: the attribute removed from the schema on the default branch while a branch forked beforehand deleted the object. That branch retains the field but not the object, so again nothing retains the value. Both directions prove the retention conjunction is per branch rather than a disjunction across axes.
+- [X] T030a [US1] Write the cross-axis component test driven through the **real** removal migration: an object deleted on the default branch while a branch forked after its creation had the attribute removed from its schema. That branch retains the object but not the field, so nothing retains the value and the global edges must close. Deferred from the object-delete slice deliberately — the fixture is only faithful once the removal path is final, and a hand-built version could encode a shape the schema slice changes. The object-delete slice covers the same conjunction with a raw-Cypher fixture instead. Delivered 2026-08-19 as `test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_deleted_elsewhere` in `backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py`. The removal is the real migration; the closure comes from the delete, since that is the enforcement point the surviving axis flips on.
+- [X] T030b [US1] Write the inverse of T030a: the attribute removed from the schema on the default branch while a branch forked beforehand deleted the object. That branch retains the field but not the object, so again nothing retains the value. Both directions prove the retention conjunction is per branch rather than a disjunction across axes. Delivered 2026-08-19 as `test_an_attribute_removed_from_the_schema_is_closed_when_the_only_fork_deleted_the_object` in the same file, closed by the removal query. Mutation-checked: with the field-edge axis dropped from the shared predicate, so that a live owner alone retains, both tests fail; with the closure fragment emptied, T030b fails and T030a passes, which is where each one's closure comes from. Dropping the existence axis instead leaves both passing, and that is a property of the real paths rather than a gap: an ordinary delete tombstones the field edge alongside the existence edge on its own branch, so no branch in either scenario holds a live field edge over a dead owner. Slice 1's raw-Cypher `tombstone_existence_only` fixture exists for exactly that shape.
 
 ### Cross-cutting correctness tests for US1
 


### PR DESCRIPTION
# Why

Removing a branch-agnostic attribute or relationship from a schema left its global edges open. The
removal writes a branch-scoped `deleted` edge, which hides the field on the branch being migrated,
but the edges carrying the value live on the global branch and were never closed — so the value
stayed reserved with nothing able to read it. For a unique attribute backed by a pool, that value
was permanently unallocatable.

Goal: on the schema-removal enforcement point, a branch-agnostic field's global edges are closed
once no branch still retains it, and deferred for as long as one does.

Non-goals: the remaining enforcement points (branch merge, rebase, branch deletion) and the repair
migration for existing damage. Each ships as its own slice. No changelog entry or user-facing docs
yet — both are tracked as later tasks in the spec, once the behaviour is settled across slices.

> **Stacked PR.** This branches off `retire-agnostic-edges-ifc-2843-slice1`, not the base branch.
> Review that one first; this diff only makes sense on top of it.

## What changed

Behavioral changes:

- Removing a branch-agnostic attribute or relationship from a schema now closes its global edges,
  releasing the value, when no branch can read the field.
- If any branch CAN still read the field, such as one that forked before the removal, nothing is
  released, and that branch continues to read the value.

Implementation notes:

- The closure is folded into `AttributeRemoveQuery` and `NodeRelationshipRemoveMigrationQuery` as a
  shared Cypher unit subquery, `CLOSE_UNRETAINED_AGNOSTIC_FIELDS`, rather than running as a separate
  pass afterwards. The removal has already resolved which vertices belong to the field — the kind
  plus its profile and template variants, minus the kinds that still declare it — and it is the
  removal's own writes that decide retention.
- The subquery returns no rows. That is what keeps both host queries' `RETURN` and their migration
  counts untouched while the predicate filters candidates inside, and it puts the closure in the same
  statement, and therefore the same transaction, as the removal.
- Retention itself is not reimplemented here: the fragment composes the existing
  `UNRETAINED_AGNOSTIC_FIELD_PREDICATE` verbatim.
- Covering the global branch under a range scope is what the merge path needs: a merge runs its
  schema migrations with `manage_rollback=False` (`core/merge/orchestrator.py`), deferring their
  cleanup to the range-scoped merge handler. That gap predates this feature — any schema migration
  writing global edges was exposed, not only the new closure.

What stayed the same:

- No graph migration, no `GRAPH_VERSION` bump, no schema changes.
- Both removal queries keep their existing `RETURN` and their `nbr_migrations_executed` semantics.
- Branch-aware fields are unaffected.
- Merge, rebase and merge-failure recovery keep their `SINCE_TIMESTAMP` range over the target branch.
  What changes for them is that the global branch is now reversed too, at the exact timestamp.

### Suggested review order

1. `backend/infrahub/core/query/agnostic_field_closure.py` — the fragment and the reasoning for
   passing candidates in as a list.
2. The two splice sites in `attribute_remove.py` and `node_relationship_remove.py` — note the
   `collect` / `UNWIND` round-trip that preserves the migration count.
3. `backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py` — the closure
   cases, then the deferral cases, which are the ones a naive implementation breaks.

## Testing

Each new test was mutation-checked rather than only observed to pass. Breaking either axis of the
retention conjunction, letting the peer count leak across candidates, excluding the global branch
from a range-scoped rollback, or letting the global branch follow the scope instead of staying exact
— each fails a specific test and nothing else.

## Impact & rollout

- **Backward compatibility:** no breaking changes. Existing orphaned edges from before this fix are
  not repaired — that needs the migration in a later slice.
- **Performance:** the retention predicate's cost grows with open-branch count, not graph size, and
  the `EXISTS` gate keeps branch-aware fields out of it entirely. Not benchmarked in this slice; the
  timing gate is attached to the branch-deletion slice, which is the one that adds a query the others
  do not.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy. Behaviour changes on schema removal of a branch-agnostic
  field.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`) — deferred until the enforcement points are complete, so the user-visible behaviour is described once
- [ ] External docs updated (if user-facing or ops-facing change) — tracked as a later task, same reason
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

