### PR TITLE
chore(agents): make pre-ci detect changed areas and close the frontend gap

### DIFF
--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -4,10 +4,12 @@ argument-hint: "[--fast] [--all]"
 allowed-tools:
   - Bash(git merge-base:*)
   - Bash(git diff:*)
-  - Bash(git status:*)
+  - Bash(git ls-files:*)
   - Bash(git rev-parse:*)
+  - Bash(sort:*)
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
+  - Bash(uv run ty check:*)
   - Bash(uv run yamllint:*)
   - Bash(uv run --directory python_testcontainers pytest:*)
   - Bash(uv lock --check:*)
@@ -42,23 +44,28 @@ them as `cd frontend/app && ...`.
 Run this first. Everything after it is conditional on the result.
 
 ```bash
-BASE_REF=$(for R in origin/develop origin/stable; do
-  git rev-parse --verify --quiet "$R" >/dev/null 2>&1 || continue
-  echo "$(git rev-list --count "$(git merge-base HEAD "$R")"..HEAD) $R"
-done | sort -n | head -1 | cut -d' ' -f2)
+BASE_REF=origin/stable
+if git rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then
+  git merge-base --is-ancestor "$(git merge-base HEAD origin/stable)" \
+    "$(git merge-base HEAD origin/develop)" && BASE_REF=origin/develop
+fi
 MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
-{ git diff --name-only "$MERGE_BASE"...HEAD; git status --porcelain | cut -c4- | sed 's/.* -> //'; } | sort -u
+{ git diff --name-only --no-renames "$MERGE_BASE"...HEAD
+  git diff --name-only --no-renames HEAD
+  git ls-files --others --exclude-standard
+} | sort -u
 ```
 
-Both `develop` and `stable` exist, and a branch may be cut from either, so the loop picks
-whichever candidate leaves HEAD fewest commits ahead — that is the one this branch actually
-forked from. Preferring `develop` unconditionally would diff a `stable`-based branch against a
-merge base tens of commits back and report every area as changed.
+Both `develop` and `stable` exist, and a branch may be cut from either, so pick the candidate
+whose merge base sits **closer to HEAD** — that is the one this branch actually forked from.
+Preferring `develop` unconditionally would diff a `stable`-based branch against a merge base tens
+of commits back and report every area as changed.
 
 The list covers **both committed and uncommitted** work — CI sees the former, you are about to
-push the latter, so both must pass. The `sed` unwraps `git status`'s rename form
-(`R  old -> new`), which would otherwise be classified as the single literal path `old -> new`
-and match no area at all.
+push the latter, so both must pass. `--no-renames` matters: with rename detection on, a moved
+file reports only its new path, so the area that lost the file is never flagged. Every command
+here is in `allowed-tools`; keep it that way, and do not reach for `git status --porcelain`
+parsing, whose `R  old -> new` form collapses into one bogus path.
 
 Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
 file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
