### PR TITLE
ci(frontend): enforce oxfmt and oxlint on the workspace packages [TBD]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,16 @@ jobs:
         run: pnpm knip
       - name: Check TypeScript regressions (Betterer)
         run: pnpm exec betterer ci
+      # The workspace packages are formatted and linted by oxfmt/oxlint, not Biome, so they need
+      # their own steps. Each runs the package's own script, which keeps CI and local in step.
+      - name: "Check formatting (oxfmt): packages/ui"
+        run: pnpm --filter @infrahub/ui run format:check
+      - name: "Check linting (oxlint): packages/ui"
+        run: pnpm --filter @infrahub/ui run lint
+      - name: "Check formatting (oxfmt): packages/graph"
+        run: pnpm --filter @infrahub/graph run format:check
+      - name: "Check linting (oxlint): packages/graph"
+        run: pnpm --filter @infrahub/graph run lint
 
   frontend-validate-openapi-types:
     if: |

--- a/changelog/+frontend-packages-lint-ci.housekeeping.md
+++ b/changelog/+frontend-packages-lint-ci.housekeeping.md
@@ -1,0 +1,1 @@
+The frontend design-system packages (`@infrahub/ui` and `@infrahub/graph`) are now format- and lint-checked in CI with their own toolchain (oxfmt and oxlint), alongside the app's existing Biome check. Both packages shipped that toolchain but nothing ever ran it, so a misformatted or lint-breaking file in either package could ship green.

--- a/dev/knowledge/frontend/design-system.md
+++ b/dev/knowledge/frontend/design-system.md
@@ -57,6 +57,24 @@ Source of truth: `frontend/packages/graph/src/index.ts`. Adopted by `path-traver
 
 A third directory exists under `frontend/packages/`: `plugins/` holds a single standalone Vite + module-federation plugin template (`plugins/template`) that is **not** a pnpm workspace member (the workspace lists `app`, `packages/schema-visualizer`, `packages/ui`, and `packages/graph`) and is unrelated to the design system.
 
+## Formatting and linting: two toolchains, split by directory
+
+`frontend/app` uses Biome. Both workspace packages use oxfmt and oxlint instead, each with its own
+`oxfmt.config.ts` and `oxlint.config.ts` (`@infrahub/ui` also sorts Tailwind classes through oxfmt).
+There is no Biome config anywhere under `frontend/packages/`, so **never run Biome there**: with no
+`biome.jsonc` to find it walks up out of the checkout, picks up an unrelated config, and reformats
+the whole file.
+
+```bash
+pnpm --filter @infrahub/ui run format          # oxfmt --write
+pnpm --filter @infrahub/ui run format:check    # what CI runs
+pnpm --filter @infrahub/ui run lint            # oxlint
+pnpm --filter @infrahub/ui run lint:fix        # oxlint --fix
+```
+
+Same four scripts for `@infrahub/graph`. CI's `frontend-lint` job runs `format:check` and `lint` for
+both packages next to the app's Biome check, so a misformatted package file fails the build.
+
 ## When to consume from `@infrahub/ui`
 
 Always, for the components above. Do not reimplement them inline in feature code, even if it "feels lighter":

--- a/frontend/app/AGENTS.md
+++ b/frontend/app/AGENTS.md
@@ -20,7 +20,7 @@ cd frontend/app && pnpm codegen    # Generate GraphQL types
 
 ## Before pushing (run the full CI gate locally)
 
-`pnpm biome:fix` alone is **not** the CI gate. The `frontend-lint` job runs three checks and
+`pnpm biome:fix` alone is **not** the CI gate. The `frontend-lint` job runs several checks and
 `frontend-tests` runs the browser test suite. Run all of them before pushing — they each fail CI
 independently:
 
@@ -29,6 +29,15 @@ cd frontend/app && pnpm exec biome ci .   # format + lint (same as CI)
 cd frontend/app && pnpm knip              # unused exports/files/deps
 cd frontend/app && pnpm exec betterer ci  # TypeScript-regression gate (NOT plain tsc)
 cd frontend/app && pnpm test              # vitest (browser mode)
+```
+
+Biome covers `frontend/app` only. `frontend/packages/ui` and `frontend/packages/graph` are formatted
+and linted by oxfmt/oxlint, and the same `frontend-lint` job gates them — never run Biome against
+them. See `dev/knowledge/frontend/design-system.md` for why and for the per-package commands:
+
+```bash
+cd frontend/app && pnpm --filter @infrahub/ui run format:check && pnpm --filter @infrahub/ui run lint
+cd frontend/app && pnpm --filter @infrahub/graph run format:check && pnpm --filter @infrahub/graph run lint
 ```
 
 ## See Also

