### PR TITLE
test(backend): stop one wedged Prefect test server from costing a whole component job

### DIFF
--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -81,6 +81,7 @@ from tests.helpers.constants import (
     PREFECT_TEST_SERVER_PORT_RANGE,
 )
 from tests.helpers.file_repo import FileRepo
+from tests.helpers.prefect_diagnostics import register_prefect_test_server
 from tests.helpers.test_client import dummy_async_request
 from tests.helpers.utils import find_available_prefect_port
 from tests.test_data import dataset01 as ds01
@@ -128,9 +129,17 @@ def neo4j_factory() -> _GraphHydrator:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def prefect_test_fixture() -> Generator[None, None, None]:
+def prefect_test_fixture(tmp_path_factory: pytest.TempPathFactory) -> Generator[None, None, None]:
+    log_dir = tmp_path_factory.getbasetemp()
+
     def _run_uvicorn_command(self: Any) -> subprocess.Popen[Any]:
-        """Patched version of prefect method to call the test server, pointing at the Infrahub entrypoint instead."""
+        """Patched version of prefect method to call the test server, pointing at the Infrahub entrypoint instead.
+
+        The server is launched through a wrapper that answers SIGUSR1 with the stacks of all its
+        threads, and its output is redirected to a file rather than left to interleave with the
+        worker's own. A server that stops answering is otherwise invisible in CI: blocked, it
+        logs nothing at all, and the tests only ever see their own timeouts.
+        """
         # used to turn off serving the UI
         server_env = {
             "PREFECT_UI_ENABLED": "0",
@@ -139,11 +148,15 @@ def prefect_test_fixture() -> Generator[None, None, None]:
             "PREFECT_SERVER_API_MAX_PARAMETER_SIZE": "0",
         }
 
