### PR TITLE
chore(agents): apply the code-doc-style rule to every frontend package

### DIFF
--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -2,8 +2,8 @@
 paths:
   - "backend/**/*.py"
   - "python_testcontainers/**/*.py"
-  - "frontend/app/src/**/*.ts"
-  - "frontend/app/src/**/*.tsx"
+  - "frontend/**/*.ts"
+  - "frontend/**/*.tsx"
 ---
 
 # Code documentation style


### PR DESCRIPTION
The `paths:` frontmatter of `.agents/rules/code-doc-style.md` only matched `frontend/app/src/**`, so the workspace packages (`packages/ui`, `packages/graph`, `packages/plugins/template`), the `schema-visualizer` submodule checkout, and `frontend/app/tests/` were outside the comment-discipline rule. Widened to `frontend/**/*.ts{,x}`.

`.claude/rules` is a symlink to `.agents/rules`, so this single edit covers the adapter too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

