### PR TITLE
fix(backend): pull the mapped remote branch when syncing a repository

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -963,7 +963,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         if repo is not None:
             try:
                 commit_before = str(repo.head.commit)
-                repo.remotes.origin.pull(branch_name)
+                repo.remotes.origin.pull(self._get_mapped_remote_branch(branch_name=branch_name))
             except GitCommandError as exc:
                 await self._raise_enriched_error(error=exc, branch_name=branch_name)
 

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -206,6 +206,46 @@ async def test_init_repoints_origin_after_location_change(
     assert relocated.get_branches_from_remote()["main"].commit == commit_b
 
 
+async def test_pull_infrahub_default_branch_pulls_repository_default_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pulling the Infrahub default branch must pull the repository's own default branch.
+
+    When the two differ, the remote has no branch named after the Infrahub default branch,
+    so pulling the unmapped name fails and flips the repository into an error state.
+    """
+    repos_dir = tmp_path / "repositories"
+    repos_dir.mkdir()
+    monkeypatch.setattr(registry, "_default_branch", "main")
+    monkeypatch.setattr(config.SETTINGS.git, "repositories_directory", str(repos_dir))
+
+    source_dir = tmp_path / "source-repo"
+    source_dir.mkdir()
+    source = Repo.init(source_dir, initial_branch="production")
+    with source.config_writer() as cfg:
+        cfg.set_value("user", "name", "Test")
+        cfg.set_value("user", "email", "test@test.local")
+    (source_dir / "data.txt").write_text("v1\n", encoding="utf-8")
+    source.index.add(["data.txt"])
+    source.index.commit("commit 1")
+
+    repository = await InfrahubRepository.new(
+        id=UUIDT.new(),
+        name="production-default-repo",
+        location=str(source_dir),
+        default_branch_name="production",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
+    )
+
+    (source_dir / "data.txt").write_text("v2\n", encoding="utf-8")
+    source.index.add(["data.txt"])
+    new_commit = source.index.commit("commit 2").hexsha
+
+    commit_after = await repository.pull(branch_name="main", update_commit_value=False)
+    assert commit_after == new_commit
+
+
 def test_check_connectivity_ignores_cwd_git_pointer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Git operations must not be affected by a broken .git worktree pointer in the process current working directory."""
     source_dir = tmp_path / "source-repo"

--- a/changelog/+repository-default-branch-pull.fixed.md
+++ b/changelog/+repository-default-branch-pull.fixed.md
@@ -1,0 +1,1 @@
+Fixed repositories whose default branch differs from the Infrahub default branch being flipped to the `error` operational status when a task worker synchronized them by pulling instead of checking out a pinned commit. The pull now targets the repository's own default branch instead of the Infrahub branch name, which does not exist on the remote.

--- a/dev/knowledge/backend/git-sync.md
+++ b/dev/knowledge/backend/git-sync.md
@@ -17,6 +17,11 @@ Read this before reasoning about which remote branches get imported or why a git
   the mapped default. The skip happens in `validate_remote_branch` (which logs
   "Ignoring import of mismatched default branch" and returns `False`), *not* in
   `_get_mapped_target_branch`.
+- The reverse mapping — from an Infrahub branch name to the remote git branch — is
+  `_get_mapped_remote_branch`. Any git operation that names a remote ref (`pull`, `push`) must
+  route the branch name through it: when the repository's default branch differs from Infrahub's,
+  the remote has no branch named after the Infrahub default, and the raw name fails with
+  "couldn't find remote ref".
 - `git.import_sync_branch_names` (settings) is a list of names or regex patterns selecting which
   other remote branches are imported during sync; branches created in Infrahub with
   `sync_with_git` are imported regardless.


### PR DESCRIPTION
## Summary

Repositories whose git default branch differs from the Infrahub default branch could be flipped to the `error` operational status by a routine background sync, even though nothing was actually wrong with the repository. This surfaced as the `backend-docker-integration` flake in `test_artifact_composition.py::test_section_artifacts` (`assert 'error' == 'online'`, [run 32490367256](https://github.com/opsmill/infrahub/actions/runs/32490367256/job/96796754359)), but it affects any multi-worker deployment using such a repository.

## Root cause

When a task worker processes a `refresh-git-fetch` broadcast without a pinned commit (the documented fallback when the publishing worker cannot resolve one), it falls back to `repo.pull()`. `pull()` passed the Infrahub branch name straight to `git pull origin <name>` — but when the repository's default branch is not the Infrahub one (the test repo uses `production`), the remote has no such ref, so the pull failed with `fatal: couldn't find remote ref main` and the error handler marked the repository `error`.

The flakiness came from the trigger, not the bug: the broken pull only runs when the pinned-commit resolution loses a race on the publishing worker; most runs take the `reset_to_commit` path and never hit it.

## Key Changes

- `pull()` now resolves the remote branch through `_get_mapped_remote_branch()` — the same mapping `push()` already uses for this exact case. The mapping is identity for every other caller: git-native branch names pass through unchanged, and a remote branch literally named after the Infrahub default is already rejected by `validate_remote_branch` when the defaults differ.
- New unit test reproducing the failure: it fails before the fix with the exact CI error (`fatal: couldn't find remote ref main`) and passes after.

## Documentation Updates

- `dev/knowledge/backend/git-sync.md` now documents the Infrahub-to-remote branch mapping alongside the existing remote-to-Infrahub one.

## Test Plan

- `uv run pytest backend/tests/unit/git/` — 199 tests, all passing (including the new reproduction test).
- `ruff` and `mypy` clean on the touched files; `docs.lint` clean.
- The flaked docker-integration test (`test_artifact_composition.py`) exercises this path end-to-end in CI; the failure was timing-dependent, so the unit test pinning the exact failing git command is the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

