### PR TITLE
fix(backend): branch registry updates

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -101,6 +101,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
             log.info(f"No migrations detected for branch '{obj.name}'")
             obj.graph_version = GRAPH_VERSION
             await obj.save(db=db)
+            registry.branch[obj.name] = obj
             return
 
         # Branch status will remain as so if the migration process fails
@@ -108,6 +109,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
         if obj.status != BranchStatus.NEED_UPGRADE_REBASE:
             obj.status = BranchStatus.NEED_UPGRADE_REBASE
             await obj.save(db=db)
+            registry.branch[obj.name] = obj
 
         try:
             log.info(f"Running migrations for branch '{obj.name}'")
@@ -120,6 +122,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
             obj.status = BranchStatus.OPEN
         obj.graph_version = GRAPH_VERSION
         await obj.save(db=db)
+        registry.branch[obj.name] = obj
 
     if send_events:
         event_context = context.to_event_context()

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -101,7 +101,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
             log.info(f"No migrations detected for branch '{obj.name}'")
             obj.graph_version = GRAPH_VERSION
             await obj.save(db=db)
-            registry.branch[obj.name] = obj
+            registry.refresh_cached_branch(obj)
             return
 
         # Branch status will remain as so if the migration process fails
@@ -109,7 +109,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
         if obj.status != BranchStatus.NEED_UPGRADE_REBASE:
             obj.status = BranchStatus.NEED_UPGRADE_REBASE
             await obj.save(db=db)
-            registry.branch[obj.name] = obj
+            registry.refresh_cached_branch(obj)
 
         try:
             log.info(f"Running migrations for branch '{obj.name}'")
