### PR TITLE
perf(backend): hand a template component the peer it carries

### DIFF
--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -217,9 +217,7 @@ async def extract_peer_data(
             # deeper templates are handled in the next level of recursion
             if await _peer_is_a_template(db=db, relationship=relationship):
                 continue
-            # The subtemplate was read with the peers its relationships name, so hand over the node
-            # where it is in hand: an id sends the checks on the new object, and the write itself,
-            # back to the database for a node already in memory.
+            # The peer is already read, so an id would send the checks and the write back to the database.
             rel_peers.append({"id": relationship.get_peer_in_hand() or relationship.peer_id})
 
         # Only set the relationship data if there are actual peers to set

--- a/backend/infrahub/core/node/create.py
+++ b/backend/infrahub/core/node/create.py
@@ -212,16 +212,19 @@ async def extract_peer_data(
             obj_peer_data[rel_name] = parent_obj
             continue
 
-        rel_peer_ids = []
+        rel_peers = []
         for relationship in relationships:
             # deeper templates are handled in the next level of recursion
             if await _peer_is_a_template(db=db, relationship=relationship):
                 continue
-            rel_peer_ids.append({"id": relationship.peer_id})
+            # The subtemplate was read with the peers its relationships name, so hand over the node
+            # where it is in hand: an id sends the checks on the new object, and the write itself,
+            # back to the database for a node already in memory.
+            rel_peers.append({"id": relationship.get_peer_in_hand() or relationship.peer_id})
 
         # Only set the relationship data if there are actual peers to set
-        if rel_peer_ids:
-            obj_peer_data[rel_name] = rel_peer_ids
+        if rel_peers:
+            obj_peer_data[rel_name] = rel_peers
 
         if rel_manager.schema.kind == RelationshipKind.PROFILE:
             obj_peer_data[rel_name] = peer_ids

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -51,8 +51,6 @@ from infrahub.core.utils import build_regex_attrs, extract_field_filters
 from infrahub.exceptions import QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from neo4j.graph import Node as Neo4jNode
 
     from infrahub.core.attribute import AttributeCreateData, BaseAttribute
@@ -212,25 +210,13 @@ class NodeCreateAllQuery(NodeQuery):
         relationships: list[RelationshipCreateData] = []
         for rel_name in self.node._relationships:
             rel_manager: RelationshipManager = getattr(self.node, rel_name)
-            peers: Mapping[str, Node] = {}
-            # This is a create query, so the node has no relationships in the database yet: only
-            # resolve peers when there are locally-set relationships to write.
-            if rel_manager.schema.cardinality == "many" and len(rel_manager._relationships):
-                # Fetch all relationship peers through a single database call for performances.
-                peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
+            # This is a create query, so the node has no relationships in the database yet: only the
+            # locally-set relationships are written. Their peers are read in one call, and a peer the
+            # caller handed over as a node is not read back.
+            if rel_manager.schema.cardinality == "many":
+                await rel_manager.read_peers_not_in_hand(db=db, branch_agnostic=self.branch_agnostic)
 
             for rel in rel_manager._relationships:
-                if rel_manager.schema.cardinality == "many":
-                    try:
-                        rel.set_peer(value=peers[rel.get_peer_id()])
-                    except KeyError:
-                        pass
-                    except ValueError:
-                        # Relationship has not been initialized yet, it means the peer does not exist in db yet
-                        # typically because it will be allocated from a resource pool. In that case, the peer
-                        # will be fetched using `rel.resolve` later.
-                        pass
-
                 rel_create_data = await rel.get_create_data(db=db, at=at)
                 if rel_create_data.peer_branch_level > deepest_branch_level or (
                     deepest_branch_name == GLOBAL_BRANCH_NAME and rel_create_data.peer_branch == registry.default_branch

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1129,9 +1129,14 @@ class RelationshipManager[RelationshipManagerPeerType]:
 
         A relationship already holding its peer as a node is left as it is: the caller handed the node
         over, and reading it back is what this avoids. A relationship without a peer id yet, such as one
-        waiting on a resource pool, is left to `Relationship.resolve()`.
+        waiting on a resource pool, or naming its peer by a default filter value, is left to
+        `Relationship.resolve()`, which reads it the only way it can be read.
         """
-        peer_ids = [rel.peer_id for rel in self._relationships if rel.peer_id and rel.get_peer_in_hand() is None]
+        peer_ids = [
+            rel.peer_id
+            for rel in self._relationships
+            if rel.peer_id and is_valid_uuid(rel.peer_id) and rel.get_peer_in_hand() is None
+        ]
         if not peer_ids:
             return
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -204,6 +204,13 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         return self._resolved_peer_kind
 
+    def get_peer_in_hand(self) -> Node | None:
+        """Return the peer as the node it is, or None when this relationship holds only its id."""
+        if self._peer is None or isinstance(self._peer, str):
+            return None
+
+        return self._peer
+
     @property
     def node_id(self) -> str:
         if self._node_id:

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -192,17 +192,13 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
         return self.peer_id
 
     def get_peer_kind(self) -> str:
-        if not self._peer or isinstance(self._peer, str):
-            return self.schema.peer
-
-        return self._peer.get_kind()
+        peer = self.get_peer_in_hand()
+        return peer.get_kind() if peer is not None else self.schema.peer
 
     def get_concrete_peer_kind(self) -> str | None:
         """Return the peer's concrete kind, or None when only the schema's (possibly generic) peer kind is known."""
-        if self._peer and not isinstance(self._peer, str):
-            return self._peer.get_kind()
-
-        return self._resolved_peer_kind
+        peer = self.get_peer_in_hand()
+        return peer.get_kind() if peer is not None else self._resolved_peer_kind
 
     def get_peer_in_hand(self) -> Node | None:
         """Return the peer as the node it is, or None when this relationship holds only its id."""

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1124,6 +1124,24 @@ class RelationshipManager[RelationshipManagerPeerType]:
             include_metadata=include_metadata,
         )
 
+    async def read_peers_not_in_hand(self, db: InfrahubDatabase, branch_agnostic: bool = False) -> None:
+        """Read, in one query, the peers the relationships hold only the id of, and hand each its node.
+
+        A relationship already holding its peer as a node is left as it is: the caller handed the node
+        over, and reading it back is what this avoids. A relationship without a peer id yet, such as one
+        waiting on a resource pool, is left to `Relationship.resolve()`.
+        """
+        peer_ids = [rel.peer_id for rel in self._relationships if rel.peer_id and rel.get_peer_in_hand() is None]
+        if not peer_ids:
+            return
+
+        peers = await registry.manager.get_many(
+            db=db, ids=peer_ids, branch=self.branch, branch_agnostic=branch_agnostic
+        )
+        for rel in self._relationships:
+            if rel.get_peer_in_hand() is None and rel.peer_id in peers:
+                rel.set_peer(value=peers[rel.peer_id])
+
     def get_branch_based_on_support_type(self) -> Branch:
         """If the attribute is branch aware, return the Branch object associated with this attribute.
 

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from infrahub.core.constants import RelationshipCardinality, RelationshipKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
-from infrahub.core.query.node import NodeListGetInfoQuery, NodeListGetRelationshipsQuery
+from infrahub.core.query.node import NodeListGetAttributeQuery, NodeListGetInfoQuery, NodeListGetRelationshipsQuery
 from infrahub.core.query.relationship import RelationshipGetPeerQuery
 from infrahub.core.registry import registry
+from infrahub.core.schema import RelationshipSchema
 from tests.constants import TestKind
 from tests.helpers.db_query_counter import CountingInfrahubDatabase
-from tests.helpers.schema import DEVICE_SCHEMA, load_schema
+from tests.helpers.schema import DEVICE_SCHEMA, TAG, load_schema
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -24,8 +27,33 @@ async def device_schema(db: InfrahubDatabase, default_branch: Branch, register_c
     await load_schema(db=db, schema=DEVICE_SCHEMA, branch_name=default_branch.name)
 
 
+@pytest.fixture
+async def device_schema_with_tagged_interfaces(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate."""
+    schema = deepcopy(DEVICE_SCHEMA)
+    schema.nodes.append(deepcopy(TAG))
+    physical_interface = next(node for node in schema.nodes if node.kind == TestKind.PHYSICAL_INTERFACE)
+    physical_interface.relationships.append(
+        RelationshipSchema(
+            name="tag",
+            kind=RelationshipKind.ATTRIBUTE,
+            optional=True,
+            peer=TestKind.TAG,
+            cardinality=RelationshipCardinality.ONE,
+        )
+    )
+    await load_schema(db=db, schema=schema, branch_name=default_branch.name)
+
+
 async def _build_template(
-    db: InfrahubDatabase, branch: Branch, name: str, nbr_interfaces: int, with_sfp: bool = False
+    db: InfrahubDatabase,
+    branch: Branch,
+    name: str,
+    nbr_interfaces: int,
+    with_sfp: bool = False,
+    tag_id: str | None = None,
 ) -> Node:
     """Build a device template, optionally giving each of its interfaces a subtemplate of its own."""
     template = await Node.init(db=db, schema=f"Template{TestKind.DEVICE}", branch=branch)
@@ -34,13 +62,15 @@ async def _build_template(
 
     for idx in range(nbr_interfaces):
         interface = await Node.init(db=db, schema=f"Template{TestKind.PHYSICAL_INTERFACE}", branch=branch)
-        await interface.new(
-            db=db,
-            template_name=f"{name}-eth{idx}",
-            name=f"eth{idx}",
-            phys_type="SFP+ (10GE)",
-            device=template.id,
-        )
+        interface_data: dict[str, Any] = {
+            "template_name": f"{name}-eth{idx}",
+            "name": f"eth{idx}",
+            "phys_type": "SFP+ (10GE)",
+            "device": template.id,
+        }
+        if tag_id:
+            interface_data["tag"] = tag_id
+        await interface.new(db=db, **interface_data)
         await interface.save(db=db)
 
         if not with_sfp:
@@ -265,3 +295,58 @@ async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_
     # read has no way to be told a node is already in hand. What matters here is that neither figure
     # grows with the width of a level.
     assert set(node_reads.values()) == {4}, f"reading the subtemplates grew with the width of a level: {node_reads}"
+
+
+async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
+    db: InfrahubDatabase, default_branch: Branch, device_schema_with_tagged_interfaces: None
+) -> None:
+    """A peer a subtemplate names is handed to the object created from it, not read again per object.
+
+    The subtemplates arrive with the peers their relationships name, so a component that carries
+    one costs what a component without one costs: its uniqueness check and its write. Naming the
+    peer by its id instead sent both the kind check on the new object and the write back to the
+    database for a node already in memory, once per component.
+    """
+    tag = await Node.init(db=db, schema=TestKind.TAG, branch=default_branch)
+    await tag.new(db=db, name="uplink")
+    await tag.save(db=db)
+
+    device_schema_obj = registry.schema.get_node_schema(name=TestKind.DEVICE, branch=default_branch)
+    node_reads = {}
+    attribute_reads = {}
+    counts = {}
+
+    for nbr_interfaces in (1, 3, 5):
+        name = f"tagged-{nbr_interfaces}"
+        template = await _build_template(
+            db=db, branch=default_branch, name=name, nbr_interfaces=nbr_interfaces, tag_id=tag.id
+        )
+        counting_db = CountingInfrahubDatabase.from_db(db=db)
+
+        device = await create_node(
+            data={"name": f"{name}-device", "object_template": {"id": template.id}},
+            db=counting_db,
+            branch=default_branch,
+            schema=device_schema_obj,
+        )
+
+        reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch, raise_on_error=True)
+        interfaces = await reloaded.interfaces.get_peers(db=db)
+        assert len(interfaces) == nbr_interfaces
+        assert {await interface.tag.get_peer_id(db=db) for interface in interfaces.values()} == {tag.id}, (
+            "the peer the template names was not written on the objects created from it"
+        )
+
+        node_reads[nbr_interfaces] = counting_db.count_for(NodeListGetInfoQuery.name)
+        attribute_reads[nbr_interfaces] = counting_db.count_for(NodeListGetAttributeQuery.name)
+        counts[nbr_interfaces] = sum(counting_db.query_counts.values())
+
+    assert counting_db.count_for(RelationshipGetPeerQuery.name) == 0
+    # The template, the peers its relationships name, and the peers the subtemplate level names:
+    # three reads, whatever the number of components carrying the tag.
+    assert set(node_reads.values()) == {3}, f"the tag was read once per component: {node_reads}"
+    assert set(attribute_reads.values()) == {3}, f"the tag's attributes were read again: {attribute_reads}"
+    per_component = (counts[3] - counts[1]) / 2
+    assert per_component == (counts[5] - counts[3]) / 2 == 2, (
+        f"a component carrying a peer costs {per_component} queries rather than a check and a write: {counts}"
+    )

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -27,11 +27,15 @@ async def device_schema(db: InfrahubDatabase, default_branch: Branch, register_c
     await load_schema(db=db, schema=DEVICE_SCHEMA, branch_name=default_branch.name)
 
 
-@pytest.fixture
+@pytest.fixture(params=[RelationshipCardinality.ONE, RelationshipCardinality.MANY], ids=["one", "many"])
 async def device_schema_with_tagged_interfaces(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, request: pytest.FixtureRequest
 ) -> None:
-    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate."""
+    """The device schema, with an interface able to point at a tag: a peer that is not a subtemplate.
+
+    Once per cardinality: the create query reads the peers of a relationship of cardinality many in one
+    batch, a path a single peer never takes.
+    """
     schema = deepcopy(DEVICE_SCHEMA)
     schema.nodes.append(deepcopy(TAG))
     physical_interface = next(node for node in schema.nodes if node.kind == TestKind.PHYSICAL_INTERFACE)
@@ -41,7 +45,7 @@ async def device_schema_with_tagged_interfaces(
             kind=RelationshipKind.ATTRIBUTE,
             optional=True,
             peer=TestKind.TAG,
-            cardinality=RelationshipCardinality.ONE,
+            cardinality=request.param,
         )
     )
     await load_schema(db=db, schema=schema, branch_name=default_branch.name)
@@ -327,9 +331,10 @@ async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
         reloaded = await NodeManager.get_one(db=db, id=device.id, branch=default_branch, raise_on_error=True)
         interfaces = await reloaded.interfaces.get_peers(db=db)
         assert len(interfaces) == nbr_interfaces
-        assert {await interface.tag.get_peer_id(db=db) for interface in interfaces.values()} == {tag.id}, (
-            "the peer the template names was not written on the objects created from it"
-        )
+        for interface in interfaces.values():
+            assert [rel.peer_id for rel in await interface.tag.get_relationships(db=db)] == [tag.id], (
+                "the peer the template names was not written on the objects created from it"
+            )
 
         node_reads[nbr_interfaces] = counting_db.count_for(NodeListGetInfoQuery.name)
         attribute_reads[nbr_interfaces] = counting_db.count_for(NodeListGetAttributeQuery.name)

--- a/backend/tests/component/templates/test_template_reads.py
+++ b/backend/tests/component/templates/test_template_reads.py
@@ -300,13 +300,7 @@ async def test_a_level_of_a_template_is_read_once_however_many_parents_it_hangs_
 async def test_a_peer_a_component_carries_is_not_read_back_for_every_component(
     db: InfrahubDatabase, default_branch: Branch, device_schema_with_tagged_interfaces: None
 ) -> None:
-    """A peer a subtemplate names is handed to the object created from it, not read again per object.
-
-    The subtemplates arrive with the peers their relationships name, so a component that carries
-    one costs what a component without one costs: its uniqueness check and its write. Naming the
-    peer by its id instead sent both the kind check on the new object and the write back to the
-    database for a node already in memory, once per component.
-    """
+    """A peer a subtemplate names is handed to the object created from it, not read again per object."""
     tag = await Node.init(db=db, schema=TestKind.TAG, branch=default_branch)
     await tag.new(db=db, name="uplink")
     await tag.save(db=db)

--- a/changelog/+template-component-peer-handover.changed.md
+++ b/changelog/+template-component-peer-handover.changed.md
@@ -1,1 +1,1 @@
-Creating objects from an object template no longer reads back the objects its components point at, such as the transceiver model every interface of a device template names, once for each component created.
+Creating objects from an object template is now faster when the objects it creates share a related object, such as the transceiver model used by every interface of a device template.

--- a/changelog/+template-component-peer-handover.changed.md
+++ b/changelog/+template-component-peer-handover.changed.md
@@ -1,0 +1,1 @@
+Creating objects from an object template no longer reads back the objects its components point at, such as the transceiver model every interface of a device template names, once for each component created.

--- a/dev/knowledge/backend/mutations.md
+++ b/dev/knowledge/backend/mutations.md
@@ -174,7 +174,11 @@ the mutation then works from it rather than reading it back:
   (`RelationshipManager.get_peer_id()`) and reads the peer only when it is named by a
   human-friendly id or a default filter value, which reading is the only way to resolve;
 - the peer-kind constraint trusts the kind a peer states, and reads only the peers named by an id;
-- `Relationship.get_create_data()` writes the edge from the peer it holds.
+- the create query reads the peers of a relationship of cardinality many in one call, and only those
+  held by id (`RelationshipManager.read_peers_not_in_hand()`); `Relationship.get_create_data()` then
+  writes the edge from the peer it holds. Before that, the create query batched every peer of such a
+  relationship through `get_peers()`, which reads whatever it is given — a component created from a
+  template read back, once per component, a peer the template read had already brought back.
 
 Passing a node keeps the rest of the payload for that relationship (its source, its owner) only if
 the node replaces the `id` inside it rather than the payload itself.


### PR DESCRIPTION
Stacked on #10423 (`fac/template-level-reads-10419`), which is the branch this work was measured against.

## What changed

Materializing a component of an object template named the peers it copies from the subtemplate by their id (`{"id": relationship.peer_id}`), although the level read had just brought those peers back as nodes. The component is now handed the node itself — as it already was for the parent it hangs from.

- `Relationship.get_peer_in_hand()` returns the peer as the node it is, or `None` when the relationship holds only its id, so the caller can tell the two apart without triggering a read.
- `extract_peer_data()` hands that node over. A peer the template read did not bring back still falls through to its id, unchanged.

## Why

A trace of an upsert creating a device with 66 components from a customer template showed 135 `node_list_get_info` queries. 128 of them were two reads of the *same* node, repeated once per component:

1. `RelationshipPeerKindConstraint` read the peer's kind, because the copied id carried none.
2. `NodeCreateAllQuery.query_init` → `Relationship.get_create_data()` → `get_peer()` read the whole node, for nothing but `peer.id` and `peer.get_branch()`.

In that trace the peer was one shared SFP node (`sfp_model` on `NetworkPhysicalInterface`), read 64 times over. The info queries were cheap (0.33 s), but the attribute read that follows each one averaged 106 ms — 6.8 s of a 15.1 s mutation.

## Measured

A device template with 65 interfaces, each naming the same 5-attribute peer:

| | before | after |
|---|---|---|
| `node_list_get_info` | 131 | **3** |
| `node_list_get_attribute` | 67 | **3** |
| `uniqueness_constraint_validation` | 66 | 66 |
| `node_create_all` | 66 | 66 |
| `node_list_get_relationship` | 2 | 2 |
| **total** | **332** | **140** |

A component carrying a peer now costs the 2 queries a component without one costs: its uniqueness check and its write. Node reads stay flat at 3, measured identical at 5, 20 and 65 interfaces.

Projected onto the traced mutation with its own per-query timings: 345 → 153 queries, ~7.2 s saved of 15.1 s. The per-component HFID uniqueness check (3.6 s, growing with the sibling count) becomes the next term.

## Second commit: the same for peers of cardinality many

`NodeCreateAllQuery.query_init` batched every peer of a many-cardinality relationship through `RelationshipManager.get_peers()`, which reads whatever it is given — so a component naming its peers through such a relationship still read them back, once per component, even when they were handed over as nodes. The create query now asks for the peers held only by id (`RelationshipManager.read_peers_not_in_hand()`), in the same single call (1161a6898).

Same shape as above, the interface naming the tag through a relationship of cardinality many:

| | before | after |
|---|---|---|
| `node_list_get_info` | 68 | **3** |
| `node_list_get_attribute` | 68 | **3** |
| `uniqueness_constraint_validation` | 66 | 66 |
| `node_create_all` | 66 | 66 |
| `node_list_get_relationship` | 2 | 2 |
| **total** | **270** | **140** |

Node reads flat at 3, measured identical at 5, 20 and 65 interfaces. `test_a_peer_a_component_carries_is_not_read_back_for_every_component` now runs once per cardinality; the `many` case failed on the previous commit with node reads of 3 + N. Green: the suites below plus `component/graphql/resource_manager`, `test_mutation_relationship`, `mutations/test_profile_resource_pool_validation` and `queries/test_resource_pool` — 798 tests.

## Testing

- New component test `test_a_peer_a_component_carries_is_not_read_back_for_every_component` pins 3 node reads / 3 attribute reads and 2 queries per component, and reloads the created objects from the database to assert the peer was actually written.
- Green: `component/templates`, `component/core/constraint_validators`, `component/core/profiles`, `component/core/node`, `component/graphql/test_mutation_{create,upsert}`, `component/core/test_{node,relationship,relationship_manager,relationship_metadata}` — 728 tests.
- `mypy` and `ruff` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