@@ -139,7 +146,12 @@ at a time.
    `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else
    (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the
    whole-repo check proves CI will pass.
-3. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
+3. `uv run ty check .` — the `python-lint` job's third step, whole-repo like CI. **Easy to
+   miss**: `ty` is otherwise only reachable through Phase 4B `backend.lint`, which the `python`
+   area does not enable, so a `models/` or root-script change would clear pre-ci and still fail
+   CI's ty step. The job's remaining step, `ruff format --check`, needs no entry here — Phase 1B
+   runs under the same gate and has already fixed formatting.
+4. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
    commit the updated lockfile.
 
 **2C. YAML** — *if yaml changed*
@@ -225,8 +237,8 @@ Verifies the generated bindings match `schema/error-catalogue.json`. On failure,
 1. `uv run invoke backend.lint` — call this task directly rather than `uv run invoke lint`, which
    bundles `main.lint`, `backend.lint` and `yamllint` into one run and so ignores the area gating
    Phases 2B and 2C apply. Its ruff step covers `backend` only, the same coverage gap noted in
-   Phase 2B; the ty and mypy output is what this check adds. CI splits these: `ty` runs in
-   `python-lint`, while
+   Phase 2B, and its ty step repeats Phase 2B's — **mypy is what this check adds**. CI splits
+   them: `ty` runs in `python-lint`, while
    `mypy` runs as a step inside `backend-tests-integration` and `backend-tests-functional`.
 2. `uv run invoke backend.validate-generated` — ensures generated schema and protocol files are
    current. If it fails, run `uv run invoke backend.generate` and report the regenerated files.
@@ -296,7 +308,7 @@ Summarize in a table. Include **every** row; mark rows as `skipped (no <area> ch
 | Ruff (CI parity) | python-lint | ... |
 | Lockfile sync | uv-check (`uv-check.yml`) | ... |
 | YAML lint (`yamllint -s .`) | yaml-lint | ... |
-| Backend lint (ty) | python-lint | ... |
+| Type check (`ty check .`) | python-lint | ... |
 | Backend lint (mypy) | backend-tests-integration, backend-tests-functional | ... |
 | Generated files | backend-validate-generated | ... |
 | GraphQL schema validation | graphql-schema | ... |

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -23,15 +23,13 @@ allowed-tools:
 
 # Pre-CI
 
-Run the locally-executable CI checks that apply to what you changed, so a push does not fail
-remotely. **Every check below mirrors a job in `.github/workflows/ci.yml` — keep them in
-parity.**
+Run the locally-executable CI checks that apply to what you changed. **Every check below mirrors
+a job in `.github/workflows/ci.yml` — keep them in parity.**
 
 **Every command runs from the repository root and must leave the working directory unchanged.**
-The parallel phases below share a single shell, so a `cd` in one command silently changes where
-its siblings run, and the `invoke` tasks then fail on relative paths such as
-`schema/schema.graphql`. The frontend checks use `pnpm --dir` for that reason - do not rewrite
-them as `cd frontend/app && ...`.
+The parallel phases share a single shell, so a `cd` in one command silently changes where its
+siblings run and the `invoke` tasks fail on relative paths. That is why the frontend checks use
+`pnpm --dir` — do not rewrite them as `cd frontend/app && ...`.
 
 **Options:**
 
@@ -68,27 +66,19 @@ else
 fi
 ```
 
-A branch may be cut from either `stable` or `develop`, so pick the candidate whose merge base
-sits **closer to HEAD** — that is the one this branch actually forked from. Preferring `develop`
-unconditionally would diff a `stable`-based branch against a merge base tens of commits back and
-report every area as changed. When the two merge bases are identical the choice is arbitrary and
-harmless, because `MERGE_BASE` comes out the same either way.
+Each line of that block earns its place — do not simplify it:
 
-Every ref is existence-checked, including the first: on a fork or a remote that carries only one
-of the two branches, an unguarded `git merge-base HEAD origin/stable` aborts the block and leaves
-`MERGE_BASE` empty, which silently detects *nothing*. An empty `BASE_REF` must fall through to
-the all-areas path below instead.
-
-The `git fetch` is what makes the comparison trustworthy: stale refs move a merge base backwards,
-which usually just over-detects, but between *two* candidates a stale ref can also flip the
-choice and narrow the diff. Detection is the whole point of this phase, so refresh first and warn
-if the fetch fails — offline, treat the result as best-effort and prefer `--all`.
-
-The list covers **both committed and uncommitted** work — CI sees the former, you are about to
-push the latter, so both must pass. `--no-renames` matters: with rename detection on, a moved
-file reports only its new path, so the area that lost the file is never flagged. Every command
-here is in `allowed-tools`; keep it that way, and do not reach for `git status --porcelain`
-parsing, whose `R  old -> new` form collapses into one bogus path.
+- The winner is the candidate whose merge base sits **closer to HEAD**, the branch's real fork
+  point. Preferring `develop` unconditionally diffs a `stable`-based branch tens of commits back.
+- **Every** ref is existence-checked, including the first. An unguarded `git merge-base` aborts
+  the block on a fork that carries only one branch, leaving `MERGE_BASE` empty and detecting
+  *nothing*. An empty `BASE_REF` must reach the all-areas fallback instead.
+- `git fetch` first: a stale ref can flip the choice between the two candidates. If it fails,
+  the run is best-effort — prefer `--all`.
+- `--no-renames` keeps both sides of a rename, so the area that *lost* a file is still flagged.
+  Do not swap in `git status --porcelain`, whose `R  old -> new` collapses into one bogus path.
+- The list covers **committed and uncommitted** work: CI sees the former, you are about to push
+  the latter.
 
 Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
 file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
@@ -103,12 +93,12 @@ file's `<area>_all` list, so local gating matches the `files-changed` outputs CI
 | **schema** | `schema/**` | Phase 4D |
 | **yaml** | `**/*.{yml,yaml}`, `**/pyproject.toml`, `**/uv.lock` | Phase 2C |
 
-`python` is deliberately narrower than `backend`. The `python-lint` job fires on `backend ||
-python`, but `backend-tests-unit`, `graphql-schema` and `json-schema` gate on `backend` alone —
-so a change to `models/` or a root script must run the lint phases and **not** the slow ones.
+`python` is deliberately narrower than `backend`: `python-lint` fires on `backend || python`, but
+`backend-tests-unit`, `graphql-schema` and `json-schema` gate on `backend` alone, so a `models/`
+or root-script change must run the lint phases and **not** the slow ones.
 
-Three frontend validation jobs are gated on their own narrow filters rather than the whole
-frontend area — check these paths separately:
+Three frontend validation jobs gate on their own narrow filters rather than the whole frontend
+area — check these paths separately:
 
 | Trigger paths | Enables |
 |---|---|
@@ -116,20 +106,18 @@ frontend area — check these paths separately:
 | `schema/schema.graphql`, `frontend/app/src/shared/api/graphql/generated/**` | Phase 3D |
 | `schema/error-catalogue.json`, `frontend/app/src/shared/api/errors/catalogue.generated.ts`, `frontend/app/scripts/generate-error-bindings.mjs` | Phase 3E |
 
-If `--all` was passed, or if you cannot determine the base ref, treat every area as changed.
+If `--all` was passed, or no base ref resolved, treat every area as changed.
 
 **State the detected areas before running anything**, e.g.
 `Detected changes: frontend, docs. Skipping backend phases.`
 
-In Phases 1, 2 and 4 the sub-step letter encodes the area — **A** = frontend, **B** = backend or
-python, **C** = docs (yaml in Phase 2), **D** = schema — so a phase skips letters where an area
-has nothing to do at that stage. Phase 2 has no `2A` because the frontend has no fast check of
-its own. Phase 3 is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual
-CI jobs.
+Sub-step letters encode the area — **A** = frontend, **B** = backend or python, **C** = docs
+(yaml in Phase 2), **D** = schema — so a phase skips letters where an area has nothing to do.
+Phase 3 is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual CI jobs.
 
-> **Phase 3A always runs, even with no frontend changes.** The `frontend-lint` job in
-> `ci.yml` has **no path filter** — it runs on every PR. A backend-only change still fails CI if
-> frontend lint is broken on your branch. Only the frontend *tests* (Phase 3B) are path-gated.
+> **Phase 3A always runs, even with no frontend changes.** The `frontend-lint` job has **no path
+> filter** — a backend-only change still fails CI if frontend lint is broken on your branch. Only
+> the frontend *tests* (Phase 3B) are path-gated.
 
 ---
 
@@ -159,35 +147,26 @@ uv run invoke docs.format
 
 ## Phase 2 — Fast checks
 
-**Send all applicable commands in a SINGLE message as parallel Bash calls.** Do not run them one
-at a time.
+**Send all applicable commands in a SINGLE message as parallel Bash calls.**
 
 **2B. Python** — *if backend or python changed*
 
-1. `uv run invoke main.lint` — report any ruff issues.
-2. `uv run ruff check . --exclude python_sdk` — the exact command CI's `python-lint` job runs.
-   Not redundant with `main.lint`: that task lints only `tasks`, `models`, `utilities`, and
-   `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else
-   (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the
-   whole-repo check proves CI will pass.
-3. `uv run ruff format --check --diff --exclude python_sdk .` — the `python-lint` job's format
-   step. Phase 1B does **not** make this redundant: `invoke format` only reformats `tasks`,
-   `models`, `utilities`, `python_testcontainers` and `backend`, so an unformatted file under
-   `development/`, `tests/` or the repo root survives it and fails CI. Same coverage gap as
-   step 2, one step later in the job.
-4. `uv run ty check .` — the job's third step, whole-repo like CI. **Easy to miss**: `ty` is
-   otherwise only reachable through Phase 4B `backend.lint`, which the `python` area does not
-   enable, so a `models/` or root-script change would clear pre-ci and still fail CI's ty step.
-5. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
-   commit the updated lockfile.
+1. `uv run invoke main.lint`
+2. `uv run ruff check . --exclude python_sdk`
+3. `uv run ruff format --check --diff --exclude python_sdk .`
+4. `uv run ty check .`
+5. `uv lock --check` — on failure run `uv lock` and commit the updated lockfile.
+
+Steps 2–4 are CI's `python-lint` job verbatim, and none is redundant with step 1 or Phase 1B: the
+`invoke` tasks only reach `tasks`, `models`, `utilities`, `python_testcontainers` and `backend`,
+so a violation under `development/`, `tests/` or the repo root passes locally and fails CI. `ty`
+is otherwise reachable only through Phase 4B, which the `python` area does not enable.
 
 **2C. YAML** — *if yaml changed*
 
-1. `uv run yamllint -s .` — the exact command CI's `yaml-lint` job runs. **Easy to miss**: that
-   job fires on any `**/*.{yml,yaml}` change, so a workflow, compose file or schema YAML edit
-   with no Python in it still has a check to pass. Run the command directly rather than
-   `uv run invoke lint`, which bundles unrelated steps; `.yamllint.yml` already ignores `.venv`,
-   `node_modules` and the vendored submodules.
+1. `uv run yamllint -s .` — CI's `yaml-lint` job verbatim. **Easy to miss**: it fires on any
+   `**/*.{yml,yaml}` change, so a workflow or compose edit with no Python in it still has a check
+   to pass. Call it directly, not via `uv run invoke lint`, which bundles unrelated steps.
 
 ---
 
@@ -197,61 +176,48 @@ at a time.
 
 ## Phase 3 — Frontend gate (CI parity)
 
-This is the **complete** set of frontend checks CI runs. Do not run a subset — a partial pass
-here is what lets `frontend-lint` and `frontend-tests` fail on the PR.
+The **complete** set of frontend checks CI runs. A partial pass here is what lets `frontend-lint`
+and `frontend-tests` fail on the PR. If dependencies are stale, first run
+`pnpm --dir frontend/app install --frozen-lockfile` (CI always does).
 
-All commands run from the repository root via `pnpm --dir`, per the note at the top of this
-file. If dependencies are stale, first run `pnpm --dir frontend/app install --frozen-lockfile`
-(CI always does).
+**3A. Lint trio — ALWAYS run, regardless of detected areas** (job `frontend-lint`). Send as
+parallel Bash calls:
 
-**3A. Lint trio — ALWAYS run, regardless of detected areas** (mirrors job `frontend-lint`).
-Send as parallel Bash calls:
-
-1. `pnpm --dir frontend/app exec biome ci .` — format + lint. Note `biome ci`, **not**
-   `biome check --write`: the `ci` variant is check-only and is what the job asserts.
+1. `pnpm --dir frontend/app exec biome ci .` — note `biome ci`, **not** `biome check --write`:
+   the `ci` variant is check-only and is what the job asserts.
 2. `pnpm --dir frontend/app run knip` — unused exports, files, and dependencies.
-3. `pnpm --dir frontend/app exec betterer ci` — TypeScript regression gate. Note `betterer ci`,
-   **not** bare `betterer`: the `ci` variant fails on any increase instead of rewriting the
-   snapshot. This is **not** the same as running `tsc`.
+3. `pnpm --dir frontend/app exec betterer ci` — note `betterer ci`, **not** bare `betterer`,
+   which rewrites the snapshot instead of failing. This is **not** the same as running `tsc`.
 
-**3B. Unit tests — if frontend changed** (mirrors job `frontend-tests`). Sequential:
+**3B. Unit tests — if frontend changed** (job `frontend-tests`). Sequential:
 
-1. `pnpm --dir frontend/app exec playwright install chromium` — the suite runs in browser mode
-   and needs the browser present. One-off per machine; skip if already installed.
-2. `pnpm --dir frontend/app run test:coverage` — the app suite, as CI runs it. Plain `pnpm test`
-   passes the same specs but skips coverage collection.
-3. `pnpm --dir frontend/packages/graph run test` — the `@infrahub/graph` package suite. **Easy to
-   miss**: it is a separate step in the same CI job and lives outside `frontend/app`.
+1. `pnpm --dir frontend/app exec playwright install chromium` — the suite runs in browser mode.
+   One-off per machine; skip if already installed.
+2. `pnpm --dir frontend/app run test:coverage` — as CI runs it; plain `pnpm test` skips coverage.
+3. `pnpm --dir frontend/packages/graph run test` — the `@infrahub/graph` suite. **Easy to miss**:
+   a separate step in the same job, living outside `frontend/app`.
 
-**3C. OpenAPI types** — *if the Phase 0 OpenAPI trigger paths changed* (mirrors job
-`frontend-validate-openapi-types`):
+**3C. OpenAPI types** — *if the OpenAPI trigger paths changed* (job
+`frontend-validate-openapi-types`). On a non-empty diff, stage and commit the regenerated file:
 
 ```bash
 pnpm --dir frontend/app run codegen:openapi && git diff --exit-code frontend/app/src/shared/api/rest/types.generated.ts
 ```
 
-Regenerates the REST types from `schema/openapi.json`, then makes the same assertion CI does. A
-non-empty diff means the types were out of sync — stage and commit the regenerated file.
-
-**3D. GraphQL types** — *if the Phase 0 GraphQL trigger paths changed* (mirrors job
-`frontend-validate-graphql-types`):
+**3D. GraphQL types** — *if the GraphQL trigger paths changed* (job
+`frontend-validate-graphql-types`). On a non-empty diff, commit both generated files:
 
 ```bash
 pnpm --dir frontend/app run codegen:graphql && git diff --exit-code frontend/app/src/shared/api/graphql/generated/graphql-env.d.ts frontend/app/src/shared/api/graphql/generated/graphql-cache.d.ts
 ```
 
-Regenerates the gql.tada output from `schema/schema.graphql`. On a non-empty diff, stage and
-commit both generated files.
-
-**3E. Error catalogue bindings** — *if the Phase 0 error-catalogue trigger paths changed*
-(mirrors job `frontend-validate-error-catalogue`):
+**3E. Error catalogue bindings** — *if the error-catalogue trigger paths changed* (job
+`frontend-validate-error-catalogue`). On failure, run
+`pnpm --dir frontend/app run generate:error-bindings` and commit the result:
 
 ```bash
 pnpm --dir frontend/app run check:error-bindings
 ```
-
-Verifies the generated bindings match `schema/error-catalogue.json`. On failure, run
-`pnpm --dir frontend/app run generate:error-bindings` and commit the result.
 
 ---
 
@@ -261,35 +227,30 @@ Verifies the generated bindings match `schema/error-catalogue.json`. On failure,
 
 **4B. Backend** — *if backend changed*
 
-1. `uv run invoke backend.lint` — call this task directly rather than `uv run invoke lint`, which
-   bundles `main.lint`, `backend.lint` and `yamllint` into one run and so ignores the area gating
-   Phases 2B and 2C apply. Its ruff step covers `backend` only, the same coverage gap noted in
-   Phase 2B, and its ty step repeats Phase 2B's — **mypy is what this check adds**. CI splits
-   them: `ty` runs in `python-lint`, while
-   `mypy` runs as a step inside `backend-tests-integration` and `backend-tests-functional`.
-2. `uv run invoke backend.validate-generated` — ensures generated schema and protocol files are
-   current. If it fails, run `uv run invoke backend.generate` and report the regenerated files.
+1. `uv run invoke backend.lint` — call this task directly, not `uv run invoke lint`, which bundles
+   `main.lint`, `backend.lint` and `yamllint` and so ignores the gating of Phases 2B and 2C. Its
+   ruff and ty steps repeat those phases — **mypy is what this adds**. CI splits them: `ty` in
+   `python-lint`, `mypy` inside `backend-tests-integration` and `backend-tests-functional`.
+2. `uv run invoke backend.validate-generated` — on failure run `uv run invoke backend.generate`
+   and report the regenerated files.
 
 **4C. Docs** — *if docs changed*
 
-1. `uv run invoke docs.lint` — markdownlint + vale, mirroring the `markdown-lint` and
-   `validate-documentation-style` jobs. Some pre-existing errors in `docs/docs/` may exist; only
-   flag errors in files the user changed. This does **not** cover the `documentation` job, which
-   runs `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
-2. `uv run invoke docs.validate` — ensures generated reference documentation (CLI, schema,
-   events, repository config, config) is current. If validation fails, the correct files are
-   already on disk — stage and commit them.
+1. `uv run invoke docs.lint` — markdownlint + vale, mirroring `markdown-lint` and
+   `validate-documentation-style`. Pre-existing errors in `docs/docs/` may exist; only flag those
+   in changed files. Does **not** cover the `documentation` job, which runs
+   `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
+2. `uv run invoke docs.validate` — generated reference docs (CLI, schema, events, repository
+   config, config). On failure the correct files are already on disk; stage and commit them.
 
 **4D. Schema** — *if backend or schema changed*
 
-1. `uv run invoke schema.validate-graphqlschema` — ensures `schema/schema.graphql` is current.
-   Regenerates then checks for uncommitted diffs. On failure the correct file is already on disk;
-   stage and commit it.
-2. `uv run invoke schema.validate-jsonschema` — same approach for `schema/openapi.json`.
+1. `uv run invoke schema.validate-graphqlschema` — regenerates, then checks for uncommitted
+   diffs. On failure the correct file is already on disk; stage and commit it.
+2. `uv run invoke schema.validate-jsonschema` — same, for `schema/openapi.json`.
 
-Both CI jobs gate on the `backend` filter, which does **not** include `schema/**` — that is why
-Phase 0 carries a `schema` area of its own. Running these on a schema-only change is deliberately
-stricter than CI, and cheap.
+Both jobs gate on the `backend` filter, which does **not** include `schema/**` — hence the
+separate `schema` area. Running these on a schema-only change is deliberately stricter than CI.
 
 ---
 
@@ -297,22 +258,21 @@ stricter than CI, and cheap.
 
 Run after all lint and validation checks pass.
 
-**5.1** — *if backend changed* (mirrors job `backend-tests-unit`):
+**5.1** — *if backend changed* (job `backend-tests-unit`):
 
 ```bash
 uv run invoke backend.test-unit
 ```
 
-**5.2** — *if testcontainers changed* (mirrors job `backend-testcontainers-unit`):
+**5.2** — *if testcontainers changed* (job `backend-testcontainers-unit`):
 
 ```bash
 uv run --directory python_testcontainers pytest --rootdir=. -c pyproject.toml -vs tests
 ```
 
-`python_testcontainers` is a **separate uv project** with its own `pyproject.toml` and lockfile,
-and 5.1 does not reach it — `backend.test-unit` runs `backend/tests/unit` only. CI runs this
-suite as a Python 3.10–3.14 matrix; one interpreter is enough locally. Note the job also fires on
-`.github/workflows/*.yml`, so a workflow edit alone puts it in scope.
+5.1 does not reach 5.2's suite: `backend.test-unit` runs `backend/tests/unit` only, and
+`python_testcontainers` is a separate uv project. CI runs it as a Python 3.10–3.14 matrix; one
+interpreter is enough locally.
 
 ---
 

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -52,7 +52,9 @@ Run only the phases for the areas that changed, plus those marked always-run. **
 the base, or whether a path counts, include it.** Over-running is cheap; a missed area is a red PR.
 
 Classify the paths using the globs from `.github/file-filters.yml`, so local gating matches the
-`files-changed` outputs CI branches on.
+`files-changed` outputs CI branches on. Two rows are intentional exceptions — do not "correct"
+them: **python** is narrowed to keep the slow phases off `models/` and root-script changes, and
+**schema** is local-only, since `backend_all` has no `schema/**` entry for it to mirror.
 
 | Area | Paths | Enables |
 |---|---|---|

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -2,6 +2,7 @@
 description: Run all locally-executable CI checks (format, lint, unit tests) for the areas you changed
 argument-hint: "[--fast] [--all]"
 allowed-tools:
+  - Bash(git fetch:*)
   - Bash(git merge-base:*)
   - Bash(git diff:*)
   - Bash(git ls-files:*)
@@ -45,22 +46,43 @@ them as `cd frontend/app && ...`.
 Run this first. Everything after it is conditional on the result.
 
 ```bash
-BASE_REF=origin/stable
-if git rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then
-  git merge-base --is-ancestor "$(git merge-base HEAD origin/stable)" \
-    "$(git merge-base HEAD origin/develop)" && BASE_REF=origin/develop
+git fetch --quiet origin stable develop 2>/dev/null || echo "WARNING: base refs may be stale"
+
+BASE_REF=""
+for R in origin/stable origin/develop; do
+  git rev-parse --verify --quiet "$R" >/dev/null || continue
+  if [ -z "$BASE_REF" ] || git merge-base --is-ancestor \
+       "$(git merge-base HEAD "$BASE_REF")" "$(git merge-base HEAD "$R")"; then
+    BASE_REF=$R
+  fi
+done
+
+if [ -z "$BASE_REF" ]; then
+  echo "No base ref resolved - treat every area as changed"
+else
+  MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
+  { git diff --name-only --no-renames "$MERGE_BASE"...HEAD
+    git diff --name-only --no-renames HEAD
+    git ls-files --others --exclude-standard
+  } | sort -u
 fi
-MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
-{ git diff --name-only --no-renames "$MERGE_BASE"...HEAD
-  git diff --name-only --no-renames HEAD
-  git ls-files --others --exclude-standard
-} | sort -u
 ```
 
-Both `develop` and `stable` exist, and a branch may be cut from either, so pick the candidate
-whose merge base sits **closer to HEAD** — that is the one this branch actually forked from.
-Preferring `develop` unconditionally would diff a `stable`-based branch against a merge base tens
-of commits back and report every area as changed.
+A branch may be cut from either `stable` or `develop`, so pick the candidate whose merge base
+sits **closer to HEAD** — that is the one this branch actually forked from. Preferring `develop`
+unconditionally would diff a `stable`-based branch against a merge base tens of commits back and
+report every area as changed. When the two merge bases are identical the choice is arbitrary and
+harmless, because `MERGE_BASE` comes out the same either way.
+
+Every ref is existence-checked, including the first: on a fork or a remote that carries only one
+of the two branches, an unguarded `git merge-base HEAD origin/stable` aborts the block and leaves
+`MERGE_BASE` empty, which silently detects *nothing*. An empty `BASE_REF` must fall through to
+the all-areas path below instead.
+
+The `git fetch` is what makes the comparison trustworthy: stale refs move a merge base backwards,
+which usually just over-detects, but between *two* candidates a stale ref can also flip the
+choice and narrow the diff. Detection is the whole point of this phase, so refresh first and warn
+if the fetch fails — offline, treat the result as best-effort and prefer `--all`.
 
 The list covers **both committed and uncommitted** work — CI sees the former, you are about to
 push the latter, so both must pass. `--no-renames` matters: with rename detection on, a moved
@@ -78,6 +100,7 @@ file's `<area>_all` list, so local gating matches the `files-changed` outputs CI
 | **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B |
 | **testcontainers** | `python_testcontainers/**`, `.github/workflows/*.yml` (any workflow, not just `ci.yml`) | Phase 5.2 |
 | **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
+| **schema** | `schema/**` | Phase 4D |
 | **yaml** | `**/*.{yml,yaml}`, `**/pyproject.toml`, `**/uv.lock` | Phase 2C |
 
 `python` is deliberately narrower than `backend`. The `python-lint` job fires on `backend ||
@@ -257,15 +280,16 @@ Verifies the generated bindings match `schema/error-catalogue.json`. On failure,
    events, repository config, config) is current. If validation fails, the correct files are
    already on disk — stage and commit them.
 
