### PR TITLE
move branch registry update out of rebase's cypher txn

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -438,7 +438,10 @@ class Branch(StandardNode):
     async def rebase(
         self, db: InfrahubDatabase, at: str | Timestamp | None = None, user_id: str = SYSTEM_USER_ID
     ) -> None:
-        """Rebase the current Branch with its origin branch."""
+        """Rebase the current Branch with its origin branch.
+
+        Mutates this instance (`branched_from`, `status`) and persists it with the given `db`.
+        """
         at = Timestamp(at)
 
         await self.rebase_graph(db=db, at=at)
@@ -446,9 +449,6 @@ class Branch(StandardNode):
         self.branched_from = at.to_string()
         self.status = BranchStatus.OPEN
         await self.save(db=db, user_id=user_id)
-
-        # Update the branch in the registry after the rebase
-        registry.branch[self.name] = self
 
     async def rebase_graph(self, db: InfrahubDatabase, at: Timestamp) -> None:
         """Rebase all relationships on this branch to a new point in time.

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -235,6 +235,10 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                 await user_branch.rebase(db=dbt, user_id=context.account.account_id, at=rebase_at)
                 log.info("Branch graph rebased")
 
+            # Only update registry after txn commit. Otherwise, branch status and branched_from
+            # could diverge between registry and database during a failed txn commit.
+            registry.branch[user_branch.name] = user_branch
+
             if migration_baseline_schema is not None and pre_rebase_schema is not None:
                 # Update the registry and run migrations after the rebase, with rollback on failure.
                 # Schema nodes were already written by the rebase, so load that schema and apply only

--- a/backend/tests/component/core/test_branch_rebase.py
+++ b/backend/tests/component/core/test_branch_rebase.py
@@ -8,6 +8,7 @@ from infrahub.auth.types import AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.tasks import rebase_branch
 from infrahub.core.constants import InfrahubKind, MetadataOptions
 from infrahub.core.initialization import create_branch
@@ -29,7 +30,12 @@ async def test_rebase_graph(
     db: InfrahubDatabase, base_dataset_02: dict, register_core_models_schema: SchemaBranch
 ) -> None:
     branch1 = await Branch.get_by_name(name="branch1", db=db)
+    cached_branched_from = registry.branch[branch1.name].branched_from
     await branch1.rebase(db=db)
+
+    # Rebasing mutates the instance it is given but must not publish it to the branch cache
+    assert branch1.branched_from != cached_branched_from
+    assert registry.branch[branch1.name].branched_from == cached_branched_from
 
     # Query all cars in MAIN, AFTER the rebase
     cars = sorted(await NodeManager.query(schema="TestCar", db=db), key=lambda c: c.id)
@@ -373,6 +379,14 @@ async def test_rebase_schemas_handed_to_the_update_coordinator(
 
     with dependency_provider.scope(build_database, lambda singleton=True: db):  # noqa: ARG005
         await rebase_branch(branch=baseline_branch.name, context=context)
+
+        # The flow publishes the branch it rebased, so the cache stops holding the pre-rebase instance
+        rebased_baseline_branch = await Branch.get_by_name(db=db, name=baseline_branch.name)
+        assert rebased_baseline_branch.branched_from != baseline_branch.branched_from
+        published_baseline_branch = registry.branch[baseline_branch.name]
+        assert published_baseline_branch is not baseline_branch
+        assert published_baseline_branch.branched_from == rebased_baseline_branch.branched_from
+        assert published_baseline_branch.status is BranchStatus.OPEN
 
         migration_calls = workflow_recorder.get_execute_calls_for(SCHEMA_APPLY_MIGRATION)
         assert len(migration_calls) == 1


### PR DESCRIPTION
small possible issue identified during unrelated changes to rebase logic, but the update to `registry.branch` does not belong within the cypher transaction covering the database-level rebase changes. in the unlikely case of a transaction commit failure, the registry's branch would be incorrectly set with a new `status` and `branched_from` that were rolled back in the database during the transaction commit failure. moving the registry update outside of `Branch.rebase()` is both more correct and safer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

