### PR TITLE
fix(backend): keep non-mutation GraphQL execution on the sync path

### DIFF
--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -301,7 +301,7 @@ class InfrahubGraphQLApp:
             background=graphql_params.context.background,
         )
 
-        GRAPHQL_RESPONSE_SIZE_METRICS.labels(**labels).observe(len(json_response.render(response)))
+        GRAPHQL_RESPONSE_SIZE_METRICS.labels(**labels).observe(len(json_response.body))
         GRAPHQL_QUERY_DEPTH_METRICS.labels(**labels).observe(await analyzed_query.calculate_depth())
         GRAPHQL_QUERY_HEIGHT_METRICS.labels(**labels).observe(await analyzed_query.calculate_height())
         # GRAPHQL_QUERY_VARS_METRICS.labels(**labels).observe(len(analyzed_query.variables))

--- a/backend/infrahub/graphql/middleware.py
+++ b/backend/infrahub/graphql/middleware.py
@@ -1,4 +1,7 @@
 from inspect import isawaitable
+from typing import Any
+
+from graphql import GraphQLResolveInfo
 
 from infrahub.branch.status_checker import BranchStatusChecker
 from infrahub.core.merge.write_blocker import MergeWriteBlocker
@@ -9,20 +12,29 @@ ALLOWED_MUTATIONS_ON_MERGED_BRANCH = ["BranchDelete"]
 ALLOWED_MUTATIONS_DURING_MERGE = ["BranchCreate", "BranchDelete"]
 
 
-async def raise_on_mutation_for_branch_status(next, root, info, **kwargs):  # type: ignore  # noqa
+def raise_on_mutation_for_branch_status(next: Any, root: Any, info: GraphQLResolveInfo, **kwargs: Any) -> Any:  # noqa: A002
+    # Stay synchronous outside the gated case: an async middleware would return a coroutine for
+    # every resolved field, forcing the whole execution onto graphql-core's async completion path.
+    # That per-field overhead is what let a single IntrospectionQuery monopolize a worker's event
+    # loop for 10+ seconds.
+    if info.operation.operation.value == "mutation" and info.path.prev is None:
+        return _gate_top_level_mutation(next, root, info, kwargs)
+    return next(root, info, **kwargs)
+
+
+async def _gate_top_level_mutation(next: Any, root: Any, info: GraphQLResolveInfo, kwargs: dict[str, Any]) -> Any:  # noqa: A002
     # Only gate at the top-level mutation field so the merge-protection cache key is read once per
     # mutation rather than once per resolved field.
-    if info.operation.operation.value == "mutation" and info.path.prev is None:
-        # Use .field_name to get the field being resolved in case the mutation includes top-level fields
-        mutation_name = info.field_name
-        merge_write_blocker = MergeWriteBlocker(cache=info.context.active_service.cache)
-        branch_status_checker = BranchStatusChecker(db=info.context.db, merge_write_blocker=merge_write_blocker)
-        if mutation_name not in ALLOWED_MUTATIONS_ON_NEED_REBASE_BRANCH:
-            branch_status_checker.check_needs_rebase_status(branch=info.context.branch)
-        if mutation_name not in ALLOWED_MUTATIONS_ON_MERGED_BRANCH:
-            branch_status_checker.check_merge_status(branch=info.context.branch)
-        if mutation_name not in ALLOWED_MUTATIONS_DURING_MERGE:
-            await branch_status_checker.check_merging_status(branch=info.context.branch)
+    # Use .field_name to get the field being resolved in case the mutation includes top-level fields
+    mutation_name = info.field_name
+    merge_write_blocker = MergeWriteBlocker(cache=info.context.active_service.cache)
+    branch_status_checker = BranchStatusChecker(db=info.context.db, merge_write_blocker=merge_write_blocker)
+    if mutation_name not in ALLOWED_MUTATIONS_ON_NEED_REBASE_BRANCH:
+        branch_status_checker.check_needs_rebase_status(branch=info.context.branch)
+    if mutation_name not in ALLOWED_MUTATIONS_ON_MERGED_BRANCH:
+        branch_status_checker.check_merge_status(branch=info.context.branch)
+    if mutation_name not in ALLOWED_MUTATIONS_DURING_MERGE:
+        await branch_status_checker.check_merging_status(branch=info.context.branch)
 
     result = next(root, info, **kwargs)
     if isawaitable(result):