-**4D. Schema** — *if backend or `schema/**` changed*
+**4D. Schema** — *if backend or schema changed*
 
 1. `uv run invoke schema.validate-graphqlschema` — ensures `schema/schema.graphql` is current.
    Regenerates then checks for uncommitted diffs. On failure the correct file is already on disk;
    stage and commit it.
 2. `uv run invoke schema.validate-jsonschema` — same approach for `schema/openapi.json`.
 
-Both CI jobs gate on the `backend` filter, which does **not** include `schema/**`. Running them
-on a schema-only change is deliberately stricter than CI, and cheap.
+Both CI jobs gate on the `backend` filter, which does **not** include `schema/**` — that is why
+Phase 0 carries a `schema` area of its own. Running these on a schema-only change is deliberately
+stricter than CI, and cheap.
 
 ---
 

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -7,7 +7,6 @@ allowed-tools:
   - Bash(git diff:*)
   - Bash(git ls-files:*)
   - Bash(git rev-parse:*)
-  - Bash(sort:*)
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
   - Bash(uv run ruff format:*)
@@ -53,10 +52,7 @@ Run only the phases for the areas that changed, plus those marked always-run. **
 the base, or whether a path counts, include it.** Over-running is cheap; a missed area is a red PR.
 
 Classify the paths using the globs from `.github/file-filters.yml`, so local gating matches the
-`files-changed` outputs CI branches on. Two areas deviate deliberately: **python** is narrower
-than CI's `python_all`, so a `models/` or root-script change runs the lint phases and not the
-slow ones; **schema** has no CI filter at all — `backend_all` excludes `schema/**`, so Phase 4D
-would otherwise never run on a schema-only change.
+`files-changed` outputs CI branches on.
 
 | Area | Paths | Enables |
 |---|---|---|
@@ -129,9 +125,7 @@ uv run invoke docs.format
 6. `uv lock --check --directory python_testcontainers` — same for the separate
    `python_testcontainers` project (job `infrahub-testcontainers-uv-check`).
 
-Steps 2–4 are CI's `python-lint` job verbatim and are repo-wide; the `invoke` tasks reach only
-`tasks`, `models`, `utilities`, `python_testcontainers` and `backend`, so a violation under
-`development/`, `tests/` or the repo root would otherwise pass locally and fail CI.
+Steps 2–4 are CI's `python-lint` job verbatim, and repo-wide — the `invoke` tasks are not.
 
 **2C. YAML** — *if yaml changed*
 
@@ -197,8 +191,8 @@ pnpm --dir frontend/app run check:error-bindings
 **4B. Backend** — *if backend changed*
 
 1. `uv run invoke backend.lint` — call this task directly, not `uv run invoke lint`, which
-   bundles `main.lint`, `backend.lint` and `yamllint` and so ignores the gating of Phases 2B and
-   2C. **mypy is what this phase adds** over those.
+   bundles `main.lint`, `backend.lint` and `yamllint`. **mypy is what this phase adds** over
+   Phase 2.
 2. `uv run invoke backend.validate-generated` — on failure run `uv run invoke backend.generate`
    and report the regenerated files.
 
