### PR TITLE
fix(backend): rebase schema migration rollback shouldn't delete branch data

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -246,12 +246,15 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                 log.info("Running migrations")
                 rebased_schema = await registry.schema.load_schema_from_db(db=db, branch=user_branch)
                 migrations = await schema_analyzer.calculate_migrations(target_schema=rebased_schema)
+                # The schema migrations need a unique timestamp so that a rollback on failure will
+                # not try to erase changes made during the graph rebase and destroy the branch.
+                migration_at = rebase_at.add(microseconds=1)
                 await schema_update_coordinator.execute(
                     branch=user_branch,
                     origin_schema=migration_baseline_schema,
                     rollback_schema=pre_rebase_schema,
                     candidate_schema=rebased_schema,
-                    at=rebase_at,
+                    at=migration_at,
                     context=context,
                     migration_executor=MigrationExecutor.WORKFLOW if send_events else MigrationExecutor.DIRECT,
                     migrations=migrations,

--- a/backend/tests/component/core/test_branch_rebase.py
+++ b/backend/tests/component/core/test_branch_rebase.py
@@ -414,3 +414,64 @@ async def test_rebase_schemas_handed_to_the_update_coordinator(
     # The restored hash has to reach storage, not just the in-memory registry the rollback wrote
     reloaded_branch = await Branch.get_by_name(db=db, name=rollback_branch.name)
     assert reloaded_branch.active_schema_hash.main == rollback_pre_rebase_hash
+
+
+async def test_failed_rebase_keeps_the_branch_data(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    dependency_provider: Provider,
+    workflow_recorder: WorkflowRecorder,
+    register_core_models_schema: SchemaBranch,
+) -> None:
+    """A rollback after failed migrations must not take the branch's own data with it."""
+    widget_kind = "TestingWidget"
+    gadget_kind = "TestingGadget"
+    widget = NodeSchema(
+        name="Widget",
+        namespace="Testing",
+        default_filter="name__value",
+        attributes=[AttributeSchema(name="name", kind="Text")],
+    )
+    gadget = NodeSchema(
+        name="Gadget",
+        namespace="Testing",
+        default_filter="name__value",
+        attributes=[AttributeSchema(name="name", kind="Text")],
+    )
+    await load_schema(db=db, schema=SchemaRoot(nodes=[widget, gadget]), update_db=True)
+
+    branch = await create_branch(db=db, branch_name="failed-rebase-branch")
+
+    branch_widget = await Node.init(db=db, schema=widget_kind, branch=branch)
+    await branch_widget.new(db=db, name="widget-on-branch")
+    await branch_widget.save(db=db)
+
+    # A schema change of the branch's own, on a kind the destination never touches, so the rebase
+    # runs migrations at all without reporting a conflict
+    branch_gadget = gadget.duplicate()
+    branch_gadget.attributes.append(AttributeSchema(name="serial", kind="Text", optional=True))
+    await load_schema(
+        db=db,
+        schema=SchemaRoot(nodes=[branch_gadget]),
+        branch_name=branch.name,
+        update_db=True,
+        limit=[gadget_kind],
+    )
+
+    # A node created on the destination after the fork, so the rebase has something to pull in
+    main_widget = await Node.init(db=db, schema=widget_kind)
+    await main_widget.new(db=db, name="widget-on-main")
+    await main_widget.save(db=db)
+
+    context = InfrahubContext.init(
+        branch=default_branch,
+        account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+    )
+    with dependency_provider.scope(build_database, lambda singleton=True: db):  # noqa: ARG005
+        workflow_recorder.execute_results[SCHEMA_APPLY_MIGRATION.name] = ["migration failed on purpose"]
+        with pytest.raises(MigrationError):
+            await rebase_branch(branch=branch.name, context=context)
+
+    rolled_back_branch = await Branch.get_by_name(db=db, name=branch.name)
+    widgets = await NodeManager.query(db=db, schema=widget_kind, branch=rolled_back_branch)
+    assert sorted(str(node.get_attribute("name").value) for node in widgets) == ["widget-on-branch", "widget-on-main"]


### PR DESCRIPTION
If the graph portion of a rebase succeeds, but the schema migration fails and rolls back, then the rollback would delete all data on the branch. This is because the graph rebase and the schema migration use the same timestamp and a rollback undoes all changes at its given timestamp. This simple fix just gives the rebase's schema migrations a timestamp one microsecond after the graph rebase. The branch will still be left in broken state following a failed rebase, but it will NOT be erased.

### How the rebase works

A rebase runs a couple of cypher queries that update every `from` and `to` time edited on the branch to be the `at` timestamp of the rebase. It also sets the `branched_from` time of the branch to the same `at` timestamp. The effect is that all the changes on the default branch before `at` are now included on the rebased branch.

If there are schema changes then the rebase operation needs to run schema migrations and these run inside of the `SchemaUpdateCoordinator`, which will rollback all the changes on its `at` timestamp in the event of a failed schema migration. If all changes on the rebasing branch have been updated to have a timestamp of `at`, then they will all be rolled back. The end result would be all of the data on the branch is deleted.

### The fix

The simple fix for this exact issue is to just move the migration timestamp 1 microsecond later, so that, if a schema migration fails, only the schema changes are rolled back and not _every_ change on the branch.

### Outstanding issues

The rollback will still leave the branch in a broken state, although less broken than before. The branch's `branched_from` time and all of its data will be set to `at`, but none of the necessary schema migrations will have run, and there is currently no way to recover the schema migrations that need to run.

This is the issue to more completely address handling a rebase failure: https://opsmill.atlassian.net/browse/IFC-3055

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

