### PR TITLE
test(component): share read-only fixture datasets at class scope

### DIFF
--- a/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
+++ b/backend/tests/component/core/constraint_validators/test_attribute_numberpool_constraints.py
@@ -21,111 +21,133 @@ from infrahub.pools.schema_number_pool_upserter import SchemaNumberPoolUpserter
 from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
 
 
-@pytest.fixture
-async def snow_incident_01(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None) -> Node:
+async def build_snow_incident(db: InfrahubDatabase, branch: Branch) -> Node:
     schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
     registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
 
     upserter = SchemaNumberPoolUpserter(db=db, schema_manager=registry.schema)
     snps = SchemaNumberPoolSynchronizer(db=db, schema_manager=registry.schema, upserter=upserter)
     await snps.run()
 
-    incident_1 = await Node.init(db=db, schema="SnowIncident", branch=default_branch)
+    incident_1 = await Node.init(db=db, schema="SnowIncident", branch=branch)
     await incident_1.new(db=db, title="The first issue")
     await incident_1.save(db=db)
 
     return incident_1
 
 
-@pytest.mark.parametrize("start_range,end_range", [(1, 500), (-20, 50)])
-async def test_query_numberpool_constraints_success(
-    db: InfrahubDatabase, default_branch: Branch, snow_incident_01: Node, start_range: int, end_range: int
-) -> None:
-    incident_schema = registry.schema.get(name="SnowIncident")
-    number = incident_schema.get_attribute(name="number")
-    assert isinstance(number.parameters, NumberPoolParameters)
-    number.parameters.start_range = start_range
-    number.parameters.end_range = end_range
+class TestNumberPoolConstraintQueries:
+    """Read-only queries against one dataset built once for the class.
 
-    node_schema = incident_schema
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
+    The schema objects mutated in the tests are per-test duplicates from the registry.
+    """
 
-    query = await AttributeNumberPoolUpdateValidatorQuery.init(
-        db=db, branch=default_branch, node_schema=node_schema, schema_path=schema_path
-    )
+    @pytest.fixture(scope="class")
+    async def snow_incident_01(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        register_core_models_schema_scope_class: SchemaBranch,
+    ) -> Node:
+        return await build_snow_incident(db=db, branch=default_branch_scope_class)
 
-    await query.execute(db=db)
+    @pytest.mark.parametrize("start_range,end_range", [(1, 500), (-20, 50)])
+    async def test_query_numberpool_constraints_success(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        snow_incident_01: Node,
+        start_range: int,
+        end_range: int,
+    ) -> None:
+        incident_schema = registry.schema.get(name="SnowIncident")
+        number = incident_schema.get_attribute(name="number")
+        assert isinstance(number.parameters, NumberPoolParameters)
+        number.parameters.start_range = start_range
+        number.parameters.end_range = end_range
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
-    assert len(all_data_paths) == 0
+        node_schema = incident_schema
+        schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
 
