### PR TITLE
chore: stop the pre-ci frontend checks from leaking the working directory

### DIFF
--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -6,7 +6,7 @@ allowed-tools:
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
   - Bash(uv lock:*)
-  - Bash(npm --prefix frontend/app run:*)
+  - Bash(pnpm --dir frontend/app run:*)
   - Bash(npx markdownlint*:*)
 ---
 
@@ -17,7 +17,7 @@ Run all locally-executable CI checks to catch issues before pushing.
 **Every command runs from the repository root and must leave the working directory unchanged.**
 The parallel phases below share a single shell, so a `cd` in one command silently changes where
 its siblings run, and the `invoke` tasks then fail on relative paths such as
-`schema/schema.graphql`. The frontend checks use `npm --prefix` for that reason - do not rewrite
+`schema/schema.graphql`. The frontend checks use `pnpm --dir` for that reason - do not rewrite
 them as `cd frontend/app && ...`.
 
 **Options:**
@@ -47,7 +47,7 @@ Auto-fixes markdown formatting issues.
 ### 3. Format and lint frontend code (Biome)
 
 ```bash
-npm --prefix frontend/app run biome:fix
+pnpm --dir frontend/app run biome:fix
 ```
 
 Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports errors that cannot be auto-fixed, report them to the user.
@@ -59,7 +59,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 1. `uv run invoke main.lint` — If ruff reports issues, report them to the user.
 2. `uv run ruff check . --exclude python_sdk` — The exact command CI's `python-lint` job runs. This is not redundant with `main.lint`: that task lints only `tasks`, `models`, `utilities`, and `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the whole-repo check proves CI will pass.
 3. `uv lock --check` — Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
-4. `npm --prefix frontend/app run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
+4. `pnpm --dir frontend/app run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
 
 ---
 
@@ -72,7 +72,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 **IMPORTANT: Send ALL 7 commands below in a SINGLE message with 7 parallel Bash tool calls.** Do NOT run them one at a time.
 
 1. `uv run invoke backend.lint` — Run separately from main.lint to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. Its ruff step covers `backend` only, the same coverage gap noted in Phase 2; the ty/mypy output is what this check adds.
-2. `npm --prefix frontend/app run betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
+2. `pnpm --dir frontend/app run betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
 3. `uv run invoke docs.lint` — Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
 4. `uv run invoke backend.validate-generated` — Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
 5. `uv run invoke schema.validate-graphqlschema` — Ensures `schema/schema.graphql` is up to date. Regenerates the file then checks for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -6,16 +6,19 @@ allowed-tools:
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
   - Bash(uv lock:*)
-  - Bash(cd frontend*:*)
-  - Bash(npm run codegen*:*)
-  - Bash(npx biome*:*)
-  - Bash(npx betterer*:*)
+  - Bash(npm --prefix frontend/app run:*)
   - Bash(npx markdownlint*:*)
 ---
 
 # Pre-CI
 
 Run all locally-executable CI checks to catch issues before pushing.
+
+**Every command runs from the repository root and must leave the working directory unchanged.**
+The parallel phases below share a single shell, so a `cd` in one command silently changes where
+its siblings run, and the `invoke` tasks then fail on relative paths such as
+`schema/schema.graphql`. The frontend checks use `npm --prefix` for that reason - do not rewrite
+them as `cd frontend/app && ...`.
 
 **Options:**
 
@@ -44,7 +47,7 @@ Auto-fixes markdown formatting issues.
 ### 3. Format and lint frontend code (Biome)
 
 ```bash
-cd frontend/app && npx biome check --write .
+npm --prefix frontend/app run biome:fix
 ```
 
 Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports errors that cannot be auto-fixed, report them to the user.
@@ -56,7 +59,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 1. `uv run invoke main.lint` — If ruff reports issues, report them to the user.
 2. `uv run ruff check . --exclude python_sdk` — The exact command CI's `python-lint` job runs. This is not redundant with `main.lint`: that task lints only `tasks`, `models`, `utilities`, and `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the whole-repo check proves CI will pass.
 3. `uv lock --check` — Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
-4. `cd frontend/app && npm run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
+4. `npm --prefix frontend/app run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
 
 ---
 
@@ -69,7 +72,7 @@ Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports 
 **IMPORTANT: Send ALL 7 commands below in a SINGLE message with 7 parallel Bash tool calls.** Do NOT run them one at a time.
 
 1. `uv run invoke backend.lint` — Run separately from main.lint to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. Its ruff step covers `backend` only, the same coverage gap noted in Phase 2; the ty/mypy output is what this check adds.
-2. `cd frontend/app && npx betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
+2. `npm --prefix frontend/app run betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
 3. `uv run invoke docs.lint` — Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
 4. `uv run invoke backend.validate-generated` — Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
 5. `uv run invoke schema.validate-graphqlschema` — Ensures `schema/schema.graphql` is up to date. Regenerates the file then checks for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.


### PR DESCRIPTION
# Why

`/pre-ci` runs its three frontend checks as `cd frontend/app && ...`. That directory change persists for every later command in the same shell, so the `invoke` tasks in the following phases execute from `frontend/app`, where relative paths like `schema/schema.graphql` and `docs/docs/reference/...` do not resolve.

Hit while running the gate before pushing another branch: `backend.validate-generated` and `docs.validate` both failed with `FileNotFoundError` for reasons that had nothing to do with the change being checked. Worse, `docs.validate` did not fail cleanly - it rewrote a generated doc with different content and *then* errored, which would have been committed had I not checked `git status`.

Phases 2 and 3 also instruct sending every command in one message as parallel Bash calls, and those share a single shell, so which siblings break depends on scheduling. Non-deterministic failures in a pre-push gate are the worst kind to debug.

## What changed

All three frontend scripts already exist in `frontend/app/package.json` (`biome:fix`, `codegen:graphql`, `betterer`), so they now run via `npm --prefix frontend/app run <script>`, which executes in that directory and leaves the caller's working directory untouched.

- Phase 1.3: `npm --prefix frontend/app run biome:fix`
- Phase 2.4: `npm --prefix frontend/app run codegen:graphql`
- Phase 3.2: `npm --prefix frontend/app run betterer`
- A short rule near the top stating that every command runs from the repository root and must leave the working directory unchanged, with the reason.
- `allowed-tools` narrowed from `Bash(cd frontend*:*)` / `Bash(npx biome*:*)` / `Bash(npx betterer*:*)` / `Bash(npm run codegen*:*)` to a single `Bash(npm --prefix frontend/app run:*)`, so the `cd` form cannot come back unnoticed.

No change to which checks run or what they assert.

## How to review

Verified rather than assumed:

- `cd frontend/app` in one Bash call leaves the *next* call's `pwd` at `frontend/app` - the leak is real, not theoretical.
- `npm --prefix frontend/app run biome` checks 1535 files (so it runs in the right directory) and `pwd` afterwards is still the repository root.

## How to test

```bash
npm --prefix frontend/app run biome   # runs in frontend/app
pwd                                   # still the repository root
```

## Impact & rollout

- **Backward compatibility:** none needed, tooling documentation only.
- **Deployment notes:** safe.

## Checklist

- [ ] Tests added/updated - not applicable, documentation only
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`) - not applicable, internal tooling
- [ ] External docs updated (if user-facing or ops-facing change) - not applicable
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [ ] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

