### PR TITLE
perf(core): create default account permissions concurrently (local-dev win, CI-neutral)

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -1,5 +1,7 @@
+import asyncio
 import importlib
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
+from functools import partial
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -360,16 +362,52 @@ async def create_ipam_namespace(
     return obj
 
 
-async def create_super_administrator_role(db: InfrahubDatabase) -> CoreAccountRole:
+async def run_in_own_session[T](db: InfrahubDatabase, task: Callable[[InfrahubDatabase], Awaitable[T]]) -> T:
+    """Give a concurrent task its own database session — a shared session cannot serve concurrent queries."""
+    async with db.start_session() as session_db:
+        return await task(session_db)
+
+
+async def create_global_permission(db: InfrahubDatabase, action: GlobalPermissions, description: str) -> Node:
     permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await permission.new(
         db=db,
-        action=GlobalPermissions.SUPER_ADMIN.value,
+        action=action.value,
         decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to do anything",
+        description=description,
     )
     await permission.save(db=db)
-    log.info(f"Created global permission: {GlobalPermissions.SUPER_ADMIN}")
+    log.info(f"Created global permission: {action}")
+
+    return permission
+
+
+async def create_object_permission(
+    db: InfrahubDatabase,
+    name: str,
+    namespace: str,
+    action: PermissionAction,
+    decision: PermissionDecision,
+    description: str,
+) -> Node:
+    permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+    await permission.new(
+        db=db,
+        name=name,
+        namespace=namespace,
+        action=action.value,
+        decision=decision.value,
+        description=description,
+    )
+    await permission.save(db=db)
+
+    return permission
+
+
+async def create_super_administrator_role(db: InfrahubDatabase) -> CoreAccountRole:
+    permission = await create_global_permission(
+        db=db, action=GlobalPermissions.SUPER_ADMIN, description="Allow a user to do anything"
+    )
 
     role_name = "Super Administrator"
     role = await Node.init(db=db, schema=CoreAccountRole)
@@ -381,65 +419,73 @@ async def create_super_administrator_role(db: InfrahubDatabase) -> CoreAccountRo
 
 
 async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
-    repo_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-    await repo_permission.new(
-        db=db,
-        action=GlobalPermissions.MANAGE_REPOSITORIES.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to manage repositories",
+    # The permissions are independent nodes, so they are created concurrently to keep
+    # this frequently exercised bootstrap path fast.
+    (
+        repo_permission,
+        schema_permission,
+        proposed_change_permission,
+        view_permission,
+        modify_permission,
+    ) = await asyncio.gather(
+        run_in_own_session(
+            db,
+            lambda dbs: create_global_permission(
+                db=dbs, action=GlobalPermissions.MANAGE_REPOSITORIES, description="Allow a user to manage repositories"
+            ),
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: create_global_permission(
+                db=dbs, action=GlobalPermissions.MANAGE_SCHEMA, description="Allow a user to manage the schema"
+            ),
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: create_global_permission(
+                db=dbs,
+                action=GlobalPermissions.MERGE_PROPOSED_CHANGE,
+                description="Allow a user to merge proposed changes",
+            ),
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: create_object_permission(
+                db=dbs,
+                name="*",
+                namespace="*",
+                action=PermissionAction.VIEW,
+                decision=PermissionDecision.ALLOW_ALL,
+                description="Allow a user to view any object in any branch",
+            ),
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: create_object_permission(
+                db=dbs,
+                name="*",
+                namespace="*",
+                action=PermissionAction.ANY,
+                decision=PermissionDecision.ALLOW_OTHER,
+                description="Allow a user to change data in non-default branches",
+            ),
+        ),
     )
-    await repo_permission.save(db=db)
-
-    schema_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-    await schema_permission.new(
-        db=db,
-        action=GlobalPermissions.MANAGE_SCHEMA.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to manage the schema",
-    )
-    await schema_permission.save(db=db)
-
-    proposed_change_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-    await proposed_change_permission.new(
-        db=db,
-        action=GlobalPermissions.MERGE_PROPOSED_CHANGE.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to merge proposed changes",
-    )
-    await proposed_change_permission.save(db=db)
 
     # Other permissions, created to keep references of them from the start
-    for permission_action in (
-        GlobalPermissions.EDIT_DEFAULT_BRANCH,
-        GlobalPermissions.MANAGE_ACCOUNTS,
-        GlobalPermissions.MANAGE_GLOBAL_PREFERENCES,
-        GlobalPermissions.MANAGE_PERMISSIONS,
-        GlobalPermissions.MERGE_BRANCH,
-        GlobalPermissions.REBASE_BRANCH,
-    ):
-        await get_or_create_global_permission(db=db, permission=permission_action)
-
-    view_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-    await view_permission.new(
-        db=db,
-        name="*",
-        namespace="*",
-        action=PermissionAction.VIEW.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to view any object in any branch",
+    await asyncio.gather(
+        *(
+            run_in_own_session(db, partial(get_or_create_global_permission, permission=permission_action))
+            for permission_action in (
+                GlobalPermissions.EDIT_DEFAULT_BRANCH,
+                GlobalPermissions.MANAGE_ACCOUNTS,
+                GlobalPermissions.MANAGE_GLOBAL_PREFERENCES,
+                GlobalPermissions.MANAGE_PERMISSIONS,
+                GlobalPermissions.MERGE_BRANCH,
+                GlobalPermissions.REBASE_BRANCH,
+            )
+        )
     )
-    await view_permission.save(db=db)
-
-    modify_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-    await modify_permission.new(
-        db=db,
-        name="*",
-        namespace="*",
-        action=PermissionAction.ANY.value,
-        decision=PermissionDecision.ALLOW_OTHER.value,
-        description="Allow a user to change data in non-default branches",
-    )
-    await modify_permission.save(db=db)
 
     role_name = "General Access"
     role = await Node.init(db=db, schema=CoreAccountRole)
@@ -461,23 +507,26 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
 
 
 async def create_proposed_change_reviewer_role(db: InfrahubDatabase) -> CoreAccountRole:
-    edit_default_branch_permission = await get_or_create_global_permission(
-        db=db, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH
+    edit_default_branch_permission, reviewer_permission, proposed_change_update_permission = await asyncio.gather(
+        run_in_own_session(
+            db, lambda dbs: get_or_create_global_permission(db=dbs, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH)
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: get_or_create_global_permission(db=dbs, permission=GlobalPermissions.REVIEW_PROPOSED_CHANGE),
+        ),
+        run_in_own_session(
+            db,
+            lambda dbs: create_object_permission(
+                db=dbs,
+                name="ProposedChange",
+                namespace="Core",
+                action=PermissionAction.UPDATE,
+                decision=PermissionDecision.ALLOW_ALL,
+                description="Allow a user to update proposed changes",
+            ),
+        ),
     )
-    reviewer_permission = await get_or_create_global_permission(
-        db=db, permission=GlobalPermissions.REVIEW_PROPOSED_CHANGE
-    )
-
-    proposed_change_update_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
-    await proposed_change_update_permission.new(
-        db=db,
-        name="ProposedChange",
-        namespace="Core",
-        action=PermissionAction.UPDATE.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to update proposed changes",
-    )
-    await proposed_change_update_permission.save(db=db)
 
     role_name = "Proposed Change Reviewer"
     role = await Node.init(db=db, schema=CoreAccountRole)
@@ -523,12 +572,27 @@ async def create_accounts_group(
     await group.save(db=db)
     log.info(f"Created account group: {name}")
 
-    for account in accounts:
-        await group.members.add(db=db, data=account)  # type: ignore[arg-type]
+    if accounts:
+        await group.members.update(db=db, data=list(accounts))  # type: ignore[arg-type]
         await group.members.save(db=db)
-        log.info(f"Assigned account group: {name} to {account.name.value}")
+        for account in accounts:
+            log.info(f"Assigned account group: {name} to {account.name.value}")
 
     return group
+
+
+async def create_super_administrators_group(db: InfrahubDatabase, accounts: Sequence[CoreAccount]) -> None:
+    administrator_role = await create_super_administrator_role(db=db)
+    await create_accounts_group(db=db, name="Super Administrators", roles=[administrator_role], accounts=accounts)
+
+
+async def create_users_group(db: InfrahubDatabase, accounts: Sequence[CoreAccount]) -> None:
+    # These two roles get-or-create the same edit-default-branch permission, so they must not run concurrently.
+    default_role = await create_default_role(db=db)
+    proposed_change_reviewer_role = await create_proposed_change_reviewer_role(db=db)
+    await create_accounts_group(
+        db=db, name="Infrahub Users", roles=[default_role, proposed_change_reviewer_role], accounts=accounts
+    )
 
 
 async def create_default_account_groups(
@@ -536,15 +600,9 @@ async def create_default_account_groups(
     admin_accounts: Sequence[CoreAccount] | None = None,
     accounts: Sequence[CoreAccount] | None = None,
 ) -> None:
-    administrator_role = await create_super_administrator_role(db=db)
-    await create_accounts_group(
-        db=db, name="Super Administrators", roles=[administrator_role], accounts=admin_accounts or []
-    )
-
-    default_role = await create_default_role(db=db)
-    proposed_change_reviewer_role = await create_proposed_change_reviewer_role(db=db)
-    await create_accounts_group(
-        db=db, name="Infrahub Users", roles=[default_role, proposed_change_reviewer_role], accounts=accounts or []
+    await asyncio.gather(
+        run_in_own_session(db, partial(create_super_administrators_group, accounts=admin_accounts or [])),
+        run_in_own_session(db, partial(create_users_group, accounts=accounts or [])),
     )
 
 

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib
 from collections.abc import Awaitable, Callable, Sequence
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from infrahub_sdk.uuidt import UUIDT
@@ -362,10 +362,23 @@ async def create_ipam_namespace(
     return obj
 
 
-async def run_in_own_session[T](db: InfrahubDatabase, task: Callable[[InfrahubDatabase], Awaitable[T]]) -> T:
-    """Give a concurrent task its own database session — a shared session cannot serve concurrent queries."""
-    async with db.start_session() as session_db:
-        return await task(session_db)
+async def run_concurrently[T](
+    db: InfrahubDatabase, tasks: Sequence[Callable[[InfrahubDatabase], Awaitable[T]]]
+) -> list[T]:
+    """Run each task against its own database session, concurrently.
+
+    A caller that opened a transaction gets sequential execution on that transaction instead:
+    a separate session commits independently of it, which would leave its writes behind on
+    rollback, and the transaction's own session cannot serve concurrent queries.
+    """
+    if db.is_transaction:
+        return [await task(db) for task in tasks]
+
+    async def in_own_session(task: Callable[[InfrahubDatabase], Awaitable[T]]) -> T:
+        async with db.start_session() as session_db:
+            return await task(session_db)
+
+    return list(await asyncio.gather(*(in_own_session(task) for task in tasks)))
 
 
 async def create_global_permission(db: InfrahubDatabase, action: GlobalPermissions, description: str) -> Node:
@@ -427,55 +440,48 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
         proposed_change_permission,
         view_permission,
         modify_permission,
-    ) = await asyncio.gather(
-        run_in_own_session(
-            db,
-            lambda dbs: create_global_permission(
-                db=dbs, action=GlobalPermissions.MANAGE_REPOSITORIES, description="Allow a user to manage repositories"
+    ) = await run_concurrently(
+        db,
+        [
+            partial(
+                create_global_permission,
+                action=GlobalPermissions.MANAGE_REPOSITORIES,
+                description="Allow a user to manage repositories",
             ),
-        ),
-        run_in_own_session(
-            db,
-            lambda dbs: create_global_permission(
-                db=dbs, action=GlobalPermissions.MANAGE_SCHEMA, description="Allow a user to manage the schema"
+            partial(
+                create_global_permission,
+                action=GlobalPermissions.MANAGE_SCHEMA,
+                description="Allow a user to manage the schema",
             ),
-        ),
-        run_in_own_session(
-            db,
-            lambda dbs: create_global_permission(
-                db=dbs,
+            partial(
+                create_global_permission,
                 action=GlobalPermissions.MERGE_PROPOSED_CHANGE,
                 description="Allow a user to merge proposed changes",
             ),
-        ),
-        run_in_own_session(
-            db,
-            lambda dbs: create_object_permission(
-                db=dbs,
+            partial(
+                create_object_permission,
                 name="*",
                 namespace="*",
                 action=PermissionAction.VIEW,
                 decision=PermissionDecision.ALLOW_ALL,
                 description="Allow a user to view any object in any branch",
             ),
-        ),
-        run_in_own_session(
-            db,
-            lambda dbs: create_object_permission(
-                db=dbs,
+            partial(
+                create_object_permission,
                 name="*",
                 namespace="*",
                 action=PermissionAction.ANY,
                 decision=PermissionDecision.ALLOW_OTHER,
                 description="Allow a user to change data in non-default branches",
             ),
-        ),
+        ],
     )
 
     # Other permissions, created to keep references of them from the start
-    await asyncio.gather(
-        *(
-            run_in_own_session(db, partial(get_or_create_global_permission, permission=permission_action))
+    await run_concurrently(
+        db,
+        [
+            partial(get_or_create_global_permission, permission=permission_action)
             for permission_action in (
                 GlobalPermissions.EDIT_DEFAULT_BRANCH,
                 GlobalPermissions.MANAGE_ACCOUNTS,
@@ -484,7 +490,7 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
                 GlobalPermissions.MERGE_BRANCH,
                 GlobalPermissions.REBASE_BRANCH,
             )
-        )
+        ],
     )
 
     role_name = "General Access"
@@ -507,25 +513,21 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
 
 
 async def create_proposed_change_reviewer_role(db: InfrahubDatabase) -> CoreAccountRole:
-    edit_default_branch_permission, reviewer_permission, proposed_change_update_permission = await asyncio.gather(
-        run_in_own_session(
-            db, lambda dbs: get_or_create_global_permission(db=dbs, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH)
+    # Annotated because the global and object permission factories return different node types.
+    permission_tasks: list[Callable[[InfrahubDatabase], Awaitable[Any]]] = [
+        partial(get_or_create_global_permission, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH),
+        partial(get_or_create_global_permission, permission=GlobalPermissions.REVIEW_PROPOSED_CHANGE),
+        partial(
+            create_object_permission,
+            name="ProposedChange",
+            namespace="Core",
+            action=PermissionAction.UPDATE,
+            decision=PermissionDecision.ALLOW_ALL,
+            description="Allow a user to update proposed changes",
         ),
-        run_in_own_session(
-            db,
-            lambda dbs: get_or_create_global_permission(db=dbs, permission=GlobalPermissions.REVIEW_PROPOSED_CHANGE),
-        ),
-        run_in_own_session(
-            db,
-            lambda dbs: create_object_permission(
-                db=dbs,
-                name="ProposedChange",
-                namespace="Core",
-                action=PermissionAction.UPDATE,
-                decision=PermissionDecision.ALLOW_ALL,
-                description="Allow a user to update proposed changes",
-            ),
-        ),
+    ]
+    edit_default_branch_permission, reviewer_permission, proposed_change_update_permission = await run_concurrently(
+        db, permission_tasks
     )
 
     role_name = "Proposed Change Reviewer"
@@ -572,10 +574,13 @@ async def create_accounts_group(
     await group.save(db=db)
     log.info(f"Created account group: {name}")
 
-    if accounts:
-        await group.members.update(db=db, data=list(accounts))  # type: ignore[arg-type]
+    # Deduplicated by id because `update` takes the list as given, where the per-account `add`
+    # it replaces skipped peers that were already members.
+    unique_accounts = list({account.id: account for account in accounts}.values())
+    if unique_accounts:
+        await group.members.update(db=db, data=unique_accounts)  # type: ignore[arg-type]
         await group.members.save(db=db)
-        for account in accounts:
+        for account in unique_accounts:
             log.info(f"Assigned account group: {name} to {account.name.value}")
 
     return group
@@ -591,9 +596,8 @@ async def create_users_group(db: InfrahubDatabase, accounts: Sequence[CoreAccoun
     # since two concurrent get-or-creates of one action would each miss and insert a duplicate.
     await get_or_create_global_permission(db=db, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH)
 
-    default_role, proposed_change_reviewer_role = await asyncio.gather(
-        run_in_own_session(db, create_default_role),
-        run_in_own_session(db, create_proposed_change_reviewer_role),
+    default_role, proposed_change_reviewer_role = await run_concurrently(
+        db, [create_default_role, create_proposed_change_reviewer_role]
     )
     await create_accounts_group(
         db=db, name="Infrahub Users", roles=[default_role, proposed_change_reviewer_role], accounts=accounts
@@ -605,9 +609,12 @@ async def create_default_account_groups(
     admin_accounts: Sequence[CoreAccount] | None = None,
     accounts: Sequence[CoreAccount] | None = None,
 ) -> None:
-    await asyncio.gather(
-        run_in_own_session(db, partial(create_super_administrators_group, accounts=admin_accounts or [])),
-        run_in_own_session(db, partial(create_users_group, accounts=accounts or [])),
+    await run_concurrently(
+        db,
+        [
+            partial(create_super_administrators_group, accounts=admin_accounts or []),
+            partial(create_users_group, accounts=accounts or []),
+        ],
     )
 
 

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -587,9 +587,14 @@ async def create_super_administrators_group(db: InfrahubDatabase, accounts: Sequ
 
 
 async def create_users_group(db: InfrahubDatabase, accounts: Sequence[CoreAccount]) -> None:
-    # These two roles get-or-create the same edit-default-branch permission, so they must not run concurrently.
-    default_role = await create_default_role(db=db)
-    proposed_change_reviewer_role = await create_proposed_change_reviewer_role(db=db)
+    # Both roles below want this permission. Creating it up front is what makes them independent,
+    # since two concurrent get-or-creates of one action would each miss and insert a duplicate.
+    await get_or_create_global_permission(db=db, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH)
+
+    default_role, proposed_change_reviewer_role = await asyncio.gather(
+        run_in_own_session(db, create_default_role),
+        run_in_own_session(db, create_proposed_change_reviewer_role),
+    )
     await create_accounts_group(
         db=db, name="Infrahub Users", roles=[default_role, proposed_change_reviewer_role], accounts=accounts
     )

--- a/backend/tests/component/core/test_initialization.py
+++ b/backend/tests/component/core/test_initialization.py
@@ -1,3 +1,4 @@
+from typing import NoReturn
 from uuid import UUID
 
 import pytest
@@ -113,6 +114,34 @@ async def test_create_default_account_groups_creates_each_permission_once(
         "Proposed Change Reviewer",
     }
     assert len(roles) == 3
+
+
+def _interrupt_transaction() -> NoReturn:
+    """Abort the enclosing transaction so it rolls back.
+
+    Raises:
+        RuntimeError: Always.
+
+    """
+    raise RuntimeError("initialization interrupted")
+
+
+async def test_create_default_account_groups_rolls_back_with_the_caller_transaction(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Permissions must be written inside a caller's transaction, not in sessions of their own.
+
+    A session opened per concurrent task commits independently, so its permissions would outlive
+    the rollback and a later retry would build duplicates on top of them.
+    """
+    with pytest.raises(RuntimeError, match=r"^initialization interrupted$"):
+        async with db.start_transaction() as dbt:
+            await create_default_account_groups(db=dbt)
+            _interrupt_transaction()
+
+    assert await NodeManager.query(db=db, schema=CoreGlobalPermission) == []
+    assert await NodeManager.query(db=db, schema=CoreAccountRole) == []
+    assert await NodeManager.query(db=db, schema=CoreAccountGroup) == []
 
 
 async def test_create_default_account_groups_assigns_every_member(

--- a/backend/tests/component/core/test_initialization.py
+++ b/backend/tests/component/core/test_initialization.py
@@ -4,11 +4,40 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.initialization import first_time_initialization, get_root_node, reset_deployment_id
+from infrahub.core.initialization import (
+    create_account,
+    create_default_account_groups,
+    first_time_initialization,
+    get_root_node,
+    reset_deployment_id,
+)
+from infrahub.core.manager import NodeManager
 from infrahub.core.preferences.repository import PreferenceRepository
+from infrahub.core.protocols import (
+    CoreAccount,
+    CoreAccountGroup,
+    CoreAccountRole,
+    CoreGlobalPermission,
+    CoreObjectPermission,
+)
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.definitions.deprecated import deprecated_models
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+
+EXPECTED_GLOBAL_PERMISSIONS = {
+    "super_admin",
+    "manage_repositories",
+    "manage_schema",
+    "merge_proposed_change",
+    "edit_default_branch",
+    "manage_accounts",
+    "manage_global_preferences",
+    "manage_permissions",
+    "merge_branch",
+    "rebase_branch",
+    "review_proposed_change",
+}
 
 
 async def test_first_time_initialization(db: InfrahubDatabase, default_branch: Branch) -> None:
@@ -46,6 +75,63 @@ async def test_first_time_initialization_converges_core_schema(db: InfrahubDatab
     candidate_schema.process()
 
     assert branch_schema.diff(other=candidate_schema).all == []
+
+
+async def test_create_default_account_groups_creates_each_permission_once(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """The permissions are created concurrently, so a lost get-or-create would duplicate a node.
+
+    Counts are asserted alongside the action names because a duplicate leaves the name set intact.
+    """
+    await create_default_account_groups(db=db)
+
+    global_permissions = await NodeManager.query(db=db, schema=CoreGlobalPermission)
+    assert {permission.action.value for permission in global_permissions} == EXPECTED_GLOBAL_PERMISSIONS
+    assert len(global_permissions) == len(EXPECTED_GLOBAL_PERMISSIONS)
+
+    object_permissions = await NodeManager.query(db=db, schema=CoreObjectPermission)
+    assert {
+        (
+            permission.namespace.value,
+            permission.name.value,
+            permission.action.value.value,
+            permission.decision.value.value,
+        )
+        for permission in object_permissions
+    } == {
+        ("*", "*", "view", 6),
+        ("*", "*", "any", 4),
+        ("Core", "ProposedChange", "update", 6),
+    }
+    assert len(object_permissions) == 3
+
+    roles = await NodeManager.query(db=db, schema=CoreAccountRole)
+    assert {role.name.value for role in roles} == {
+        "Super Administrator",
+        "General Access",
+        "Proposed Change Reviewer",
+    }
+    assert len(roles) == 3
+
+
+async def test_create_default_account_groups_assigns_every_member(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    admin = await create_account(db=db, name="admin-1", password="Testing1234", token_value=None)
+    bot = await create_account(db=db, name="bot-1", password="Testing1234", token_value=None)
+    user = await create_account(db=db, name="user-1", password="Testing1234", token_value=None)
+
+    await create_default_account_groups(db=db, admin_accounts=[admin, bot], accounts=[user])
+
+    groups = {group.name.value: group for group in await NodeManager.query(db=db, schema=CoreAccountGroup)}
+    assert set(groups) == {"Super Administrators", "Infrahub Users"}
+
+    admin_members = await groups["Super Administrators"].members.get_peers(db=db, peer_type=CoreAccount)
+    assert {member.id for member in admin_members.values()} == {admin.id, bot.id}
+
+    user_members = await groups["Infrahub Users"].members.get_peers(db=db, peer_type=CoreAccount)
+    assert {member.id for member in user_members.values()} == {user.id}
 
 
 async def test_reset_deployment_id_generates_new_uuid(db: InfrahubDatabase, default_branch: Branch) -> None:

--- a/changelog/+parallelize-default-account-groups.changed.md
+++ b/changelog/+parallelize-default-account-groups.changed.md
@@ -1,0 +1,1 @@
+Speed up creation of the default account groups, roles and permissions by creating independent permission nodes concurrently. This shortens first-time initialization and the `infrahub upgrade` path that rebuilds the default groups.


### PR DESCRIPTION
Follow-up to #10362, which profiled the `core-schema` component shard and found `create_default_account_groups` was the biggest per-class cost outside the test files themselves. It issued ~42 sequential database round-trips and runs at the setup of every `TestInfrahubApp`-derived test class (161 across `backend/tests`), plus first-time initialization and the `infrahub upgrade` path.

## What changed

Permission nodes within a role, and the two role/group chains, are independent, so they now run concurrently via `asyncio.gather`. Ordering that matters is preserved:

- permissions complete before the role that references them
- roles complete before the group that references them
- `create_default_role` and `create_proposed_change_reviewer_role` stay sequential, because both get-or-create the same `edit_default_branch` permission and racing them risks duplicates

Each concurrent task runs in its own database session (`run_in_own_session`) — a Neo4j session cannot serve concurrent queries, and sharing one raises `RuntimeError: read() called while another coroutine is already waiting for incoming data`. Two helpers (`create_global_permission`, `create_object_permission`) were extracted to remove repeated init/new/save blocks.

The `edit_default_branch` permission was the one node two concurrent paths both wanted, so it is now created up front. That removes the shared node rather than relying on ordering, and the two roles run concurrently as a result. Worth knowing for review: injecting the duplicate bug deliberately did **not** reproduce it in a single run, so this invariant cannot be guarded by a test — which is why it is fixed structurally instead.

## Measured impact: local yes, CI no

**Locally: 13.02s → 7.69s (−41%)** for one `create_default_account_groups` call — controlled, back-to-back on the same machine with the change stashed/unstashed. Across a local component run (~41 classes) that is roughly 3.5 minutes.

**In GitHub Actions: no measurable improvement.** Comparing this PR's run against #10362's run (same day, same base, differing only by this change):

| job | class boots | baseline | this PR | delta |
|---|---|---|---|---|
| unit 3.12 / 3.13 / 3.14 | 0 (control) | 197 / 205 / 187s | 180 / 211 / 163s | −8.6% / +2.9% / −12.8% |
| functional (serial) | 53 | 767s | 697s | −9.1% |
| integration | 60 | 1167s | 1204s | +3.2% |
| component (other) | 14 | 1247s | 1262s | +1.2% |
| component (graphql) | 10 | 716s | 755s | +5.4% |
| component (core-diff) | 12 | 601s | 655s | +9.0% |

Summed over the five affected jobs: 4498s → 4573s (+75s). The unit jobs do identical work in both runs and still vary by ±13%, which is the noise floor; every treatment job sits inside it with mixed signs. A per-class comparison of the same `TestInfrahubApp` setups averaged +2.3s.

The comparison is not blind: #10362's fixture change is present in the baseline and absent here, so `core-schema` should be slower by ~55s (110 worker-seconds ÷ 2 workers) — observed 515s → 572s, +57s. The same method that resolves a ~55s effect to within 2s finds nothing here.

**Why local doesn't transfer:** locally Neo4j runs in Docker Desktop's VM on macOS where each `Node.save` costs 0.1–0.9s; CI runs it natively on Linux at far lower latency. Parallelizing sequential round-trips saves about `(N−1) × latency`, so a ~10× lower latency removes most of the benefit.

**So the case for merging is local developer experience** — roughly 3.5 minutes off a full local component run — not CI wall time. The production paths are a weaker argument than they first appear: `first_time_initialization` and `upgrade` each call this exactly once, so they save seconds at most, and less than that against a low-latency database. Reasonable to reject on the grounds that the added concurrency isn't worth it if CI is the only thing you optimize for.

## Test Plan

- Three new tests in `backend/tests/component/core/test_initialization.py`: every permission created exactly once (counts as well as names, since a duplicate leaves the name set intact), every account assigned to its group (covering the switch from a per-account `members.add` to a single `members.update`), and permissions rolling back with a caller's transaction. That last one is a real regression guard: without the transaction check it fails, finding 11 permission nodes that survived the rollback. 9 passed.
- `backend/tests/component/core/convert_object_type` (real `TestInfrahubApp` classes): 9 passed.
- `backend/tests/unit/permissions`: 64 passed.
- Full CI green on the first commit; re-running for the hardening commit.
- `ruff check`, `ruff format`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