-
-async def test_query_numberpool_constraints_too_small(
-    db: InfrahubDatabase, default_branch: Branch, snow_incident_01: Node
-) -> None:
-    incident_schema = registry.schema.get(name="SnowIncident")
-    number = incident_schema.get_attribute(name="number")
-    assert isinstance(number.parameters, NumberPoolParameters)
-    number.parameters.start_range = 10
-    number.parameters.end_range = 20
-
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
-
-    query = await AttributeNumberPoolUpdateValidatorQuery.init(
-        db=db, branch=default_branch, node_schema=incident_schema, schema_path=schema_path
-    )
-
-    await query.execute(db=db)
-
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
-    assert len(all_data_paths) == 1
-    assert (
-        DataPath(
-            branch=default_branch.name,
-            path_type=PathType.ATTRIBUTE,
-            node_id=snow_incident_01.id,
-            kind="SnowIncident",
-            field_name="number",
-            value=1,
+        query = await AttributeNumberPoolUpdateValidatorQuery.init(
+            db=db, branch=default_branch_scope_class, node_schema=node_schema, schema_path=schema_path
         )
-        in all_data_paths
-    )
 
+        await query.execute(db=db)
 
-async def test_query_numberpool_constraints_too_large(
-    db: InfrahubDatabase, default_branch: Branch, snow_incident_01: Node
-) -> None:
-    incident_schema = registry.schema.get(name="SnowIncident")
-    number = incident_schema.get_attribute(name="number")
-    assert isinstance(number.parameters, NumberPoolParameters)
-    number.parameters.start_range = -20
-    number.parameters.end_range = -10
+        grouped_paths = await query.get_paths()
+        all_data_paths = grouped_paths.get_all_data_paths()
+        assert len(all_data_paths) == 0
 
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
+    async def test_query_numberpool_constraints_too_small(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, snow_incident_01: Node
+    ) -> None:
+        incident_schema = registry.schema.get(name="SnowIncident")
+        number = incident_schema.get_attribute(name="number")
+        assert isinstance(number.parameters, NumberPoolParameters)
+        number.parameters.start_range = 10
+        number.parameters.end_range = 20
 
-    query = await AttributeNumberPoolUpdateValidatorQuery.init(
-        db=db, branch=default_branch, node_schema=incident_schema, schema_path=schema_path
-    )
+        schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
 
-    await query.execute(db=db)
-
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
-    assert len(all_data_paths) == 1
-    assert (
-        DataPath(
-            branch=default_branch.name,
-            path_type=PathType.ATTRIBUTE,
-            node_id=snow_incident_01.id,
-            kind="SnowIncident",
-            field_name="number",
-            value=1,
+        query = await AttributeNumberPoolUpdateValidatorQuery.init(
+            db=db, branch=default_branch_scope_class, node_schema=incident_schema, schema_path=schema_path
         )
-        in all_data_paths
-    )
+
+        await query.execute(db=db)
+
+        grouped_paths = await query.get_paths()
+        all_data_paths = grouped_paths.get_all_data_paths()
+        assert len(all_data_paths) == 1
+        assert (
+            DataPath(
+                branch=default_branch_scope_class.name,
+                path_type=PathType.ATTRIBUTE,
+                node_id=snow_incident_01.id,
+                kind="SnowIncident",
+                field_name="number",
+                value=1,
+            )
+            in all_data_paths
+        )
+
+    async def test_query_numberpool_constraints_too_large(
+        self, db: InfrahubDatabase, default_branch_scope_class: Branch, snow_incident_01: Node
+    ) -> None:
+        incident_schema = registry.schema.get(name="SnowIncident")
+        number = incident_schema.get_attribute(name="number")
+        assert isinstance(number.parameters, NumberPoolParameters)
+        number.parameters.start_range = -20
+        number.parameters.end_range = -10
+
+        schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="SnowIncident", field_name="number")
+
+        query = await AttributeNumberPoolUpdateValidatorQuery.init(
+            db=db, branch=default_branch_scope_class, node_schema=incident_schema, schema_path=schema_path
+        )
+
+        await query.execute(db=db)
+
+        grouped_paths = await query.get_paths()
+        all_data_paths = grouped_paths.get_all_data_paths()
+        assert len(all_data_paths) == 1
+        assert (
+            DataPath(
+                branch=default_branch_scope_class.name,
+                path_type=PathType.ATTRIBUTE,
+                node_id=snow_incident_01.id,
+                kind="SnowIncident",
+                field_name="number",
+                value=1,
+            )
+            in all_data_paths
+        )
+
+
+@pytest.fixture
+async def snow_incident_01(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None) -> Node:
+    return await build_snow_incident(db=db, branch=default_branch)
 
 
 async def test_validator_range(
@@ -134,15 +156,9 @@ async def test_validator_range(
     default_branch: Branch,
     snow_incident_01: Node,
 ) -> None:
+    # Mutates the registry schema branch and rebases, so it keeps function-scoped isolation.
     await branch.rebase(db=db)
 
-    """
-    person_schema = registry.schema.get(name="TestPerson", branch=branch)
-    height_attr = person_schema.get_attribute(name="height")
-    height_attr.parameters.min_value = 100
-    height_attr.parameters.max_value = 150
-    registry.schema.set(name="TestPerson", schema=person_schema, branch=branch.name)
-    """
     incident_schema = registry.schema.get_node_schema(name="SnowIncident")
     number = incident_schema.get_attribute(name="number")
     assert isinstance(number.parameters, NumberPoolParameters)

--- a/backend/tests/component/core/constraint_validators/test_relationship_peer_common_parent_update.py
+++ b/backend/tests/component/core/constraint_validators/test_relationship_peer_common_parent_update.py
@@ -7,6 +7,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.constants import PathType, SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
@@ -53,122 +54,190 @@ async def add_lag_to_device(
     return lag
 
 
-@pytest.fixture
-async def device_schema(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+def register_device_schema(branch: Branch) -> SchemaRoot:
     schema = copy.deepcopy(DEVICE_SCHEMA)
     schema.nodes.append(LAG_INTERFACE)
     schema.get(name=TestKind.DEVICE).generate_template = False
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
     return schema
 
 
-@pytest.fixture
-async def data_empty_lags(db: InfrahubDatabase, device_schema: SchemaRoot, default_branch: Branch) -> dict[str, Node]:
+async def build_data_empty_lags(db: InfrahubDatabase, branch: Branch) -> dict[str, Node]:
     d_1 = await Node.init(db=db, schema=TestKind.DEVICE)
     await d_1.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
     await d_1.save(db=db)
-    d_1_lag = await add_lag_to_device(db=db, branch=default_branch, device=d_1, name="ae0", members=[])
+    d_1_lag = await add_lag_to_device(db=db, branch=branch, device=d_1, name="ae0", members=[])
 
     d_2 = await Node.init(db=db, schema=TestKind.DEVICE)
     await d_2.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
     await d_2.save(db=db)
-    d_2_lag = await add_lag_to_device(db=db, branch=default_branch, device=d_2, name="ae0", members=[])
+    d_2_lag = await add_lag_to_device(db=db, branch=branch, device=d_2, name="ae0", members=[])
 
     return {"d_1": d_1, "d_2": d_2, "d_1_lag": d_1_lag, "d_2_lag": d_2_lag}
+
+
+async def build_data_invalid_lag(db: InfrahubDatabase, branch: Branch) -> dict[str, Node]:
+    d_1 = await Node.init(db=db, schema=TestKind.DEVICE)
+    await d_1.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
+    await d_1.save(db=db)
+    d_1_interfaces = await add_interfaces_to_device(db=db, branch=branch, device=d_1)
+    d_1_lag = await add_lag_to_device(db=db, branch=branch, device=d_1, name="ae0", members=d_1_interfaces)
+
+    d_2 = await Node.init(db=db, schema=TestKind.DEVICE)
+    await d_2.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
+    await d_2.save(db=db)
+    await add_interfaces_to_device(db=db, branch=branch, device=d_2)
+    d_2_lag = await add_lag_to_device(db=db, branch=branch, device=d_2, name="ae0", members=d_1_interfaces)
+
+    return {"d_1": d_1, "d_2": d_2, "d_1_lag": d_1_lag, "d_2_lag": d_2_lag}
+
+
+def build_validator_query_kwargs(branch: Branch) -> dict[str, Any]:
+    lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
+    interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
+    return {
+        "branch": branch,
+        "node_schema": lag_schema,
+        "schema_path": SchemaPath(
+            path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
+        ),
+        "relationship": lag_schema.get_relationship(name="members"),
+        "parent_relationship": lag_schema.get_relationship(name="device"),
+        "peer_parent_relationship": interface_schema.get_relationship(name="device"),
+    }
+
+
+class TestQueryWithEmptyLags:
+    """Read-only tests sharing one dataset built once for the class."""
+
+    @pytest.fixture(scope="class")
+    async def data_empty_lags(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> dict[str, Node]:
+        register_device_schema(branch=default_branch_scope_class)
+        return await build_data_empty_lags(db=db, branch=default_branch_scope_class)
+
+    @pytest.fixture(scope="class", params=["main", "branch2"])
+    async def branch(
+        self,
+        request: pytest.FixtureRequest,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        data_empty_lags: dict[str, Node],
+    ) -> Branch:
+        if request.param == "main":
+            return default_branch_scope_class
+
+        return await create_branch(branch_name=str(request.param), db=db)
+
+    async def test_query_no_relationships(
+        self, db: InfrahubDatabase, branch: Branch, data_empty_lags: dict[str, Any]
+    ) -> None:
+        query = await RelationshipPeerParentValidatorQuery.init(db=db, **build_validator_query_kwargs(branch=branch))
+        await query.execute(db=db)
+
+        grouped_paths = await query.get_paths()
+        all_paths = grouped_paths.get_all_data_paths()
+        assert len(all_paths) == 0
+
+
+class TestQueryWithInvalidLag:
+    """Read-only tests sharing one dataset built once for the class."""
+
+    @pytest.fixture(scope="class")
+    async def data_invalid_lag(self, db: InfrahubDatabase, default_branch_scope_class: Branch) -> dict[str, Node]:
+        register_device_schema(branch=default_branch_scope_class)
+        return await build_data_invalid_lag(db=db, branch=default_branch_scope_class)
+
+    @pytest.fixture(scope="class", params=["main", "branch2"])
+    async def branch(
+        self,
+        request: pytest.FixtureRequest,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        data_invalid_lag: dict[str, Node],
+    ) -> Branch:
+        if request.param == "main":
+            return default_branch_scope_class
+
+        return await create_branch(branch_name=str(request.param), db=db)
+
+    @pytest.fixture(scope="class")
+    async def expected_invalid_lag_data_paths(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        data_invalid_lag: dict[str, Node],
+        branch: Branch,
+    ) -> set[DataPath]:
+        branch_d2_lag = await NodeManager.get_one(db=db, branch=branch, id=data_invalid_lag["d_2_lag"].id)
+        d2_lag_members = await branch_d2_lag.members.get_peers(db=db)
+        return {
+            DataPath(
+                branch=default_branch_scope_class.name,
+                path_type=PathType.RELATIONSHIP_ONE,
+                node_id=member.id,
+                kind=member.get_kind(),
+                field_name="device",
+                peer_id=data_invalid_lag["d_1"].id,
+            )
+            for member in d2_lag_members.values()
+        }
+
+    async def test_query_invalid_lag(
+        self,
+        db: InfrahubDatabase,
+        data_invalid_lag: dict[str, Node],
+        expected_invalid_lag_data_paths: set[DataPath],
+        branch: Branch,
+    ) -> None:
+        query = await RelationshipPeerParentValidatorQuery.init(db=db, **build_validator_query_kwargs(branch=branch))
+        await query.execute(db=db)
+
+        grouped_paths = await query.get_paths()
+        all_paths = grouped_paths.get_all_data_paths()
+        assert set(all_paths) == expected_invalid_lag_data_paths
+
+    async def test_validator(
+        self,
+        db: InfrahubDatabase,
+        default_branch_scope_class: Branch,
+        data_invalid_lag: dict[str, Node],
+        expected_invalid_lag_data_paths: set[DataPath],
+        branch: Branch,
+    ) -> None:
+        lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
+
+        request = SchemaConstraintValidatorRequest(
+            branch=branch,
+            constraint_name="relationship.common_parent.update",
+            node_schema=lag_schema,
+            schema_path=SchemaPath(
+                path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
+            ),
+            schema_branch=registry.schema.get_schema_branch(default_branch_scope_class.name),
+        )
+
+        constraint_checker = RelationshipPeerParentChecker(db=db, branch=branch)
+        grouped_data_paths = await constraint_checker.check(request)
+
+        assert len(grouped_data_paths) == 1
+        all_paths = grouped_data_paths[0].get_all_data_paths()
+        assert all_paths
+
+
+@pytest.fixture
+async def device_schema(db: InfrahubDatabase, default_branch: Branch) -> SchemaRoot:
+    return register_device_schema(branch=default_branch)
 
 
 @pytest.fixture
 async def data_invalid_lag(db: InfrahubDatabase, device_schema: SchemaRoot, default_branch: Branch) -> dict[str, Node]:
-    d_1 = await Node.init(db=db, schema=TestKind.DEVICE)
-    await d_1.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
-    await d_1.save(db=db)
-    d_1_interfaces = await add_interfaces_to_device(db=db, branch=default_branch, device=d_1)
-    d_1_lag = await add_lag_to_device(db=db, branch=default_branch, device=d_1, name="ae0", members=d_1_interfaces)
-
-    d_2 = await Node.init(db=db, schema=TestKind.DEVICE)
-    await d_2.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
-    await d_2.save(db=db)
-    await add_interfaces_to_device(db=db, branch=default_branch, device=d_2)
-    d_2_lag = await add_lag_to_device(db=db, branch=default_branch, device=d_2, name="ae0", members=d_1_interfaces)
-
-    return {"d_1": d_1, "d_2": d_2, "d_1_lag": d_1_lag, "d_2_lag": d_2_lag}
-
-
-@pytest.fixture
-async def expected_invalid_lag_data_paths(
-    db: InfrahubDatabase, default_branch: Branch, data_invalid_lag: dict[str, Node], branch: Branch
-) -> set[DataPath]:
-    branch_d2_lag = await NodeManager.get_one(db=db, branch=branch, id=data_invalid_lag["d_2_lag"].id)
-    d2_lag_members = await branch_d2_lag.members.get_peers(db=db)
-    return {
-        DataPath(
-            branch=default_branch.name,
-            path_type=PathType.RELATIONSHIP_ONE,
-            node_id=member.id,
-            kind=member.get_kind(),
-            field_name="device",
-            peer_id=data_invalid_lag["d_1"].id,
-        )
-        for member in d2_lag_members.values()
-    }
-
-
-async def test_query_no_relationships(db: InfrahubDatabase, branch: Branch, data_empty_lags: dict[str, Any]) -> None:
-    lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
-    interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
-
-    query = await RelationshipPeerParentValidatorQuery.init(
-        db=db,
-        branch=branch,
-        node_schema=lag_schema,
-        schema_path=SchemaPath(
-            path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
-        ),
-        relationship=lag_schema.get_relationship(name="members"),
-        parent_relationship=lag_schema.get_relationship(name="device"),
-        peer_parent_relationship=interface_schema.get_relationship(name="device"),
-    )
-    await query.execute(db=db)
-
-    grouped_paths = await query.get_paths()
-    all_paths = grouped_paths.get_all_data_paths()
-    assert len(all_paths) == 0
-
-
-async def test_query_invalid_lag(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    data_invalid_lag: dict[str, Node],
-    expected_invalid_lag_data_paths: set[DataPath],
-    branch: Branch,
-) -> None:
-    lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
-    interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
-
-    query = await RelationshipPeerParentValidatorQuery.init(
-        db=db,
-        branch=branch,
-        node_schema=lag_schema,
-        schema_path=SchemaPath(
-            path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
-        ),
-        relationship=lag_schema.get_relationship(name="members"),
-        parent_relationship=lag_schema.get_relationship(name="device"),
-        peer_parent_relationship=interface_schema.get_relationship(name="device"),
-    )
-    await query.execute(db=db)
-
-    grouped_paths = await query.get_paths()
-    all_paths = grouped_paths.get_all_data_paths()
-    assert set(all_paths) == expected_invalid_lag_data_paths
+    return await build_data_invalid_lag(db=db, branch=default_branch)
 
 
 async def test_query_deleted_lag_members(
     db: InfrahubDatabase, data_invalid_lag: dict[str, Node], branch: Branch
 ) -> None:
-    lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
-    interface_schema = registry.schema.get(TestKind.PHYSICAL_INTERFACE)
-
+    # Mutates the shared-looking dataset, so it keeps its own function-scoped copy.
     for lag in [data_invalid_lag["d_1_lag"], data_invalid_lag["d_2_lag"]]:
         branch_lag = await NodeManager.get_one(db=db, branch=branch, id=lag.id)
         await branch_lag.members.update(db=db, data=None)
@@ -176,46 +245,9 @@ async def test_query_deleted_lag_members(
 
         assert not await branch_lag.members.get_peers(db=db)
 
-    query = await RelationshipPeerParentValidatorQuery.init(
-        db=db,
-        branch=branch,
-        node_schema=lag_schema,
-        schema_path=SchemaPath(
-            path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
-        ),
-        relationship=lag_schema.get_relationship(name="members"),
-        parent_relationship=lag_schema.get_relationship(name="device"),
-        peer_parent_relationship=interface_schema.get_relationship(name="device"),
-    )
+    query = await RelationshipPeerParentValidatorQuery.init(db=db, **build_validator_query_kwargs(branch=branch))
     await query.execute(db=db)
 
     grouped_paths = await query.get_paths()
     all_paths = grouped_paths.get_all_data_paths()
     assert len(all_paths) == 0
-
-
-async def test_validator(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    data_invalid_lag: dict[str, Node],
-    expected_invalid_lag_data_paths: set[DataPath],
-    branch: Branch,
-) -> None:
-    lag_schema = registry.schema.get(name=TestKind.LAG_INTERFACE)
-
-    request = SchemaConstraintValidatorRequest(
-        branch=branch,
-        constraint_name="relationship.common_parent.update",
-        node_schema=lag_schema,
-        schema_path=SchemaPath(
-            path_type=SchemaPathType.RELATIONSHIP, schema_kind=lag_schema.kind, field_name="members"
-        ),
-        schema_branch=registry.schema.get_schema_branch(default_branch.name),
-    )
-
-    constraint_checker = RelationshipPeerParentChecker(db=db, branch=branch)
-    grouped_data_paths = await constraint_checker.check(request)
-
-    assert len(grouped_data_paths) == 1
-    all_paths = grouped_data_paths[0].get_all_data_paths()
-    assert all_paths


### PR DESCRIPTION
## Measured improvements

Full `core-schema` shard, `-n 2`, same machine, before → after (identical results: 1187 passed / 10 skipped):

| file | in-shard setup time |
|---|---|
| `test_relationship_peer_common_parent_update.py` | 151.7s → **6.7s** |
| `test_attribute_numberpool_constraints.py` | 75.8s → **16.2s** |

Roughly ~110 worker-seconds saved per shard run after correcting for run-to-run environment variance. Read-only tests now share one class-scoped dataset (built via the `default_branch_scope_class` chain) instead of wiping and rebuilding per test — safe because pytest runs with `--dist loadscope`, so a class's tests always execute contiguously on one xdist worker. Tests that mutate shared state (`test_query_deleted_lag_members`, `test_validator_range`) keep their own function-scoped copies.

Profiling notes: the per-test full-graph `DETACH DELETE` wipe measured 0.04s avg over 577 wipes — it is *not* a meaningful cost; the expense is per-node writes in data fixtures (~0.1–0.9s per `Node.save` round-trip).

## 📓  How to review
!**Use side-by-side view!**
<img width="1272" height="640" alt="Screenshot 2026-08-21 at 11 21 52" src="https://github.com/user-attachments/assets/9be43830-0bae-404b-9015-428950e5fc48" />


## Follow-ups (not in this PR)

- Mutation-heavy files (`test_number_pool_query`, `test_relationship_count`, `test_attribute_choices_update`, `test_node_applier`) need the ipam pattern instead (module-scoped dataset + per-test `DeleteAfterTimeQuery` rollback, unique branch names).
- `create_default_account_groups` runs 42 sequential queries (~7–12s) in every `TestInfrahubApp` class boot.
- Fail-fast timeout around the Prefect task-manager setup (source of the recent 300s CI timeouts).

## Test Plan

- `uv run pytest -n 2 backend/tests/component/core/...` full shard: 1187 passed / 10 skipped, matching baseline.
- Both restructured files also verified standalone (8/8 and 6/6 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