@@ -208,11 +202,9 @@ pnpm --dir frontend/app run check:error-bindings
    `validate-documentation-style`. Pre-existing errors in `docs/docs/` may exist; only flag those
    in changed files. Does **not** cover the `documentation` job, which runs
    `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
-2. `uv run invoke docs.validate` — generated reference docs (CLI, schema, events, repository
-   config, config). **Run this if docs or *any* Python changed** — `backend/` included: it
-   mirrors `validate-generated-documentation`, which fires on `python || documentation`, and CI's
-   `python` filter is `**/*.py`. These docs are generated from Python source, and 4B step 2 does
-   not cover them. On failure the correct files are already on disk; stage and commit them.
+2. `uv run invoke docs.validate` — reference docs generated from Python source (CLI, schema,
+   events, repository config, config). On failure the correct files are already on disk; stage
+   and commit them.
 
 **4D. Schema** — *if backend or schema changed*
 
@@ -238,8 +230,7 @@ uv run invoke backend.test-unit
 uv run --directory python_testcontainers pytest --rootdir=. -c pyproject.toml -vs tests
 ```
 
-`python_testcontainers` is a separate uv project, so 5.1 does not reach this suite. CI runs it as
-a Python 3.10–3.14 matrix; one interpreter is enough locally.
+CI runs this as a Python 3.10–3.14 matrix; one interpreter is enough locally.
 
 ---
 

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -5,7 +5,6 @@ allowed-tools:
   - Bash(git fetch:*)
   - Bash(git merge-base:*)
   - Bash(git diff:*)
-  - Bash(git status:*)
   - Bash(git ls-files:*)
   - Bash(git rev-parse:*)
   - Bash(sort:*)
@@ -44,11 +43,15 @@ never `cd frontend/app && ...`.
 
 Identify which areas below this branch touched — committed, staged, and untracked — relative to
 its base: `stable`, `develop`, a `release-*` branch, whichever long-lived branch it forked from.
-Fetch the candidates first so the base is not stale, and keep both sides of a rename. Run only
-the phases for the areas that changed, plus those marked always-run.
+`git fetch` the candidates first so the base is not stale, then collect paths from three places:
+`git diff --name-only --no-renames <merge-base>...HEAD` for committed work, the same command
+against `HEAD` for staged and unstaged work, and `git ls-files --others --exclude-standard` for
+untracked files. Keep `--no-renames` — it reports both sides of a rename, so the area that *lost*
+a file is still flagged. Do not substitute `git status --porcelain`, which collapses
+`R  old -> new` into one path that matches no area.
 
-**When unsure about the base, or whether a path counts, include it.** Over-running is cheap;
-a missed area is a red PR.
+Run only the phases for the areas that changed, plus those marked always-run. **When unsure about
+the base, or whether a path counts, include it.** Over-running is cheap; a missed area is a red PR.
 
 Classify the paths using the globs from `.github/file-filters.yml`, so local gating matches the
 `files-changed` outputs CI branches on. Two areas deviate deliberately: **python** is narrower
@@ -59,7 +62,7 @@ would otherwise never run on a schema-only change.
 | Area | Paths | Enables |
 |---|---|---|
 | **frontend** | `frontend/app/**`, `frontend/packages/**`, `frontend/package.json`, `frontend/pnpm-workspace.yaml`, `frontend/pnpm-lock.yaml`, `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts`, `development/**`, `tasks/**`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1A, 3B |
-| **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4D, 5.1 |
+| **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4C.2, 4D, 5.1 |
 | **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B, 4C.2 |
 | **testcontainers** | `python_testcontainers/**`, `.github/workflows/*.yml` (any workflow, not just `ci.yml`) | Phase 5.2 |
 | **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
@@ -200,17 +203,17 @@ pnpm --dir frontend/app run check:error-bindings
 2. `uv run invoke backend.validate-generated` — on failure run `uv run invoke backend.generate`
    and report the regenerated files.
 
-**4C. Docs** — *if docs changed; step 2 also if python changed*
+**4C. Docs** — *if docs changed; step 2 also if any Python changed*
 
 1. `uv run invoke docs.lint` — markdownlint + vale, mirroring `markdown-lint` and
    `validate-documentation-style`. Pre-existing errors in `docs/docs/` may exist; only flag those
    in changed files. Does **not** cover the `documentation` job, which runs
    `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
 2. `uv run invoke docs.validate` — generated reference docs (CLI, schema, events, repository
-   config, config). **Run this if docs *or* python changed**: it mirrors
-   `validate-generated-documentation`, which fires on `python || documentation` because these
-   docs are generated from Python source. On failure the correct files are already on disk;
-   stage and commit them.
+   config, config). **Run this if docs or *any* Python changed** — `backend/` included: it
+   mirrors `validate-generated-documentation`, which fires on `python || documentation`, and CI's
+   `python` filter is `**/*.py`. These docs are generated from Python source, and 4B step 2 does
+   not cover them. On failure the correct files are already on disk; stage and commit them.
 
 **4D. Schema** — *if backend or schema changed*
 

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
   - Bash(uv run yamllint:*)
+  - Bash(uv run --directory python_testcontainers pytest:*)
   - Bash(uv lock --check:*)
   - Bash(uv lock:*)
   - Bash(pnpm --dir frontend/app:*)
@@ -41,10 +42,18 @@ them as `cd frontend/app && ...`.
 Run this first. Everything after it is conditional on the result.
 
 ```bash
