### PR TITLE
test: key the Prefect task manager setup memo on the server

### DIFF
--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -1,9 +1,18 @@
-"""Run the Prefect task manager setup once per test process.
+"""Run the Prefect task manager setup once per Prefect server.
 
 The task manager setup registers blocks, worker pools, deployments and builtin
-triggers against the per-process Prefect test server. The inputs are static and
-the calls are slow (several seconds of API round-trips), so fixtures should reuse
-a single setup per process instead of repeating it for every test or test class.
+triggers against the Prefect server the current settings point at. The inputs are
+static and the calls are slow (several seconds of API round-trips), so fixtures
+should reuse a single setup per server instead of repeating it for every test or
+test class.
+
+The memoization is keyed on the Prefect API URL, not on the process. A single
+test process talks to more than one Prefect server: the session-scoped
+``prefect_test_fixture`` runs an ephemeral in-process harness, while the
+module-scoped ``prefect`` fixture points ``PREFECT_API_URL`` at a testcontainer
+for the duration of a module. Memoizing per process let the first server's setup
+satisfy the second one's fixtures, leaving that server without deployments —
+``setup_triggers`` then raised ``KeyError`` on the empty deployment mapping.
 
 A failure is remembered the same way a success is. An unreachable Prefect test
 server does not fail fast — the setup blocks until the pytest timeout fires — so
@@ -16,20 +25,33 @@ themselves before yielding back, otherwise later tests will observe the corrupti
 
 from collections.abc import Awaitable, Callable
 
+from prefect.settings import get_current_settings
+
 from infrahub.workflows.initialization import setup_task_manager
 
 
+def _current_prefect_api_url() -> str | None:
+    return get_current_settings().api.url
+
+
 class TaskManagerSetup:
-    def __init__(self, setup: Callable[[], Awaitable[None]] = setup_task_manager) -> None:
+    def __init__(
+        self,
+        setup: Callable[[], Awaitable[None]] = setup_task_manager,
+        server_key: Callable[[], str | None] = _current_prefect_api_url,
+    ) -> None:
         self._setup = setup
-        self._initialized = False
-        self._failure: BaseException | None = None
+        self._server_key = server_key
+        self._initialized: set[str | None] = set()
+        self._failures: dict[str | None, BaseException] = {}
 
     async def run_once(self) -> None:
-        if self._failure is not None:
-            raise RuntimeError("Prefect task manager setup already failed in this process") from self._failure
+        server = self._server_key()
 
-        if self._initialized:
+        if server in self._failures:
+            raise RuntimeError(f"Prefect task manager setup already failed for {server}") from self._failures[server]
+
+        if server in self._initialized:
             return
 
         try:
@@ -37,10 +59,10 @@ class TaskManagerSetup:
         # The pytest timeout raises Failed, which derives from BaseException, and that is
         # the failure worth remembering most.
         except BaseException as exc:
-            self._failure = exc
+            self._failures[server] = exc
             raise
 
-        self._initialized = True
+        self._initialized.add(server)
 
 
 _setup = TaskManagerSetup()

--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -6,13 +6,14 @@ static and the calls are slow (several seconds of API round-trips), so fixtures
 should reuse a single setup per server instead of repeating it for every test or
 test class.
 
-The memoization is keyed on the Prefect API URL, not on the process. A single
-test process talks to more than one Prefect server: the session-scoped
-``prefect_test_fixture`` runs an ephemeral in-process harness, while the
-module-scoped ``prefect`` fixture points ``PREFECT_API_URL`` at a testcontainer
-for the duration of a module. Memoizing per process let the first server's setup
-satisfy the second one's fixtures, leaving that server without deployments —
-``setup_triggers`` then raised ``KeyError`` on the empty deployment mapping.
+The memoization is keyed on the Prefect API URL, not on the process. One test
+process talks to more than one Prefect server — an ephemeral in-process one for
+the whole session and a container that modules opt into — and each needs its own
+registration; a setup done against one server says nothing about the other.
+
+The memo assumes every server it has seen lives for the rest of the process. A
+server torn down and recreated at a URL the memo already holds would be skipped,
+so callers must only target session-lived servers.
 
 A failure is remembered the same way a success is. An unreachable Prefect test
 server does not fail fast — the setup blocks until the pytest timeout fires — so

--- a/backend/tests/unit/helpers/test_task_manager.py
+++ b/backend/tests/unit/helpers/test_task_manager.py
@@ -29,9 +29,19 @@ class FailingSetup(RecordingSetup):
         raise self.error
 
 