-        return subprocess.Popen(
+        log_path = log_dir / f"prefect-test-server-{self.port}.log"
+        # Held open for the lifetime of the server process, which outlives this function.
+        log_file = log_path.open("wb")
+
+        process = subprocess.Popen(
             args=[
                 sys.executable,
                 "-m",
-                "uvicorn",
+                "tests.helpers.prefect_test_server",
                 # "--app-dir",
                 # str(infrahub.__module_path__.parent),
                 "--factory",
@@ -162,7 +175,11 @@ def prefect_test_fixture() -> Generator[None, None, None]:
                 **server_env,
                 **get_current_settings().to_environment_variables(exclude_unset=True),
             },
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
         )
+        register_prefect_test_server(port=self.port, process=process, log_path=log_path)
+        return process
 
     os.environ["PREFECT_FLOWS_HEARTBEAT_FREQUENCY"] = PREFECT_FLOW_HEARTBEAT_FREQUENCY_SECONDS
     os.environ["PREFECT_SERVER_EVENTS_PROACTIVE_GRANULARITY"] = PREFECT_EVENTS_PROACTIVE_GRANULARITY

--- a/backend/tests/component/test_prefect_test_server_diagnostics.py
+++ b/backend/tests/component/test_prefect_test_server_diagnostics.py
@@ -1,0 +1,22 @@
+"""The Prefect test server report, against the real ephemeral server."""
+
+import io
+
+from prefect.client.orchestration import PrefectClient
+
+from tests.helpers.prefect_diagnostics import dump_prefect_test_server_diagnostics
+
+
+async def test_the_server_answers_a_stack_dump_request_and_survives_it(prefect_client: PrefectClient) -> None:
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("probing the server", stream=out)
+
+    reported = out.getvalue()
+    assert "probing the server" in reported
+    assert "Current thread" in reported
+    assert "uvicorn" in reported
+
+    # A server killed by the signal that asked it what it was doing would take every later test
+    # with it.
+    assert (await prefect_client.api_healthcheck()) is None

--- a/backend/tests/helpers/prefect_diagnostics.py
+++ b/backend/tests/helpers/prefect_diagnostics.py
@@ -1,0 +1,138 @@
+"""Report on an ephemeral Prefect test server that stopped answering.
+
+When a Prefect test server wedges, the test process only ever sees the symptom: read timeouts,
+websocket handshakes that never complete, and pytest timeouts on every fixture that needs the
+task manager. Nothing in the CI log describes the server itself, so the same failure keeps
+coming back undiagnosed.
+
+Whoever launches such a server registers it here along with the file its output is redirected
+to. Code that gives up on a Prefect call then asks every registered server for the stacks of all
+its threads (SIGUSR1) and prints the tail of its log. pytest captures that as part of the failing
+test, so the report travels with the failure into the CI log.
+
+Nothing here raises: it runs on a path that is already failing, and a broken diagnostic must not
+replace the original error.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import time
+import traceback
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TextIO
+
+if TYPE_CHECKING:
+    import subprocess  # noqa: S404 - the server being reported on is a subprocess
+    from pathlib import Path
+
+# How much of the server log to show. Enough to hold the stack dump of every thread plus
+# whatever the server complained about before it went quiet.
+LOG_TAIL_LINES = 300
+
+# Upper bound on how long the server is given to write its stack dump. faulthandler writes
+# synchronously from the signal handler, so this only covers signal delivery.
+STACK_DUMP_TIMEOUT_SECONDS = 2.0
+STACK_DUMP_POLL_SECONDS = 0.05
+
+
+@dataclass(frozen=True)
+class PrefectTestServerProcess:
+    """An ephemeral Prefect test server subprocess and the file its output is redirected to."""
+
+    port: int
+    process: subprocess.Popen[Any]
+    log_path: Path
+
+
+_servers: list[PrefectTestServerProcess] = []
+
+
+def register_prefect_test_server(port: int, process: subprocess.Popen[Any], log_path: Path) -> None:
+    """Record a Prefect test server subprocess so its state can be reported on later.
+
+    Register every launch attempt: the ephemeral server is restarted on a port collision, and a
+    registration whose process has died reports itself as such instead of being silently skipped.
+    """
+    _servers.append(PrefectTestServerProcess(port=port, process=process, log_path=log_path))
+
+
+def clear_prefect_test_servers() -> None:
+    _servers.clear()
+
+
+def dump_prefect_test_server_diagnostics(reason: str, stream: TextIO | None = None) -> None:
+    """Print what every registered Prefect test server is doing, prefixed by ``reason``.
+
+    A no-op when no server was registered, which is every suite that does not run one.
+    """
+    if not _servers:
+        return
+
+    out = stream if stream is not None else sys.stderr
+    try:
+        print(f"\n{'=' * 30} Prefect test server diagnostics {'=' * 30}", file=out)
+        print(reason, file=out)
+        for server in _servers:
+            _dump_server(server, out=out)
+        print("=" * 93, file=out)
+    except Exception:
+        print("Failed to report on the Prefect test server:", file=out)
+        traceback.print_exc(file=out)
+
+
+def _dump_server(server: PrefectTestServerProcess, out: TextIO) -> None:
+    print(f"\n--- Prefect test server on port {server.port} (pid {server.process.pid}) ---", file=out)
+    size_before = _log_size(server)
+    if _request_stack_dump(server, out=out):
+        _wait_for_stack_dump(server, size_before=size_before)
+    _print_log_tail(server, out=out)
+
+
+def _request_stack_dump(server: PrefectTestServerProcess, out: TextIO) -> bool:
+    """Ask the server to write the stacks of all its threads to its log. True if it was alive."""
+    exit_code = server.process.poll()
+    if exit_code is not None:
+        print(f"process exited with code {exit_code} before it could be asked for its stacks", file=out)
+        return False
+
+    try:
+        server.process.send_signal(signal.SIGUSR1)
+    except OSError as exc:
+        print(f"could not signal the process for a stack dump: {exc}", file=out)
+        return False
+    return True
+
+
+def _wait_for_stack_dump(server: PrefectTestServerProcess, size_before: int) -> None:
+    deadline = time.monotonic() + STACK_DUMP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if _log_size(server) > size_before:
+            return
+        time.sleep(STACK_DUMP_POLL_SECONDS)
+
+
+def _log_size(server: PrefectTestServerProcess) -> int:
+    try:
+        return server.log_path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _print_log_tail(server: PrefectTestServerProcess, out: TextIO) -> None:
+    try:
+        lines = server.log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        print(f"could not read {server.log_path}: {exc}", file=out)
+        return
+
+    if not lines:
+        print(f"{server.log_path} is empty: the server neither logged nor answered the stack dump", file=out)
+        return
+
+    dropped = max(len(lines) - LOG_TAIL_LINES, 0)
+    if dropped:
+        print(f"... {dropped} earlier lines in {server.log_path}", file=out)
+    for line in lines[-LOG_TAIL_LINES:]:
+        print(line, file=out)

--- a/backend/tests/helpers/prefect_test_server.py
+++ b/backend/tests/helpers/prefect_test_server.py
@@ -1,0 +1,45 @@
+"""Entry point for the ephemeral Prefect test server subprocess.
+
+This is a plain uvicorn run of the Infrahub Prefect application, wrapped only to make a wedged
+server diagnosable.
+
+A Prefect test server that stops answering takes its whole pytest worker down with it: every
+later test that needs the task manager blocks until a timeout fires. Such a server is invisible
+in a CI log — blocked, it logs nothing at all, and the tests only ever see their own timeouts.
+
+``faulthandler`` gives the test process a way to ask what it is doing. On SIGUSR1 the server
+writes the stack of every one of its threads to stderr, which the launcher redirects to a file.
+faulthandler writes from inside the signal handler rather than scheduling Python code to run, so
+it still answers when the interpreter is too wedged to execute anything else.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import signal
+import sys
+from typing import TextIO
+
+
+def enable_stack_dump_on_signal(file: TextIO | None = None) -> None:
+    """Answer SIGUSR1 with the stack of every thread, written to ``file`` (stderr by default).
+
+    The signal is not chained on: its default action is to kill the process, and a server that
+    dies of being asked what it is doing can only be asked once.
+    """
+    faulthandler.register(signal.SIGUSR1, file=file if file is not None else sys.stderr, all_threads=True, chain=False)
+
+
+def main() -> None:
+    # Fatal errors (a segfault in a native driver, a hard stack overflow) would otherwise leave
+    # nothing but an exit code behind.
+    faulthandler.enable()
+    enable_stack_dump_on_signal()
+
+    from uvicorn.main import main as uvicorn_main  # noqa: PLC0415 - the uvicorn CLI is the process this module wraps
+
+    uvicorn_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -16,19 +16,41 @@ server torn down and recreated at a URL the memo already holds would be skipped,
 so callers must only target session-lived servers.
 
 A failure is remembered the same way a success is. An unreachable Prefect test
-server does not fail fast — the setup blocks until the pytest timeout fires — so
-retrying it for every later test class costs that timeout each time and buries the
+server does not fail fast — the setup blocks until a timeout fires — so retrying
+it for every later test class costs that timeout each time and buries the
 original cause under a wall of identical errors.
+
+For that to work the setup has to fail *inside* the coroutine, which is why it
+carries its own timeout instead of leaning on the pytest one. pytest-timeout runs
+in signal mode, and SIGALRM is raised in whichever frame the main thread happens
+to be in — for an async fixture that is the event loop driver, several frames
+above the coroutine. Nothing here would see it, nothing would be remembered, and
+the next test would start the setup over again. Worse, the abandoned coroutine
+stays pending on the session-scoped loop and runs on in between later tests,
+hanging tests that never touch Prefect at all.
+
+A timed-out setup can leave a partially registered server behind. That is no worse
+than what the pytest timeout did, and the memo makes sure nothing builds on it.
 
 Tests that intentionally corrupt the shared task manager state must restore it
 themselves before yielding back, otherwise later tests will observe the corruption.
 """
 
+import asyncio
 from collections.abc import Awaitable, Callable
 
 from prefect.settings import get_current_settings
 
 from infrahub.workflows.initialization import setup_task_manager
+from tests.helpers.prefect_diagnostics import dump_prefect_test_server_diagnostics
+
+# Ceiling for one setup attempt. It has to stay under the 300s pytest timeout, so that a wedged
+# server is reported from inside the coroutine, and far enough above how long the registration
+# takes on a loaded CI runner (tens of seconds, the slowest calls bounded by Prefect's own 60s
+# client request timeout) that a slow run is never mistaken for a wedged one. That margin is the
+# one worth paying for: giving up too early is remembered, and would condemn a healthy server for
+# the rest of the session.
+SETUP_TIMEOUT_SECONDS = 180.0
 
 
 def _current_prefect_api_url() -> str | None:
@@ -40,9 +62,13 @@ class TaskManagerSetup:
         self,
         setup: Callable[[], Awaitable[None]] = setup_task_manager,
         server_key: Callable[[], str | None] = _current_prefect_api_url,
+        timeout: float = SETUP_TIMEOUT_SECONDS,
+        report_failure: Callable[[str], None] = dump_prefect_test_server_diagnostics,
     ) -> None:
         self._setup = setup
         self._server_key = server_key
+        self._timeout = timeout
+        self._report_failure = report_failure
         self._initialized: set[str | None] = set()
         self._failures: dict[str | None, BaseException] = {}
 
@@ -56,11 +82,13 @@ class TaskManagerSetup:
             return
 
         try:
-            await self._setup()
+            async with asyncio.timeout(self._timeout):
+                await self._setup()
         # The pytest timeout raises Failed, which derives from BaseException, and that is
         # the failure worth remembering most.
         except BaseException as exc:
             self._failures[server] = exc
+            self._report_failure(f"Prefect task manager setup failed for {server}: {exc!r}")
             raise
 
         self._initialized.add(server)

--- a/backend/tests/unit/helpers/test_prefect_diagnostics.py
+++ b/backend/tests/unit/helpers/test_prefect_diagnostics.py
@@ -1,0 +1,156 @@
+"""Tests for the Prefect test server report in tests.helpers.prefect_diagnostics."""
+
+import faulthandler
+import io
+import os
+import signal
+import subprocess  # noqa: S404
+import sys
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.prefect_diagnostics import (
+    LOG_TAIL_LINES,
+    clear_prefect_test_servers,
+    dump_prefect_test_server_diagnostics,
+    register_prefect_test_server,
+)
+from tests.helpers.prefect_test_server import enable_stack_dump_on_signal
+
+STARTUP_TIMEOUT_SECONDS = 30.0
+STARTUP_POLL_SECONDS = 0.05
+
+
+@pytest.fixture(autouse=True)
+def registered_servers() -> Generator[None, None, None]:
+    clear_prefect_test_servers()
+    yield
+    clear_prefect_test_servers()
+
+
+@pytest.fixture
+def idle_server(tmp_path: Path) -> Generator[tuple[subprocess.Popen[bytes], Path], None, None]:
+    """A process standing in for a Prefect test server: it answers SIGUSR1 and nothing else."""
+    log_path = tmp_path / "server.log"
+    script_path = tmp_path / "idle_server.py"
+    script_path.write_text(
+        "import time\n"
+        "from tests.helpers.prefect_test_server import enable_stack_dump_on_signal\n"
+        "enable_stack_dump_on_signal()\n"
+        "print('server ready', flush=True)\n"
+        "time.sleep(600)\n"
+    )
+    with log_path.open("wb") as log_file:
+        process = subprocess.Popen(
+            args=[sys.executable, str(script_path)],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    try:
+        _wait_for_startup(process=process, log_path=log_path)
+        yield process, log_path
+    finally:
+        process.kill()
+        process.wait()
+
+
+@pytest.fixture
+def exited_server(tmp_path: Path) -> tuple[subprocess.Popen[bytes], Path]:
+    """A stand-in server that is already gone by the time anything asks it for its stacks."""
+    log_path = tmp_path / "server.log"
+    with log_path.open("wb") as log_file:
+        process = subprocess.Popen(
+            args=[sys.executable, "-c", "raise SystemExit(3)"],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    process.wait()
+    return process, log_path
+
+
+def _wait_for_startup(process: subprocess.Popen[bytes], log_path: Path) -> None:
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if "server ready" in log_path.read_text(encoding="utf-8"):
+            return
+        if process.poll() is not None:
+            pytest.fail(f"the stand-in server exited with {process.returncode}: {log_path.read_text(encoding='utf-8')}")
+        time.sleep(STARTUP_POLL_SECONDS)
+    pytest.fail("the stand-in server never reported itself ready")
+
+
+def test_sigusr1_dumps_the_stack_of_every_thread(tmp_path: Path) -> None:
+    """The report is worthless unless a wedged server answers this signal with its stacks."""
+    dump_path = tmp_path / "stacks.log"
+    with dump_path.open("w") as dump_file:
+        enable_stack_dump_on_signal(file=dump_file)
+        try:
+            os.kill(os.getpid(), signal.SIGUSR1)
+        finally:
+            faulthandler.unregister(signal.SIGUSR1)
+
+    dumped = dump_path.read_text()
+    assert "Current thread" in dumped
+    assert "test_sigusr1_dumps_the_stack_of_every_thread" in dumped
+
+
+def test_nothing_is_reported_when_no_server_is_registered() -> None:
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("setup timed out", stream=out)
+
+    assert not out.getvalue()
+
+
+def test_a_registered_server_is_asked_for_its_stacks(idle_server: tuple[subprocess.Popen[bytes], Path]) -> None:
+    process, log_path = idle_server
+    register_prefect_test_server(port=4242, process=process, log_path=log_path)
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("setup timed out", stream=out)
+
+    reported = out.getvalue()
+    assert "setup timed out" in reported
+    assert f"Prefect test server on port 4242 (pid {process.pid})" in reported
+    assert "Current thread" in reported
+    assert f'File "{log_path.parent / "idle_server.py"}", line 5 in <module>' in reported
+
+
+def test_an_unreadable_log_is_reported_without_raising(
+    tmp_path: Path, idle_server: tuple[subprocess.Popen[bytes], Path]
+) -> None:
+    process, _ = idle_server
+    missing_log = tmp_path / "nowhere" / "server.log"
+    register_prefect_test_server(port=4242, process=process, log_path=missing_log)
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("setup timed out", stream=out)
+
+    assert f"could not read {missing_log}" in out.getvalue()
+
+
+def test_a_dead_server_reports_its_exit_code(exited_server: tuple[subprocess.Popen[bytes], Path]) -> None:
+    process, log_path = exited_server
+    register_prefect_test_server(port=4242, process=process, log_path=log_path)
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("setup timed out", stream=out)
+
+    assert "process exited with code 3 before it could be asked for its stacks" in out.getvalue()
+
+
+def test_only_the_tail_of_a_long_log_is_reported(exited_server: tuple[subprocess.Popen[bytes], Path]) -> None:
+    process, log_path = exited_server
+    log_path.write_text("".join(f"line {index}\n" for index in range(LOG_TAIL_LINES + 10)))
+    register_prefect_test_server(port=4242, process=process, log_path=log_path)
+    out = io.StringIO()
+
+    dump_prefect_test_server_diagnostics("setup timed out", stream=out)
+
+    reported = out.getvalue()
+    assert f"... 10 earlier lines in {log_path}" in reported
+    assert "line 9\n" not in reported
+    assert f"line {LOG_TAIL_LINES + 9}\n" in reported

--- a/backend/tests/unit/helpers/test_task_manager.py
+++ b/backend/tests/unit/helpers/test_task_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from tests.helpers.task_manager import TaskManagerSetup
@@ -114,3 +116,59 @@ async def test_failure_that_bypasses_exception_is_remembered() -> None:
         await once.run_once()
 
     assert setup.calls == 1
+
+
+class HangingSetup(RecordingSetup):
+    """Stands in for a Prefect test server that accepts connections but never answers."""
+
+    async def __call__(self) -> None:
+        await super().__call__()
+        await asyncio.Event().wait()
+
+
+class RecordingReport:
+    """Keeps the diagnostic reports a failed setup asked for."""
+
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+
+    def __call__(self, reason: str) -> None:
+        self.reasons.append(reason)
+
+
+async def test_hanging_setup_gives_up_inside_the_coroutine() -> None:
+    """The pytest timeout fires above the coroutine, so a hang has to be bounded here."""
+    setup = HangingSetup()
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://wedged/api"), timeout=0.05)
+
+    with pytest.raises(TimeoutError):
+        await once.run_once()
+
+    with pytest.raises(RuntimeError, match=r"^Prefect task manager setup already failed for http://wedged/api$"):
+        await once.run_once()
+
+    assert setup.calls == 1
+
+
+async def test_a_failed_setup_is_reported_once() -> None:
+    setup = FailingSetup(TimeoutError("prefect server is unreachable"))
+    report = RecordingReport()
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://server-a/api"), report_failure=report)
+
+    with pytest.raises(TimeoutError):
+        await once.run_once()
+    with pytest.raises(RuntimeError):
+        await once.run_once()
+
+    assert report.reasons == [
+        "Prefect task manager setup failed for http://server-a/api: TimeoutError('prefect server is unreachable')"
+    ]
+
+
+async def test_a_successful_setup_is_not_reported() -> None:
+    report = RecordingReport()
+    once = TaskManagerSetup(setup=RecordingSetup(), server_key=MovingServer(), report_failure=report)
+
+    await once.run_once()
+
+    assert report.reasons == []


### PR DESCRIPTION
# Why

One Prefect test server that stops answering currently costs a whole `backend-tests-component` job. On develop run [32874262393](https://github.com/opsmill/infrahub/actions/runs/32874262393/job/97888958473), gw0's ephemeral server went unresponsive at 16:57 and the job died 35 minutes later at the 1800s xdist session timeout — 3 failures, 15 errors. The same family hit develop again the same morning (run 32818780299), that time against the Prefect container.

Two things made it that expensive, and this PR fixes both. It does **not** fix the wedge itself — that root cause is still unknown, which is precisely what the second commit is for.

## What changed

**A hung task-manager setup is now remembered the first time it hangs.**

`setup_task_manager_once()` already memoizes a failure so that one wedged server doesn't cost a 300s pytest timeout per test. It never armed: pytest-timeout runs in signal mode, so SIGALRM is raised in whichever frame the main thread is in — for an async fixture that is the event loop driver, several frames above the coroutine. `run_once`'s `except BaseException` never saw it, nothing was recorded, and the next test started the setup over. Three tests burned the full 300s each before the memo finally armed (when an abandoned coroutine raised `ReadTimeout` on its own), and those abandoned coroutines stayed pending on the session-scoped loop, going on to hang `profiles/test_gather.py` — which never touches Prefect — for another 900s.

The setup now carries its own 180s ceiling, so it fails *inside* the coroutine. The margin is deliberate: a false timeout is memoized too, and would condemn a healthy server for the rest of the session, so the budget sits ~6x above a healthy setup and well under the 300s pytest timeout.

**A wedged server can now be asked what it is doing.**

Previously nothing described the server itself — blocked, it logs nothing, and the tests only ever see their own timeouts. The ephemeral server now boots through an entry point that answers SIGUSR1 with the stack of every one of its threads (`chain=False`; chaining would let the signal's default action kill the server), its output goes to a file per port, and both the stacks and the log tail are printed when a Prefect call gives up:

```
--- Prefect test server on port 28354 (pid 3060674) ---
Thread ... [Thread-3 (_conn] (most recent call first):
  File ".../aiosqlite/core.py", line 59 in _connection_worker_thread
...
Current thread ... [python] (most recent call first):
  File ".../uvicorn/server.py", line 65 in run
```

That is enough to confirm or kill the standing SQLite-contention hypothesis (see the comment on `PREFECT_SERVER_NONESSENTIAL_SERVICE_ENV_VARS`) the next time a server wedges.

**Note for the merge-up:** `stable` globally ignores the `BLE` ruff rules and `develop` does not, so the blanket `except Exception` guarding the report (a broken diagnostic must never replace the failure that triggered it) needs a `# noqa: BLE001` on `develop` and must not carry one here — RUF100 flags it as unused on `stable`. That is the one line that will need adding when this reaches `develop`.

**What stayed the same:** no product code touched — this is entirely test infrastructure. The server's own configuration (env, log level, port range) is unchanged.

## How to review

`backend/tests/helpers/task_manager.py` and `backend/tests/helpers/prefect_diagnostics.py` are the substance; the conftest change is just the launcher wiring.

The value worth scrutiny is `SETUP_TIMEOUT_SECONDS = 180`. Too low and a slow-but-healthy CI runner gets its server condemned for the whole session; too high and the failure escapes to the pytest timeout, which is the bug being fixed here.

## How to test

```bash
uv run pytest --no-cov backend/tests/unit/helpers
uv run pytest --no-cov --neo4j backend/tests/component/test_prefect_test_server_diagnostics.py
```

Validated locally beyond CI:

- The real ephemeral server answers a stack-dump request **and survives it** (asserted by the new component test) — a server killed by the signal asking what it was doing would take every later test with it.
- The whole failure path, by SIGSTOPping the live server: `TimeoutError` at the budget → memoized → next call fails fast with `RuntimeError: already failed` → report printed. A stopped server reports "neither logged nor answered the stack dump", which usefully distinguishes unschedulable from blocked-in-Python.
- `backend/tests/component/api/test_40_schema.py` + `backend/tests/component/profiles` (the modules that failed in the run above): 37 passed.
- `uv run invoke format`, `lint`, and `backend.validate-component-shards` clean.

## Impact & rollout

- **Backward compatibility:** test-only; no runtime behaviour changes.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added (test-infrastructure only; no user-visible change)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content