--- a/backend/tests/unit/graphql/test_middleware.py
+++ b/backend/tests/unit/graphql/test_middleware.py
@@ -1,0 +1,38 @@
+from inspect import isawaitable
+
+from graphql import build_schema, execute, get_introspection_query, parse
+
+from infrahub.graphql.middleware import raise_on_mutation_for_branch_status
+
+SCHEMA = build_schema("type Query { greeting: String }")
+
+
+def test_query_execution_stays_synchronous() -> None:
+    """A query through the branch-status middleware must complete without touching the event loop.
+
+    If the middleware returns a coroutine for non-mutation fields, every resolved field takes
+    graphql-core's async completion path; a single IntrospectionQuery then blocks a worker's event
+    loop for several seconds, starving every other request handled by that worker.
+    """
+    result = execute(
+        SCHEMA,
+        parse("{ greeting }"),
+        root_value={"greeting": "hello"},
+        middleware=[raise_on_mutation_for_branch_status],
+    )
+
+    assert not isawaitable(result)
+    assert result.errors is None
+    assert result.data == {"greeting": "hello"}
+
+
+def test_introspection_execution_stays_synchronous() -> None:
+    result = execute(
+        SCHEMA,
+        parse(get_introspection_query(descriptions=True)),
+        middleware=[raise_on_mutation_for_branch_status],
+    )
+
+    assert not isawaitable(result)
+    assert result.errors is None
+    assert result.data is not None

--- a/changelog/+graphql-query-sync-execution-path.fixed.md
+++ b/changelog/+graphql-query-sync-execution-path.fixed.md
@@ -1,0 +1,1 @@
+Sped up GraphQL query execution by keeping non-mutation requests on the synchronous resolution path. The branch-status middleware previously wrapped every resolved field in a coroutine, which made large read queries — most visibly the GraphQL sandbox's schema introspection — take 10+ seconds and starve other requests handled by the same API worker while they ran.

--- a/dev/README.md
+++ b/dev/README.md
@@ -63,6 +63,7 @@ Backend architecture documentation in [knowledge/backend/](knowledge/backend/):
 - [message-bus.md](knowledge/backend/message-bus.md) - Message bus system
 - [api-backpressure.md](knowledge/backend/api-backpressure.md) - Priority-aware load shedding and the database-stress signal
 - [telemetry.md](knowledge/backend/telemetry.md) - Anonymous usage telemetry (categories, windowing, retention, degradation)
+- [graphql-execution.md](knowledge/backend/graphql-execution.md) - Sync vs async field completion and why middleware must stay synchronous
 
 Frontend architecture documentation in [knowledge/frontend/](knowledge/frontend/):
 