-BASE_REF=$(git rev-parse --verify --quiet origin/develop >/dev/null 2>&1 && echo origin/develop || echo origin/stable)
+BASE_REF=$(for R in origin/develop origin/stable; do
+  git rev-parse --verify --quiet "$R" >/dev/null 2>&1 || continue
+  echo "$(git rev-list --count "$(git merge-base HEAD "$R")"..HEAD) $R"
+done | sort -n | head -1 | cut -d' ' -f2)
 MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
 { git diff --name-only "$MERGE_BASE"...HEAD; git status --porcelain | cut -c4- | sed 's/.* -> //'; } | sort -u
 ```
+
+Both `develop` and `stable` exist, and a branch may be cut from either, so the loop picks
+whichever candidate leaves HEAD fewest commits ahead — that is the one this branch actually
+forked from. Preferring `develop` unconditionally would diff a `stable`-based branch against a
+merge base tens of commits back and report every area as changed.
 
 The list covers **both committed and uncommitted** work — CI sees the former, you are about to
 push the latter, so both must pass. The `sed` unwraps `git status`'s rename form
@@ -59,6 +68,7 @@ file's `<area>_all` list, so local gating matches the `files-changed` outputs CI
 | **frontend** | `frontend/app/**`, `frontend/packages/**`, `frontend/package.json`, `frontend/pnpm-workspace.yaml`, `frontend/pnpm-lock.yaml`, `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts`, `development/**`, `tasks/**`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1A, 3B |
 | **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4D, 5 |
 | **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B |
+| **testcontainers** | `python_testcontainers/**`, `.github/workflows/*.yml` (any workflow, not just `ci.yml`) | Phase 5.2 |
 | **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
 | **yaml** | `**/*.{yml,yaml}`, `**/pyproject.toml`, `**/uv.lock` | Phase 2C |
 
@@ -243,13 +253,26 @@ on a schema-only change is deliberately stricter than CI, and cheap.
 
 ---
 
-## Phase 5 — Backend unit tests
+## Phase 5 — Slow unit tests
 
-*If backend changed.* Run after all lint and validation checks pass.
+Run after all lint and validation checks pass.
+
+**5.1** — *if backend changed* (mirrors job `backend-tests-unit`):
 
 ```bash
 uv run invoke backend.test-unit
 ```
+
+**5.2** — *if testcontainers changed* (mirrors job `backend-testcontainers-unit`):
+
+```bash
+uv run --directory python_testcontainers pytest --rootdir=. -c pyproject.toml -vs tests
+```
+
+`python_testcontainers` is a **separate uv project** with its own `pyproject.toml` and lockfile,
+and 5.1 does not reach it — `backend.test-unit` runs `backend/tests/unit` only. CI runs this
+suite as a Python 3.10–3.14 matrix; one interpreter is enough locally. Note the job also fires on
+`.github/workflows/*.yml`, so a workflow edit alone puts it in scope.
 
 ---
 
@@ -281,6 +304,7 @@ Summarize in a table. Include **every** row; mark rows as `skipped (no <area> ch
 | Docs lint (markdownlint + vale) | markdown-lint, validate-documentation-style | ... |
 | Generated docs validation | validate-generated-documentation | ... |
 | Backend unit tests | backend-tests-unit | ... |
+| Testcontainers unit tests | backend-testcontainers-unit | ... |
 
 Then state one of:
 

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -1,18 +1,25 @@
 ---
-description: Run all locally-executable CI checks (format, lint, unit tests)
-argument-hint: "[--fast]"
+description: Run all locally-executable CI checks (format, lint, unit tests) for the areas you changed
+argument-hint: "[--fast] [--all]"
 allowed-tools:
+  - Bash(git merge-base:*)
+  - Bash(git diff:*)
+  - Bash(git status:*)
+  - Bash(git rev-parse:*)
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
   - Bash(uv lock --check:*)
   - Bash(uv lock:*)
-  - Bash(pnpm --dir frontend/app run:*)
+  - Bash(pnpm --dir frontend/app:*)
+  - Bash(pnpm --dir frontend/packages/graph:*)
   - Bash(npx markdownlint*:*)
 ---
 
 # Pre-CI
 
-Run all locally-executable CI checks to catch issues before pushing.
+Run the locally-executable CI checks that apply to what you changed, so a push does not fail
+remotely. **Every check below mirrors a job in `.github/workflows/ci.yml` — keep them in
+parity.**
 
 **Every command runs from the repository root and must leave the working directory unchanged.**
 The parallel phases below share a single shell, so a `cd` in one command silently changes where
@@ -22,95 +29,241 @@ them as `cd frontend/app && ...`.
 
 **Options:**
 
-- `--fast` — Run only formatting and fast lint checks (~20s). Skips backend lint (ty/mypy), Betterer, docs lint, generated file and doc validation, schema validation, and unit tests.
+- `--fast` — Formatting and fast lint only (~20s). Skips backend lint (ty/mypy), Betterer, docs
+  lint, generated-file and doc validation, schema validation, and all unit tests.
+- `--all` — Skip detection and run every phase regardless of what changed.
+
+---
+
+## Phase 0 — Detect what changed
+
+Run this first. Everything after it is conditional on the result.
+
+```bash
+BASE_REF=$(git rev-parse --verify --quiet origin/develop >/dev/null 2>&1 && echo origin/develop || echo origin/stable)
+MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
+{ git diff --name-only "$MERGE_BASE"...HEAD; git status --porcelain | cut -c4-; } | sort -u
+```
+
+The list covers **both committed and uncommitted** work — CI sees the former, you are about to
+push the latter, so both must pass.
+
+Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
+file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
+
+| Area | Paths | Enables |
+|---|---|---|
+| **frontend** | `frontend/app/**`, `frontend/packages/**`, `frontend/package.json`, `frontend/pnpm-workspace.yaml`, `frontend/pnpm-lock.yaml`, `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts`, `development/**`, `tasks/**`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1A, 3B |
+| **backend** | `backend/**`, `python_sdk`, `python_testcontainers/**`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml`, plus **any** `**/*.py` (the `python-lint` job also fires on the `python` filter, so `models/`, `utilities/` and root scripts count) | Phases 1B, 2B, 4B, 4D, 5 |
+| **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
+
+Three frontend validation jobs are gated on their own narrow filters rather than the whole
+frontend area — check these paths separately:
+
+| Trigger paths | Enables |
+|---|---|
+| `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts` | Phase 3C |
+| `schema/schema.graphql`, `frontend/app/src/shared/api/graphql/generated/**` | Phase 3D |
+| `schema/error-catalogue.json`, `frontend/app/src/shared/api/errors/catalogue.generated.ts`, `frontend/app/scripts/generate-error-bindings.mjs` | Phase 3E |
+
+If `--all` was passed, or if you cannot determine the base ref, treat every area as changed.
+
+**State the detected areas before running anything**, e.g.
+`Detected changes: frontend, docs. Skipping backend phases.`
+
+In Phases 1, 2 and 4 the sub-step letter encodes the area — **A** = frontend, **B** = backend,
+**C** = docs, **D** = schema — so a phase skips letters where an area has nothing to do at that
+stage. Phase 2 has a `2B` and no `2A` because the frontend has no fast check of its own. Phase 3
+is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual CI jobs.
+
+> **Phase 3A always runs, even with no frontend changes.** The `frontend-lint` job in
+> `ci.yml` has **no path filter** — it runs on every PR. A backend-only change still fails CI if
+> frontend lint is broken on your branch. Only the frontend *tests* (Phase 3B) are path-gated.
+
+---
 
 ## Phase 1 — Auto-fix formatting (sequential)
 
-Run these **sequentially** — they modify files and must complete before lint checks.
+These modify files and must complete before any lint check.
 
-### 1. Format all Python code
-
-```bash
-uv run invoke format
-```
-
-This auto-fixes formatting issues via ruff. Always run this first.
-
-### 2. Format documentation
-
-```bash
-uv run invoke docs.format
-```
-
-Auto-fixes markdown formatting issues.
-
-### 3. Format and lint frontend code (Biome)
+**1A. Frontend** — *if frontend changed*
 
 ```bash
 pnpm --dir frontend/app run biome:fix
 ```
 
-Auto-fixes formatting and lint issues in TypeScript/TSX files. If Biome reports errors that cannot be auto-fixed, report them to the user.
+**1B. Python** — *if backend changed*
 
-## Phase 2 — Fast checks (parallel)
+```bash
+uv run invoke format
+```
 
-**IMPORTANT: Send ALL 4 commands below in a SINGLE message with 4 parallel Bash tool calls.** Do NOT run them one at a time.
+**1C. Documentation** — *if docs changed*
 
-1. `uv run invoke main.lint` — If ruff reports issues, report them to the user.
-2. `uv run ruff check . --exclude python_sdk` — The exact command CI's `python-lint` job runs. This is not redundant with `main.lint`: that task lints only `tasks`, `models`, `utilities`, and `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the whole-repo check proves CI will pass.
-3. `uv lock --check` — Ensures `uv.lock` matches `pyproject.toml`. If this fails, run `uv lock` and commit the updated lockfile.
-4. `pnpm --dir frontend/app run codegen:graphql` — Regenerates `graphql-env.d.ts` and `graphql-cache.d.ts` from `schema/schema.graphql`. If the files change, they need to be staged and committed.
-
----
-
-> **If `--fast` was specified, stop here** and report results. Show the summary table with slow checks marked as "skipped".
+```bash
+uv run invoke docs.format
+```
 
 ---
 
-## Phase 3 — Slow checks (parallel)
+## Phase 2 — Fast checks
 
-**IMPORTANT: Send ALL 7 commands below in a SINGLE message with 7 parallel Bash tool calls.** Do NOT run them one at a time.
+**Send all applicable commands in a SINGLE message as parallel Bash calls.** Do not run them one
+at a time.
 
-1. `uv run invoke backend.lint` — Run separately from main.lint to avoid `uv run invoke lint` which includes a `yamllint -s .` step that fails on vendored packages in `.venv`. Its ruff step covers `backend` only, the same coverage gap noted in Phase 2; the ty/mypy output is what this check adds.
-2. `pnpm --dir frontend/app run betterer` — Ensures no new TypeScript errors are introduced. The issue count must stay the same or decrease. If it increases, report the new issues to the user.
-3. `uv run invoke docs.lint` — Report any errors. Note: some pre-existing errors in `docs/docs/` may exist — only flag errors in files the user has changed.
-4. `uv run invoke backend.validate-generated` — Ensures generated schema and protocol files are up to date. If this fails, run `uv run invoke backend.generate` and report the regenerated files.
-5. `uv run invoke schema.validate-graphqlschema` — Ensures `schema/schema.graphql` is up to date. Regenerates the file then checks for uncommitted diffs. If validation fails, the correct file is already on disk — just stage and commit it.
-6. `uv run invoke schema.validate-jsonschema` — Ensures `schema/openapi.json` is up to date. Same approach as GraphQL schema validation.
-7. `uv run invoke docs.validate` — Ensures generated reference documentation (CLI, schema, events, repository config, config) is up to date. Regenerates the docs then checks for uncommitted diffs. If validation fails, the correct files are already on disk — stage and commit them.
+**2B. Python** — *if backend changed*
 
-## Phase 4 — Unit tests
+1. `uv run invoke main.lint` — report any ruff issues.
+2. `uv run ruff check . --exclude python_sdk` — the exact command CI's `python-lint` job runs.
+   Not redundant with `main.lint`: that task lints only `tasks`, `models`, `utilities`, and
+   `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else
+   (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the
+   whole-repo check proves CI will pass.
+3. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
+   commit the updated lockfile.
 
-Run after all lint/validation checks pass.
+---
+
+> **If `--fast` was specified, stop here** and report results, marking slow checks as "skipped".
+
+---
+
+## Phase 3 — Frontend gate (CI parity)
+
+This is the **complete** set of frontend checks CI runs. Do not run a subset — a partial pass
+here is what lets `frontend-lint` and `frontend-tests` fail on the PR.
+
+All commands run from the repository root via `pnpm --dir`, per the note at the top of this
+file. If dependencies are stale, first run `pnpm --dir frontend/app install --frozen-lockfile`
+(CI always does).
+
+**3A. Lint trio — ALWAYS run, regardless of detected areas** (mirrors job `frontend-lint`).
+Send as parallel Bash calls:
+
+1. `pnpm --dir frontend/app exec biome ci .` — format + lint. Note `biome ci`, **not**
+   `biome check --write`: the `ci` variant is check-only and is what the job asserts.
+2. `pnpm --dir frontend/app run knip` — unused exports, files, and dependencies.
+3. `pnpm --dir frontend/app exec betterer ci` — TypeScript regression gate. Note `betterer ci`,
+   **not** bare `betterer`: the `ci` variant fails on any increase instead of rewriting the
+   snapshot. This is **not** the same as running `tsc`.
+
+**3B. Unit tests — if frontend changed** (mirrors job `frontend-tests`). Sequential:
+
+1. `pnpm --dir frontend/app exec playwright install chromium` — the suite runs in browser mode
+   and needs the browser present. One-off per machine; skip if already installed.
+2. `pnpm --dir frontend/app run test:coverage` — the app suite, as CI runs it. Plain `pnpm test`
+   passes the same specs but skips coverage collection.
+3. `pnpm --dir frontend/packages/graph run test` — the `@infrahub/graph` package suite. **Easy to
+   miss**: it is a separate step in the same CI job and lives outside `frontend/app`.
+
+**3C. OpenAPI types** — *if the Phase 0 OpenAPI trigger paths changed* (mirrors job
+`frontend-validate-openapi-types`):
+
+```bash
+pnpm --dir frontend/app run codegen:openapi && git diff --exit-code frontend/app/src/shared/api/rest/types.generated.ts
+```
+
+Regenerates the REST types from `schema/openapi.json`, then makes the same assertion CI does. A
+non-empty diff means the types were out of sync — stage and commit the regenerated file.
+
+**3D. GraphQL types** — *if the Phase 0 GraphQL trigger paths changed* (mirrors job
+`frontend-validate-graphql-types`):
+
+```bash
+pnpm --dir frontend/app run codegen:graphql && git diff --exit-code frontend/app/src/shared/api/graphql/generated/graphql-env.d.ts frontend/app/src/shared/api/graphql/generated/graphql-cache.d.ts
+```
+
+Regenerates the gql.tada output from `schema/schema.graphql`. On a non-empty diff, stage and
+commit both generated files.
+
+**3E. Error catalogue bindings** — *if the Phase 0 error-catalogue trigger paths changed*
+(mirrors job `frontend-validate-error-catalogue`):
+
+```bash
+pnpm --dir frontend/app run check:error-bindings
+```
+
+Verifies the generated bindings match `schema/error-catalogue.json`. On failure, run
+`pnpm --dir frontend/app run generate:error-bindings` and commit the result.
+
+---
+
+## Phase 4 — Slow backend and docs checks
+
+**Send all applicable commands in a SINGLE message as parallel Bash calls.**
+
+**4B. Backend** — *if backend changed*
+
+1. `uv run invoke backend.lint` — run separately from `main.lint` to avoid
+   `uv run invoke lint`, which includes a `yamllint -s .` step that fails on vendored packages in
+   `.venv`. Its ruff step covers `backend` only, the same coverage gap noted in Phase 2B; the
+   ty and mypy output is what this check adds. CI splits these: `ty` runs in `python-lint`, while
+   `mypy` runs as a step inside `backend-tests-integration` and `backend-tests-functional`.
+2. `uv run invoke backend.validate-generated` — ensures generated schema and protocol files are
+   current. If it fails, run `uv run invoke backend.generate` and report the regenerated files.
+
+**4C. Docs** — *if docs changed*
+
+1. `uv run invoke docs.lint` — markdownlint + vale, mirroring the `markdown-lint` and
+   `validate-documentation-style` jobs. Some pre-existing errors in `docs/docs/` may exist; only
+   flag errors in files the user changed. This does **not** cover the `documentation` job, which
+   runs `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
+2. `uv run invoke docs.validate` — ensures generated reference documentation (CLI, schema,
+   events, repository config, config) is current. If validation fails, the correct files are
+   already on disk — stage and commit them.
+
+**4D. Schema** — *if backend or `schema/**` changed*
+
+1. `uv run invoke schema.validate-graphqlschema` — ensures `schema/schema.graphql` is current.
+   Regenerates then checks for uncommitted diffs. On failure the correct file is already on disk;
+   stage and commit it.
+2. `uv run invoke schema.validate-jsonschema` — same approach for `schema/openapi.json`.
+
+Both CI jobs gate on the `backend` filter, which does **not** include `schema/**`. Running them
+on a schema-only change is deliberately stricter than CI, and cheap.
+
+---
+
+## Phase 5 — Backend unit tests
+
+*If backend changed.* Run after all lint and validation checks pass.
 
 ```bash
 uv run invoke backend.test-unit
 ```
 
-Report pass/fail summary.
+---
 
-## After All Checks
+## After all checks
 
-Summarize results in a table:
+Summarize in a table. Include **every** row; mark rows as `skipped (no <area> changes)` or
+`skipped (--fast)` rather than omitting them, so it is obvious what was not covered.
 
-| Check | Status |
-|-------|--------|
-| Python format | ... |
-| Docs format | ... |
-| Frontend format/lint | ... |
-| Main Python lint | ... |
-| Ruff (CI parity) | ... |
-| Lockfile sync | ... |
-| Frontend GraphQL types | ... |
-| Backend lint (ty/mypy) | ... |
-| TS regressions (Betterer) | ... |
-| Docs lint | ... |
-| Generated files | ... |
-| GraphQL schema validation | ... |
-| JSON schema validation | ... |
-| Generated docs validation | ... |
-| Unit tests | ... |
+| Check | CI job | Status |
+|-------|--------|--------|
+| Frontend format/lint (`biome ci`) | frontend-lint | ... |
+| Frontend unused exports (`knip`) | frontend-lint | ... |
+| Frontend TS regressions (`betterer ci`) | frontend-lint | ... |
+| Frontend unit tests (`test:coverage`) | frontend-tests | ... |
+| `@infrahub/graph` unit tests | frontend-tests | ... |
+| OpenAPI types | frontend-validate-openapi-types | ... |
+| Frontend GraphQL types | frontend-validate-graphql-types | ... |
+| Error catalogue bindings | frontend-validate-error-catalogue | ... |
+| Python format | python-lint | ... |
+| Main Python lint | python-lint | ... |
+| Ruff (CI parity) | python-lint | ... |
+| Lockfile sync | uv-check (`uv-check.yml`) | ... |
+| Backend lint (ty) | python-lint | ... |
+| Backend lint (mypy) | backend-tests-integration, backend-tests-functional | ... |
+| Generated files | backend-validate-generated | ... |
+| GraphQL schema validation | graphql-schema | ... |
+| JSON schema validation | json-schema | ... |
+| Docs lint (markdownlint + vale) | markdown-lint, validate-documentation-style | ... |
+| Generated docs validation | validate-generated-documentation | ... |
+| Backend unit tests | backend-tests-unit | ... |
 
-If `--fast` was used, show skipped checks as "skipped".
-If everything passed (or was skipped), tell the user they're ready to push.
-If anything failed, list the specific failures and suggest fixes.
+Then state one of:
+
+- **All applicable checks passed — safe to push.** Name the areas that were skipped and why.
+- **Failed.** List each failure with the exact command and suggested fix. Do not describe the
+  branch as ready to push.

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -34,8 +34,8 @@ never `cd frontend/app && ...`.
 
 **Options:**
 
-- `--fast` — Formatting and fast lint only (~20s). Skips backend lint (ty/mypy), Betterer, docs
-  lint, generated-file and doc validation, schema validation, and all unit tests.
+- `--fast` — Formatting and fast lint only (~20s). Skips mypy, Betterer, docs lint,
+  generated-file and doc validation, schema validation, and all unit tests.
 - `--all` — Skip detection and run every phase regardless of what changed.
 
 ---
@@ -50,14 +50,17 @@ the phases for the areas that changed, plus those marked always-run.
 **When unsure about the base, or whether a path counts, include it.** Over-running is cheap;
 a missed area is a red PR.
 
-Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
-file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
+Classify the paths using the globs from `.github/file-filters.yml`, so local gating matches the
+`files-changed` outputs CI branches on. Two areas deviate deliberately: **python** is narrower
+than CI's `python_all`, so a `models/` or root-script change runs the lint phases and not the
+slow ones; **schema** has no CI filter at all — `backend_all` excludes `schema/**`, so Phase 4D
+would otherwise never run on a schema-only change.
 
 | Area | Paths | Enables |
 |---|---|---|
 | **frontend** | `frontend/app/**`, `frontend/packages/**`, `frontend/package.json`, `frontend/pnpm-workspace.yaml`, `frontend/pnpm-lock.yaml`, `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts`, `development/**`, `tasks/**`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1A, 3B |
-| **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4D, 5 |
-| **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B |
+| **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4D, 5.1 |
+| **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B, 4C.2 |
 | **testcontainers** | `python_testcontainers/**`, `.github/workflows/*.yml` (any workflow, not just `ci.yml`) | Phase 5.2 |
 | **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
 | **schema** | `schema/**` | Phase 4D |
@@ -119,7 +122,10 @@ uv run invoke docs.format
 2. `uv run ruff check . --exclude python_sdk`
 3. `uv run ruff format --check --diff --exclude python_sdk .`
 4. `uv run ty check .`
-5. `uv lock --check` — on failure run `uv lock` and commit the updated lockfile.
+5. `uv lock --check` — root project (job `infrahub-uv-check`). On failure run `uv lock` and
+   commit the updated lockfile.
+6. `uv lock --check --directory python_testcontainers` — same for the separate
+   `python_testcontainers` project (job `infrahub-testcontainers-uv-check`).
 
 Steps 2–4 are CI's `python-lint` job verbatim and are repo-wide; the `invoke` tasks reach only
 `tasks`, `models`, `utilities`, `python_testcontainers` and `backend`, so a violation under
@@ -194,14 +200,17 @@ pnpm --dir frontend/app run check:error-bindings
 2. `uv run invoke backend.validate-generated` — on failure run `uv run invoke backend.generate`
    and report the regenerated files.
 
-**4C. Docs** — *if docs changed*
+**4C. Docs** — *if docs changed; step 2 also if python changed*
 
 1. `uv run invoke docs.lint` — markdownlint + vale, mirroring `markdown-lint` and
    `validate-documentation-style`. Pre-existing errors in `docs/docs/` may exist; only flag those
    in changed files. Does **not** cover the `documentation` job, which runs
    `uv run invoke docs.build` — run that manually if you touched the Docusaurus config.
 2. `uv run invoke docs.validate` — generated reference docs (CLI, schema, events, repository
-   config, config). On failure the correct files are already on disk; stage and commit them.
+   config, config). **Run this if docs *or* python changed**: it mirrors
+   `validate-generated-documentation`, which fires on `python || documentation` because these
+   docs are generated from Python source. On failure the correct files are already on disk;
+   stage and commit them.
 
 **4D. Schema** — *if backend or schema changed*
 
@@ -250,7 +259,7 @@ Summarize in a table. Include **every** row; mark rows as `skipped (no <area> ch
 | Python format (`ruff format --check`) | python-lint | ... |
 | Main Python lint | python-lint | ... |
 | Ruff (CI parity) | python-lint | ... |
-| Lockfile sync | uv-check (`uv-check.yml`) | ... |
+| Lockfiles (root + testcontainers) | infrahub-uv-check, infrahub-testcontainers-uv-check | ... |
 | YAML lint (`yamllint -s .`) | yaml-lint | ... |
 | Type check (`ty check .`) | python-lint | ... |
 | Backend lint (mypy) | backend-tests-integration, backend-tests-functional | ... |

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash(git fetch:*)
   - Bash(git merge-base:*)
   - Bash(git diff:*)
+  - Bash(git status:*)
   - Bash(git ls-files:*)
   - Bash(git rev-parse:*)
   - Bash(sort:*)
@@ -27,9 +28,9 @@ Run the locally-executable CI checks that apply to what you changed. **Every che
 a job in `.github/workflows/ci.yml` — keep them in parity.**
 
 **Every command runs from the repository root and must leave the working directory unchanged.**
-The parallel phases share a single shell, so a `cd` in one command silently changes where its
-siblings run and the `invoke` tasks fail on relative paths. That is why the frontend checks use
-`pnpm --dir` — do not rewrite them as `cd frontend/app && ...`.
+The parallel phases share a single shell, so a `cd` in one command changes where its siblings run
+and the `invoke` tasks then fail on relative paths. Use `pnpm --dir` for the frontend checks —
+never `cd frontend/app && ...`.
 
 **Options:**
 
@@ -41,44 +42,13 @@ siblings run and the `invoke` tasks fail on relative paths. That is why the fron
 
 ## Phase 0 — Detect what changed
 
-Run this first. Everything after it is conditional on the result.
+Identify which areas below this branch touched — committed, staged, and untracked — relative to
+its base: `stable`, `develop`, a `release-*` branch, whichever long-lived branch it forked from.
+Fetch the candidates first so the base is not stale, and keep both sides of a rename. Run only
+the phases for the areas that changed, plus those marked always-run.
 
-```bash
-git fetch --quiet origin stable develop 2>/dev/null || echo "WARNING: base refs may be stale"
-
-BASE_REF=""
-for R in origin/stable origin/develop; do
-  git rev-parse --verify --quiet "$R" >/dev/null || continue
-  if [ -z "$BASE_REF" ] || git merge-base --is-ancestor \
-       "$(git merge-base HEAD "$BASE_REF")" "$(git merge-base HEAD "$R")"; then
-    BASE_REF=$R
-  fi
-done
-
-if [ -z "$BASE_REF" ]; then
-  echo "No base ref resolved - treat every area as changed"
-else
-  MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
-  { git diff --name-only --no-renames "$MERGE_BASE"...HEAD
-    git diff --name-only --no-renames HEAD
-    git ls-files --others --exclude-standard
-  } | sort -u
-fi
-```
-
-Each line of that block earns its place — do not simplify it:
-
-- The winner is the candidate whose merge base sits **closer to HEAD**, the branch's real fork
-  point. Preferring `develop` unconditionally diffs a `stable`-based branch tens of commits back.
-- **Every** ref is existence-checked, including the first. An unguarded `git merge-base` aborts
-  the block on a fork that carries only one branch, leaving `MERGE_BASE` empty and detecting
-  *nothing*. An empty `BASE_REF` must reach the all-areas fallback instead.
-- `git fetch` first: a stale ref can flip the choice between the two candidates. If it fails,
-  the run is best-effort — prefer `--all`.
-- `--no-renames` keeps both sides of a rename, so the area that *lost* a file is still flagged.
-  Do not swap in `git status --porcelain`, whose `R  old -> new` collapses into one bogus path.
-- The list covers **committed and uncommitted** work: CI sees the former, you are about to push
-  the latter.
+**When unsure about the base, or whether a path counts, include it.** Over-running is cheap;
+a missed area is a red PR.
 
 Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
 file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
@@ -93,10 +63,6 @@ file's `<area>_all` list, so local gating matches the `files-changed` outputs CI
 | **schema** | `schema/**` | Phase 4D |
 | **yaml** | `**/*.{yml,yaml}`, `**/pyproject.toml`, `**/uv.lock` | Phase 2C |
 
-`python` is deliberately narrower than `backend`: `python-lint` fires on `backend || python`, but
-`backend-tests-unit`, `graphql-schema` and `json-schema` gate on `backend` alone, so a `models/`
-or root-script change must run the lint phases and **not** the slow ones.
-
 Three frontend validation jobs gate on their own narrow filters rather than the whole frontend
 area — check these paths separately:
 
@@ -106,14 +72,12 @@ area — check these paths separately:
 | `schema/schema.graphql`, `frontend/app/src/shared/api/graphql/generated/**` | Phase 3D |
 | `schema/error-catalogue.json`, `frontend/app/src/shared/api/errors/catalogue.generated.ts`, `frontend/app/scripts/generate-error-bindings.mjs` | Phase 3E |
 
-If `--all` was passed, or no base ref resolved, treat every area as changed.
-
 **State the detected areas before running anything**, e.g.
 `Detected changes: frontend, docs. Skipping backend phases.`
 
-Sub-step letters encode the area — **A** = frontend, **B** = backend or python, **C** = docs
-(yaml in Phase 2), **D** = schema — so a phase skips letters where an area has nothing to do.
-Phase 3 is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual CI jobs.
+Sub-step letters are stable per area — **A** frontend, **B** backend or python, **C** docs (yaml
+in Phase 2), **D** schema — so a phase omits letters where an area has nothing to do. Phase 3 is
+entirely frontend: `3A`–`3E` enumerate its individual CI jobs.
 
 > **Phase 3A always runs, even with no frontend changes.** The `frontend-lint` job has **no path
 > filter** — a backend-only change still fails CI if frontend lint is broken on your branch. Only
@@ -157,16 +121,14 @@ uv run invoke docs.format
 4. `uv run ty check .`
 5. `uv lock --check` — on failure run `uv lock` and commit the updated lockfile.
 
-Steps 2–4 are CI's `python-lint` job verbatim, and none is redundant with step 1 or Phase 1B: the
-`invoke` tasks only reach `tasks`, `models`, `utilities`, `python_testcontainers` and `backend`,
-so a violation under `development/`, `tests/` or the repo root passes locally and fails CI. `ty`
-is otherwise reachable only through Phase 4B, which the `python` area does not enable.
+Steps 2–4 are CI's `python-lint` job verbatim and are repo-wide; the `invoke` tasks reach only
+`tasks`, `models`, `utilities`, `python_testcontainers` and `backend`, so a violation under
+`development/`, `tests/` or the repo root would otherwise pass locally and fail CI.
 
 **2C. YAML** — *if yaml changed*
 
-1. `uv run yamllint -s .` — CI's `yaml-lint` job verbatim. **Easy to miss**: it fires on any
-   `**/*.{yml,yaml}` change, so a workflow or compose edit with no Python in it still has a check
-   to pass. Call it directly, not via `uv run invoke lint`, which bundles unrelated steps.
+1. `uv run yamllint -s .` — CI's `yaml-lint` job. Call it directly, not via
+   `uv run invoke lint`, which bundles unrelated steps.
 
 ---
 
@@ -176,26 +138,25 @@ is otherwise reachable only through Phase 4B, which the `python` area does not e
 
 ## Phase 3 — Frontend gate (CI parity)
 
-The **complete** set of frontend checks CI runs. A partial pass here is what lets `frontend-lint`
-and `frontend-tests` fail on the PR. If dependencies are stale, first run
+The **complete** set of frontend checks CI runs. If dependencies are stale, first run
 `pnpm --dir frontend/app install --frozen-lockfile` (CI always does).
 
 **3A. Lint trio — ALWAYS run, regardless of detected areas** (job `frontend-lint`). Send as
 parallel Bash calls:
 
-1. `pnpm --dir frontend/app exec biome ci .` — note `biome ci`, **not** `biome check --write`:
-   the `ci` variant is check-only and is what the job asserts.
+1. `pnpm --dir frontend/app exec biome ci .` — `biome ci`, **not** `biome check --write`: only
+   the `ci` variant is check-only.
 2. `pnpm --dir frontend/app run knip` — unused exports, files, and dependencies.
-3. `pnpm --dir frontend/app exec betterer ci` — note `betterer ci`, **not** bare `betterer`,
-   which rewrites the snapshot instead of failing. This is **not** the same as running `tsc`.
+3. `pnpm --dir frontend/app exec betterer ci` — `betterer ci`, **not** bare `betterer`, which
+   rewrites the snapshot instead of failing.
 
 **3B. Unit tests — if frontend changed** (job `frontend-tests`). Sequential:
 
 1. `pnpm --dir frontend/app exec playwright install chromium` — the suite runs in browser mode.
    One-off per machine; skip if already installed.
-2. `pnpm --dir frontend/app run test:coverage` — as CI runs it; plain `pnpm test` skips coverage.
-3. `pnpm --dir frontend/packages/graph run test` — the `@infrahub/graph` suite. **Easy to miss**:
-   a separate step in the same job, living outside `frontend/app`.
+2. `pnpm --dir frontend/app run test:coverage` — plain `pnpm test` skips coverage.
+3. `pnpm --dir frontend/packages/graph run test` — the `@infrahub/graph` suite, a second step of
+   the same job living outside `frontend/app`.
 
 **3C. OpenAPI types** — *if the OpenAPI trigger paths changed* (job
 `frontend-validate-openapi-types`). On a non-empty diff, stage and commit the regenerated file:
@@ -227,10 +188,9 @@ pnpm --dir frontend/app run check:error-bindings
 
 **4B. Backend** — *if backend changed*
 
-1. `uv run invoke backend.lint` — call this task directly, not `uv run invoke lint`, which bundles
-   `main.lint`, `backend.lint` and `yamllint` and so ignores the gating of Phases 2B and 2C. Its
-   ruff and ty steps repeat those phases — **mypy is what this adds**. CI splits them: `ty` in
-   `python-lint`, `mypy` inside `backend-tests-integration` and `backend-tests-functional`.
+1. `uv run invoke backend.lint` — call this task directly, not `uv run invoke lint`, which
+   bundles `main.lint`, `backend.lint` and `yamllint` and so ignores the gating of Phases 2B and
+   2C. **mypy is what this phase adds** over those.
 2. `uv run invoke backend.validate-generated` — on failure run `uv run invoke backend.generate`
    and report the regenerated files.
 
@@ -248,9 +208,6 @@ pnpm --dir frontend/app run check:error-bindings
 1. `uv run invoke schema.validate-graphqlschema` — regenerates, then checks for uncommitted
    diffs. On failure the correct file is already on disk; stage and commit it.
 2. `uv run invoke schema.validate-jsonschema` — same, for `schema/openapi.json`.
-
-Both jobs gate on the `backend` filter, which does **not** include `schema/**` — hence the
-separate `schema` area. Running these on a schema-only change is deliberately stricter than CI.
 
 ---
 
@@ -270,16 +227,15 @@ uv run invoke backend.test-unit
 uv run --directory python_testcontainers pytest --rootdir=. -c pyproject.toml -vs tests
 ```
 
-5.1 does not reach 5.2's suite: `backend.test-unit` runs `backend/tests/unit` only, and
-`python_testcontainers` is a separate uv project. CI runs it as a Python 3.10–3.14 matrix; one
-interpreter is enough locally.
+`python_testcontainers` is a separate uv project, so 5.1 does not reach this suite. CI runs it as
+a Python 3.10–3.14 matrix; one interpreter is enough locally.
 
 ---
 
 ## After all checks
 
 Summarize in a table. Include **every** row; mark rows as `skipped (no <area> changes)` or
-`skipped (--fast)` rather than omitting them, so it is obvious what was not covered.
+`skipped (--fast)` rather than omitting them.
 
 | Check | CI job | Status |
 |-------|--------|--------|

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(sort:*)
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
+  - Bash(uv run ruff format:*)
   - Bash(uv run ty check:*)
   - Bash(uv run yamllint:*)
   - Bash(uv run --directory python_testcontainers pytest:*)
@@ -146,12 +147,15 @@ at a time.
    `python_testcontainers`, and `backend.lint` only `backend`, so a violation anywhere else
    (`development/`, root-level scripts, `tests/`) passes locally and fails in CI. Only the
    whole-repo check proves CI will pass.
-3. `uv run ty check .` — the `python-lint` job's third step, whole-repo like CI. **Easy to
-   miss**: `ty` is otherwise only reachable through Phase 4B `backend.lint`, which the `python`
-   area does not enable, so a `models/` or root-script change would clear pre-ci and still fail
-   CI's ty step. The job's remaining step, `ruff format --check`, needs no entry here — Phase 1B
-   runs under the same gate and has already fixed formatting.
-4. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
+3. `uv run ruff format --check --diff --exclude python_sdk .` — the `python-lint` job's format
+   step. Phase 1B does **not** make this redundant: `invoke format` only reformats `tasks`,
+   `models`, `utilities`, `python_testcontainers` and `backend`, so an unformatted file under
+   `development/`, `tests/` or the repo root survives it and fails CI. Same coverage gap as
+   step 2, one step later in the job.
+4. `uv run ty check .` — the job's third step, whole-repo like CI. **Easy to miss**: `ty` is
+   otherwise only reachable through Phase 4B `backend.lint`, which the `python` area does not
+   enable, so a `models/` or root-script change would clear pre-ci and still fail CI's ty step.
+5. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
    commit the updated lockfile.
 
 **2C. YAML** — *if yaml changed*
@@ -303,7 +307,7 @@ Summarize in a table. Include **every** row; mark rows as `skipped (no <area> ch
 | OpenAPI types | frontend-validate-openapi-types | ... |
 | Frontend GraphQL types | frontend-validate-graphql-types | ... |
 | Error catalogue bindings | frontend-validate-error-catalogue | ... |
-| Python format | python-lint | ... |
+| Python format (`ruff format --check`) | python-lint | ... |
 | Main Python lint | python-lint | ... |
 | Ruff (CI parity) | python-lint | ... |
 | Lockfile sync | uv-check (`uv-check.yml`) | ... |

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -8,6 +8,7 @@ allowed-tools:
   - Bash(git rev-parse:*)
   - Bash(uv run invoke:*)
   - Bash(uv run ruff check:*)
+  - Bash(uv run yamllint:*)
   - Bash(uv lock --check:*)
   - Bash(uv lock:*)
   - Bash(pnpm --dir frontend/app:*)
@@ -42,11 +43,13 @@ Run this first. Everything after it is conditional on the result.
 ```bash
 BASE_REF=$(git rev-parse --verify --quiet origin/develop >/dev/null 2>&1 && echo origin/develop || echo origin/stable)
 MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
-{ git diff --name-only "$MERGE_BASE"...HEAD; git status --porcelain | cut -c4-; } | sort -u
+{ git diff --name-only "$MERGE_BASE"...HEAD; git status --porcelain | cut -c4- | sed 's/.* -> //'; } | sort -u
 ```
 
 The list covers **both committed and uncommitted** work — CI sees the former, you are about to
-push the latter, so both must pass.
+push the latter, so both must pass. The `sed` unwraps `git status`'s rename form
+(`R  old -> new`), which would otherwise be classified as the single literal path `old -> new`
+and match no area at all.
 
 Classify the paths using the same globs as `.github/file-filters.yml`. Each area below is that
 file's `<area>_all` list, so local gating matches the `files-changed` outputs CI branches on:
@@ -54,8 +57,14 @@ file's `<area>_all` list, so local gating matches the `files-changed` outputs CI
 | Area | Paths | Enables |
 |---|---|---|
 | **frontend** | `frontend/app/**`, `frontend/packages/**`, `frontend/package.json`, `frontend/pnpm-workspace.yaml`, `frontend/pnpm-lock.yaml`, `schema/openapi.json`, `frontend/app/src/shared/api/rest/types.generated.ts`, `development/**`, `tasks/**`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1A, 3B |
-| **backend** | `backend/**`, `python_sdk`, `python_testcontainers/**`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml`, plus **any** `**/*.py` (the `python-lint` job also fires on the `python` filter, so `models/`, `utilities/` and root scripts count) | Phases 1B, 2B, 4B, 4D, 5 |
+| **backend** | `backend/**`, `python_sdk`, `development/**`, `tasks/**`, `**/pyproject.toml`, `**/uv.lock`, `.github/workflows/ci.yml`, `.github/file-filters.yml` | Phases 1B, 2B, 4B, 4D, 5 |
+| **python** | any other `**/*.py` — `models/`, `utilities/`, `python_testcontainers/`, `tests/`, root scripts | Phases 1B, 2B |
 | **docs** | `docs/**`, `**/*.{md,mdx}`, `.vale/**`, `.vale.ini`, `package.json`, `package-lock.json`, `development/**`, `tasks/**`, `python_sdk` | Phases 1C, 4C |
+| **yaml** | `**/*.{yml,yaml}`, `**/pyproject.toml`, `**/uv.lock` | Phase 2C |
+
+`python` is deliberately narrower than `backend`. The `python-lint` job fires on `backend ||
+python`, but `backend-tests-unit`, `graphql-schema` and `json-schema` gate on `backend` alone —
+so a change to `models/` or a root script must run the lint phases and **not** the slow ones.
 
 Three frontend validation jobs are gated on their own narrow filters rather than the whole
 frontend area — check these paths separately:
@@ -71,10 +80,11 @@ If `--all` was passed, or if you cannot determine the base ref, treat every area
 **State the detected areas before running anything**, e.g.
 `Detected changes: frontend, docs. Skipping backend phases.`
 
-In Phases 1, 2 and 4 the sub-step letter encodes the area — **A** = frontend, **B** = backend,
-**C** = docs, **D** = schema — so a phase skips letters where an area has nothing to do at that
-stage. Phase 2 has a `2B` and no `2A` because the frontend has no fast check of its own. Phase 3
-is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual CI jobs.
+In Phases 1, 2 and 4 the sub-step letter encodes the area — **A** = frontend, **B** = backend or
+python, **C** = docs (yaml in Phase 2), **D** = schema — so a phase skips letters where an area
+has nothing to do at that stage. Phase 2 has no `2A` because the frontend has no fast check of
+its own. Phase 3 is the exception: it is entirely frontend, so `3A`–`3E` enumerate its individual
+CI jobs.
 
 > **Phase 3A always runs, even with no frontend changes.** The `frontend-lint` job in
 > `ci.yml` has **no path filter** — it runs on every PR. A backend-only change still fails CI if
@@ -92,7 +102,7 @@ These modify files and must complete before any lint check.
 pnpm --dir frontend/app run biome:fix
 ```
 
