### PR TITLE
perf(backend): read an object template a level at a time

### DIFF
--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -217,9 +217,7 @@ async def extract_peer_data(
             # deeper templates are handled in the next level of recursion
             if await _peer_is_a_template(db=db, relationship=relationship):
                 continue
-            # The subtemplate was read with the peers its relationships name, so hand over the node
-            # where it is in hand: an id sends the checks on the new object, and the write itself,
-            # back to the database for a node already in memory.
+            # The peer is already read, so an id would send the checks and the write back to the database.
             rel_peers.append({"id": relationship.get_peer_in_hand() or relationship.peer_id})
 
         # Only set the relationship data if there are actual peers to set

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -8,7 +8,6 @@ from infrahub.core.constants import (
     PROFILES_RELATIONSHIP_NAME,
     SYSTEM_USER_ID,
     MetadataOptions,
-    RelationshipCardinality,
     RelationshipKind,
 )
 from infrahub.core.constants.schema import RESOURCE_POOL_REL_SUFFIX
@@ -29,32 +28,44 @@ if TYPE_CHECKING:
     from infrahub.core.node import SchemaProtocol
     from infrahub.core.protocols import CoreObjectTemplate
     from infrahub.core.relationship.model import Relationship, RelationshipManager
-    from infrahub.core.schema import MainSchemaTypes, NonGenericSchemaTypes, RelationshipSchema
+    from infrahub.core.schema import MainSchemaTypes, NonGenericSchemaTypes
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
-async def get_template_relationship_peers(
-    db: InfrahubDatabase, template: CoreObjectTemplate, relationship: RelationshipSchema
-) -> Mapping[str, CoreObjectTemplate]:
-    """For a given relationship on the template, fetch the related peers."""
-    template_relationship_manager: RelationshipManager = getattr(template, relationship.name)
-    peers: Mapping[str, CoreObjectTemplate]
-    if relationship.cardinality == RelationshipCardinality.MANY:
-        peers = await template_relationship_manager.get_peers(db=db, include_metadata=MetadataOptions.SOURCE)
-    else:
-        template_relationship_peer = await template_relationship_manager.get_peer(db=db)
-        peers = {template_relationship_peer.id: template_relationship_peer} if template_relationship_peer else {}
+async def get_component_subtemplates(
+    db: InfrahubDatabase, obj: Node, template: CoreObjectTemplate, fields: list
+) -> list[CoreObjectTemplate]:
+    """The subtemplates the component relationships of this template name.
 
-    # Every peer is a subtemplate of its own, read here with the relationships materializing it reads.
+    The template was read with those relationships and with the peers they name, so naming its
+    subtemplates costs no query.
+    """
+    subtemplates: list[CoreObjectTemplate] = []
+    for relationship in obj.get_relationships(kind=RelationshipKind.COMPONENT, exclude=fields):
+        template_relationship_manager: RelationshipManager = getattr(template, relationship.name)
+        for template_relationship in await template_relationship_manager.get_relationships(db=db):
+            subtemplates.append(cast("CoreObjectTemplate", await template_relationship.get_peer(db=db)))
+    return subtemplates
+
+
+async def read_subtemplates(db: InfrahubDatabase, branch: Branch, subtemplates: list[CoreObjectTemplate]) -> None:
+    """Read a whole level of subtemplates, with the relationships materializing them consults.
+
+    The peers those relationships name are read with them, which is what leaves the level below
+    already in memory by the time it is walked.
+    """
     await registry.manager.prefetch_relationships(
         db=db,
-        nodes=cast("Iterable[Node]", peers.values()),
-        names={name for peer in peers.values() for name in get_relationship_names_to_read(schema=peer.get_schema())},
-        branch=template_relationship_manager.branch,
+        nodes=cast("Iterable[Node]", subtemplates),
+        names={
+            name
+            for subtemplate in subtemplates
+            for name in get_relationship_names_to_read(schema=subtemplate.get_schema())
+        },
+        branch=branch,
         include_metadata=MetadataOptions.SOURCE,
     )
-    return peers
 
 
 async def _peer_is_a_template(db: InfrahubDatabase, relationship: Relationship) -> bool:
@@ -198,68 +209,97 @@ async def allocate_from_resource_pools(
             )
 
 
+async def create_component(
+    db: InfrahubDatabase,
+    branch: Branch,
+    constraint_runner: NodeConstraintRunner,
+    parent_obj: Node,
+    parent_template: CoreObjectTemplate,
+    subtemplate: CoreObjectTemplate,
+    at: Timestamp | None = None,
+    user_id: str = SYSTEM_USER_ID,
+) -> Node:
+    """Create the object a subtemplate describes, as a component of the object holding it."""
+    # We retrieve peer schema for each peer in case we are processing a relationship which is based on a generic
+    obj_peer_schema = registry.schema.get_node_schema(
+        name=subtemplate.get_schema().kind.removeprefix("Template"),
+        branch=branch,
+        duplicate=False,
+    )
+    obj_peer_data = await extract_peer_data(
+        db=db,
+        template_peer=subtemplate,
+        obj_peer_schema=obj_peer_schema,
+        parent_obj=parent_obj,
+        current_template=parent_template,
+    )
+
+    obj_peer = await Node.init(schema=obj_peer_schema, db=db, branch=branch, at=at)
+    await obj_peer.new(db=db, **obj_peer_data)
+    await constraint_runner.check(node=obj_peer, field_filters=list(obj_peer_data))
+
+    await allocate_from_resource_pools(db=db, branch=branch, obj=obj_peer, template=subtemplate, at=at, user_id=user_id)
+
+    template_profile_ids = await get_profile_ids(db=db, obj=subtemplate)
+    if template_profile_ids:
+        node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
+        await node_profiles_applier.apply_profiles(node=obj_peer)
+
+    await obj_peer.save(db=db, user_id=user_id)
+    NodeCreationContext.record_if_active(node=obj_peer)
+    return obj_peer
+
+
 async def handle_template_relationships(
     db: InfrahubDatabase,
     branch: Branch,
     obj: Node,
     template: CoreObjectTemplate,
     fields: list,
-    constraint_runner: NodeConstraintRunner | None = None,
     at: Timestamp | None = None,
     user_id: str = SYSTEM_USER_ID,
 ) -> None:
-    if constraint_runner is None:
-        component_registry = get_component_registry()
-        constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
+    """Create the objects the components of a template describe, one level of the template at a time.
 
-    for relationship in obj.get_relationships(kind=RelationshipKind.COMPONENT, exclude=fields):
-        template_relationship_peers = await get_template_relationship_peers(
-            db=db, template=template, relationship=relationship
-        )
-        if not template_relationship_peers:
-            continue
+    The subtemplates of a level are all named before any of them is walked, so the level is read
+    once for every parent it hangs from rather than once per parent. `template` itself was read that
+    way by the caller, which is why the walk starts with a level already in memory.
+    """
+    component_registry = get_component_registry()
+    constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
 
-        for template_relationship_peer in template_relationship_peers.values():
-            # We retrieve peer schema for each peer in case we are processing a relationship which is based on a generic
-            obj_peer_schema = registry.schema.get_node_schema(
-                name=template_relationship_peer.get_schema().kind.removeprefix("Template"),
-                branch=branch,
-                duplicate=False,
+    level: list[tuple[Node, CoreObjectTemplate]] = [(obj, template)]
+    while level:
+        parents_with_subtemplates: list[tuple[Node, CoreObjectTemplate, list[CoreObjectTemplate]]] = []
+        for parent_obj, parent_template in level:
+            subtemplates = await get_component_subtemplates(
+                db=db, obj=parent_obj, template=parent_template, fields=fields
             )
-            obj_peer_data = await extract_peer_data(
-                db=db,
-                template_peer=template_relationship_peer,
-                obj_peer_schema=obj_peer_schema,
-                parent_obj=obj,
-                current_template=template,
-            )
+            parents_with_subtemplates.append((parent_obj, parent_template, subtemplates))
 
-            obj_peer = await Node.init(schema=obj_peer_schema, db=db, branch=branch, at=at)
-            await obj_peer.new(db=db, **obj_peer_data)
-            await constraint_runner.check(node=obj_peer, field_filters=list(obj_peer_data))
+        level_subtemplates = [
+            subtemplate for _, _, subtemplates in parents_with_subtemplates for subtemplate in subtemplates
+        ]
+        if not level_subtemplates:
+            return
 
-            await allocate_from_resource_pools(
-                db=db, branch=branch, obj=obj_peer, template=template_relationship_peer, at=at, user_id=user_id
-            )
+        await read_subtemplates(db=db, branch=branch, subtemplates=level_subtemplates)
 
-            template_profile_ids = await get_profile_ids(db=db, obj=template_relationship_peer)
-            if template_profile_ids:
-                node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
-                await node_profiles_applier.apply_profiles(node=obj_peer)
-
-            await obj_peer.save(db=db, user_id=user_id)
-            NodeCreationContext.record_if_active(node=obj_peer)
-
-            await handle_template_relationships(
-                db=db,
-                branch=branch,
-                constraint_runner=constraint_runner,
-                obj=obj_peer,
-                template=template_relationship_peer,
-                fields=fields,
-                at=at,
-                user_id=user_id,
-            )
+        next_level: list[tuple[Node, CoreObjectTemplate]] = []
+        for parent_obj, parent_template, subtemplates in parents_with_subtemplates:
+            for subtemplate in subtemplates:
+                obj_peer = await create_component(
+                    db=db,
+                    branch=branch,
+                    constraint_runner=constraint_runner,
+                    parent_obj=parent_obj,
+                    parent_template=parent_template,
+                    subtemplate=subtemplate,
+                    at=at,
+                    user_id=user_id,
+                )
+                next_level.append((obj_peer, subtemplate))
+        level = next_level
 
 
 async def get_profile_ids(db: InfrahubDatabase, obj: Node | CoreObjectTemplate) -> set[str]:

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -212,16 +212,19 @@ async def extract_peer_data(
             obj_peer_data[rel_name] = parent_obj
             continue
 
-        rel_peer_ids = []
+        rel_peers = []
         for relationship in relationships:
             # deeper templates are handled in the next level of recursion
             if await _peer_is_a_template(db=db, relationship=relationship):
                 continue
-            rel_peer_ids.append({"id": relationship.peer_id})
+            # The subtemplate was read with the peers its relationships name, so hand over the node
+            # where it is in hand: an id sends the checks on the new object, and the write itself,
+            # back to the database for a node already in memory.
+            rel_peers.append({"id": relationship.get_peer_in_hand() or relationship.peer_id})
 
         # Only set the relationship data if there are actual peers to set
-        if rel_peer_ids:
-            obj_peer_data[rel_name] = rel_peer_ids
+        if rel_peers:
+            obj_peer_data[rel_name] = rel_peers
 
         if rel_manager.schema.kind == RelationshipKind.PROFILE:
             obj_peer_data[rel_name] = peer_ids

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast, overload
 
 from infrahub import lock
@@ -33,8 +34,29 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
+@dataclass
+class TemplateComponent:
+    """A subtemplate to materialize, the schema of the object it describes, and what it holds.
+
+    `components` is filled in once the level below this subtemplate has been read.
+    """
+
+    subtemplate: CoreObjectTemplate
+    schema: NonGenericSchemaTypes
+    components: list[TemplateComponent] = field(default_factory=list)
+
+
+@dataclass
+class _SubtemplateParent:
+    """A template of the level being walked, and the list its components are recorded in."""
+
+    schema: MainSchemaTypes
+    template: CoreObjectTemplate
+    components: list[TemplateComponent]
+
+
 async def get_component_subtemplates(
-    db: InfrahubDatabase, obj: Node, template: CoreObjectTemplate, fields: list
+    db: InfrahubDatabase, schema: MainSchemaTypes, template: CoreObjectTemplate, fields: list
 ) -> list[CoreObjectTemplate]:
     """The subtemplates the component relationships of this template name.
 
@@ -42,7 +64,9 @@ async def get_component_subtemplates(
     subtemplates costs no query.
     """
     subtemplates: list[CoreObjectTemplate] = []
-    for relationship in obj.get_relationships(kind=RelationshipKind.COMPONENT, exclude=fields):
+    for relationship in schema.relationships:
+        if relationship.kind != RelationshipKind.COMPONENT or relationship.name in fields:
+            continue
         template_relationship_manager: RelationshipManager = getattr(template, relationship.name)
         for template_relationship in await template_relationship_manager.get_relationships(db=db):
             subtemplates.append(cast("CoreObjectTemplate", await template_relationship.get_peer(db=db)))
@@ -53,7 +77,9 @@ async def read_subtemplates(db: InfrahubDatabase, branch: Branch, subtemplates: 
     """Read a whole level of subtemplates, with the relationships materializing them consults.
 
     The peers those relationships name are read with them, which is what leaves the level below
-    already in memory by the time it is walked.
+    already in memory by the time it is walked. Those peers include the parents the level points
+    back at, which the walk already holds and reads again: the batched read has no way to be told a
+    node is in hand.
     """
     await registry.manager.prefetch_relationships(
         db=db,
@@ -66,6 +92,52 @@ async def read_subtemplates(db: InfrahubDatabase, branch: Branch, subtemplates: 
         branch=branch,
         include_metadata=MetadataOptions.SOURCE,
     )
+
+
+async def read_template_components(
+    db: InfrahubDatabase, branch: Branch, schema: MainSchemaTypes, template: CoreObjectTemplate, fields: list
+) -> list[TemplateComponent]:
+    """The tree of subtemplates under this template, read one level at a time.
+
+    The subtemplates a level names are all known before any of them is read, so a level is read once
+    for every parent it hangs from rather than once per parent. Reading a level names the level
+    below it, which is what the next turn of the loop reads. `template` itself was read that way by
+    the caller, which is why the walk starts with a level already in memory.
+    """
+    # The walk starts at the template itself; the components it names are what is returned.
+    components: list[TemplateComponent] = []
+    level = [_SubtemplateParent(schema=schema, template=template, components=components)]
+
+    while level:
+        next_level: list[_SubtemplateParent] = []
+        level_components: list[TemplateComponent] = []
+        for parent in level:
+            subtemplates = await get_component_subtemplates(
+                db=db, schema=parent.schema, template=parent.template, fields=fields
+            )
+            for subtemplate in subtemplates:
+                # We retrieve peer schema for each peer in case we are processing a relationship which is based on a generic
+                component = TemplateComponent(
+                    subtemplate=subtemplate,
+                    schema=registry.schema.get_node_schema(
+                        name=subtemplate.get_schema().kind.removeprefix("Template"), branch=branch, duplicate=False
+                    ),
+                )
+                parent.components.append(component)
+                level_components.append(component)
+                next_level.append(
+                    _SubtemplateParent(schema=component.schema, template=subtemplate, components=component.components)
+                )
+
+        if not level_components:
+            break
+
+        await read_subtemplates(
+            db=db, branch=branch, subtemplates=[component.subtemplate for component in level_components]
+        )
+        level = next_level
+
+    return components
 
 
 async def _peer_is_a_template(db: InfrahubDatabase, relationship: Relationship) -> bool:
@@ -215,32 +287,28 @@ async def create_component(
     constraint_runner: NodeConstraintRunner,
     parent_obj: Node,
     parent_template: CoreObjectTemplate,
-    subtemplate: CoreObjectTemplate,
+    component: TemplateComponent,
     at: Timestamp | None = None,
     user_id: str = SYSTEM_USER_ID,
 ) -> Node:
     """Create the object a subtemplate describes, as a component of the object holding it."""
-    # We retrieve peer schema for each peer in case we are processing a relationship which is based on a generic
-    obj_peer_schema = registry.schema.get_node_schema(
-        name=subtemplate.get_schema().kind.removeprefix("Template"),
-        branch=branch,
-        duplicate=False,
-    )
     obj_peer_data = await extract_peer_data(
         db=db,
-        template_peer=subtemplate,
-        obj_peer_schema=obj_peer_schema,
+        template_peer=component.subtemplate,
+        obj_peer_schema=component.schema,
         parent_obj=parent_obj,
         current_template=parent_template,
     )
 
-    obj_peer = await Node.init(schema=obj_peer_schema, db=db, branch=branch, at=at)
+    obj_peer = await Node.init(schema=component.schema, db=db, branch=branch, at=at)
     await obj_peer.new(db=db, **obj_peer_data)
     await constraint_runner.check(node=obj_peer, field_filters=list(obj_peer_data))
 
-    await allocate_from_resource_pools(db=db, branch=branch, obj=obj_peer, template=subtemplate, at=at, user_id=user_id)
+    await allocate_from_resource_pools(
+        db=db, branch=branch, obj=obj_peer, template=component.subtemplate, at=at, user_id=user_id
+    )
 
-    template_profile_ids = await get_profile_ids(db=db, obj=subtemplate)
+    template_profile_ids = await get_profile_ids(db=db, obj=component.subtemplate)
     if template_profile_ids:
         node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
         await node_profiles_applier.apply_profiles(node=obj_peer)
@@ -248,6 +316,47 @@ async def create_component(
     await obj_peer.save(db=db, user_id=user_id)
     NodeCreationContext.record_if_active(node=obj_peer)
     return obj_peer
+
+
+async def create_components(
+    db: InfrahubDatabase,
+    branch: Branch,
+    constraint_runner: NodeConstraintRunner,
+    parent_obj: Node,
+    parent_template: CoreObjectTemplate,
+    components: list[TemplateComponent],
+    at: Timestamp | None = None,
+    user_id: str = SYSTEM_USER_ID,
+) -> None:
+    """Create the objects these subtemplates describe, depth first.
+
+    A component and the components it holds are created one after the other. A resource pool serving
+    more than one level hands its resources out in the order the components are created, so walking
+    the tree in any other order would move the resources each component is given.
+
+    The subtemplates were read before any of them is created, so this creates without reading.
+    """
+    for component in components:
+        obj_peer = await create_component(
+            db=db,
+            branch=branch,
+            constraint_runner=constraint_runner,
+            parent_obj=parent_obj,
+            parent_template=parent_template,
+            component=component,
+            at=at,
+            user_id=user_id,
+        )
+        await create_components(
+            db=db,
+            branch=branch,
+            constraint_runner=constraint_runner,
+            parent_obj=obj_peer,
+            parent_template=component.subtemplate,
+            components=component.components,
+            at=at,
+            user_id=user_id,
+        )
 
 
 async def handle_template_relationships(
@@ -259,47 +368,31 @@ async def handle_template_relationships(
     at: Timestamp | None = None,
     user_id: str = SYSTEM_USER_ID,
 ) -> None:
-    """Create the objects the components of a template describe, one level of the template at a time.
+    """Create the objects the components of a template describe.
 
-    The subtemplates of a level are all named before any of them is walked, so the level is read
-    once for every parent it hangs from rather than once per parent. `template` itself was read that
-    way by the caller, which is why the walk starts with a level already in memory.
+    The template is read a level at a time and the objects are created depth first. Those are two
+    different walks on purpose: reading a whole level at once costs one read per level rather than
+    one per parent, while creating a component together with the components it holds keeps the
+    order in which a resource pool shared by several levels is drawn from.
     """
+    components = await read_template_components(
+        db=db, branch=branch, schema=obj.get_schema(), template=template, fields=fields
+    )
+    if not components:
+        return
+
     component_registry = get_component_registry()
     constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
-
-    level: list[tuple[Node, CoreObjectTemplate]] = [(obj, template)]
-    while level:
-        parents_with_subtemplates: list[tuple[Node, CoreObjectTemplate, list[CoreObjectTemplate]]] = []
-        for parent_obj, parent_template in level:
-            subtemplates = await get_component_subtemplates(
-                db=db, obj=parent_obj, template=parent_template, fields=fields
-            )
-            parents_with_subtemplates.append((parent_obj, parent_template, subtemplates))
-
-        level_subtemplates = [
-            subtemplate for _, _, subtemplates in parents_with_subtemplates for subtemplate in subtemplates
-        ]
-        if not level_subtemplates:
-            return
-
-        await read_subtemplates(db=db, branch=branch, subtemplates=level_subtemplates)
-
-        next_level: list[tuple[Node, CoreObjectTemplate]] = []
-        for parent_obj, parent_template, subtemplates in parents_with_subtemplates:
-            for subtemplate in subtemplates:
-                obj_peer = await create_component(
-                    db=db,
-                    branch=branch,
-                    constraint_runner=constraint_runner,
-                    parent_obj=parent_obj,
-                    parent_template=parent_template,
-                    subtemplate=subtemplate,
-                    at=at,
-                    user_id=user_id,
-                )
-                next_level.append((obj_peer, subtemplate))
-        level = next_level
+    await create_components(
+        db=db,
+        branch=branch,
+        constraint_runner=constraint_runner,
+        parent_obj=obj,
+        parent_template=template,
+        components=components,
+        at=at,
+        user_id=user_id,
+    )
 
 
 async def get_profile_ids(db: InfrahubDatabase, obj: Node | CoreObjectTemplate) -> set[str]:

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -51,8 +51,6 @@ from infrahub.core.utils import build_regex_attrs, extract_field_filters
 from infrahub.exceptions import QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from neo4j.graph import Node as Neo4jNode
 
     from infrahub.core.attribute import AttributeCreateData, BaseAttribute
@@ -212,25 +210,13 @@ class NodeCreateAllQuery(NodeQuery):
         relationships: list[RelationshipCreateData] = []
         for rel_name in self.node._relationships:
             rel_manager: RelationshipManager = getattr(self.node, rel_name)
-            peers: Mapping[str, Node] = {}
-            # This is a create query, so the node has no relationships in the database yet: only
-            # resolve peers when there are locally-set relationships to write.
-            if rel_manager.schema.cardinality == "many" and len(rel_manager._relationships):
-                # Fetch all relationship peers through a single database call for performances.
-                peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
+            # This is a create query, so the node has no relationships in the database yet: only the
+            # locally-set relationships are written. Their peers are read in one call, and a peer the
+            # caller handed over as a node is not read back.
+            if rel_manager.schema.cardinality == "many":
+                await rel_manager.read_peers_not_in_hand(db=db, branch_agnostic=self.branch_agnostic)
 
             for rel in rel_manager._relationships:
-                if rel_manager.schema.cardinality == "many":
-                    try:
-                        rel.set_peer(value=peers[rel.get_peer_id()])
-                    except KeyError:
-                        pass
-                    except ValueError:
-                        # Relationship has not been initialized yet, it means the peer does not exist in db yet
-                        # typically because it will be allocated from a resource pool. In that case, the peer
-                        # will be fetched using `rel.resolve` later.
-                        pass
-
                 rel_create_data = await rel.get_create_data(db=db, at=at)
                 if rel_create_data.peer_branch_level > deepest_branch_level or (
                     deepest_branch_name == GLOBAL_BRANCH_NAME and rel_create_data.peer_branch == registry.default_branch

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1129,9 +1129,14 @@ class RelationshipManager[RelationshipManagerPeerType]:
 
         A relationship already holding its peer as a node is left as it is: the caller handed the node
         over, and reading it back is what this avoids. A relationship without a peer id yet, such as one
-        waiting on a resource pool, is left to `Relationship.resolve()`.
+        waiting on a resource pool, or naming its peer by a default filter value, is left to
+        `Relationship.resolve()`, which reads it the only way it can be read.
         """
-        peer_ids = [rel.peer_id for rel in self._relationships if rel.peer_id and rel.get_peer_in_hand() is None]
+        peer_ids = [
+            rel.peer_id
+            for rel in self._relationships
+            if rel.peer_id and is_valid_uuid(rel.peer_id) and rel.get_peer_in_hand() is None
+        ]
         if not peer_ids:
             return
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -204,6 +204,13 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         return self._resolved_peer_kind
 
+    def get_peer_in_hand(self) -> Node | None:
+        """Return the peer as the node it is, or None when this relationship holds only its id."""
+        if self._peer is None or isinstance(self._peer, str):
+            return None
+
+        return self._peer
+
     @property
     def node_id(self) -> str:
         if self._node_id:

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -192,17 +192,13 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         return self.peer_id
 
     def get_peer_kind(self) -> str:
-        if not self._peer or isinstance(self._peer, str):
-            return self.schema.peer
-
-        return self._peer.get_kind()
+        peer = self.get_peer_in_hand()
+        return peer.get_kind() if peer is not None else self.schema.peer
 
     def get_concrete_peer_kind(self) -> str | None:
         """Return the peer's concrete kind, or None when only the schema's (possibly generic) peer kind is known."""
-        if self._peer and not isinstance(self._peer, str):
-            return self._peer.get_kind()
-
-        return self._resolved_peer_kind
+        peer = self.get_peer_in_hand()
+        return peer.get_kind() if peer is not None else self._resolved_peer_kind
 
     def get_peer_in_hand(self) -> Node | None:
         """Return the peer as the node it is, or None when this relationship holds only its id."""

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1124,6 +1124,24 @@ class RelationshipManager[RelationshipManagerPeerType]:
             include_metadata=include_metadata,
         )
 
+    async def read_peers_not_in_hand(self, db: InfrahubDatabase, branch_agnostic: bool = False) -> None:
+        """Read, in one query, the peers the relationships hold only the id of, and hand each its node.
+
+        A relationship already holding its peer as a node is left as it is: the caller handed the node
+        over, and reading it back is what this avoids. A relationship without a peer id yet, such as one
+        waiting on a resource pool, is left to `Relationship.resolve()`.
+        """
+        peer_ids = [rel.peer_id for rel in self._relationships if rel.peer_id and rel.get_peer_in_hand() is None]
+        if not peer_ids:
+            return
+
+        peers = await registry.manager.get_many(
+            db=db, ids=peer_ids, branch=self.branch, branch_agnostic=branch_agnostic
+        )
+        for rel in self._relationships:
+            if rel.get_peer_in_hand() is None and rel.peer_id in peers:
+                rel.set_peer(value=peers[rel.peer_id])
+
     def get_branch_based_on_support_type(self) -> Branch:
         """If the attribute is branch aware, return the Branch object associated with this attribute.
 

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -585,14 +585,6 @@ async def device_schema_with_component_pools(
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Reading the template a level at a time also creates the components a level at a time, so a "
-        "component and the component it holds no longer take adjacent addresses from a shared pool. "
-        "Remove this marker once the walk creates the components depth first again."
-    ),
-    strict=True,
-)
 async def test_one_pool_shared_by_two_component_levels_allocates_depth_first(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/backend/tests/component/core/node/test_template_pool_allocation.py
+++ b/backend/tests/component/core/node/test_template_pool_allocation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from ipaddress import ip_interface
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -9,6 +10,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipCardinality
 from infrahub.core.initialization import initialize_registry
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
@@ -561,3 +563,111 @@ async def test_create_template_with_invalid_number_pool_id(
     )
     with pytest.raises(NodeNotFoundError):
         await template.save(db=db)
+
+
+@pytest.fixture
+async def device_schema_with_component_pools(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_schema: SchemaBranch,
+    init_nodes_registry: None,
+) -> None:
+    """Put a primary_ip on both levels of components, so one pool can serve the two of them."""
+    schema = copy.deepcopy(DEVICE_SCHEMA)
+    for kind in (TestKind.PHYSICAL_INTERFACE, TestKind.SFP):
+        node = next(n for n in schema.nodes if n.kind == kind)
+        node.relationships.append(
+            RelationshipSchema(
+                name="primary_ip", peer="IpamIPAddress", cardinality=RelationshipCardinality.ONE, optional=True
+            )
+        )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Reading the template a level at a time also creates the components a level at a time, so a "
+        "component and the component it holds no longer take adjacent addresses from a shared pool. "
+        "Remove this marker once the walk creates the components depth first again."
+    ),
+    strict=True,
+)
+async def test_one_pool_shared_by_two_component_levels_allocates_depth_first(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    device_schema_with_component_pools: None,
+    ip_address_pool: CoreIPAddressPool,
+) -> None:
+    """A component and the component it holds take adjacent addresses from a shared pool.
+
+    The device template carries interfaces, each interface carries an SFP, and one pool serves both
+    levels. The pool hands the next free address to each caller in turn, so the order the components
+    are created in decides which address each one gets. An interface and its own SFP are created one
+    after the other, which is what keeps their two addresses next to each other.
+    """
+    template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.DEVICE}", branch=default_branch)
+    interface_template_schema = registry.schema.get_template_schema(
+        name=f"Template{TestKind.PHYSICAL_INTERFACE}", branch=default_branch
+    )
+    sfp_template_schema = registry.schema.get_template_schema(name=f"Template{TestKind.SFP}", branch=default_branch)
+
+    template = await Node.init(schema=template_schema, db=db, branch=default_branch)
+    await template.new(db=db, template_name="pool-order-template", manufacturer="Acme", weight=1, airflow="Passive")
+    await template.save(db=db)
+
+    for idx in range(3):
+        interface = await Node.init(schema=interface_template_schema, db=db, branch=default_branch)
+        await interface.new(
+            db=db,
+            template_name=f"pool-order-eth{idx}",
+            name=f"eth{idx}",
+            phys_type="SFP+ (10GE)",
+            device=template.id,
+            primary_ip_from_resource_pool={"id": ip_address_pool.id},
+        )
+        await interface.save(db=db)
+
+        sfp = await Node.init(schema=sfp_template_schema, db=db, branch=default_branch)
+        await sfp.new(
+            db=db,
+            template_name=f"pool-order-eth{idx}-sfp",
+            phys_type="SFP+ (10GE)",
+            serial_number=f"pool-order-sn{idx}",
+            interface=interface.id,
+            primary_ip_from_resource_pool={"id": ip_address_pool.id},
+        )
+        await sfp.save(db=db)
+
+    node_schema = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+    device = await create_node(
+        data={"name": "pool-order-device", "object_template": {"id": template.id}},
+        db=db,
+        branch=default_branch,
+        schema=node_schema,
+    )
+
+    reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch, raise_on_error=True)
+    allocated: dict[str, tuple[int, int]] = {}
+    for interface in (await reloaded.interfaces.get_peers(db=db)).values():
+        sfp = await interface.sfp.get_peer(db=db)
+        assert sfp is not None, "the second level of the template was not materialized"
+        interface_ip = await interface.primary_ip.get_peer(db=db)
+        sfp_ip = await sfp.primary_ip.get_peer(db=db)
+        assert interface_ip is not None, f"{interface.name.value} was not allocated an address"
+        assert sfp_ip is not None, f"the SFP of {interface.name.value} was not allocated an address"
+        allocated[interface.name.value] = (
+            int(ip_interface(interface_ip.address.value).ip),
+            int(ip_interface(sfp_ip.address.value).ip),
+        )
+
+    assert len(allocated) == 3
+    addresses = [address for pair in allocated.values() for address in pair]
+    assert len(set(addresses)) == 6, f"an address was handed out twice: {allocated}"
+
+    # Which interface the pool serves first is not fixed, so only the adjacency is asserted.
+    for name, (interface_address, sfp_address) in sorted(allocated.items()):
+        assert sfp_address == interface_address + 1, (
+            f"{name} took {interface_address} and its SFP took {sfp_address}: the SFP is no longer "
+            f"allocated right after the interface holding it"
+        )

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
-from infrahub.core.query.node import NodeListGetInfoQuery, NodeListGetRelationshipsQuery
+from infrahub.core.query.node import NodeListGetAttributeQuery, NodeListGetInfoQuery, NodeListGetRelationshipsQuery
 from infrahub.core.query.relationship import RelationshipGetPeerQuery
 from infrahub.core.registry import registry
+from infrahub.core.schema import RelationshipSchema
 from tests.constants import TestKind
 from tests.helpers.db_query_counter import CountingInfrahubDatabase
-from tests.helpers.schema import DEVICE_SCHEMA, load_schema
+from tests.helpers.schema import DEVICE_SCHEMA, TAG, load_schema
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -24,8 +27,33 @@ async def device_schema(db: InfrahubDatabase, default_branch: Branch, register_c
     await load_schema(db=db, schema=DEVICE_SCHEMA, branch_name=default_branch.name)
 
 
+@pytest.fixture
+async def device_schema_with_tagged_interfaces(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate."""
+    schema = deepcopy(DEVICE_SCHEMA)
+    schema.nodes.append(deepcopy(TAG))
+    physical_interface = next(node for node in schema.nodes if node.kind == TestKind.PHYSICAL_INTERFACE)
+    physical_interface.relationships.append(
+        RelationshipSchema(
+            name="tag",
+            kind=RelationshipKind.ATTRIBUTE,
+            optional=True,
+            peer=TestKind.TAG,
+            cardinality=RelationshipCardinality.ONE,
+        )
+    )
+    await load_schema(db=db, schema=schema, branch_name=default_branch.name)
+
+
 async def _build_template(
-    db: InfrahubDatabase, branch: Branch, name: str, nbr_interfaces: int, with_sfp: bool = False
+    db: InfrahubDatabase,
+    branch: Branch,
+    name: str,
+    nbr_interfaces: int,
+    with_sfp: bool = False,
+    tag_id: str | None = None,
 ) -> Node:
     """Build a device template, optionally giving each of its interfaces a subtemplate of its own."""
     template = await Node.init(db=db, schema=f"Template{TestKind.DEVICE}", branch=branch)
@@ -34,13 +62,15 @@ async def _build_template(
 
     for idx in range(nbr_interfaces):
         interface = await Node.init(db=db, schema=f"Template{TestKind.PHYSICAL_INTERFACE}", branch=branch)
-        await interface.new(
-            db=db,
-            template_name=f"{name}-eth{idx}",
-            name=f"eth{idx}",
-            phys_type="SFP+ (10GE)",
-            device=template.id,
-        )
+        interface_data: dict[str, Any] = {
+            "template_name": f"{name}-eth{idx}",
+            "name": f"eth{idx}",
+            "phys_type": "SFP+ (10GE)",
+            "device": template.id,
+        }
+        if tag_id:
+            interface_data["tag"] = tag_id
+        await interface.new(db=db, **interface_data)
         await interface.save(db=db)
 
         if not with_sfp:
@@ -265,3 +295,58 @@ async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_
     # read has no way to be told a node is already in hand. What matters here is that neither figure
     # grows with the width of a level.
     assert set(node_reads.values()) == {4}, f"reading the subtemplates grew with the width of a level: {node_reads}"
+
+
+async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
+    db: InfrahubDatabase, default_branch: Branch, device_schema_with_tagged_interfaces: None
+) -> None:
+    """A peer a subtemplate names is handed to the object created from it, not read again per object.
+
+    The subtemplates arrive with the peers their relationships name, so a component that carries
+    one costs what a component without one costs: its uniqueness check and its write. Naming the
+    peer by its id instead sent both the kind check on the new object and the write back to the
+    database for a node already in memory, once per component.
+    """
+    tag = await Node.init(db=db, schema=TestKind.TAG, branch=default_branch)
+    await tag.new(db=db, name="uplink")
+    await tag.save(db=db)
+
+    device_schema_obj = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+    node_reads = {}
+    attribute_reads = {}
+    counts = {}
+
+    for nbr_interfaces in (1, 3, 5):
+        name = f"tagged-{nbr_interfaces}"
+        template = await _build_template(
+            db=db, branch=default_branch, name=name, nbr_interfaces=nbr_interfaces, tag_id=tag.id
+        )
+        counting_db = CountingInfrahubDatabase.from_db(db=db)
+
+        device = await create_node(
+            data={"name": f"{name}-device", "object_template": {"id": template.id}},
+            db=counting_db,
+            branch=default_branch,
+            schema=device_schema_obj,
+        )
+
+        reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch, raise_on_error=True)
+        interfaces = await reloaded.interfaces.get_peers(db=db)
+        assert len(interfaces) == nbr_interfaces
+        assert {await interface.tag.get_peer_id(db=db) for interface in interfaces.values()} == {tag.id}, (
+            "the peer the template names was not written on the objects created from it"
+        )
+
+        node_reads[nbr_interfaces] = counting_db.count_for(NodeListGetInfoQuery.name)
+        attribute_reads[nbr_interfaces] = counting_db.count_for(NodeListGetAttributeQuery.name)
+        counts[nbr_interfaces] = sum(counting_db.query_counts.values())
+
+    assert counting_db.count_for(RelationshipGetPeerQuery.name) == 0
+    # The template, the peers its relationships name, and the peers the subtemplate level names:
+    # three reads, whatever the number of components carrying the tag.
+    assert set(node_reads.values()) == {3}, f"the tag was read once per component: {node_reads}"
+    assert set(attribute_reads.values()) == {3}, f"the tag's attributes were read again: {attribute_reads}"
+    per_component = (counts[3] - counts[1]) / 2
+    assert per_component == (counts[5] - counts[3]) / 2 == 2, (
+        f"a component carrying a peer costs {per_component} queries rather than a check and a write: {counts}"
+    )

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -27,11 +27,15 @@ async def device_schema(db: InfrahubDatabase, default_branch: Branch, register_c
     await load_schema(db=db, schema=DEVICE_SCHEMA, branch_name=default_branch.name)
 
 
-@pytest.fixture
+@pytest.fixture(params=[RelationshipCardinality.ONE, RelationshipCardinality.MANY], ids=["one", "many"])
 async def device_schema_with_tagged_interfaces(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, request: pytest.FixtureRequest
 ) -> None:
-    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate."""
+    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate.
+
+    Once per cardinality: the create query reads the peers of a relationship of cardinality many in one
+    batch, a path a single peer never takes.
+    """
     schema = deepcopy(DEVICE_SCHEMA)
     schema.nodes.append(deepcopy(TAG))
     physical_interface = next(node for node in schema.nodes if node.kind == TestKind.PHYSICAL_INTERFACE)
@@ -41,7 +45,7 @@ async def device_schema_with_tagged_interfaces(
             kind=RelationshipKind.ATTRIBUTE,
             optional=True,
             peer=TestKind.TAG,
-            cardinality=RelationshipCardinality.ONE,
+            cardinality=request.param,
         )
     )
     await load_schema(db=db, schema=schema, branch_name=default_branch.name)
@@ -327,9 +331,10 @@ async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
         reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch, raise_on_error=True)
         interfaces = await reloaded.interfaces.get_peers(db=db)
         assert len(interfaces) == nbr_interfaces
-        assert {await interface.tag.get_peer_id(db=db) for interface in interfaces.values()} == {tag.id}, (
-            "the peer the template names was not written on the objects created from it"
-        )
+        for interface in interfaces.values():
+            assert [rel.peer_id for rel in await interface.tag.get_relationships(db=db)] == [tag.id], (
+                "the peer the template names was not written on the objects created from it"
+            )
 
         node_reads[nbr_interfaces] = counting_db.count_for(NodeListGetInfoQuery.name)
         attribute_reads[nbr_interfaces] = counting_db.count_for(NodeListGetAttributeQuery.name)

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -7,7 +7,7 @@ import pytest
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
-from infrahub.core.query.node import NodeListGetRelationshipsQuery
+from infrahub.core.query.node import NodeListGetInfoQuery, NodeListGetRelationshipsQuery
 from infrahub.core.query.relationship import RelationshipGetPeerQuery
 from infrahub.core.registry import registry
 from tests.constants import TestKind
@@ -219,9 +219,47 @@ async def test_creating_from_a_nested_template_reads_no_peer_at_either_depth(
         counts[nbr_interfaces] = sum(counting_db.query_counts.values())
 
     # The interface costs the 2 queries a component costs at the first level; the SFP under it costs
-    # 6, because the recursion prefetches the relationships of each subtemplate one parent at a time
-    # rather than once for the whole level. What matters here is that the figure does not drift: the
-    # tree costs the same per interface however wide it gets.
+    # 3, those same 2 plus the count constraint on its mandatory parent. Reading the second level
+    # costs nothing per interface: a level of subtemplates is read once, not once per parent.
     per_interface = (counts[3] - counts[1]) / 2
     assert per_interface == (counts[5] - counts[3]) / 2, f"the cost per nested interface is not constant: {counts}"
-    assert per_interface <= 8, f"an interface and the SFP under it cost {per_interface} queries: {counts}"
+    assert per_interface <= 5, f"an interface and the SFP under it cost {per_interface} queries: {counts}"
+
+
+async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_from(
+    db: InfrahubDatabase, default_branch: Branch, device_schema: None
+) -> None:
+    """The subtemplates of a level are read together, so a level costs one read, not one per parent.
+
+    The device template holds interfaces, each of which holds an SFP. Those SFP subtemplates hang
+    from as many parents as there are interfaces, and are read once for all of them.
+    """
+    device_schema_obj = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+    relationship_reads = {}
+    node_reads = {}
+
+    for nbr_interfaces in (1, 3, 5):
+        name = f"levels-{nbr_interfaces}"
+        template = await _build_template(
+            db=db, branch=default_branch, name=name, nbr_interfaces=nbr_interfaces, with_sfp=True
+        )
+        counting_db = CountingInfrahubDatabase.from_db(db=db)
+
+        await create_node(
+            data={"name": f"{name}-device", "object_template": {"id": template.id}},
+            db=counting_db,
+            branch=default_branch,
+            schema=device_schema_obj,
+        )
+
+        relationship_reads[nbr_interfaces] = counting_db.count_for(NodeListGetRelationshipsQuery.name)
+        node_reads[nbr_interfaces] = counting_db.count_for(NodeListGetInfoQuery.name)
+
+    # One relationship read per level: the template, the interface subtemplates, the SFP subtemplates.
+    assert set(relationship_reads.values()) == {3}, (
+        f"a level was read once per parent rather than once: {relationship_reads}"
+    )
+    # Each of those reads brings back the peers it names, which is how a level is in memory before
+    # it is walked. Nothing reads a subtemplate again afterwards, so the nodes read are those three
+    # sets of peers plus the template the create was given.
+    assert set(node_reads.values()) == {4}, f"a subtemplate was read back after the level it came in: {node_reads}"

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -300,13 +300,7 @@ async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_
 async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
     db: InfrahubDatabase, default_branch: Branch, device_schema_with_tagged_interfaces: None
 ) -> None:
-    """A peer a subtemplate names is handed to the object created from it, not read again per object.
-
-    The subtemplates arrive with the peers their relationships name, so a component that carries
-    one costs what a component without one costs: its uniqueness check and its write. Naming the
-    peer by its id instead sent both the kind check on the new object and the write back to the
-    database for a node already in memory, once per component.
-    """
+    """A peer a subtemplate names is handed to the object created from it, not read again per object."""
     tag = await Node.init(db=db, schema=TestKind.TAG, branch=default_branch)
     await tag.new(db=db, name="uplink")
     await tag.save(db=db)

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -259,7 +259,9 @@ async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_
     assert set(relationship_reads.values()) == {3}, (
         f"a level was read once per parent rather than once: {relationship_reads}"
     )
-    # Each of those reads brings back the peers it names, which is how a level is in memory before
-    # it is walked. Nothing reads a subtemplate again afterwards, so the nodes read are those three
-    # sets of peers plus the template the create was given.
-    assert set(node_reads.values()) == {4}, f"a subtemplate was read back after the level it came in: {node_reads}"
+    # Four node reads: the template the create was given, then the peers each of those three reads
+    # names. A level's read names the level below it and the parents it points back at, so the last
+    # two bring back the device template and the whole interface level a second time — the batched
+    # read has no way to be told a node is already in hand. What matters here is that neither figure
+    # grows with the width of a level.
+    assert set(node_reads.values()) == {4}, f"reading the subtemplates grew with the width of a level: {node_reads}"

--- a/changelog/+template-component-peer-handover.changed.md
+++ b/changelog/+template-component-peer-handover.changed.md
@@ -1,1 +1,1 @@
-Creating objects from an object template no longer reads back the objects its components point at, such as the transceiver model every interface of a device template names, once for each component created.
+Creating objects from an object template is now faster when the objects it creates share a related object, such as the transceiver model used by every interface of a device template.

--- a/changelog/+template-component-peer-handover.changed.md
+++ b/changelog/+template-component-peer-handover.changed.md
@@ -1,0 +1,1 @@
+Creating objects from an object template no longer reads back the objects its components point at, such as the transceiver model every interface of a device template names, once for each component created.

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -36,7 +36,7 @@ mutate_create()
                       -> add_human_friendly_id()
                       -> add_display_label()
                       -> NodeCreateAllQuery  # bulk Neo4j insert
-            -> handle_template_relationships()  # recursive template instantiation
+            -> handle_template_relationships()  # template instantiation, read a level at a time
        -> apply profiles if applicable
   -> emit NodeCreatedEvent
 ```

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -174,7 +174,11 @@ the mutation then works from it rather than reading it back:
   (`RelationshipManager.get_peer_id()`) and reads the peer only when it is named by a
   human-friendly id or a default filter value, which reading is the only way to resolve;
 - the peer-kind constraint trusts the kind a peer states, and reads only the peers named by an id;
-- `Relationship.get_create_data()` writes the edge from the peer it holds.
+- the create query reads the peers of a relationship of cardinality many in one call, and only those
+  held by id (`RelationshipManager.read_peers_not_in_hand()`); `Relationship.get_create_data()` then
+  writes the edge from the peer it holds. Before that, the create query batched every peer of such a
+  relationship through `get_peers()`, which reads whatever it is given — a component created from a
+  template read back, once per component, a peer the template read had already brought back.
 
 Passing a node keeps the rest of the payload for that relationship (its source, its owner) only if
 the node replaces the `id` inside it rather than the payload itself.

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -160,6 +160,10 @@ peers the manager already read rather than reading them again:
   schemas of the nodes declare, and `NodeManager.prefetch_relationships()` narrows it further to the
   relationships the caller names — reading a node's every edge would pull in the relationships that
   point *at* it, such as the objects created from an object template or the nodes using a profile.
+- The peers of a prefetched relationship come back as nodes rather than ids, so a caller that
+  prefetched walks them without reading them back. Applying an object template leans on this: each
+  level of subtemplates arrives with the read of the level above it (see
+  [Object Templates](templates.md)).
 
 ### The peers a mutation already holds
 

--- a/dev/knowledge/backend/templates.md
+++ b/dev/knowledge/backend/templates.md
@@ -13,7 +13,7 @@ Object Templates are user-defined "shape" objects: a template node holds default
 | `backend/infrahub/core/schema/definitions/core/template.py` | `core_object_template` and `core_object_component_template` generics — the core base kinds every template inherits from. |
 | `backend/infrahub/core/schema/schema_branch.py` | Generation of per-kind template schemas from `generate_template`-enabled nodes (`manage_object_template_schemas`, `add_relationships_to_template`, etc.). |
 | `backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py` | Constraint preventing both a fixed value and a pool reference being set on the same template field. |
-| `backend/infrahub/core/node/create.py` | `handle_template_relationships()` recursively materializes component-template peers as real instances. |
+| `backend/infrahub/core/node/create.py` | `handle_template_relationships()` materializes component-template peers as real instances, a level of the template at a time. |
 | `backend/infrahub/core/node/__init__.py` | `Node.handle_object_template()` is the call site that constructs and invokes `NodeTemplateApplier` during node field processing. |
 
 ## Core Kinds
@@ -62,7 +62,7 @@ When a user creates an object with `object_template={id: ...}`, `Node.handle_obj
 4. Merges only previously-absent keys back into `fields`, preserving user input.
 5. Returns the set of `pool_pending_fields` — fields whose pool allocation was deferred (e.g., because the chosen allocator is the no-op variant).
 
-After save, `handle_template_relationships()` (`core/node/create.py`) walks the new node's `COMPONENT` relationships and recursively materializes any subtemplate peers as their own real objects, recursing into their components.
+After save, `handle_template_relationships()` (`core/node/create.py`) walks the new node's `COMPONENT` relationships and materializes any subtemplate peers as their own real objects, then walks their components in turn — a whole level of the template at a time, so the level is read once rather than once per parent.
 
 ### What applying a template reads
 
@@ -76,24 +76,27 @@ names, once on the node it creates under the lock — from that single read: `No
 carries it, and `_do_create_node()` uses it instead of asking the saved node which template it came
 from.
 
-The peers of the template's component relationships are read the same way, with the relationships
-materializing them consults, and each component is then created from the ids and kinds those
-relationships carry.
+The peers of the template's component relationships come back with that read, so the subtemplates
+of the first level are already in memory; each component is then created from the ids and kinds
+those relationships carry.
 
-The cost of a create is then the template read (3 queries), the node's own uniqueness check and
-write, and 2 queries per component (its uniqueness check and its write). It does not grow with the
-number of objects created from the template before.
+`handle_template_relationships()` walks the template a level at a time rather than a parent at a
+time. The subtemplates a level names are all known before any of them is materialized, so the whole
+level is read at once — one relationship read covering every subtemplate of the level, which brings
+back the peers naming the level below. A level therefore costs the same read whether it hangs from
+one parent or from a hundred.
 
-That 2-query figure is for a component at the first level. A component that is itself a template
-holding components of its own costs more, because the recursion prefetches each subtemplate's
-relationships one parent at a time rather than once for the whole level. With the test schema's
-device -> interface -> SFP, an interface costs 2 and the SFP under it costs 6: a batched
-relationship read, a batched peer read (two queries, one for the node and one for its attributes),
-its own count constraint, its uniqueness check, and its write. The cost stays constant per
-interface however wide the tree gets, so it does not drift, but prefetching a whole level at once
-is the obvious next saving, tracked in
-[#10419](https://github.com/opsmill/infrahub/issues/10419). `test_template_reads.py` measures both
-depths.
+A level read costs 3 queries: one relationship read, plus one read of the peers it names (a node
+read and an attribute read). A create pays one of those for the template and one for each level of
+subtemplates under it. The rest of its cost is the 2 queries reading the template node itself, the
+node's own uniqueness check and write, and 2 queries per component — its uniqueness check and its
+write — plus a count constraint for any mandatory parent that component declares. None of it grows
+with the number of objects created from the template before.
+
+On the test schema's device -> interface -> SFP, a device created from a template carrying ten
+interfaces costs 30 queries, and one carrying five interfaces each holding an SFP costs 38.
+Widening a level costs only what its components cost; deepening the tree adds one level read.
+`test_template_reads.py` measures both depths and guards the per-level read.
 
 ### Group Propagation
 

--- a/dev/knowledge/backend/templates.md
+++ b/dev/knowledge/backend/templates.md
@@ -13,7 +13,7 @@ Object Templates are user-defined "shape" objects: a template node holds default
 | `backend/infrahub/core/schema/definitions/core/template.py` | `core_object_template` and `core_object_component_template` generics — the core base kinds every template inherits from. |
 | `backend/infrahub/core/schema/schema_branch.py` | Generation of per-kind template schemas from `generate_template`-enabled nodes (`manage_object_template_schemas`, `add_relationships_to_template`, etc.). |
 | `backend/infrahub/core/relationship/constraints/template_resource_pool_exclusive.py` | Constraint preventing both a fixed value and a pool reference being set on the same template field. |
-| `backend/infrahub/core/node/create.py` | `handle_template_relationships()` materializes component-template peers as real instances, a level of the template at a time. |
+| `backend/infrahub/core/node/create.py` | `handle_template_relationships()` reads the template's component peers a level at a time, then materializes them as real instances depth first. |
 | `backend/infrahub/core/node/__init__.py` | `Node.handle_object_template()` is the call site that constructs and invokes `NodeTemplateApplier` during node field processing. |
 
 ## Core Kinds
@@ -62,7 +62,7 @@ When a user creates an object with `object_template={id: ...}`, `Node.handle_obj
 4. Merges only previously-absent keys back into `fields`, preserving user input.
 5. Returns the set of `pool_pending_fields` — fields whose pool allocation was deferred (e.g., because the chosen allocator is the no-op variant).
 
-After save, `handle_template_relationships()` (`core/node/create.py`) walks the new node's `COMPONENT` relationships and materializes any subtemplate peers as their own real objects, then walks their components in turn — a whole level of the template at a time, so the level is read once rather than once per parent.
+After save, `handle_template_relationships()` (`core/node/create.py`) walks the new node's `COMPONENT` relationships and materializes any subtemplate peers as their own real objects, then walks their components in turn. It reads the subtemplates a level at a time and creates the objects depth first — see [What applying a template reads](#what-applying-a-template-reads) for why those are two different walks.
 
 ### What applying a template reads
 
@@ -80,18 +80,27 @@ The peers of the template's component relationships come back with that read, so
 of the first level are already in memory; each component is then created from the ids and kinds
 those relationships carry.
 
-`handle_template_relationships()` walks the template a level at a time rather than a parent at a
-time. The subtemplates a level names are all known before any of them is materialized, so the whole
-level is read at once — one relationship read covering every subtemplate of the level, which brings
-back the peers naming the level below. A level therefore costs the same read whether it hangs from
-one parent or from a hundred.
+`handle_template_relationships()` reads the subtemplates a level at a time rather than a parent at
+a time. The subtemplates a level names are all known before any of them is read, so the whole level
+is read at once — one relationship read covering every subtemplate of the level, which brings back
+the peers naming the level below. A level therefore costs the same read whether it hangs from one
+parent or from a hundred.
+
+The objects are created in a separate, depth-first walk over what that read produced
+(`read_template_components()` then `create_components()`). The two walks are deliberately different:
+a component and the components it holds are created one after the other, because a resource pool
+that serves more than one level hands its resources out in the order the components are created.
+Creating a whole level at a time would move the resource each component is given.
+`test_template_pool_allocation.py` pins that order.
 
 A level read costs 3 queries: one relationship read, plus one read of the peers it names (a node
-read and an attribute read). A create pays one of those for the template and one for each level of
-subtemplates under it. The rest of its cost is the 2 queries reading the template node itself, the
-node's own uniqueness check and write, and 2 queries per component — its uniqueness check and its
-write — plus a count constraint for any mandatory parent that component declares. None of it grows
-with the number of objects created from the template before.
+read and an attribute read). Those peers are the level below *and* the parents the level points back
+at, which the walk already holds and reads again — the batched read has no way to be told a node is
+in hand. A create pays one of those reads for the template and one for each level of subtemplates
+under it. The rest of its cost is the 2 queries reading the template node itself, the node's own
+uniqueness check and write, and 2 queries per component — its uniqueness check and its write — plus
+a count constraint for any mandatory parent that component declares. None of it grows with the
+number of objects created from the template before.
 
 On the test schema's device -> interface -> SFP, a device created from a template carrying ten
 interfaces costs 30 queries, and one carrying five interfaces each holding an SFP costs 38.
@@ -146,6 +155,7 @@ Templates can reference resource pools instead of fixed values. The integration 
 | Path | Coverage |
 |------|----------|
 | `backend/tests/component/templates/test_template_applier.py` | End-to-end behaviour of `NodeTemplateApplier` (attributes, relationships, resource pools, `*_for_instances` group propagation). |
+| `backend/tests/component/core/node/test_template_pool_allocation.py` | Resource pools on templates, including the order a pool shared by two component levels is drawn from. |
 | `backend/tests/component/core/schema_manager/test_template_resource_pool_relationships.py` | Schema-level emission of `_from_resource_pool` rels for IP and Number cases. |
 | `backend/tests/component/core/schema_manager/test_template_group_relationships.py` | Schema-level emission of `member_of_groups_for_instances` / `subscriber_of_groups_for_instances` on templates. |
 | `backend/tests/integration/templates/` | Lifecycle tests (template attribute updates, resource pool wiring). |


### PR DESCRIPTION
## Summary

Materializing the components of an object template walked it one parent at a time. Every subtemplate was read together with the relationships materializing it consults, so a template with ten interfaces issued ten reads for the interface level rather than one, and each level below the first paid those 3 reads again on every branch of the tree. A wide tree did not degrade, but a deep one multiplied.

The peers of a whole level are known before any of them is read, so the template is now read level by level: `read_template_components()` names the subtemplates every parent of a level holds, reads them in one call, and returns the tree it read. That read brings back the peers those subtemplates name, which is what leaves the level below already in memory — so the first level is no longer read back either, having arrived with the template.

Creating is a separate, depth-first walk over that tree (`create_components()`), which reads nothing. The two walks are deliberately different: a resource pool serving more than one level hands its resources out in the order the components are created, so creating a level at a time would move the resource each component is given. That regression was caught in review by @gmazoyer, who wrote the test pinning it.

Closes #10419.

## Measured

On the test schema's `device -> interface -> SFP`, per extra interface at depth two:

| query | before | after |
|---|---|---|
| `node_create_all` | 2 | 2 |
| `uniqueness_constraint_validation` | 2 | 2 |
| `relationship_count_per_node` | 1 | 1 |
| `node_list_get_info` | 1 | 0 |
| `node_list_get_attribute` | 1 | 0 |
| `node_list_get_relationship` | 1 | 0 |
| **total** | **8** | **5** |

Every read is now constant per level. What is left per interface is the two objects' uniqueness checks and writes, plus the count constraint on the SFP's mandatory parent.

Total queries for a create through `create_node()`:

| Template | Before | After |
|---|---|---|
| 1 interface, each holding an SFP | 20 | 18 |
| 3 interfaces, each holding an SFP | 36 | 28 |
| 5 interfaces, each holding an SFP | 52 | 38 |
| 1 interface, flat | 14 | 12 |
| 5 interfaces, flat | 22 | 20 |
| 10 interfaces, flat | 32 | 30 |

The flat rows improve by the same 2 queries at any width: the subtemplates of the first level came back with the template read and are no longer read a second time. That was the `RelationshipManager.get_peers()` re-read #10413 left in place — this resolves it for the template path, where both reads ask for the same metadata and the walk owns both ends. The general case in `get_peers()` is untouched.

## Test Plan

- `test_creating_from_a_nested_template_reads_no_peer_at_either_depth` — its bound moves from 8 queries per interface to 5, which is the assertion #10419 predicted would move.
- `test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_from` — new. Asserts 3 relationship reads and 4 node reads whatever the width of the second level; before this branch they were 3/5/7 and 5/7/9 for 1/3/5 interfaces.
- `test_one_pool_shared_by_two_component_levels_allocates_depth_first` — added by @gmazoyer in review as a strict xfail; kept as written, with the marker removed. A component and the component it holds take adjacent addresses from a pool serving both levels.
- `uv run pytest backend/tests/component backend/tests/unit/graphql backend/tests/unit/core` — 4 549 passed, 29 skipped. `backend/tests/component/core/test_branch_rebase.py` is deselected: its two failures are Redis connection refusals from the local environment and reproduce identically with this branch's code reverted.
- `uv run invoke lint` (ruff, ty, mypy over 1 631 files) and `uv run invoke docs.validate` are clean.

## Documentation Updates

- `dev/knowledge/backend/templates.md` — the two walks and why they differ, and the cost of a create restated in terms of level reads: 3 queries per level, one for the template and one for each level of subtemplates under it. A level's read also brings back the parents it points back at, which the walk already holds — recorded rather than fixed.
- `dev/knowledge/backend/mutations.md` — the mechanism the walk leans on: a prefetched relationship carries its peers as nodes, so a caller that prefetched does not read them back.
No changelog fragment: `+faster-creates-from-object-templates.changed.md`, added by the branch below, already covers this for a reader of the release notes.

## Related Context

Stacked on #10413, which removed the per-relationship peer reads underneath this recursion and left the recursion's per-parent shape alone to keep that branch scoped. Measurements are taken on top of that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