@@ -122,7 +122,7 @@ async def migrate_branch(branch: str, context: InfrahubContext, send_events: boo
             obj.status = BranchStatus.OPEN
         obj.graph_version = GRAPH_VERSION
         await obj.save(db=db)
-        registry.branch[obj.name] = obj
+        registry.refresh_cached_branch(obj)
 
     if send_events:
         event_context = context.to_event_context()

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -163,6 +163,14 @@ class Registry:
 
         raise BranchNotFoundError(identifier=branch)
 
+    def refresh_cached_branch(self, branch: Branch) -> None:
+        """Replace this worker's cached copy of a branch, when it already holds one.
+
+        Do not create, which requires schema loading.
+        """
+        if branch.name in self.branch:
+            self.branch[branch.name] = branch
+
     async def get_branch(
         self,
         db: InfrahubDatabase,

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -253,8 +253,8 @@ class BranchUpdate(Mutation):
         async with graphql_context.db.start_transaction() as db:
             await obj.save(db=db, user_id=graphql_context.active_account_session.account_id)
 
-        # update registry after txn commit, so it cannot diverge from db on failure
-        registry.branch[obj.name] = obj
+        # Update the registry after the txn commits, so it cannot diverge from the db on failure
+        registry.refresh_cached_branch(obj)
 
         return cls(ok=True)
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -253,6 +253,9 @@ class BranchUpdate(Mutation):
         async with graphql_context.db.start_transaction() as db:
             await obj.save(db=db, user_id=graphql_context.active_account_session.account_id)
 
+        # update registry after txn commit, so it cannot diverge from db on failure
+        registry.branch[obj.name] = obj
+
         return cls(ok=True)
 
 

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -39,7 +39,10 @@ async def create_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
 
 
 async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
-    """Update the registry for a branch if the schema hash has changed or the branch was rebased."""
+    """Update the registry for a branch when it no longer matches the database.
+
+    A changed schema hash reloads the schema; any other field difference only replaces the cached ``Branch``.
+    """
     existing_branch: Branch = registry.branch[branch.name]
 
     if not existing_branch.schema_hash:
@@ -63,7 +66,7 @@ async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
                 worker=WORKER_IDENTITY,
             )
             registry.branch[branch.name] = branch
-        elif existing_branch.status != branch.status:
+        elif existing_branch.model_dump(exclude={"schema_hash"}) != branch.model_dump(exclude={"schema_hash"}):
             log.info(f"Updating registry branch cache for {branch.name=}")
             registry.branch[branch.name] = branch
         return

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -7,6 +7,7 @@ from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.log import get_logger
+from infrahub.utils import log_exception_guard
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
@@ -95,10 +96,12 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
                 # have an associated schema
                 continue
 
-            if active_branch.name in registry.branch:
-                await update_branch_registry(db=db, branch=active_branch)
-            else:
-                await create_branch_registry(db=db, branch=active_branch)
+            # Absorb a failure on one branch rather than abandoning the sweep
+            with log_exception_guard(log, f"Failed to refresh branch {active_branch.name!r} in the registry"):
+                if active_branch.name in registry.branch:
+                    await update_branch_registry(db=db, branch=active_branch)
+                else:
+                    await create_branch_registry(db=db, branch=active_branch)
 
         purged_branches = await registry.purge_inactive_branches(db=db, active_branches=active_branches)
         purged_branches.update(

--- a/backend/tests/component/core/merge/conftest.py
+++ b/backend/tests/component/core/merge/conftest.py
@@ -13,8 +13,6 @@ from infrahub.core.rollback import GraphRollbacker
 from infrahub.locks.cleaner import StaleLockCleaner
 
 if TYPE_CHECKING:
-    import pytest
-
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
@@ -24,20 +22,6 @@ if TYPE_CHECKING:
 # Recovery finds the durably flagged branch directly, so the liveness grace period is irrelevant to
 # most tests; those that exercise the MERGING liveness gate override it per-call.
 GRACE_PERIOD_SECONDS = 180
-
-
-def find_logged_event(caplog: pytest.LogCaptureFixture, *, event: str, branch: str) -> dict | None:
-    """Return the structured payload of a captured log entry with the given event name and branch.
-
-    Structured logs are captured as the event dict on the record, so the returned mapping carries the
-    event's bound fields (worker id, timestamps, ...) for the caller to assert on. Returns ``None`` when
-    no matching entry was captured.
-    """
-    for record in caplog.records:
-        message = record.msg
-        if isinstance(message, dict) and message.get("event") == event and message.get("branch") == branch:
-            return message
-    return None
 
 
 class InMemorySchemaRecoverer(MergeFailureRecoverer):

--- a/backend/tests/component/core/merge/test_failure_detection.py
+++ b/backend/tests/component/core/merge/test_failure_detection.py
@@ -15,8 +15,7 @@ from infrahub.services.component import InfrahubComponent
 from infrahub.worker import WORKER_IDENTITY
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
-
-from .conftest import find_logged_event
+from tests.helpers.log import find_logged_event
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase

--- a/backend/tests/component/core/merge/test_recovery.py
+++ b/backend/tests/component/core/merge/test_recovery.py
@@ -23,12 +23,12 @@ from infrahub.services.component import InfrahubComponent
 from infrahub.worker import WORKER_IDENTITY
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
+from tests.helpers.log import find_logged_event
 
 from .conftest import (
     FailAtBranchResetRecoverer,
     FailAtLockReleaseRecoverer,
     build_recovery,
-    find_logged_event,
 )
 
 if TYPE_CHECKING:

--- a/backend/tests/component/core/test_branch_migrate.py
+++ b/backend/tests/component/core/test_branch_migrate.py
@@ -42,6 +42,5 @@ async def test_migrate_branch_publishes_migrated_branch(
     assert migrated_branch.status is BranchStatus.OPEN
 
     published_branch = registry.branch[branch.name]
-    assert published_branch is not branch
     assert published_branch.graph_version == GRAPH_VERSION
     assert published_branch.status is BranchStatus.OPEN

--- a/backend/tests/component/core/test_branch_migrate.py
+++ b/backend/tests/component/core/test_branch_migrate.py
@@ -1,0 +1,47 @@
+from uuid import uuid4
+
+from fast_depends import Provider
+
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import InfrahubContext
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.branch.tasks import migrate_branch
+from infrahub.core.graph import GRAPH_VERSION
+from infrahub.core.initialization import create_branch
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.workers.dependencies import build_database
+
+
+async def test_migrate_branch_publishes_migrated_branch(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+    dependency_provider: Provider,
+) -> None:
+    """The flow migrates an instance of its own, so it has to publish that instance itself."""
+    branch = await create_branch(db=db, branch_name="migrate-branch")
+    assert registry.branch[branch.name] is branch
+
+    # A branch as an upgrade leaves it behind: its graph version trails the application
+    branch.graph_version = GRAPH_VERSION - 1
+    await branch.save(db=db)
+
+    context = InfrahubContext.init(
+        branch=default_branch,
+        account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+    )
+    with dependency_provider.scope(build_database, lambda singleton=True: db):  # noqa: ARG005
+        await migrate_branch(branch=branch.name, context=context, send_events=False)
+
+    migrated_branch = await Branch.get_by_name(db=db, name=branch.name)
+    assert migrated_branch.graph_version == GRAPH_VERSION
+    assert migrated_branch.status is BranchStatus.OPEN
+
+    published_branch = registry.branch[branch.name]
+    assert published_branch is not branch
+    assert published_branch.graph_version == GRAPH_VERSION
+    assert published_branch.status is BranchStatus.OPEN

--- a/backend/tests/component/graphql/mutations/test_branch.py
+++ b/backend/tests/component/graphql/mutations/test_branch.py
@@ -588,9 +588,8 @@ async def test_branch_update_description(
 
     branch4_updated = await Branch.get_by_name(db=db, name="branch4")
 
-    # The mutation publishes the branch it saved, so the cache stops holding the pre-update instance
+    # The mutation publishes what it saved, so the cache reflects the committed description
     cached_branch4 = registry.branch["branch4"]
-    assert cached_branch4 is not branch4
     assert cached_branch4.description == "testing"
     assert cached_branch4.description == branch4_updated.description
 

--- a/backend/tests/component/graphql/mutations/test_branch.py
+++ b/backend/tests/component/graphql/mutations/test_branch.py
@@ -588,6 +588,12 @@ async def test_branch_update_description(
 
     branch4_updated = await Branch.get_by_name(db=db, name="branch4")
 
+    # The mutation publishes the branch it saved, so the cache stops holding the pre-update instance
+    cached_branch4 = registry.branch["branch4"]
+    assert cached_branch4 is not branch4
+    assert cached_branch4.description == "testing"
+    assert cached_branch4.description == branch4_updated.description
+
     assert branch4.updated_at == branch4.created_at
     assert branch4_updated.description == "testing"
     assert branch4.updated_at

--- a/backend/tests/component/graphql/mutations/test_branch.py
+++ b/backend/tests/component/graphql/mutations/test_branch.py
@@ -601,6 +601,51 @@ async def test_branch_update_description(
     assert branch4_updated.updated_by == session_admin.account_id
 
 
+async def test_branch_update_leaves_an_unknown_branch_out_of_the_registry(
+    db: InfrahubDatabase, base_dataset_02: dict, session_admin: AccountSession, local_services: InfrahubServices
+) -> None:
+    """A branch this worker has never seen must stay out of the cache, so refresh_branches still creates it.
+
+    `Branch.get_by_name` does not load the schema, so caching it here would leave an entry that the sweep
+    treats as already present and never repairs.
+    """
+    branch5 = await create_branch(branch_name="branch5", db=db)
+    # Undo what create_branch cached: this stands in for a branch created on another worker
+    del registry.branch[branch5.name]
+
+    query = """
+    mutation {
+    BranchUpdate(
+        data: {
+        name: "branch5",
+        description: "testing"
+        }
+    ) {
+        ok
+    }
+    }
+    """
+
+    gql_params = await prepare_graphql_params(
+        db=db, branch=registry.default_branch, account_session=session_admin, service=local_services
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["BranchUpdate"]["ok"] is True
+
+    # The write still landed; only the cache was left for the sweep to populate
+    assert (await Branch.get_by_name(db=db, name="branch5")).description == "testing"
+    assert branch5.name not in registry.branch
+
+
 async def test_branch_merge_wrong_branch(
     db: InfrahubDatabase,
     base_dataset_02: dict[str, Any],

--- a/backend/tests/component/tasks/test_registry.py
+++ b/backend/tests/component/tasks/test_registry.py
@@ -8,6 +8,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.tasks.registry import refresh_branches
+from tests.helpers.log import find_logged_events
 
 
 async def test_refresh_branches_continues_past_a_branch_it_cannot_refresh(
@@ -38,12 +39,7 @@ async def test_refresh_branches_continues_past_a_branch_it_cannot_refresh(
         await refresh_branches(db=db)
 
     # The branch it gave up on has to be reported, with its traceback: absorbed is not silent
-    failures = [
-        record.msg
-        for record in caplog.records
-        if isinstance(record.msg, dict)
-        and record.msg.get("event") == f"Failed to refresh branch '{broken_branch.name}' in the registry"
-    ]
+    failures = find_logged_events(caplog, event=f"Failed to refresh branch '{broken_branch.name}' in the registry")
     assert len(failures) == 1
     assert failures[0]["level"] == "error"
     assert failures[0]["exc_info"]

--- a/backend/tests/component/tasks/test_registry.py
+++ b/backend/tests/component/tasks/test_registry.py
@@ -45,3 +45,37 @@ async def test_refresh_branches_continues_past_a_branch_it_cannot_refresh(
     assert failures[0]["exc_info"]
 
     assert registry.branch[stale_branch.name].branched_from == rebased_branch.branched_from
+
+
+async def test_refresh_branches_syncs_a_field_that_only_changed_in_the_database(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+) -> None:
+    """A change that leaves the schema hash, branched_from and status alone must still reach the cache."""
+    branch = await create_branch(db=db, branch_name="described-branch")
+
+    # Stands in for a BranchUpdate that ran on another worker
+    updated_branch = await Branch.get_by_name(db=db, name=branch.name)
+    updated_branch.description = "written on another worker"
+    await updated_branch.save(db=db)
+    assert registry.branch[branch.name].description != updated_branch.description
+
+    await refresh_branches(db=db)
+
+    assert registry.branch[branch.name].description == updated_branch.description
+
+
+async def test_refresh_branches_leaves_an_unchanged_branch_alone(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+) -> None:
+    """A freshly loaded copy of an unchanged branch must compare equal to the cached one, or every sweep replaces it."""
+    branch = await create_branch(db=db, branch_name="quiet-branch")
+    cached = registry.branch[branch.name]
+
+    await refresh_branches(db=db)
+    await refresh_branches(db=db)
+
+    assert registry.branch[branch.name] is cached

--- a/backend/tests/component/tasks/test_registry.py
+++ b/backend/tests/component/tasks/test_registry.py
@@ -1,0 +1,53 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import NULL_VALUE
+from infrahub.core.initialization import create_branch
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.tasks.registry import refresh_branches
+
+
+async def test_refresh_branches_continues_past_a_branch_it_cannot_refresh(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The sweep is the only thing that repairs a stale cache entry, so one bad branch must not end it."""
+    broken_branch = await create_branch(db=db, branch_name="broken-branch")
+    stale_branch = await create_branch(db=db, branch_name="stale-branch")
+
+    # A branch row whose schema hash never reached storage — how the global branch and a graph
+    # predating the field look. Reading it back raises from Branch.active_schema_hash
+    await db.execute_query(
+        query="MATCH (n:Branch {name: $branch_name}) SET n.schema_hash = $null_value",
+        params={"branch_name": broken_branch.name, "null_value": NULL_VALUE},
+    )
+    assert (await Branch.get_by_name(db=db, name=broken_branch.name)).schema_hash is None
+
+    # Something for the sweep to pick up: a rebase timestamp that only exists in the database
+    rebased_branch = await Branch.get_by_name(db=db, name=stale_branch.name)
+    rebased_branch.branched_from = Timestamp().to_string()
+    await rebased_branch.save(db=db)
+    assert registry.branch[stale_branch.name].branched_from != rebased_branch.branched_from
+
+    with caplog.at_level("ERROR", logger="infrahub"):
+        await refresh_branches(db=db)
+
+    # The branch it gave up on has to be reported, with its traceback: absorbed is not silent
+    failures = [
+        record.msg
+        for record in caplog.records
+        if isinstance(record.msg, dict)
+        and record.msg.get("event") == f"Failed to refresh branch '{broken_branch.name}' in the registry"
+    ]
+    assert len(failures) == 1
+    assert failures[0]["level"] == "error"
+    assert failures[0]["exc_info"]
+
+    published_branch = registry.branch[stale_branch.name]
+    assert published_branch is not stale_branch
+    assert published_branch.branched_from == rebased_branch.branched_from

--- a/backend/tests/component/tasks/test_registry.py
+++ b/backend/tests/component/tasks/test_registry.py
@@ -48,6 +48,4 @@ async def test_refresh_branches_continues_past_a_branch_it_cannot_refresh(
     assert failures[0]["level"] == "error"
     assert failures[0]["exc_info"]
 
-    published_branch = registry.branch[stale_branch.name]
-    assert published_branch is not stale_branch
-    assert published_branch.branched_from == rebased_branch.branched_from
+    assert registry.branch[stale_branch.name].branched_from == rebased_branch.branched_from

--- a/backend/tests/helpers/log.py
+++ b/backend/tests/helpers/log.py
@@ -1,15 +1,17 @@
-"""Install the infrahub.log traceback suppression filter for a test, then remove it again."""
+"""Helpers for asserting on what the code under test logged."""
 
 from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from infrahub.log import PREFECT_RUN_LOGGERS, install_traceback_suppression_filter
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    import pytest
 
     from infrahub.log import TracebackSuppressionFilter
 
@@ -23,3 +25,25 @@ def traceback_suppression() -> Iterator[TracebackSuppressionFilter]:
     finally:
         for prefect_logger_name in PREFECT_RUN_LOGGERS:
             logging.getLogger(prefect_logger_name).removeFilter(traceback_filter)
+
+
+def find_logged_events(caplog: pytest.LogCaptureFixture, *, event: str, **fields: Any) -> list[dict]:
+    """Return the structured payloads of the captured log entries with the given event name and bound fields.
+
+    Structured logs are captured as the event dict on the record, so each returned mapping carries the
+    event's bound fields (level, worker id, timestamps, ...) for the caller to assert on. Pass any of those
+    fields as a keyword to narrow the match; entries are returned in the order they were captured.
+    """
+    return [
+        record.msg
+        for record in caplog.records
+        if isinstance(record.msg, dict)
+        and record.msg.get("event") == event
+        and all(record.msg.get(name) == value for name, value in fields.items())
+    ]
+
+
+def find_logged_event(caplog: pytest.LogCaptureFixture, *, event: str, **fields: Any) -> dict | None:
+    """Return the structured payload of the first matching log entry, or ``None`` when none was captured."""
+    matches = find_logged_events(caplog, event=event, **fields)
+    return matches[0] if matches else None

--- a/backend/tests/unit/core/test_registry.py
+++ b/backend/tests/unit/core/test_registry.py
@@ -1,0 +1,25 @@
+from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.registry import Registry
+
+
+def _branch(name: str, description: str = "") -> Branch:
+    return Branch(name=name, description=description, status=BranchStatus.OPEN, is_default=False, sync_with_git=False)
+
+
+def test_refresh_cached_branch_replaces_an_entry_the_worker_holds() -> None:
+    registry = Registry()
+    registry.branch["branch1"] = _branch("branch1")
+
+    registry.refresh_cached_branch(_branch("branch1", description="updated"))
+
+    assert registry.branch["branch1"].description == "updated"
+
+
+def test_refresh_cached_branch_leaves_a_branch_the_worker_does_not_hold_uncached() -> None:
+    """Inserting here would cache a branch without its schema, which refresh_branches never repairs."""
+    registry = Registry()
+
+    registry.refresh_cached_branch(_branch("branch1"))
+
+    assert "branch1" not in registry.branch

--- a/changelog/+branch-update-registry-cache.fixed.md
+++ b/changelog/+branch-update-registry-cache.fixed.md
@@ -1,0 +1,1 @@
+Update the in-memory cache for branches following a BranchUpdate mutation or a run of the migrate_branch task.

--- a/changelog/+branch-update-registry-cache.fixed.md
+++ b/changelog/+branch-update-registry-cache.fixed.md
@@ -1,1 +1,1 @@
-Update the in-memory cache for branches following a BranchUpdate mutation or a run of the migrate_branch task.
+Update the in-memory cache for branches after a branch change is saved to prevent the cache diverging from the database. The BranchUpdate mutation and the Prefect task to run database migrations against a branch are both fixed.

--- a/changelog/+refresh-branches-per-branch-failure.fixed.md
+++ b/changelog/+refresh-branches-per-branch-failure.fixed.md
@@ -1,0 +1,1 @@
+A branch that cannot be refreshed into a worker's in-memory registry no longer aborts the periodic branch refresh. The failure is logged and the remaining branches are still refreshed.


### PR DESCRIPTION
two or three small fixes
1. update branch registry during a BranchUpdate mutation once it succeeds
2. update branch registry in the `migrate_branch` task when branch state is saved to the database
3. if an error is raised during the `refresh_branches` task, log the exception and continue, so that other branches can still be refreshed

the first two show the need for a `BranchSaver` component that would handle making the change to the database and then updating the registry so that they cannot get out of sync

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

