### PR TITLE
test(frontend): keep playwright interception always on so vi.mock cannot race Fetch.enable

### DIFF
--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -1,7 +1,39 @@
-import { playwright } from "@vitest/browser-playwright";
+import { type PlaywrightBrowserProvider, playwright } from "@vitest/browser-playwright";
 import { defineConfig, mergeConfig } from "vitest/config";
 
 import viteConfig from "./vite.config";
+
+// vi.mock in browser mode is served through Playwright request interception, which the
+// provider enables on a session's first registered mock and disables again when a test
+// file's mocks are cleared. Chromium applies that enable asynchronously (the CDP ack does
+// not wait for the renderer's loader factories to update), so a module fetched within the
+// first ~1ms after registration can slip past the route and load unmocked — the recurring
+// "vi.mocked(...).mockX is not a function" flake that hits a random test file. Installing a
+// route that never matches keeps interception enabled for the whole session, so per-file
+// mock registration becomes a pure matcher update with no enable/disable transition to race.
+function playwrightWithAlwaysOnInterception() {
+  const provider = playwright();
+  return {
+    ...provider,
+    providerFactory(...args: Parameters<typeof provider.providerFactory>) {
+      const instance = provider.providerFactory(...args) as PlaywrightBrowserProvider;
+      const anchored = new WeakSet<object>();
+      const openPage = instance.openPage.bind(instance);
+      instance.openPage = async (sessionId, url, options) => {
+        await openPage(sessionId, url, options);
+        const context = instance.contexts.get(sessionId);
+        if (context && !anchored.has(context)) {
+          anchored.add(context);
+          await context.route(
+            () => false,
+            () => {}
+          );
+        }
+      };
+      return instance;
+    },
+  };
+}
 
 export default mergeConfig(
   viteConfig,
@@ -54,7 +86,7 @@ export default mergeConfig(
       browser: {
         enabled: true,
         headless: true,
-        provider: playwright(),
+        provider: playwrightWithAlwaysOnInterception(),
         instances: [
           {
             browser: "chromium",


### PR DESCRIPTION
## Summary

Fixes the longest-running frontend CI flake: roughly 1 in 30-100 `frontend-tests` runs, one random test file fails wholesale with `TypeError: vi.mocked(...).mockX is not a function` (the `vitest-mock-corruption` bucket in the flakiness ledger, most recently on PR #10365). The file's `vi.mock(...)` never takes effect and the real module is linked, so every test in it fails and a full re-run is the only recovery.

## Root cause

vitest 4's browser mode serves `vi.mock` automocks through Playwright request interception and tears all routes down after each test file, so Chromium's `Fetch` interception is disabled and re-enabled around every file that uses mocks. Chromium applies that enable asynchronously — the CDP ack does not wait for the renderer's loader factories to update — so a module fetched within ~1ms of `context.route()` resolving can slip past the route and load unmocked.

Full instrumented analysis posted upstream: [vitest-dev/vitest#8339 (comment)](https://github.com/vitest-dev/vitest/issues/8339#issuecomment-5369644130) — the flake was reproduced locally at ~20% per run on a 5-file subset, and all six captured failures show the mocked module's plain URL reaching the Vite server 0-1ms after the fully-awaited route registration, with no interception.

## Key Changes

- `vitest.config.ts` wraps the playwright provider (`playwrightWithAlwaysOnInterception`) to install a permanent never-matching route per browser context, keeping interception enabled for the whole session. Mock registration becomes a pure matcher update with no enable/disable transition left to race.

## Validation

- Without the fix: 6 corrupted runs out of 30 stress iterations of `vitest run src/entities/tasks` (including the exact failures seen on CI: `task-status.test.tsx`, `is-task-running-on-branch.test.ts`, `cancel-task.test.ts`).
- With the fix: **74/74 stress iterations clean** (40 via patched provider, 34 via this config wrapper), plus the full suite green with coverage, twice.
- `biome ci`, `knip`, and `betterer ci` all pass.

## Trade-off

Interception now stays active for unmocked files too, so every module request pauses through the Playwright server. Locally (32 parallel sessions) the suite goes from ~28s to ~43s wall; CI runs far fewer sessions, so the relative cost should be smaller — worth watching the `frontend-tests` duration on this PR against the ~2.5min baseline.

## Test Plan

- `frontend-tests` CI job on this PR.
- The flake strikes ~1 in 30-100 runs, so absence of the error on one run proves little — the stress-loop numbers above are the real evidence. If the error signature ever reappears, the upstream issue is the place to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

