### PR TITLE
chore: clear most mypy and ty suppressions for infrahub.database

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -65,7 +65,7 @@ class SchemaManager(NodeManager):
     def _get_from_cache(self, key: int) -> Any:
         return self._cache[key]
 
-    def set(self, name: str, schema: NodeSchema | GenericSchema, branch: str | None = None) -> int:
+    def set(self, name: str, schema: MainSchemaTypes, branch: str | None = None) -> int:
         branch = branch or registry.default_branch
 
         if branch not in self._branches:

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -35,6 +35,7 @@ from infrahub.core.constants import (
     GLOBAL_BRANCH_NAME,
 )
 from infrahub.core.query import QueryType
+from infrahub.core.schema import GenericSchema, NodeSchema
 from infrahub.exceptions import DatabaseError, QueryTimeoutError
 from infrahub.log import get_logger
 from infrahub.utils import InfrahubStringEnum
@@ -50,8 +51,11 @@ from .metrics import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    # neo4j only exports the concrete trust stores, not the base class the driver accepts.
+    from neo4j._conf import TrustStore
+
     from infrahub.core.branch import Branch
-    from infrahub.core.schema import GenericSchema, MainSchemaTypes, NodeSchema
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.schema_branch import SchemaBranch
 
 validated_database = {}
@@ -98,7 +102,7 @@ class DatabaseSchemaManager:
 
     def get_node_schema(self, name: str, branch: Branch | str | None = None, duplicate: bool = True) -> NodeSchema:
         schema = self.get(name=name, branch=branch, duplicate=duplicate)
-        if schema.is_node_schema:
+        if isinstance(schema, NodeSchema):
             return schema
 
         raise ValueError("The selected node is not of type NodeSchema")
@@ -107,16 +111,17 @@ class DatabaseSchemaManager:
         self, name: str, branch: Branch | str | None = None, duplicate: bool = True
     ) -> GenericSchema:
         schema = self.get(name=name, branch=branch, duplicate=duplicate)
-        if schema.is_generic_schema:
+        if isinstance(schema, GenericSchema):
             return schema
 
         raise ValueError("The selected node is not of type GenericSchema")
 
-    def set(self, name: str, schema: MainSchemaTypes, branch: str | None = None) -> int:
+    def set(self, name: str, schema: MainSchemaTypes, branch: str | None = None) -> None:
         branch_name = get_branch_name(branch=branch)
         if branch_name not in self._db._schemas:
-            return registry.schema.set(name=name, schema=schema, branch=branch)
-        return self._db._schemas[branch_name].set(name=name, schema=schema)
+            registry.schema.set(name=name, schema=schema, branch=branch)
+            return
+        self._db._schemas[branch_name].set(name=name, schema=schema)
 
     def has(self, name: str, branch: Branch | str | None = None) -> bool:
         branch_name = get_branch_name(branch=branch)
@@ -227,7 +232,7 @@ class InfrahubDatabase:
             mode=InfrahubDatabaseMode.SESSION,
             db_type=self.db_type,
             default_neo4j_runtime=self.default_neo4j_runtime,
-            schemas=schemas or self._schemas.values(),
+            schemas=schemas or list(self._schemas.values()),
             driver=self._driver,
             session_mode=session_mode,
             queries_names_to_config=self.queries_names_to_config,
@@ -241,7 +246,7 @@ class InfrahubDatabase:
             mode=InfrahubDatabaseMode.TRANSACTION,
             db_type=self.db_type,
             default_neo4j_runtime=self.default_neo4j_runtime,
-            schemas=schemas or self._schemas.values(),
+            schemas=schemas or list(self._schemas.values()),
             driver=self._driver,
             session=self._session,
             session_mode=self._session_mode,
@@ -292,6 +297,16 @@ class InfrahubDatabase:
 
         return self
 
+    def _get_open_session(self) -> AsyncSession:
+        if self._session is None:
+            raise RuntimeError("No database session is currently open")
+        return self._session
+
+    def _get_open_transaction(self) -> AsyncTransaction:
+        if self._transaction is None:
+            raise RuntimeError("No database transaction is currently open")
+        return self._transaction
+
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None,
@@ -299,22 +314,23 @@ class InfrahubDatabase:
         traceback: TracebackType | None,
     ) -> None:
         if self._mode == InfrahubDatabaseMode.SESSION:
-            await self._session.close()
+            await self._get_open_session().close()
             return
 
         if self._mode == InfrahubDatabaseMode.TRANSACTION:
+            transaction = self._get_open_transaction()
             if exc_type is not None:
-                await self._transaction.rollback()
+                await transaction.rollback()
             else:
                 try:
-                    await self._transaction.commit()
+                    await transaction.commit()
                 except Neo4jError as exc:
                     raise exc
                 finally:
-                    await self._transaction.close()
+                    await transaction.close()
 
             if self._is_session_local:
-                await self._session.close()
+                await self._get_open_session().close()
 
     async def close(self) -> None:
         await self._driver.close()
@@ -426,27 +442,28 @@ class InfrahubDatabase:
         name: str | None = "undefined",
         timeout_seconds: float | None = None,
     ) -> AsyncResult:
-        _query: str | Query = query
         if self.is_transaction:
             # An explicit transaction's timeout is fixed at begin_transaction time, so a
             # per-query timeout cannot be applied here; auto-commit queries carry it on the
             # Query wrapper below.
-            execution_method = await self.transaction(name=name)
-        else:
-            _query = Query(
-                text=query,
-                metadata={"name": name, "infrahub_id": f"{trace.get_current_span().get_span_context().span_id:x}"},
-                timeout=timeout_seconds,
-            )
-            execution_method = await self.session()
+            transaction = await self.transaction(name=name)
+            try:
+                return await transaction.run(query=query, parameters=params)
+            except ServiceUnavailable as exc:
+                log.error("Database Service unavailable", error=str(exc))
+                raise DatabaseError(message="Unable to connect to the database") from exc
 
+        session = await self.session()
+        auto_commit_query = Query(
+            text=query,
+            metadata={"name": name, "infrahub_id": f"{trace.get_current_span().get_span_context().span_id:x}"},
+            timeout=timeout_seconds,
+        )
         try:
-            response = await execution_method.run(query=_query, parameters=params)
+            return await session.run(query=auto_commit_query, parameters=params)
         except ServiceUnavailable as exc:
             log.error("Database Service unavailable", error=str(exc))
             raise DatabaseError(message="Unable to connect to the database") from exc
-
-        return response
 
     def render_list_comprehension(self, items: str, item_name: str) -> str:
         if self.db_type == DatabaseType.MEMGRAPH:
@@ -542,7 +559,7 @@ def build_address_resolver(members: list[str], default_port: int) -> Callable[[A
 
 
 async def get_db(retry: int = 0) -> AsyncDriver:
-    trusted_certificates = TrustSystemCAs()
+    trusted_certificates: TrustStore = TrustSystemCAs()
     if config.SETTINGS.database.tls_insecure:
         trusted_certificates = TrustAll()
     elif config.SETTINGS.database.tls_ca_file:

--- a/backend/tests/unit/database/test_run_query.py
+++ b/backend/tests/unit/database/test_run_query.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from neo4j import AsyncGraphDatabase, Query
+from neo4j.exceptions import ClientError, ServiceUnavailable
+
+from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode
+from infrahub.exceptions import DatabaseError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from neo4j import AsyncDriver, AsyncResult, AsyncSession, AsyncTransaction
+
+QUERY = "MATCH (n) RETURN n"
+PARAMS = {"kind": "TestCar"}
+QUERY_NAME = "unit_probe"
+TIMEOUT_SECONDS = 12.5
+
+
+class RecordingRunner:
+    """Satisfies the run() contract of AsyncSession and AsyncTransaction, keeping every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any] | None]] = []
+        self.result = cast("AsyncResult", object())
+
+    async def run(self, query: Any, parameters: dict[str, Any] | None = None) -> AsyncResult:
+        self.calls.append((query, parameters))
+        return self.result
+
+
+class FailingRunner:
+    """Satisfies the same run() contract, but every query fails with the given error."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def run(self, query: Any, parameters: dict[str, Any] | None = None) -> AsyncResult:
+        raise self.error
+
+
+@dataclass
+class ModeTestCase:
+    name: str
+    """Descriptive name for the test scenario."""
+
+    mode: InfrahubDatabaseMode
+    """The database mode that decides which execution path run_query takes."""
+
+
+MODE_TEST_CASES: list[ModeTestCase] = [
+    ModeTestCase(
+        name="explicit_transaction",
+        mode=InfrahubDatabaseMode.TRANSACTION,
+    ),
+    ModeTestCase(
+        name="auto_commit_session",
+        mode=InfrahubDatabaseMode.SESSION,
+    ),
+]
+
+
+@pytest.fixture
+async def driver() -> AsyncGenerator[AsyncDriver, None]:
+    # Building a driver opens no connection, and these tests never execute against it.
+    driver = AsyncGraphDatabase.driver("bolt://127.0.0.1:9", auth=("neo4j", "unused"))
+    yield driver
+    await driver.close()
+
+
+def build_db(
+    driver: AsyncDriver, mode: InfrahubDatabaseMode, runner: RecordingRunner | FailingRunner
+) -> InfrahubDatabase:
+    if mode == InfrahubDatabaseMode.TRANSACTION:
+        return InfrahubDatabase(driver=driver, mode=mode, transaction=cast("AsyncTransaction", runner))
+    return InfrahubDatabase(driver=driver, mode=mode, session=cast("AsyncSession", runner))
+
+
+async def run_probe(db: InfrahubDatabase) -> AsyncResult:
+    return await db.run_query(query=QUERY, params=PARAMS, name=QUERY_NAME, timeout_seconds=TIMEOUT_SECONDS)
+
+
+async def test_explicit_transaction_runs_the_query_unwrapped(driver: AsyncDriver) -> None:
+    """A transaction's timeout is fixed when it begins, so the query cannot carry one of its own."""
+    runner = RecordingRunner()
+    db = build_db(driver=driver, mode=InfrahubDatabaseMode.TRANSACTION, runner=runner)
+
+    result = await run_probe(db)
+
+    assert result is runner.result
+    assert runner.calls == [(QUERY, PARAMS)]
+
+
+async def test_auto_commit_session_wraps_the_query_with_the_timeout(driver: AsyncDriver) -> None:
+    runner = RecordingRunner()
+    db = build_db(driver=driver, mode=InfrahubDatabaseMode.SESSION, runner=runner)
+
+    result = await run_probe(db)
+
+    assert result is runner.result
+    assert len(runner.calls) == 1
+    recorded_query, recorded_params = runner.calls[0]
+    assert recorded_params == PARAMS
+    assert isinstance(recorded_query, Query)
+    assert recorded_query.text == QUERY
+    assert recorded_query.timeout == TIMEOUT_SECONDS
+    assert set(recorded_query.metadata or {}) == {"name", "infrahub_id"}
+    assert (recorded_query.metadata or {})["name"] == QUERY_NAME
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in MODE_TEST_CASES],
+)
+async def test_service_unavailable_becomes_database_error(driver: AsyncDriver, test_case: ModeTestCase) -> None:
+    error = ServiceUnavailable("the database went away")
+    db = build_db(driver=driver, mode=test_case.mode, runner=FailingRunner(error=error))
+
+    with pytest.raises(DatabaseError, match=r"^Unable to connect to the database$") as exc_info:
+        await run_probe(db)
+
+    assert exc_info.value.__cause__ is error
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in MODE_TEST_CASES],
+)
+async def test_other_database_errors_are_not_translated(driver: AsyncDriver, test_case: ModeTestCase) -> None:
+    error = ClientError("invalid syntax")
+    db = build_db(driver=driver, mode=test_case.mode, runner=FailingRunner(error=error))
+
+    with pytest.raises(ClientError, match=r"^invalid syntax$") as exc_info:
+        await run_probe(db)
+
+    assert exc_info.value is error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,12 +323,10 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = "infrahub.database"
 disable_error_code = [
+    # Only remaining violation: AsyncGraphDatabase.driver() rejects `resolver=None` in the neo4j
+    # stubs even though None is the driver's own runtime default. To remove this we would have to
+    # always pass a resolver, including for a single member and for an empty address_members list.
     "arg-type",
-    "assignment",
-    "index",
-    "misc",
-    "return-value",
-    "union-attr",
 ]
 
 [[tool.mypy.overrides]]
@@ -1625,10 +1623,12 @@ include = ["backend/infrahub/database/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
+# Queries are assembled at runtime, so they are `str` where the neo4j stubs require `LiteralString`.
+# Also covers the `resolver=None` violation described in the mypy override for infrahub.database.
 invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
+# IndexManagerBase and its subclasses define a `list` method, which shadows the builtin for every
+# `list[...]` annotation in those class bodies. To remove this the method has to be renamed.
 invalid-type-form = "ignore"
-unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]


