### PR TITLE
fix(e2e): wait for a closed toast to detach before creating the next object

### DIFF
--- a/tests/e2e/objects/profiles/test_multi_profiles.py
+++ b/tests/e2e/objects/profiles/test_multi_profiles.py
@@ -47,7 +47,9 @@ class TestMultiProfiles:
         await admin_page.get_by_role("button", name="Save").click()
         await expect(admin_page.get_by_text("InfraInterface created")).to_be_visible()
         await admin_page.get_by_test_id("close-alert").click()
-        await expect(admin_page.get_by_text("InfraInterface created")).not_to_be_visible()
+        # Wait for detachment, not invisibility: a closed toast stays hidden in the DOM through its
+        # exit animation, and a next toast with the same text mounting beside it breaks strict mode.
+        await expect(admin_page.get_by_text("InfraInterface created")).to_have_count(0)
 
         # L2 profile v1
         await admin_page.get_by_test_id("create-object-button").click()
@@ -58,7 +60,7 @@ class TestMultiProfiles:
         await admin_page.get_by_role("button", name="Save").click()
         await expect(admin_page.get_by_text("InfraInterfaceL2 created")).to_be_visible()
         await admin_page.get_by_test_id("close-alert").click()
-        await expect(admin_page.get_by_text("InfraInterfaceL2 created")).not_to_be_visible()
+        await expect(admin_page.get_by_text("InfraInterfaceL2 created")).to_have_count(0)
 
         # L2 profile v2
         await admin_page.get_by_test_id("create-object-button").click()


### PR DESCRIPTION
## What

`test_create_3_profiles_and_use_them_in_the_form` (foundation shard) flakes with a Playwright strict-mode violation: `get_by_text("InfraInterfaceL2 created")` resolves to 2 elements. Seen on [PR #10394's run](https://github.com/opsmill/infrahub/actions/runs/32844242747) (attempt 1); passed on rerun with zero code change.

## Why

The failure's call log shows the mechanism directly:

```
- locator resolved to <p class="text-sm text-green-800">InfraInterfaceL2 created</p>
  - unexpected value "hidden"
- strict mode violation: ... resolved to 2 elements
```

Clicking `close-alert` hides the toast but react-toastify keeps it in the DOM through its exit animation. `not_to_be_visible()` passes on `hidden`, the test races ahead, and the next creation's identical toast mounts while the old one is still detaching — two matches, strict mode fails.

## Fix

Assert `to_have_count(0)` after each close, which waits for detachment rather than invisibility. `to_have_count(0)` is already the established pattern elsewhere in the suite (e.g. `test_preferences_permissions.py`).

The only other `close-alert` use (`test_groups.py`) never recreates a same-text toast, so it does not have the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