-**1B. Python** — *if backend changed*
+**1B. Python** — *if backend or python changed*
 
 ```bash
 uv run invoke format
@@ -111,7 +121,7 @@ uv run invoke docs.format
 **Send all applicable commands in a SINGLE message as parallel Bash calls.** Do not run them one
 at a time.
 
-**2B. Python** — *if backend changed*
+**2B. Python** — *if backend or python changed*
 
 1. `uv run invoke main.lint` — report any ruff issues.
 2. `uv run ruff check . --exclude python_sdk` — the exact command CI's `python-lint` job runs.
@@ -121,6 +131,14 @@ at a time.
    whole-repo check proves CI will pass.
 3. `uv lock --check` — ensures `uv.lock` matches `pyproject.toml`. If it fails, run `uv lock` and
    commit the updated lockfile.
+
+**2C. YAML** — *if yaml changed*
+
+1. `uv run yamllint -s .` — the exact command CI's `yaml-lint` job runs. **Easy to miss**: that
+   job fires on any `**/*.{yml,yaml}` change, so a workflow, compose file or schema YAML edit
+   with no Python in it still has a check to pass. Run the command directly rather than
+   `uv run invoke lint`, which bundles unrelated steps; `.yamllint.yml` already ignores `.venv`,
+   `node_modules` and the vendored submodules.
 
 ---
 
@@ -194,10 +212,11 @@ Verifies the generated bindings match `schema/error-catalogue.json`. On failure,
 
 **4B. Backend** — *if backend changed*
 
-1. `uv run invoke backend.lint` — run separately from `main.lint` to avoid
-   `uv run invoke lint`, which includes a `yamllint -s .` step that fails on vendored packages in
-   `.venv`. Its ruff step covers `backend` only, the same coverage gap noted in Phase 2B; the
-   ty and mypy output is what this check adds. CI splits these: `ty` runs in `python-lint`, while
+1. `uv run invoke backend.lint` — call this task directly rather than `uv run invoke lint`, which
+   bundles `main.lint`, `backend.lint` and `yamllint` into one run and so ignores the area gating
+   Phases 2B and 2C apply. Its ruff step covers `backend` only, the same coverage gap noted in
+   Phase 2B; the ty and mypy output is what this check adds. CI splits these: `ty` runs in
+   `python-lint`, while
    `mypy` runs as a step inside `backend-tests-integration` and `backend-tests-functional`.
 2. `uv run invoke backend.validate-generated` — ensures generated schema and protocol files are
    current. If it fails, run `uv run invoke backend.generate` and report the regenerated files.
@@ -253,6 +272,7 @@ Summarize in a table. Include **every** row; mark rows as `skipped (no <area> ch
 | Main Python lint | python-lint | ... |
 | Ruff (CI parity) | python-lint | ... |
 | Lockfile sync | uv-check (`uv-check.yml`) | ... |
+| YAML lint (`yamllint -s .`) | yaml-lint | ... |
 | Backend lint (ty) | python-lint | ... |
 | Backend lint (mypy) | backend-tests-integration, backend-tests-functional | ... |
 | Generated files | backend-validate-generated | ... |

--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -46,9 +46,8 @@ its base: `stable`, `develop`, a `release-*` branch, whichever long-lived branch
 `git fetch` the candidates first so the base is not stale, then collect paths from three places:
 `git diff --name-only --no-renames <merge-base>...HEAD` for committed work, the same command
 against `HEAD` for staged and unstaged work, and `git ls-files --others --exclude-standard` for
-untracked files. Keep `--no-renames` — it reports both sides of a rename, so the area that *lost*
-a file is still flagged. Do not substitute `git status --porcelain`, which collapses
-`R  old -> new` into one path that matches no area.
+untracked files. Keep `--no-renames`: without it a rename reports only the new path, so the area
+that *lost* the file is never flagged.
 
 Run only the phases for the areas that changed, plus those marked always-run. **When unsure about
 the base, or whether a path counts, include it.** Over-running is cheap; a missed area is a red PR.


### PR DESCRIPTION
## Problem

`/pre-ci` describes itself as running "all locally-executable CI checks", but it ran only part of the frontend gate. It could report all-green while `frontend-lint` and `frontend-tests` failed on the PR.

Checked against `.github/workflows/ci.yml`:

**Missing entirely**
- `pnpm knip` — step 2 of the `frontend-lint` job
- `pnpm test:coverage` — the `frontend-tests` job (Phase 4 ran only `backend.test-unit`)
- `frontend/packages/graph` tests — a separate step of the same job, outside `frontend/app`

**Wrong variants**
- `npx biome check --write .` instead of `pnpm exec biome ci .` — the auto-fix variant, not the check-only one CI asserts
- `npx betterer` instead of `pnpm exec betterer ci` — bare `betterer` rewrites the snapshot rather than failing on an increase
- `npx` / `npm` used throughout a pnpm workspace

## Change

**Phase 0 — detect what changed.** Diffs against the merge-base with `origin/develop` (falling back to `origin/stable`) *and* includes the working tree, since uncommitted work is about to be pushed too. Paths are classified with the same globs as `.github/file-filters.yml`, so each area's phases run only when relevant. `--all` forces every phase.

**Phase 3 — complete frontend gate,** at CI parity, with each command annotated with the job it mirrors.

Two things worth flagging for reviewers:

- `frontend-lint` has **no path filter** in `ci.yml` — it runs on every PR. A backend-only change still fails CI if frontend lint is broken. Phase 3A therefore always runs the lint trio regardless of detection.
- `frontend-tests` runs a **second suite** in `frontend/packages/graph`. It is also absent from the four-command gate documented in `frontend/app/AGENTS.md`.

The summary table now lists skipped rows explicitly (`skipped (no backend changes)`) rather than omitting them, so partial coverage is visible rather than reading as a full pass.

## Notes

- No changelog fragment: internal agent tooling, not user-facing.
- Detection is path-based only — no branch-name logic, so it behaves the same for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