--- a/frontend/packages/ui/src/styles/theme.css
+++ b/frontend/packages/ui/src/styles/theme.css
@@ -53,20 +53,12 @@
   --selected-shadow: 0 0 #0000;
   --selected-highlight: var(--highlight), var(--selected);
 
-  --card: linear-gradient(
-    to bottom,
-    var(--color-stone-50) 0%,
-    var(--color-white) 10%
-  );
+  --card: linear-gradient(to bottom, var(--color-stone-50) 0%, var(--color-white) 10%);
   --card-shadow:
     inset 0 2px 0 rgb(255 255 255), inset 0 -1px 2px 1px rgb(0 0 0 / 0.03),
     0 1px 1px rgb(0 0 0 / 0.02);
 
-  --card-header: linear-gradient(
-    to bottom,
-    var(--color-white) 0%,
-    var(--color-neutral-50) 100%
-  );
+  --card-header: linear-gradient(to bottom, var(--color-white) 0%, var(--color-neutral-50) 100%);
   --card-header-foreground: var(--color-neutral-700);
   --card-header-shadow: inset 0 1px 0 rgb(255 255 255 / 0.85);
 
@@ -78,8 +70,7 @@
 
   --modal-frame: --alpha(var(--color-white) / 25%);
   --modal-frame-border: var(--border);
-  --modal-shadow:
-    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --modal-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 
   --table-cell: var(--color-stone-50);
   --table-cell-pinned: var(--color-white);
@@ -121,44 +112,25 @@
   --popover: --alpha(var(--color-stone-900) / 70%);
 
   --highlight:
-    radial-gradient(
-      72% 100% at 50% 100%,
-      rgb(255 255 255 / 0.09),
-      transparent 72%
-    ),
+    radial-gradient(72% 100% at 50% 100%, rgb(255 255 255 / 0.09), transparent 72%),
     linear-gradient(rgb(255 255 255 / 0.02), rgb(255 255 255 / 0.02));
   --highlight-foreground: var(--foreground);
 
   --selected:
-    radial-gradient(
-      72% 100% at 50% 100%,
-      rgb(255 255 255 / 0.16),
-      transparent 72%
-    ),
+    radial-gradient(72% 100% at 50% 100%, rgb(255 255 255 / 0.16), transparent 72%),
     linear-gradient(rgb(255 255 255 / 0.05), rgb(255 255 255 / 0.05));
   --selected-foreground: var(--foreground);