+class MovingServer:
+    """Stands in for the settings lookup, so a test can move the API URL between calls."""
+
+    def __init__(self, url: str | None = "http://server-a/api") -> None:
+        self.url = url
+
+    def __call__(self) -> str | None:
+        return self.url
+
+
 async def test_setup_runs_once_across_repeated_calls() -> None:
     setup = RecordingSetup()
-    once = TaskManagerSetup(setup=setup)
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer())
 
     await once.run_once()
     await once.run_once()
@@ -40,16 +50,36 @@ async def test_setup_runs_once_across_repeated_calls() -> None:
     assert setup.calls == 1
 
 
+async def test_setup_runs_again_for_a_different_server() -> None:
+    """A process talks to several Prefect servers; each needs its own deployments registered."""
+    setup = RecordingSetup()
+    server = MovingServer("http://harness/api")
+    once = TaskManagerSetup(setup=setup, server_key=server)
+
+    await once.run_once()
+    server.url = "http://container/api"
+    await once.run_once()
+    await once.run_once()
+
+    assert setup.calls == 2
+
+    # Coming back to the first server still reuses its setup.
+    server.url = "http://harness/api"
+    await once.run_once()
+
+    assert setup.calls == 2
+
+
 async def test_failed_setup_is_reported_without_being_rerun() -> None:
     setup = FailingSetup(TimeoutError("prefect server is unreachable"))
-    once = TaskManagerSetup(setup=setup)
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://server-a/api"))
 
     with pytest.raises(TimeoutError, match=r"^prefect server is unreachable$"):
         await once.run_once()
 
     for _ in range(3):
         with pytest.raises(
-            RuntimeError, match=r"^Prefect task manager setup already failed in this process$"
+            RuntimeError, match=r"^Prefect task manager setup already failed for http://server-a/api$"
         ) as exc_info:
             await once.run_once()
         assert isinstance(exc_info.value.__cause__, TimeoutError)
@@ -57,14 +87,30 @@ async def test_failed_setup_is_reported_without_being_rerun() -> None:
     assert setup.calls == 1
 
 
+async def test_failure_is_remembered_per_server() -> None:
+    """One unreachable server must not condemn the next one the process points at."""
+    setup = FailingSetup(TimeoutError("prefect server is unreachable"))
+    server = MovingServer("http://broken/api")
+    once = TaskManagerSetup(setup=setup, server_key=server)
+
+    with pytest.raises(TimeoutError):
+        await once.run_once()
+
+    server.url = "http://healthy/api"
+    with pytest.raises(TimeoutError):
+        await once.run_once()
+
+    assert setup.calls == 2
+
+
 async def test_failure_that_bypasses_exception_is_remembered() -> None:
     setup = FailingSetup(TimeoutFailure("Timeout >300.0s"))
-    once = TaskManagerSetup(setup=setup)
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://server-a/api"))
 
     with pytest.raises(TimeoutFailure, match=r"^Timeout >300\.0s$"):
         await once.run_once()
 
-    with pytest.raises(RuntimeError, match=r"^Prefect task manager setup already failed in this process$"):
+    with pytest.raises(RuntimeError, match=r"^Prefect task manager setup already failed for http://server-a/api$"):
         await once.run_once()
 
     assert setup.calls == 1

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -432,6 +432,29 @@ it. Two rules follow:
   comparison saturates and can never be true again. Read newest-first
   (`FlowRunSort.EXPECTED_START_TIME_DESC`) and identify the run by its id or parameters instead.
 
+### A Component Test Process Talks to Two Prefect Servers
+
+There is no single "the Prefect server" in a component test process. Two fixtures each provide one,
+and which is current depends on the fixtures the test asked for:
+
+| Fixture | Scope | Server |
+|---------|-------|--------|
+| `prefect_test_fixture` (autouse, `component/conftest.py`) | session | ephemeral `prefect_test_harness` subprocess |
+| `prefect` (`tests/conftest.py`) | **module** | `prefect_container`, via a `temporary_settings` override of `PREFECT_API_URL` |
+
+The `prefect` override lasts only as long as the module that requested it. A test that does not
+depend on `prefect` therefore falls back to the harness server, even in a process where the
+container is running — `component/api/conftest.py::workflow_local` and
+`TestInfrahubApp.workflow_local` sit on opposite sides of this line.
+
+**Never memoize server-side registration per process.** `setup_task_manager` registers blocks,
+worker pools, deployments and builtin triggers against whichever server is current, so a
+process-wide "already done" flag lets the first server's setup satisfy fixtures pointing at the
+second. The second server then has no deployments, and `setup_triggers` raises `KeyError` on the
+empty deployment mapping rather than failing anywhere near the cause.
+`tests/helpers/task_manager.py` keys its memo on `get_current_settings().api.url` for this reason;
+anything else cached against a Prefect server needs the same treatment.
+
 ### Functional Tests with `TestInfrahubApp`
 
 `TestInfrahubApp` provides a `memory_cache` fixture (class-scoped) that injects a `MemoryCache` via `dependency_provider.scope(build_cache, ...)`. Use it in functional tests to pre-fill and assert on cache state:


### PR DESCRIPTION
## Summary

`backend-tests-component (other)` has been failing on every run since 92eaffbf1 landed — on `stable` and on every PR branched from it. This is a hard regression, not a flake: the job fails the same way every time, so nobody gets a green CI signal on `stable`.

This restores the job to green.

## Key Changes

- The Prefect task manager setup is memoized **per Prefect server** instead of per process, so every server a test process talks to gets its deployments registered.
- A failed setup is likewise remembered per server, so one unreachable Prefect server no longer condemns the next one a module points at.
- `dev/knowledge/backend/testing.md` now records that a component test process runs two Prefect servers, and the rule that follows from it.

## Root Cause

There is no single "the Prefect server" in a component test process. Two fixtures each provide one:

| Fixture | Scope | Server |
|---------|-------|--------|
| `prefect_test_fixture` (autouse) | session | ephemeral `prefect_test_harness` subprocess |
| `prefect` | **module** | `prefect_container`, via a `temporary_settings` override of `PREFECT_API_URL` |

`setup_task_manager_once()` memoized per process. 92eaffbf1 moved `ScopedRecomputeTestBase.workflow_recorder` (which depends on `prefect` → container) onto that memo, but `component/api/conftest.py::workflow_local` is function-scoped with no `prefect` dependency, so it runs against the harness — and on `gw0` the api tests go first and claim the memo.

The container therefore never had its deployments registered. `read_deployments()` returned nothing, and `setup_triggers` did `mapping[self.name]` on an empty dict:

```
backend/infrahub/trigger/models.py:235: in get_prefect
    deployment_id = mapping[self.name]
E   KeyError: 'computed_attribute_process_transform'
```

Proven by probing the URL at each call site:

```
[PROBE] setup_task_manager_once -> api_url=http://127.0.0.1:14659/api  initialized=False  ← harness (api test)
[PROBE] setup_task_manager_once -> api_url=http://localhost:41167/api  initialized=True   ← container, skipped
```

The `transform` vs `jinja2` variation between runs is only which module the shard scheduled first.

This keeps what 92eaffbf1 was after — the per-class re-runs that burned a 300s pytest timeout each against a wedged server are still gone — while stopping one server's registration from standing in for another's.

## Failing Runs

- [`32835658586`](https://github.com/opsmill/infrahub/actions/runs/32835658586/job/97773746498) — 9 failed, `KeyError: 'computed_attribute_process_transform'`
- [`32835468017`](https://github.com/opsmill/infrahub/actions/runs/32835468017/job/97763472270) (`stable`) — 5 failed, `KeyError: 'computed_attribute_process_jinja2'`

## Documentation Updates

- `dev/knowledge/backend/testing.md` — new *A Component Test Process Talks to Two Prefect Servers* section, next to the existing note on Prefect server state outliving the test class.

## Test Plan

Deterministic repro — **fails on the parent commit, passes here** (~65s, no full suite needed):

```bash
INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest --no-cov -p no:randomly --neo4j \
  backend/tests/component/api/test_40_schema.py::test_schema_load_blocked_on_merged_branch \
  backend/tests/component/computed_attribute/test_scoped_recompute_python.py
```

Also run locally:

- `api/test_40_schema.py` + `computed_attribute/` + `trigger/` in one process — **59 passed**
- `backend/tests/unit/helpers/test_task_manager.py` — **5 passed** (2 new: re-setup on a new server, per-server failure isolation)
- `ruff format`, `ruff check`, `mypy` clean on the changed files

CI check to watch: **backend-tests-component (other)**.

## Notes

Test-only change, so no changelog fragment — matching 9ce068665 and 92eaffbf1.

The underlying fixture asymmetry remains: `component/api/conftest.py::workflow_local` targets a different Prefect server than every `prefect`-based fixture. This PR makes that harmless rather than resolving it. Converging them onto one server is a larger change to which server those api tests run against, and is left for a follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

