### PR TITLE
test(backend): keep prefect test servers off kernel-ephemeral ports

### DIFF
--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -15,6 +15,7 @@ from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
 from neo4j._codec.hydration.v1.hydration_handler import _GraphHydrator
 from prefect.client.orchestration import PrefectClient, get_client
+from prefect.server.api.server import SubprocessASGIServer
 from prefect.settings import get_current_settings
 from prefect.testing.utilities import prefect_test_harness
 from pytest_httpx import HTTPXMock
@@ -77,9 +78,11 @@ from tests.helpers.constants import (
     PREFECT_EVENTS_PROACTIVE_GRANULARITY,
     PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS,
     PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS,
+    PREFECT_TEST_SERVER_PORT_RANGE,
 )
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_client import dummy_async_request
+from tests.helpers.utils import find_available_prefect_port
 from tests.test_data import dataset01 as ds01
 
 
@@ -144,9 +147,13 @@ def prefect_test_fixture() -> Generator[None, None, None]:
     os.environ["PREFECT_SERVER_EVENTS_PROACTIVE_GRANULARITY"] = PREFECT_EVENTS_PROACTIVE_GRANULARITY
     os.environ.update(PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS)
 
-    with patch("prefect.server.api.server.SubprocessASGIServer._run_uvicorn_command", _run_uvicorn_command):
-        with prefect_test_harness(server_startup_timeout=60):
-            yield
+    with (
+        patch.object(SubprocessASGIServer, "_port_range", PREFECT_TEST_SERVER_PORT_RANGE),
+        patch("prefect.server.api.server.SubprocessASGIServer._run_uvicorn_command", _run_uvicorn_command),
+        patch("prefect.testing.utilities._find_available_port", find_available_prefect_port),
+        prefect_test_harness(server_startup_timeout=60),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/backend/tests/functional/conftest.py
+++ b/backend/tests/functional/conftest.py
@@ -1,14 +1,18 @@
 import os
 from collections.abc import Generator
+from unittest.mock import patch
 
 import pytest
+from prefect.server.api.server import SubprocessASGIServer
 from prefect.testing.utilities import prefect_test_harness
 
 from infrahub import config
 from tests.helpers.constants import (
     PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS,
     PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS,
+    PREFECT_TEST_SERVER_PORT_RANGE,
 )
+from tests.helpers.utils import find_available_prefect_port
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -16,7 +20,11 @@ def prefect_test_fixture() -> Generator[None]:
     os.environ["PREFECT_FLOWS_HEARTBEAT_FREQUENCY"] = PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS
     os.environ.update(PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS)
 
-    with prefect_test_harness(server_startup_timeout=60):
+    with (
+        patch.object(SubprocessASGIServer, "_port_range", PREFECT_TEST_SERVER_PORT_RANGE),
+        patch("prefect.testing.utilities._find_available_port", find_available_prefect_port),
+        prefect_test_harness(server_startup_timeout=60),
+    ):
         yield
 
 

--- a/backend/tests/helpers/constants.py
+++ b/backend/tests/helpers/constants.py
@@ -32,6 +32,14 @@ PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS = "30"
 # judged promptly and predictably.
 PREFECT_EVENTS_PROACTIVE_GRANULARITY = "PT1S"
 
+# Ephemeral Prefect test servers get a random loopback port from this pool. It must stay
+# clear of the kernel's ephemeral range (32768+ by default): the harness reserves its port
+# by binding port 0 and releasing it seconds before the server process binds it again, and
+# on a shared CI runner that gap lets outgoing connections or dynamically published
+# container ports — which draw from the same ephemeral pool — grab the port, so the
+# harness's health probe reaches a foreign socket and fails the whole session.
+PREFECT_TEST_SERVER_PORT_RANGE = range(10000, 30000)
+
 # The test Prefect servers (ephemeral subprocess and the prefect container fixture) run
 # every background service in-process against a single SQLite database. SQLite serializes
 # writers, so the periodic services contend with the API and with trigger/event processing;

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -1,4 +1,7 @@
+import random
+import socket
 import time
+from contextlib import closing
 from pathlib import Path
 
 import httpx
@@ -12,7 +15,30 @@ from tests.helpers.constants import (
     PORT_HTTP_NEO4J,
     PORT_PREFECT,
     PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS,
+    PREFECT_TEST_SERVER_PORT_RANGE,
 )
+
+
+def find_available_prefect_port() -> int:
+    """Pick a free loopback port for an ephemeral Prefect test server.
+
+    Replaces prefect.testing.utilities._find_available_port, whose bind-port-0 reservation
+    draws from the kernel's ephemeral range and collides with other processes on a shared
+    CI runner (see PREFECT_TEST_SERVER_PORT_RANGE).
+
+    Raises:
+        RuntimeError: If no free port is found after 50 attempts.
+
+    """
+    for _ in range(50):
+        port = random.choice(PREFECT_TEST_SERVER_PORT_RANGE)
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+        return port
+    raise RuntimeError("Unable to find an available port for the Prefect test server")
 
 
 def get_exposed_port(container: DockerContainer, port: int) -> int:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -2,10 +2,12 @@ import asyncio
 import os
 from pathlib import Path
 from typing import Any, Generator
+from unittest.mock import patch
 
 import pytest
 import yaml
 from infrahub_sdk.uuidt import UUIDT
+from prefect.server.api.server import SubprocessASGIServer
 from prefect.testing.utilities import prefect_test_harness
 from pytest import TempPathFactory
 
@@ -22,8 +24,10 @@ from infrahub.utils import get_models_dir
 from tests.helpers.constants import (
     PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS,
     PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS,
+    PREFECT_TEST_SERVER_PORT_RANGE,
 )
 from tests.helpers.file_repo import FileRepo
+from tests.helpers.utils import find_available_prefect_port
 
 
 @pytest.fixture(scope="session")
@@ -119,5 +123,9 @@ def prefect_test_fixture() -> Generator:
     os.environ["PREFECT_FLOWS_HEARTBEAT_FREQUENCY"] = PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS
     os.environ.update(PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS)
 
-    with prefect_test_harness(server_startup_timeout=180):
+    with (
+        patch.object(SubprocessASGIServer, "_port_range", PREFECT_TEST_SERVER_PORT_RANGE),
+        patch("prefect.testing.utilities._find_available_port", find_available_prefect_port),
+        prefect_test_harness(server_startup_timeout=180),
+    ):
         yield


### PR DESCRIPTION
## Summary

Removes a CI failure mode where one xdist worker's entire test session (1000+ setup errors) is lost to a single `httpx.ReadError: [Errno 104] Connection reset by peer` during Prefect test-harness startup — seen on the `backend-tests-component (other)` job in run 32416373910.

`prefect_test_harness` reserves its server port by binding port 0 and releasing it, so the port comes from the kernel's ephemeral range (32768-60999) and stays up for grabs for the several seconds the uvicorn child spends importing Infrahub before it binds. On a shared CI runner, anything drawing from that pool — dynamically published testcontainer ports, outgoing connections — can take the port in that window. The harness health probe then reaches a foreign socket; if that socket resets the connection, the whole worker session errors, because Prefect's startup loop only retries connection refusals (`httpx.ConnectError`) and pytest caches the failed session-scoped fixture.

## Key Changes

- The component, functional, and integration suites now boot their ephemeral Prefect servers on a random port from a quiet pool (`10000-29999`) outside the kernel's ephemeral range, instead of a kernel-assigned ephemeral port — collisions with other processes on a shared runner become rare instead of routine.
- The `start()` restart path (uvicorn exit code 3 on a bind conflict) re-picks from the same pool via `SubprocessASGIServer._port_range`.
- The port picker lives in `tests/helpers/utils.py` with stdlib-only imports so the shared root conftest (and therefore unit-test startup) stays free of the heavy `prefect.server` import.

This is a probability mitigation, not a full fix — the underlying Prefect issues (check-then-use port reservation, and the startup probe treating one `ReadError` as fatal despite remaining timeout budget) are upstream candidates.

## Test Plan

- Replicated the fixture body directly: the harness boots on a port inside the new range and serves `/health` (verified ports 16831/22973 across runs).
- `pytest backend/tests/component/git/test_repository_config.py` — 6 passed (full component fixture path including the patched picker).
- `pytest backend/tests/unit/config backend/tests/unit/auth` — 149 passed (root conftest chain unaffected).
- `ruff check`, `ruff format --check`, `mypy` clean on the touched files (20 pre-existing mypy errors in the component conftest are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

