### PR TITLE
fix(ci): make the keyword scanner see history and fail on scan errors

### DIFF
--- a/.github/workflows/keyword-scan.yml
+++ b/.github/workflows/keyword-scan.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: the scan checks every commit message, and the default depth-1 clone
+          # exposes only the single (synthetic merge) commit, making that check vacuous.
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/utilities/scan.py
+++ b/utilities/scan.py
@@ -10,7 +10,7 @@ def find_keyword_violations(
     repo_root: Path,
     exclude_dirs: set[str],
     exclude_patterns: tuple[str, ...],
-) -> list[str]:
+) -> tuple[list[str], int]:
     """Traverse files once and check each line for any prohibited keyword.
 
     Args:
@@ -20,10 +20,13 @@ def find_keyword_violations(
         exclude_patterns: Tuple of filename patterns to exclude.
 
     Returns:
-        List of file paths (as strings) where any keyword was found.
+        A tuple of (file paths where any keyword was found, number of files that could not be
+        scanned). A skipped file is an error, not a pass: a scan that could not read a file must
+        not report a clean repository.
 
     """
     violations = []
+    errors = 0
     lowered_keywords = [k.lower() for k in keywords]
 
     for path in repo_root.rglob("*"):
@@ -38,8 +41,9 @@ def find_keyword_violations(
                         violations.append(str(path))
                         break
         except Exception:
+            errors += 1
             logging.exception(f"Error occurred while scanning {path}")
-    return violations
+    return violations, errors
 
 
 def find_keyword_in_git_commits(keywords: list[str]) -> list[str]:
@@ -56,20 +60,22 @@ def find_keyword_in_git_commits(keywords: list[str]) -> list[str]:
     lowered_keywords = [k.lower() for k in keywords]
     try:
         result = subprocess.run(
-            ["/usr/bin/git", "log", "--pretty=format:%H:%s"],
+            ["/usr/bin/git", "log", "--pretty=format:%H %s"],
             capture_output=True,
             encoding="utf-8",
             check=True,
         )
-        for line in result.stdout.splitlines():
-            try:
-                commit_hash, message = line.split(":", 1)
-            except ValueError:
-                continue
-            if any(keyword in message.lower() for keyword in lowered_keywords):
-                violations.append(commit_hash)
     except Exception:
+        # A commit scan that could not run has not scanned anything: fail instead of
+        # reporting a clean history.
         logging.exception("Error occurred while scanning git commit messages")
+        print("::error::Unable to scan git commit messages")
+        sys.exit(1)
+
+    for line in result.stdout.splitlines():
+        commit_hash, _, message = line.partition(" ")
+        if any(keyword in message.lower() for keyword in lowered_keywords):
+            violations.append(commit_hash)
     return violations
 
 
@@ -104,14 +110,16 @@ def main() -> None:
     exclude_patterns = ("*.log", "*.lock", ".env", "package-lock.json")
     repo_root = Path.cwd()
 
-    violations = find_keyword_violations(keywords, repo_root, exclude_dirs, exclude_patterns)
+    violations, scan_errors = find_keyword_violations(keywords, repo_root, exclude_dirs, exclude_patterns)
     commit_violations = find_keyword_in_git_commits(keywords)
 
-    if violations or commit_violations:
+    if violations or commit_violations or scan_errors:
         if violations:
             print(f"::error::Keyword scan failed - prohibited terms found in {len(violations)} file(s)")
         if commit_violations:
             print(f"::error::Prohibited keywords found in {len(commit_violations)} git commit(s)")
+        if scan_errors:
+            print(f"::error::{scan_errors} file(s) could not be scanned")
         print("Contact security team for details on specific violations")
         sys.exit(1)
     else:


### PR DESCRIPTION
## What

The Keyword Scanner workflow has been green while two of its checks were not actually running.

**1. The commit-message scan was vacuous.** `actions/checkout` clones at depth 1, so `utilities/scan.py`'s `git log` sees exactly one commit — for `pull_request` events a synthetic `Merge X into Y` — and every real commit message went unscanned. The checkout now uses `fetch-depth: 0`. (Cost: a full-history clone on each run; that is what matches the script's intent of scanning all messages.)

**2. A scan that errored reported a clean repository.** Both scan functions caught every exception, logged it, and returned partial results:

- a failed `git log` produced an empty violation list and the ✅ success message;
- a file that could not be read was skipped silently.

A failed commit scan now exits non-zero, and unscannable files are counted and fail the run with `N file(s) could not be scanned`.

Also folds the commit parsing onto `%H %s` + `partition`, which stops silently skipping commits whose log line had no colon.

## Verification

Run against a scratch repository with a dummy `KEYWORDS_LIST` (the real list is a secret and never needed):

| case | old | new |
|---|---|---|
| clean repo | pass | pass |
| keyword in a file | fail | fail |
| keyword in a commit message | fail (only with history) | fail |
| `KEYWORDS_LIST` unset | fail | fail |
| `git log` unavailable | **✅ pass (silent)** | fail |
| unreadable file | **✅ pass (silent)** | fail |

No change to the keyword semantics, exclusions, or the no-details-in-output policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

