### PR TITLE
docs: add agent rule for changelog fragment content

### DIFF
--- a/.agents/rules/changelog-entries.md
+++ b/.agents/rules/changelog-entries.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "changelog/*.md"
+---
+
+# Changelog entries
+
+Every file here is a Towncrier fragment that is published verbatim in the product's release
+notes. The audience is people who run and use Infrahub, not the people who wrote the patch.
+They read it to answer one question: does this change affect me, and what do I do differently
+now?
+
+Mechanics (naming, change types, `towncrier create`) are covered by the
+`creating-changelog-entries` skill and `docs/docs/development/changelog.mdx`. This rule is about
+what the text says.
+
+## Write for the user, not the reviewer
+
+State the change in terms of what a user sees, does, or no longer has to work around. A reader
+who has never opened the codebase must be able to tell whether the entry concerns them.
+
+- For a fix: what went wrong from the outside - what looked broken, was rejected, was slow, was
+  silently lost - and that it no longer does.
+- For a feature or change: what is now possible, and anything the user must do differently
+  (a changed default, a new field, a value that is no longer accepted).
+
+Frame it around the user-facing surface they already know - the UI, the API and its fields, the
+CLI, branches, schema, the upgrade - not around the internals that implement it.
+
+## Leave the implementation out
+
+Skip module paths, class and function names, internal services, database and query details,
+and the shape of the fix. If a detail only makes sense to someone reading the diff, it does not
+belong in the changelog. That reasoning belongs in the commit message, the PR description, or
+`dev/knowledge/`.
+
+Avoid:
+
+- "Refactored the branch-diff resolver to short-circuit on empty payloads."
+- "Fixed a `None` dereference in `SchemaBranch.process_inheritance`."
+
+Prefer:
+
+- "Fixed the diff view timing out on branches with no changes."
+- "Fixed an error when saving a schema where a node inherits from a generic."
+
+## Say why it matters when it isn't obvious
+
+One extra sentence is worth it when the user cannot otherwise judge the impact: which
+installations are affected, whether data was wrong in a way they may still be looking at,
+whether anything happens automatically on upgrade, or what they need to do. Skip it when the
+first sentence already answers "does this affect me?" - length is not the goal, and an entry
+that pads a one-line fix reads as noise.
+
+## Style
+
+- Past tense, describing the change as shipped ("Fixed …", "Added …", "Removed …").
+- Start with the change, not with the context that led to it.
+- One sentence by default. Only go longer for the impact above, and keep it plain prose.
+- No issue numbers or PR links in the body. The filename carries that reference: the part before
+  the change type is the GitHub issue the change closes (`1234.fixed.md`), and Towncrier turns it
+  into a link appended to the rendered entry. A change with no issue behind it uses the `+`
+  prefix and a short slug instead (`+block-user-branched-from.fixed.md`), which renders with no
+  link. Either way, don't restate the reference in the text.
+- Refer to things by the names the product uses in the UI, the docs, and the API.


### PR DESCRIPTION
# Why

Changelog fragments regularly get written as if the reader had the diff in front of them: module
paths, class names, and the shape of the fix. Towncrier publishes those files verbatim in the
release notes, where the audience is people running Infrahub, not the people who wrote the patch.

The `creating-changelog-entries` skill covers the mechanics (naming, change types,
`towncrier create`), but nothing is attached to the files themselves at edit time.

## What changed

- New rule `.agents/rules/changelog-entries.md`, scoped to `changelog/*.md`, so it loads whenever
  a fragment is being written or edited.
- The rule covers content only and defers mechanics to the existing skill and
  `docs/docs/development/changelog.mdx` rather than duplicating them:
  - **Write for the user, not the reviewer** - frame the change against the UI, API, CLI,
    branches, schema, or upgrade; for a fix, what looked broken from the outside.
  - **Leave the implementation out** - with avoid/prefer examples.
  - **Say why it matters when it isn't obvious** - one extra sentence for impact, explicitly not
    license to pad a one-line fix.
  - **Style** - past tense, lead with the change, one sentence by default, and no issue
    references in the body since the filename carries them and Towncrier renders the link.

`.claude/rules` is a symlink to `.agents/rules`, so no adapter mirroring was needed.

## How to review

Read the rule against the fragments currently in `changelog/` - they are the examples the
guidance was calibrated against.

## Impact & rollout

Documentation for AI coding agents only. No product code, no behavior change.

## Checklist

- [ ] Tests added/updated
- [ ] [Changelog entry](../.agents/skills/creating-changelog-entries/SKILL.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