-  --selected-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.08), 0 1px 2px rgb(0 0 0 / 0.6);
+  --selected-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08), 0 1px 2px rgb(0 0 0 / 0.6);
 
   --card: linear-gradient(180deg, #201d1c 0%, #191716 55%, #141312 100%);
-  --card-shadow:
-    inset 0 2px 2px 1px rgb(32 28 26 / 0.2), 0 1px 2px rgb(0 0 0 / 0.5);
+  --card-shadow: inset 0 2px 2px 1px rgb(32 28 26 / 0.2), 0 1px 2px rgb(0 0 0 / 0.5);
 
-  --card-header: linear-gradient(
-    180deg,
-    rgb(255 251 246 / 0.045) 0%,
-    rgb(255 251 246 / 0.03) 100%
-  );
+  --card-header: linear-gradient(180deg, rgb(255 251 246 / 0.045) 0%, rgb(255 251 246 / 0.03) 100%);
   --card-header-foreground: var(--color-stone-300);
-  --card-header-shadow:
-    inset 0 1px 0 lch(24.13 2.26 37.96), 0 0 2px oklch(0.16 0.01 0);
+  --card-header-shadow: inset 0 1px 0 lch(24.13 2.26 37.96), 0 0 2px oklch(0.16 0.01 0);
 
   --secondary:
-    radial-gradient(
-      120% 55% at 0% 0%,
-      rgb(255 255 255 / 0.005),
-      transparent 62%
-    ),
+    radial-gradient(120% 55% at 0% 0%, rgb(255 255 255 / 0.005), transparent 62%),
     linear-gradient(180deg, #1a1817 0%, #0d0c0b 18%, #000000 100%);
   --secondary-shadow: 0 0 #0000;
 

--- a/frontend/packages/ui/src/theme/theme-provider.tsx
+++ b/frontend/packages/ui/src/theme/theme-provider.tsx
@@ -29,9 +29,11 @@ export function ThemeProvider({ canChoose, defaultTheme, children }: ThemeProvid
 
   const theme: ResolvedTheme = canChoose ? (choice ?? defaultTheme) : defaultTheme;
 
-  // Before paint, not after: the pre-paint script can only replay a theme this browser has already
-  // resolved once, so a first-time visitor starts with no class at all. A passive effect would let
-  // that first commit paint in the wrong palette and then snap.
+  /*
+   * Before paint, not after: the pre-paint script can only replay a theme this browser has already
+   * resolved once, so a first-time visitor starts with no class at all. A passive effect would let
+   * that first commit paint in the wrong palette and then snap.
+   */
   useLayoutEffect(() => {
     applyTheme(theme);
     mirrorResolvedTheme(theme);


### PR DESCRIPTION
Closes #10390

## ⚠️ This touches CI — needs a human decision before merge

`AGENTS.md` lists CI/CD workflow changes under **Ask First**. This PR is prepared, verified, and
left in draft deliberately: the frontend owner should confirm the approach before it lands.

## What is enforced now

`frontend/packages/ui` and `frontend/packages/graph` ship `oxfmt.config.ts` + `oxlint.config.ts` and
the matching package scripts, but nothing ever ran them — the `frontend-lint` job's only frontend
gate is `biome ci .` scoped to `frontend/app`. Both packages have been unchecked since they were
created (`packages/ui` since 2026-03-18, `packages/graph` since 2026-06-11).

Four steps are added to the existing `frontend-lint` job, each running the package's own script:

```yaml
- run: pnpm --filter @infrahub/ui run format:check      # oxfmt --check
- run: pnpm --filter @infrahub/ui run lint              # oxlint
- run: pnpm --filter @infrahub/graph run format:check
- run: pnpm --filter @infrahub/graph run lint
```

Calling the package scripts rather than the binaries keeps CI and local in step: if a package
changes its tool or flags, CI follows without a workflow edit.

**No extra install step is needed.** `pnpm install --frozen-lockfile` with
`working-directory: ./frontend/app` installs the *whole* workspace, not just the app — verified from
a clean worktree: after that exact command, `frontend/packages/{ui,graph}/node_modules/.bin/` both
contain `oxfmt` and `oxlint`.

## Scope

Deliberately **not** in this PR: unifying the frontend on one toolchain. Biome owns the app and the
existing CI wiring, oxfmt owns the design system and has Tailwind class sorting configured; that
decision belongs to the frontend owner and is deferred in the issue. This PR only makes CI run what
each package already declares.

## Pre-existing violations fixed

Turning the checks on surfaced three violations, all in `packages/ui`. `packages/graph` was already
clean on all four checks. Fixed with the packages' own tools — **2 files, +15/−41**:

| File | Check | Fix |
|---|---|---|
| `src/styles/theme.css` | oxfmt | `oxfmt --write` — reflows 6 CSS custom properties that were wrapped at a narrower width than oxfmt's (+10/−38) |
| `src/theme/theme-provider.tsx` | oxlint `capitalized-comments` (×2) | Manual (+5/−3) |

The one manual fix: `oxlint --fix` "fixes" a wrapped three-line `//` comment by capitalising each
continuation line, turning it into `A passive effect would let / That first commit paint in the wrong
palette` — grammatical nonsense. Rewrapped as a single block comment instead, which satisfies the
rule without mangling the prose. No other file was touched; no wholesale reformatting.

## Proof the checks fail on bad input

A green check that checks nothing is worse than no check, so each of the four was run against a
deliberately broken file (`console.log(   "probe"    )` appended, then reverted):

| Command | Clean tree | With probe |
|---|---|---|
| `pnpm --filter @infrahub/ui run format:check` | pass, 60 files | **exit 1** — `src/theme/theme-provider.tsx` |
| `pnpm --filter @infrahub/ui run lint` | pass | **exit 1** — `eslint(no-console)` |
| `pnpm --filter @infrahub/graph run format:check` | pass, 25 files | **exit 1** — `src/index.ts` |
| `pnpm --filter @infrahub/graph run lint` | pass | **exit 1** — `eslint(no-console)` |

`biome ci .` on `frontend/app` still passes (1457 files, no fixes applied) and `yamllint -s` is clean
on the modified workflow.

**Confirmed in CI on this PR** — the `frontend-lint` job ran all four new steps and they passed:
`Check formatting (oxfmt): packages/ui` · `Check linting (oxlint): packages/ui` ·
`Check formatting (oxfmt): packages/graph` · `Check linting (oxlint): packages/graph`.
That the binaries resolved at all is the proof that no extra install step is needed.

## Docs

The split was undocumented, which is how running Biome against a package file (and silently
reformatting it to a parent checkout's config) became possible. Recorded in two places:

- `dev/knowledge/frontend/design-system.md` — a short "Formatting and linting" section: which
  directory uses which tool, the per-package commands, and why Biome must never be run under
  `frontend/packages/`.
- `frontend/app/AGENTS.md` — a pointer in "Before pushing", since that section presented Biome as
  *the* frontend formatter.

Plus a `changelog/+frontend-packages-lint-ci.housekeeping.md` fragment.

## Follow-up not taken here

`.agents/commands/pre-ci.md` phase 1 still runs only `biome check --write .` for the frontend. Adding
the two packages there would mirror this gate locally, but #10385 is touching that file right now, so
it is left for a separate change.