--- a/dev/knowledge/backend/graphql-execution.md
+++ b/dev/knowledge/backend/graphql-execution.md
@@ -1,0 +1,52 @@
+# GraphQL Execution Paths
+
+> Part of: `dev/knowledge/backend/` | Related: [mutations.md](mutations.md), [branch-status.md](branch-status.md), [api-backpressure.md](api-backpressure.md)
+
+How graphql-core decides between synchronous and asynchronous field completion, and why per-field hooks such as middleware must stay synchronous on the hot path.
+
+## Sync vs async completion is decided per field
+
+graphql-core has no global execution mode. For every resolved field it checks whether the resolver returned an awaitable:
+
+- Plain value: the field completes synchronously, inline, with no event-loop involvement.
+- Awaitable: the field takes the async completion path — a coroutine object is created, wrapped, awaited, and often gathered with its siblings.
+
+A query whose resolvers all return plain values therefore executes as one synchronous pass, and `execute()` returns an `ExecutionResult` directly instead of an awaitable.
+
+## Middleware multiplies by the number of fields
+
+Middleware registered on `execute()` wraps **every field resolver**, including the default resolver used for plain attribute access and for every introspection meta-field. The consequence:
+
+- An `async def` middleware makes every field return a coroutine — even fields whose resolver is a plain synchronous value. The entire execution is forced onto the async completion path, paying coroutine creation, `ensure_future`, and gather overhead per field.
+- The overhead is roughly 10 µs per field. Ordinary queries resolve tens to hundreds of fields and never notice. An `IntrospectionQuery` against the full schema resolves on the order of a million fields: measured on the e2e image, introspection took 12.3 s through an async middleware versus 0.85 s on the synchronous path.
+
+Because that work is pure CPU inside one coroutine, it never yields meaningfully: the worker's event loop is pinned for the whole execution, and every other request handled by that worker — including static asset serving — waits. One abandoned sandbox introspection starving the next page load was the root cause of the long-standing `ipam-breadcrumb` e2e flake.
+
+## The pattern: synchronous dispatch, async only where needed
+
+Write middleware as a plain `def` that returns the resolver's raw result, and return a coroutine only on the narrow path that genuinely needs to await something:
+
+```python
+def my_middleware(next, root, info, **kwargs):
+    if <needs async work for this specific field>:
+        return _async_gate(next, root, info, kwargs)
+    return next(root, info, **kwargs)
+
+
+async def _async_gate(next, root, info, kwargs):
+    await do_the_async_check()
+    result = next(root, info, **kwargs)
+    if isawaitable(result):
+        return await result
+    return result
+```
+
+Returning the raw result is safe: graphql-core already handles awaitables returned by real async resolvers, so the middleware does not need to await on their behalf.
+
+`raise_on_mutation_for_branch_status` (`backend/infrahub/graphql/middleware.py`) is the worked example: it gates only top-level mutation fields through its async branch, so queries — and the response payload fields of mutations — stay on the synchronous path. `backend/tests/unit/graphql/test_middleware.py` pins the invariant that query and introspection execution completes without returning an awaitable.
+
+## When adding per-field hooks
+
+- Prefer no middleware at all: a check that runs once per request belongs in the request handler (`InfrahubGraphQLApp._handle_http_request`), not in a per-field hook.
+- If a hook must be middleware, keep the common path synchronous and branch to async only for the fields that need it.
+- Resolvers themselves are unaffected by this guidance: a resolver that performs I/O should of course be `async` — the cost being avoided is wrapping the *synchronous* majority of fields in needless coroutines.


### PR DESCRIPTION
## Summary

GraphQL read queries were paying a hidden per-field tax: the branch-status middleware is an `async` function, so every resolved field of every query returned a coroutine and pushed the whole execution onto graphql-core's async completion path. For large reads this is dramatic — the GraphQL sandbox's schema introspection took **12.3s** of event-loop-pinning CPU per visit (0.85s on the sync path), during which the affected API worker served nothing else.

This is also the root cause of CI's top e2e flake, `test_should_display_breadcrumb_on_ipam_page` (12 hits across 3 weeks): the sandbox e2e test closes its page ~1.4s in, the abandoned introspection keeps pinning a worker, and HAProxy parks exactly one of the next page load's asset requests on that worker's idle keep-alive connection. `/ipam` is the next test in file order, and on shared runners the park exceeds the 30s expect timeout — a blank page with one asset request forever in flight (all six downloadable failure traces show exactly one request with status `-1` among ~165 sub-20ms ones).

## Key Changes

- Every non-mutation GraphQL request now executes on graphql-core's synchronous resolution path; the middleware dispatches to an async gate only for top-level mutation fields, so mutation blocking on merged/needs-rebase/merging branches behaves exactly as before.
- The GraphQL response-size metric reuses the already-rendered response body instead of serializing the multi-MB payload a second time.
- New unit test pins the invariant that query/introspection execution completes without touching the event loop (it fails against the previous middleware).

## Test Plan

- `backend/tests/unit/graphql/` — 125 tests pass, including the new sync-path regression tests.
- `backend/tests/functional/branch/test_branch_needs_rebase.py` — the mutation gate still blocks writes on a NEED_REBASE branch and still allows `BranchRebase`.
- Validated on the e2e testcontainers stack (fix hot-patched into the running image): introspection over the LB 12.3s → ~0.9s; a 25-iteration sandbox→/ipam browser loop reproducing the flake went from p50 10.1s / p90 12.4s page loads to p50 0.40s / max 1.75s with zero failures.
- Watch the `E2E-testing-pytest-playwright (branches_repo)` job — the flaky test lives there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