### PR DESCRIPTION
# Why

The `infrahub.database` override in `pyproject.toml` disabled six mypy error codes, and the matching ty override ignored five rules. Both were placeholders for "fix the code later". Two of the mypy entries (`index`, `misc`) suppressed nothing at all any more.

Goal: fix the underlying type errors rather than trim the list, and document precisely what would be required to remove whatever is left.

Non-goals: no behaviour changes, and no rename of the index managers' `list()` method (see below).

## What changed

**Behavioral changes:** none intended. One API signature is narrower:

- `DatabaseSchemaManager.set()` now returns `None`. Its `int` annotation was wrong on one of its two paths - the branch-local one returns `SchemaBranch.set`'s `str` hash - and no caller in this repo uses the value. Worth a grep in infrahub-enterprise.

**Fixes behind the removed suppressions:**

- `get_node_schema` / `get_generic_schema` narrow with `isinstance`, matching the shape the equivalent accessors on `SchemaManager` already use (`backend/infrahub/core/schema/manager.py:110-124`).
- `SchemaManager.set` widened to `MainSchemaTypes` - what it already forwards to `SchemaBranch.set` and what `DatabaseSchemaManager` already passes it. Annotation-only; note this means mypy no longer blocks passing a profile/template schema there.
- `InfrahubDatabase(schemas=...)` gets a `list` instead of `dict_values`.
- `__aexit__` reads the session/transaction through guarded accessors instead of dereferencing them unchecked.
- `run_query` split so the explicit-transaction and auto-commit paths each pass the query form their execution method accepts. The transaction acquisition deliberately stays outside the `try`, so a `ServiceUnavailable` raised by `begin_transaction()` still propagates raw instead of becoming a `DatabaseError` - that's why the `except` clause is duplicated.
- `trusted_certificates` annotated with `TrustStore`, the base the driver's own signature accepts. neo4j exports only the three concrete subclasses, so it is imported under `TYPE_CHECKING`; a future neo4j reshuffle would break type-checking, never runtime.

**Result:** mypy 16 violations -> 1, six disabled codes -> one. ty 26 diagnostics -> 14, five ignored rules -> three.

**What stayed the same:** no schema, migration, GraphQL or API changes. No new dependencies. No changelog fragment (internal typing debt).

## How to review

Focus on two things:

1. **`run_query`** - the only non-trivial rewrite. Equivalence was checked by characterising old and new against recording/failing doubles across six scenarios (both modes x success / `ServiceUnavailable` / other `Neo4jError`), capturing the exact object handed to `run()`, the return value and the exception chain. Output was byte-identical. That characterisation is now committed as `backend/tests/unit/database/test_run_query.py`; inverting the mode branch in the source makes all 6 of its cases fail, so it does detect regressions.
2. **The new runtime import** - `from infrahub.core.schema import GenericSchema, NodeSchema` moved from `TYPE_CHECKING` to module level, which adds 193 modules (79 of them `infrahub.*`) to `infrahub.database`'s import-time closure. No cycle exists: after importing `infrahub.core.schema` alone, `infrahub.database` is absent from `sys.modules`, so nothing in that closure imports back. All 964 modules under `backend/infrahub` import cleanly, matching the pre-change baseline exactly. Happy to move it into the two methods if you would rather keep the import surface flat.

The `pyproject.toml` diff is the summary of what's left and why.

## How to test

```bash
uv run invoke lint                                    # ruff + ty + mypy, with the reduced ignore lists
uv run pytest backend/tests/unit/database -q          # includes the new run_query tests
INFRAHUB_USE_TEST_CONTAINERS=false uv run pytest \
  backend/tests/component/core/migrations/graph/test_014.py -q   # drives the rewritten __aexit__
```

Two pre-existing failures are unrelated to this branch and reproduce identically on `develop`: `backend/tests/unit/services/adapters/workflow/test_local_stamping.py` (4 tests, needs a Prefect API on :4200) and `npx betterer` (34 new TS issues; this branch contains no frontend files).

## Impact & rollout

- **Backward compatibility:** `db.schema.set()` no longer returns a value; nothing in this repo consumed it.
- **Performance:** unchanged; `infrahub.database` now imports more modules at startup.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`) - not applicable, internal typing debt
- [ ] External docs updated (if user-facing or ops-facing change) - not applicable
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge) - not applicable
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

