### PR TITLE
test(backend): use memoized task manager setup in recompute fixtures

### DIFF
--- a/backend/tests/component/computed_attribute/_base.py
+++ b/backend/tests/component/computed_attribute/_base.py
@@ -18,8 +18,8 @@ from infrahub.core.schema.computed_attribute import ComputedAttribute, ComputedA
 from infrahub.events.schema_action import ChangedElementsPayload  # noqa: TC001  used in dataclass field
 from infrahub.server import app
 from infrahub.workers.dependencies import build_workflow
-from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.task_manager import setup_task_manager_once
 from tests.helpers.test_app import TestInfrahubAppBase
 
 if TYPE_CHECKING:
@@ -140,7 +140,7 @@ class ScopedRecomputeTestBase(TestInfrahubAppBase):
     ) -> AsyncGenerator[WorkflowRecorder, None]:
         original = config.OVERRIDE.workflow
         recorder = WorkflowRecorder()
-        await setup_task_manager()
+        await setup_task_manager_once()
         config.OVERRIDE.workflow = recorder
         with dependency_provider.scope(build_workflow, lambda: recorder):
             yield recorder


### PR DESCRIPTION
## Summary

The `backend-tests-component (other)` job intermittently loses 8 tests and ~10 minutes to `Failed: Timeout >300.0s` setup errors in the computed-attribute recompute classes ([example run](https://github.com/opsmill/infrahub/actions/runs/32524607011/job/96904112356)). The shared recompute fixture re-ran the full `setup_task_manager()` Prefect flow once per test class, so when a worker's ephemeral Prefect test server degrades mid-session, each recompute class blocks until the 300s pytest timeout — while every other class skips the setup through the process-wide memoization helper and keeps passing.

## Key Changes

- `ScopedRecomputeTestBase.workflow_recorder` now calls `setup_task_manager_once()` like its sibling `TestInfrahubApp.workflow_local`, so the task-manager setup runs once per xdist worker process and a degraded Prefect test server can no longer cost a 300s timeout per recompute class.
- No behavioral change for the tests: they reconcile their own `computed_attr_python` automations through `process_transform_lifecycle`, and nothing asserts on the builtin automations the per-class re-run was force-rewriting.

## Related Context

In the failing run, `setup_triggers` hung indefinitely against one worker's wedged ephemeral Prefect server (event deliveries failing, deployment/automation reads timing out) and both recompute classes burned a full 300s each — while the same fixture passed on the healthy worker minutes earlier, and every class using the memoized helper passed on the sick worker. The memoization helper's docstring documents exactly this failure mode; the recompute base class had simply never been converted.

## Test Plan

- `uv run pytest backend/tests/component/computed_attribute/ --neo4j` in a single process, so all classes share one Prefect server and the recompute classes exercise the memoized skip path: 28 passed.
- Watch `backend-tests-component (other)` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

