### PR TITLE
fix(frontend): stop long first-column values covering the row actions

### DIFF
--- a/changelog/9743.fixed.md
+++ b/changelog/9743.fixed.md
@@ -1,0 +1,1 @@
+Long values in an object table's first column no longer overflow onto the row action menu and the horizontal scrollbar. Table columns are now capped and truncated, with the full value shown on hover.

--- a/frontend/app/src/entities/branches/ui/branches-table/branches-data-table.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/branches-data-table.tsx
@@ -1,6 +1,8 @@
 import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import React from "react";
 
+import { COLUMN_MAX_WIDTH, WIDE_COLUMN_MAX_WIDTH } from "@/shared/components/table/style";
+
 import { useAuth } from "@/entities/authentication/ui/auth-provider";
 import type { BranchListItem } from "@/entities/branches/domain/model/branch";
 import { BranchesToolbar } from "@/entities/branches/ui/branches-table/branches-toolbar";
@@ -14,8 +16,16 @@ export interface BranchesDataTableProps extends React.HTMLAttributes<HTMLDivElem
   gridTemplateColumns?: (columnCount: number) => string;
 }
 
+// Same capping rule as the shared DataTable: `fit-content` so short columns shrink
+// to fit, with a ceiling so one long value cannot stretch the column off-screen.
 const defaultGridTemplateColumns = (columnCount: number) =>
-  `minmax(auto, 400px) auto minmax(150px, 200px) repeat(${columnCount - 4}, auto) 2.5rem`;
+  [
+    `fit-content(${WIDE_COLUMN_MAX_WIDTH})`,
+    `fit-content(${COLUMN_MAX_WIDTH})`,
+    "minmax(150px, 200px)",
+    `repeat(${columnCount - 4}, fit-content(${COLUMN_MAX_WIDTH}))`,
+    "2.5rem",
+  ].join(" ");
 
 export function BranchesDataTable({
   columns,

--- a/frontend/app/src/entities/branches/ui/branches-table/branches-data-table.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/branches-data-table.tsx
@@ -54,7 +54,9 @@ export function BranchesDataTable({
   const selectedRows = table.getSelectedRowModel().flatRows.map((row) => row.original);
 
   return (
-    <div className="grid content-start" style={style} {...props}>
+    // See DataTable: `min-w-max` keeps the columns at their own width and lets the
+    // table scroll instead of compressing every track to fit the container.
+    <div className="grid min-w-max content-start" style={style} {...props}>
       {selectedRows.length > 0 && (
         <BranchesToolbar selectedBranches={selectedRows} onClose={table.resetRowSelection} />
       )}

--- a/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
@@ -40,9 +40,11 @@ export function BranchNameCell({ branch, isSelected, onClickCheckbox }: BranchNa
             variant="ghost"
             size="sm"
             href={getBranchDetailsUrl(branch.name)}
-            className="truncate rounded-full px-2.5 text-custom-blue-700 data-hovered:bg-custom-blue-700/10 data-hovered:underline"
+            className="min-w-0 shrink rounded-full px-2.5 text-custom-blue-700 data-hovered:bg-custom-blue-700/10 data-hovered:underline"
           >
-            {branch.name}
+            {/* The ellipsis has to sit on a child: `text-overflow` does nothing on
+                the button's own flex box. */}
+            <span className="truncate">{branch.name}</span>
           </LinkButton>
 
           <Row className="gap-1">

--- a/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-table/cells/branch-name-cell.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, LinkButton } from "@infrahub/ui";
+import { Checkbox, LinkButton, Tooltip } from "@infrahub/ui";
 import type { PressEvent } from "react-aria-components";
 
 import { Col, Row } from "@/shared/components/container";
@@ -36,16 +36,18 @@ export function BranchNameCell({ branch, isSelected, onClickCheckbox }: BranchNa
 
       <Col className="gap-0.5 overflow-hidden">
         <Row className="gap-1">
-          <LinkButton
-            variant="ghost"
-            size="sm"
-            href={getBranchDetailsUrl(branch.name)}
-            className="min-w-0 shrink rounded-full px-2.5 text-custom-blue-700 data-hovered:bg-custom-blue-700/10 data-hovered:underline"
-          >
-            {/* The ellipsis has to sit on a child: `text-overflow` does nothing on
-                the button's own flex box. */}
-            <span className="truncate">{branch.name}</span>
-          </LinkButton>
+          <Tooltip message={branch.name}>
+            <LinkButton
+              variant="ghost"
+              size="sm"
+              href={getBranchDetailsUrl(branch.name)}
+              className="min-w-0 shrink rounded-full px-2.5 text-custom-blue-700 data-hovered:bg-custom-blue-700/10 data-hovered:underline"
+            >
+              {/* The ellipsis has to sit on a child: `text-overflow` does nothing on
+                  the button's own flex box. */}
+              <span className="truncate">{branch.name}</span>
+            </LinkButton>
+          </Tooltip>
 
           <Row className="gap-1">
             {branch.is_default && <BranchDefaultBadge />}

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/get-ip-prefix-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/get-ip-prefix-table-columns.tsx
@@ -72,11 +72,14 @@ export const getIpPrefixTableColumns = (schema: ModelSchema): Array<ColumnDef<No
             isSelected={row.getIsSelected()}
             onClickCheckbox={getToggleSelectedRowHandler({ row, table })}
             label={
-              <Row className="gap-2.5">
+              // The ancestor markers stay outside the truncating element, so the
+              // ellipsis lands on the text itself rather than the row being clipped
+              // mid-character, and the markers keep their size in a capped column.
+              <Row className="min-w-0 gap-2.5">
                 {[...Array(ipPrefixNode.ancestors.count)].map((_, i) => (
-                  <div className="size-1 rounded-full bg-custom-blue-600/40" key={i} />
+                  <div className="size-1 shrink-0 rounded-full bg-custom-blue-600/40" key={i} />
                 ))}
-                {value}
+                <span className="truncate">{value}</span>
               </Row>
             }
             // The label is markup, so the prefix has to be named explicitly for the

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/get-ip-prefix-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/get-ip-prefix-table-columns.tsx
@@ -79,6 +79,9 @@ export const getIpPrefixTableColumns = (schema: ModelSchema): Array<ColumnDef<No
                 {value}
               </Row>
             }
+            // The label is markup, so the prefix has to be named explicitly for the
+            // truncated value to stay readable on hover.
+            tooltipLabel={value}
           />
         );
       },

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/color-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/color-cell.tsx
@@ -5,7 +5,8 @@ export function ColorCell({ color }: { color: TextAttribute }) {
 
   return (
     <div className="inline-flex items-center gap-1.5">
-      <div className="size-4 rounded-sm" style={{ backgroundColor: color.value }} /> {color.value}
+      <div className="size-4 shrink-0 rounded-sm" style={{ backgroundColor: color.value }} />{" "}
+      {color.value}
     </div>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/color-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/color-cell.tsx
@@ -4,9 +4,9 @@ export function ColorCell({ color }: { color: TextAttribute }) {
   if (!color.value) return "-";
 
   return (
-    <div className="inline-flex items-center gap-1.5">
-      <div className="size-4 shrink-0 rounded-sm" style={{ backgroundColor: color.value }} />{" "}
-      {color.value}
+    <div className="inline-flex min-w-0 items-center gap-1.5">
+      <div className="size-4 shrink-0 rounded-sm" style={{ backgroundColor: color.value }} />
+      <span className="truncate">{color.value}</span>
     </div>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/node-kind-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/node-kind-cell.tsx
@@ -8,8 +8,9 @@ export function NodeKindCell({ kind }: { kind: string }) {
   if (!schema) return "-";
 
   return (
-    <div className="flex items-center gap-2">
-      {schema.label} <Badge>{schema.namespace}</Badge>
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{schema.label}</span>
+      <Badge className="shrink-0">{schema.namespace}</Badge>
     </div>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
@@ -31,6 +31,8 @@ export function StickyRightCell({ className, isMuted, children, ...props }: Stic
   return (
     <TableCell
       className={classNames(
+        // Matches StickyLeftCell's z-1 so an over-wide first column can never paint
+        // over the row actions, even on a viewport narrower than the column cap.
         "sticky right-0 z-1 -ml-px size-10 items-center justify-center border-l",
         isMuted ? cellMutedStyle : "bg-white",
         className

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/style.tsx
@@ -31,7 +31,7 @@ export function StickyRightCell({ className, isMuted, children, ...props }: Stic
   return (
     <TableCell
       className={classNames(
-        "sticky right-0 -ml-px size-10 items-center justify-center border-l",
+        "sticky right-0 z-1 -ml-px size-10 items-center justify-center border-l",
         isMuted ? cellMutedStyle : "bg-white",
         className
       )}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
@@ -11,6 +11,11 @@ export interface TableIdentifierCellProps {
   objectKind: string;
   objectId: string;
   label: React.ReactNode;
+  /**
+   * Full text to show on hover. Only needed when `label` is composed markup rather
+   * than a plain string — a string label is used as its own tooltip.
+   */
+  tooltipLabel?: string;
   isSelected?: boolean;
   onClickCheckbox?: (e: PressEvent) => void;
   overrideParams?: overrideQueryParams[];
@@ -20,6 +25,7 @@ export function TableIdentifierCell({
   objectKind,
   objectId,
   label,
+  tooltipLabel,
   isSelected,
   onClickCheckbox,
   overrideParams,
@@ -32,8 +38,9 @@ export function TableIdentifierCell({
 
       {/* The label is truncated to keep the sticky column from covering the row
           actions, so surface the full value on hover. `Tooltip` renders its children
-          untouched when `message` is empty, which covers non-string labels. */}
-      <Tooltip message={typeof label === "string" ? label : undefined}>
+          untouched when `message` is empty, so a composed label with no
+          `tooltipLabel` simply gets no tooltip. */}
+      <Tooltip message={tooltipLabel ?? (typeof label === "string" ? label : undefined)}>
         <LinkButton
           variant="ghost"
           size="sm"

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-identifier-cell.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, LinkButton } from "@infrahub/ui";
+import { Checkbox, LinkButton, Tooltip } from "@infrahub/ui";
 import type { PressEvent } from "react-aria-components";
 
 import type { overrideQueryParams } from "@/shared/api/rest/fetch";
@@ -30,14 +30,21 @@ export function TableIdentifierCell({
     <StickyLeftCell data-testid="identifier-cell">
       {isAuthenticated && <Checkbox isSelected={isSelected} onPress={onClickCheckbox} />}
 
-      <LinkButton
-        variant="ghost"
-        size="sm"
-        href={getObjectDetailsUrl(objectKind, objectId, overrideParams)}
-        className="-mx-1 truncate rounded-xl px-2 text-custom-blue-700 hover:underline"
-      >
-        {label}
-      </LinkButton>
+      {/* The label is truncated to keep the sticky column from covering the row
+          actions, so surface the full value on hover. `Tooltip` renders its children
+          untouched when `message` is empty, which covers non-string labels. */}
+      <Tooltip message={typeof label === "string" ? label : undefined}>
+        <LinkButton
+          variant="ghost"
+          size="sm"
+          href={getObjectDetailsUrl(objectKind, objectId, overrideParams)}
+          className="-mx-1 min-w-0 shrink rounded-xl px-2 text-custom-blue-700 hover:underline"
+        >
+          {/* The button is a flex container, where `text-overflow` has no effect, so
+              the ellipsis has to live on a child of it. */}
+          <span className="truncate">{label}</span>
+        </LinkButton>
+      </Tooltip>
     </StickyLeftCell>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
@@ -49,10 +49,10 @@ export function RelationshipNodeDisplay({ node }: { node: NodeCore }) {
       variant="outline"
       size="sm"
       href={getObjectDetailsUrl(node.__typename, node.id)}
-      className="truncate rounded-full pr-2.5 hover:border-custom-blue-700 hover:underline"
+      className="min-w-0 shrink rounded-full pr-2.5 hover:border-custom-blue-700 hover:underline"
     >
       <Icon icon={getSchemaIcon(schema)} className="text-custom-blue-800" />
-      {getNodeLabel(node)}
+      <span className="truncate">{getNodeLabel(node)}</span>
     </LinkButton>
   );
 }

--- a/frontend/app/src/shared/components/table/data-table.test.tsx
+++ b/frontend/app/src/shared/components/table/data-table.test.tsx
@@ -24,7 +24,10 @@ interface DemoRow {
   label: string;
 }
 
-const buildColumns = (label: (row: DemoRow) => React.ReactNode): ColumnDef<DemoRow>[] => [
+const buildColumns = (
+  label: (row: DemoRow) => React.ReactNode,
+  tooltipLabel?: string
+): ColumnDef<DemoRow>[] => [
   {
     id: "identifier",
     header: () => <StickyLeftCell>Name</StickyLeftCell>,
@@ -33,6 +36,7 @@ const buildColumns = (label: (row: DemoRow) => React.ReactNode): ColumnDef<DemoR
         objectKind="TestingOverflowDemo"
         objectId={row.original.id}
         label={label(row.original)}
+        tooltipLabel={tooltipLabel}
       />
     ),
   },
@@ -182,5 +186,18 @@ describe("DataTable first column tooltip", () => {
     // absence rather than racing it.
     await new Promise((resolve) => setTimeout(resolve, 600));
     expect(component.getByRole("tooltip").query()).toBeNull();
+  });
+
+  test("shows the tooltip for a composed label when one is named explicitly", async () => {
+    // GIVEN a label built from markup rather than a plain string
+    const nodeLabelColumns = buildColumns(() => <span>{LONG_LABEL}</span>, LONG_LABEL);
+    const component = await renderTable(nodeLabelColumns, [rows[1]!]);
+
+    // WHEN
+    await initPointerTracking(component.locator);
+    await component.getByRole("link", { name: LONG_LABEL }).hover();
+
+    // THEN
+    await expect.element(component.getByRole("tooltip", { name: LONG_LABEL })).toBeVisible();
   });
 });

--- a/frontend/app/src/shared/components/table/data-table.test.tsx
+++ b/frontend/app/src/shared/components/table/data-table.test.tsx
@@ -1,0 +1,164 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { describe, expect, test } from "vitest";
+
+import { DataTable } from "@/shared/components/table/data-table";
+
+import { StickyLeftCell } from "@/entities/nodes/object/ui/object-table/cells/style";
+import { TableIdentifierCell } from "@/entities/nodes/object/ui/object-table/cells/table-identifier-cell";
+
+import { render } from "../../../../tests/components/render";
+import { initPointerTracking } from "../../../../tests/components/utils";
+
+// A single unbreakable token is the worst case: its min-content width equals its
+// max-content width, so nothing but a capped grid track can keep it in bounds.
+const LONG_LABEL =
+  "core-aggregation-switch-amsterdam-east-campus-distribution-layer-replacing-the-decommissioned-nexus-pair";
+const SHORT_LABEL = "atl1-core1";
+
+interface DemoRow {
+  id: string;
+  __typename: string;
+  label: string;
+}
+
+const buildColumns = (label: (row: DemoRow) => React.ReactNode): ColumnDef<DemoRow>[] => [
+  {
+    id: "identifier",
+    header: () => <StickyLeftCell>Name</StickyLeftCell>,
+    cell: ({ row }) => (
+      <TableIdentifierCell
+        objectKind="TestingOverflowDemo"
+        objectId={row.original.id}
+        label={label(row.original)}
+      />
+    ),
+  },
+  {
+    id: "description",
+    header: () => <div>Description</div>,
+    cell: () => <div>a description</div>,
+  },
+  {
+    id: "status",
+    header: () => <div>Status</div>,
+    cell: () => <div>active</div>,
+  },
+  {
+    id: "actions",
+    header: () => <div />,
+    cell: () => (
+      <div data-testid="actions-cell" className="sticky right-0 size-10">
+        ...
+      </div>
+    ),
+  },
+];
+
+const columns = buildColumns((row) => row.label);
+
+const rows: DemoRow[] = [
+  { id: "1", __typename: "TestingOverflowDemo", label: SHORT_LABEL },
+  { id: "2", __typename: "TestingOverflowDemo", label: LONG_LABEL },
+];
+
+// The narrow, horizontally scrollable wrapper is what makes this a real test: it is
+// the container the sticky cells pin against, and the one the first column must not
+// outgrow.
+const renderTable = (columnDefs: ColumnDef<DemoRow>[], data: DemoRow[]) =>
+  render(
+    <div className="w-[600px] overflow-x-auto">
+      <DataTable columns={columnDefs} data={data} />
+    </div>
+  );
+
+const identifierCells = () =>
+  Array.from(document.querySelectorAll('[data-testid="identifier-cell"]'));
+
+describe("DataTable first column overflow", () => {
+  test("caps the first column instead of letting it grow with its content", async () => {
+    // GIVEN
+    await renderTable(columns, rows);
+
+    // THEN
+    const cells = identifierCells();
+    expect(cells).toHaveLength(2);
+
+    // Unconstrained, this renders at ~800px. The bound is deliberately loose so the
+    // test tracks "a cap exists", not the exact cap value.
+    expect(cells[1]!.getBoundingClientRect().width).toBeLessThanOrEqual(400);
+  });
+
+  test("keeps the column shrink-to-fit rather than padding it out to the cap", async () => {
+    // GIVEN
+    await renderTable(columns, [rows[0]!]);
+
+    // THEN
+    const shortOnlyCell = identifierCells()[0]!;
+
+    // With only short content the track must size to that content, not to the cap.
+    expect(shortOnlyCell.getBoundingClientRect().width).toBeLessThan(320);
+  });
+
+  test("actually truncates the overflowing label", async () => {
+    // GIVEN
+    await renderTable(columns, rows);
+
+    // THEN
+    const link = identifierCells()[1]!.querySelector("a")!;
+    const truncatedLabel = link.querySelector("span")!;
+
+    // Before the fix this fails: the cell box grows to fit the text, so `truncate`
+    // has nothing to clip and scrollWidth === clientWidth.
+    expect(truncatedLabel.scrollWidth).toBeGreaterThan(truncatedLabel.clientWidth);
+
+    // The ellipsis only renders if the clipping happens on a child of the button,
+    // since `text-overflow` has no effect on a flex container.
+    expect(getComputedStyle(truncatedLabel).textOverflow).toBe("ellipsis");
+    expect(getComputedStyle(truncatedLabel).display).toBe("block");
+
+    // And the button itself must stay inside the capped column.
+    expect(link.scrollWidth).toBeLessThanOrEqual(link.clientWidth);
+  });
+
+  test("does not let the first column cover the row action menu", async () => {
+    // GIVEN
+    await renderTable(columns, rows);
+
+    // THEN
+    const identifierRect = identifierCells()[1]!.getBoundingClientRect();
+    const actionsRect = document
+      .querySelectorAll('[data-testid="actions-cell"]')[1]!
+      .getBoundingClientRect();
+
+    expect(identifierRect.right).toBeLessThanOrEqual(actionsRect.left);
+  });
+});
+
+describe("DataTable first column tooltip", () => {
+  test("shows the full value on hover when the label is a string", async () => {
+    // GIVEN
+    const component = await renderTable(columns, rows);
+
+    // WHEN
+    await initPointerTracking(component.locator);
+    await component.getByRole("link", { name: LONG_LABEL }).hover();
+
+    // THEN
+    await expect.element(component.getByRole("tooltip", { name: LONG_LABEL })).toBeVisible();
+  });
+
+  test("renders no tooltip when the label is not a plain string", async () => {
+    // GIVEN
+    const nodeLabelColumns = buildColumns(() => <span>{LONG_LABEL}</span>);
+    const component = await renderTable(nodeLabelColumns, [rows[1]!]);
+
+    // WHEN
+    await initPointerTracking(component.locator);
+    await component.getByRole("link", { name: LONG_LABEL }).hover();
+
+    // THEN — the tooltip opens after a 200ms delay, so wait past it before asserting
+    // absence rather than racing it.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(component.getByRole("tooltip").query()).toBeNull();
+  });
+});

--- a/frontend/app/src/shared/components/table/data-table.test.tsx
+++ b/frontend/app/src/shared/components/table/data-table.test.tsx
@@ -3,7 +3,10 @@ import { describe, expect, test } from "vitest";
 
 import { DataTable } from "@/shared/components/table/data-table";
 
-import { StickyLeftCell } from "@/entities/nodes/object/ui/object-table/cells/style";
+import {
+  StickyLeftCell,
+  StickyRightCell,
+} from "@/entities/nodes/object/ui/object-table/cells/style";
 import { TableIdentifierCell } from "@/entities/nodes/object/ui/object-table/cells/table-identifier-cell";
 
 import { render } from "../../../../tests/components/render";
@@ -46,11 +49,7 @@ const buildColumns = (label: (row: DemoRow) => React.ReactNode): ColumnDef<DemoR
   {
     id: "actions",
     header: () => <div />,
-    cell: () => (
-      <div data-testid="actions-cell" className="sticky right-0 size-10">
-        ...
-      </div>
-    ),
+    cell: () => <StickyRightCell data-testid="actions-cell">...</StickyRightCell>,
   },
 ];
 
@@ -118,6 +117,29 @@ describe("DataTable first column overflow", () => {
 
     // And the button itself must stay inside the capped column.
     expect(link.scrollWidth).toBeLessThanOrEqual(link.clientWidth);
+  });
+
+  test("keeps the sticky footer above the sticky row actions", async () => {
+    // GIVEN a table that renders its count footer
+    await render(
+      <div className="w-[600px] overflow-x-auto">
+        <DataTable columns={columns} data={rows} count={rows.length} />
+      </div>
+    );
+
+    // THEN every footer cell outranks the sticky action cells, so the last row's
+    // action menu cannot punch through the count bar.
+    const grid = document.querySelector('[style*="grid-template-columns"]')!;
+    const footerCells = [...grid.children].filter(
+      (el) => getComputedStyle(el).position === "sticky" && getComputedStyle(el).bottom === "0px"
+    );
+    expect(footerCells.length).toBeGreaterThan(0);
+
+    const actionsZ =
+      Number(getComputedStyle(document.querySelector('[data-testid="actions-cell"]')!).zIndex) || 0;
+    for (const cell of footerCells) {
+      expect(Number(getComputedStyle(cell).zIndex) || 0).toBeGreaterThan(actionsZ);
+    }
   });
 
   test("does not let the first column cover the row action menu", async () => {

--- a/frontend/app/src/shared/components/table/data-table.test.tsx
+++ b/frontend/app/src/shared/components/table/data-table.test.tsx
@@ -123,6 +123,30 @@ describe("DataTable first column overflow", () => {
     expect(link.scrollWidth).toBeLessThanOrEqual(link.clientWidth);
   });
 
+  test("renders an ellipsis for a composed label that truncates its own text", async () => {
+    // GIVEN a label shaped like the IP prefix column: markers alongside the value,
+    // with only the value truncating.
+    const composedColumns = buildColumns(() => (
+      <span className="flex min-w-0 gap-1">
+        <span className="size-1 shrink-0 rounded-full bg-black" />
+        <span className="truncate" data-testid="composed-value">
+          {LONG_LABEL}
+        </span>
+      </span>
+    ));
+    await renderTable(composedColumns, [rows[1]!]);
+
+    // THEN the ellipsis lands on the text, not on an ancestor that would clip the
+    // whole row mid-character.
+    const value = document.querySelector<HTMLElement>('[data-testid="composed-value"]')!;
+    expect(value.scrollWidth).toBeGreaterThan(value.clientWidth);
+    expect(getComputedStyle(value).textOverflow).toBe("ellipsis");
+
+    // And the markers keep their width instead of collapsing in the capped column.
+    const marker = document.querySelector<HTMLElement>('[data-testid="identifier-cell"] .size-1')!;
+    expect(marker.getBoundingClientRect().width).toBeGreaterThan(0);
+  });
+
   test("keeps the sticky footer above the sticky row actions", async () => {
     // GIVEN a table that renders its count footer
     await render(

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -33,8 +33,14 @@ export interface DataTableProps<T> extends React.HTMLAttributes<HTMLDivElement> 
   gridTemplateColumns?: (columnCount: number) => string;
 }
 
+// `fit-content` keeps short columns shrink-to-fit while capping long ones. A bare
+// `auto` track has no ceiling, so a single long value grows the column past the
+// viewport — and because the first column is sticky, it then paints over the row
+// action menu and the horizontal scrollbar.
+const COLUMN_MAX_WIDTH = "20rem";
+
 const defaultGridTemplateColumns = (columnCount: number) =>
-  `repeat(${columnCount - 2}, auto) 1fr 2.5rem`;
+  `repeat(${columnCount - 2}, fit-content(${COLUMN_MAX_WIDTH})) 1fr 2.5rem`;
 
 export function DataTable<T extends NodeCore>({
   columnOrder,

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -9,7 +9,7 @@ import {
 import React from "react";
 
 import { Row } from "@/shared/components/container";
-import { cellFooterStyle, cellsStyle } from "@/shared/components/table/style";
+import { COLUMN_MAX_WIDTH, cellFooterStyle, cellsStyle } from "@/shared/components/table/style";
 import { classNames } from "@/shared/utils/common";
 import { formatNumberDisplay } from "@/shared/utils/number";
 
@@ -37,8 +37,6 @@ export interface DataTableProps<T> extends React.HTMLAttributes<HTMLDivElement> 
 // `auto` track has no ceiling, so a single long value grows the column past the
 // viewport — and because the first column is sticky, it then paints over the row
 // action menu and the horizontal scrollbar.
-const COLUMN_MAX_WIDTH = "20rem";
-
 const defaultGridTemplateColumns = (columnCount: number) =>
   `repeat(${columnCount - 2}, fit-content(${COLUMN_MAX_WIDTH})) 1fr 2.5rem`;
 

--- a/frontend/app/src/shared/components/table/data-table.tsx
+++ b/frontend/app/src/shared/components/table/data-table.tsx
@@ -85,8 +85,11 @@ export function DataTable<T extends NodeCore>({
 
   const selectedRows = table.getSelectedRowModel().flatRows.map((row) => row.original);
 
+  // `min-w-max` stops the grid from being squeezed into its scroll container.
+  // Without it the tracks compress until columns are unreadably narrow instead of
+  // keeping their width and letting the table scroll horizontally.
   return (
-    <div className="grid content-start" style={style} {...props}>
+    <div className="grid min-w-max content-start" style={style} {...props}>
       {allHeaders.map((header) => {
         return flexRender(header.column.columnDef.header, {
           ...header.getContext(),
@@ -115,7 +118,9 @@ export function DataTable<T extends NodeCore>({
         Array.from({ length: allHeaders.length }).map((_, index) => (
           <div
             key={index}
-            className={classNames(cellsStyle, cellFooterStyle, index === 0 && "left-0 z-10")}
+            // The whole footer bar has to outrank the sticky body cells, not just its
+            // first cell, or the last row's sticky action menu punches through it.
+            className={classNames(cellsStyle, cellFooterStyle, "z-10", index === 0 && "left-0")}
           >
             {index === 0 && (
               <>

--- a/frontend/app/src/shared/components/table/style.tsx
+++ b/frontend/app/src/shared/components/table/style.tsx
@@ -1,3 +1,16 @@
+/**
+ * How wide a column may grow before its contents truncate. Grid tracks sized `auto`
+ * have no ceiling, so without a cap one long value stretches the whole column past
+ * the viewport. Use with `fit-content()` so short columns still shrink to fit.
+ */
+export const COLUMN_MAX_WIDTH = "20rem";
+
+/**
+ * Cap for identifier columns that stack more than a bare label — a name alongside
+ * badges and a description needs more room before truncating.
+ */
+export const WIDE_COLUMN_MAX_WIDTH = "25rem";
+
 // `min-w-0` lets the cell shrink below its content's intrinsic width, which is what
 // makes the `truncate` classes on cell contents actually clip instead of growing the
 // column.

--- a/frontend/app/src/shared/components/table/style.tsx
+++ b/frontend/app/src/shared/components/table/style.tsx
@@ -1,4 +1,8 @@
-export const cellsStyle = "flex items-center gap-1.5 p-2 text-sm h-10 bg-white disabled:bg-white";
+// `min-w-0` lets the cell shrink below its content's intrinsic width, which is what
+// makes the `truncate` classes on cell contents actually clip instead of growing the
+// column.
+export const cellsStyle =
+  "flex min-w-0 items-center gap-1.5 p-2 text-sm h-10 bg-white disabled:bg-white";
 
 export const cellHeaderStyle =
   "z-1 sticky top-0 border-r border-y border-gray-200 hover:bg-gray-100 font-medium";


### PR DESCRIPTION
# Why

In object list tables, a long value in the first column stretched that column past the viewport. Because the first column is sticky, it stayed pinned and painted **over** the row's three-dots action menu and the horizontal scrollbar — and scrolling could never bring the hidden tail into view, so the value was unreadable and the controls it covered were unusable.

Goal: long values stay inside their column, the row actions and scrollbar stay reachable, and the full value is still readable.

Non-goals: no column resizing, no persisted column widths, no change to which columns are shown.

Closes #9743

<img width="1463" height="895" alt="Capture d’écran 2026-08-26 à 16 02 39" src="https://github.com/user-attachments/assets/1a02a0ac-d160-4889-b05e-4d8d45f549d2" />

<img width="1469" height="909" alt="Capture d’écran 2026-08-26 à 16 08 25" src="https://github.com/user-attachments/assets/4af612ad-c4d0-4388-8523-7e25c4511f16" />

## What changed

The object list is a CSS Grid, not an HTML `<table>`. Two things combined to cause this:

1. `data-table.tsx` sized tracks `repeat(N-2, auto)`. An `auto` track has an **uncapped max-content maximum**, so one long value stretched the whole column.
2. `cellsStyle` had no `min-w-0`.

Together those made the `truncate` classes already present on every cell **inert** — the cell box simply grew to fit its text, so `overflow: hidden` had nothing to clip: `scrollWidth === clientWidth`, 776 vs 776.

The first column was the visible victim only because it is `sticky left-0 z-1`, so it travelled with the viewport and outranked the actions cell. Measured before the fix: identifier cell right edge at **786.9px**, actions cell left edge at **560px** — a 227px overlap.

### Behavioral changes

- Columns cap at `20rem` and truncate with an ellipsis instead of growing without limit.
- The row action menu and horizontal scrollbar stay reachable on every row.
- Hovering a truncated identifier shows the full value in a tooltip.
- Wide tables **scroll horizontally** rather than squeezing every column to fit.

### Implementation notes

- **`fit-content(20rem)` rather than `minmax(0, 20rem)`** — the latter pads *every* short column out to the cap. `fit-content` keeps short columns shrink-to-fit. Note `minmax(<len>, fit-content(<len>))` is not valid CSS, so a track-level floor is not expressible.
- **`min-w-0` on `cellsStyle`** drives the grid track's automatic minimum to 0, so the cap holds even for a long unbroken token (the worst case, where min-content == max-content).
- **`min-w-max` on the grid container.** Without it the grid compresses to its scroll container, starving columns — one real data column drops to **21px** and horizontal scrolling disappears. `min-w-max` lets tracks keep their width and the container scroll.
- **Ellipsis moved onto a child `<span>`.** `text-overflow` has no effect on a flex container, and `Button`'s base classes are `inline-flex shrink-0` — so the link needed `min-w-0 shrink` to fit the capped column, and the ellipsis needed a block-level child to render on.
- **No `overflow-hidden` on cells** — it would clip the sticky columns' gradient fades, which bleed outside the cell box by design.
- **Stacking order:** `StickyRightCell` gains `z-1` to match `StickyLeftCell`, so an over-wide first column can never repaint over the actions even on a viewport narrower than the cap. The count footer moves to `z-10` on *every* cell (not just the first) so the last row's action menu cannot punch through it.
- Column caps are now named constants in `shared/components/table/style.tsx` (`COLUMN_MAX_WIDTH`, `WIDE_COLUMN_MAX_WIDTH`) shared by both grid tables, replacing a hard-coded `400px` in the branches table.
- `tooltipLabel` was added for callers whose label is composed markup rather than a string — only the IP-prefix column, which was otherwise truncating with no way to read the value.

### What stayed the same

No schema, API or GraphQL changes. No change to column order or which columns render. Tasks, diff views and resource-manager tables use a different table component and are untouched.

## How to review

Start with the two lines that actually fix the bug:

1. `shared/components/table/data-table.tsx` — the track template and `min-w-max`.
2. `shared/components/table/style.tsx` — `min-w-0` and the shared constants.

Then the cell-level follow-through, which is mechanical but load-bearing: `table-identifier-cell.tsx`, `table-relationship-cell.tsx`, `branch-name-cell.tsx`, `color-cell.tsx`, `node-kind-cell.tsx`.

**`cellsStyle` is shared**, so this touches nine `DataTable` consumers (object list, relationship tabs, role-manager ×5, IPAM ×2) plus the branches table. That is the main risk surface and the part most worth a second opinion.

Worth extra scrutiny: the `20rem` / `25rem` cap values are a judgement call, not derived from anything.

## How to test

```bash
cd frontend/app
pnpm test src/shared/components/table/data-table.test.tsx
```

On `stable` these tests fail on the cap (`708 > 400`) and on truncation being inert (`776 === 776`).

To reproduce by hand, load a schema whose `display_label` is a long `Text` attribute, open its object list, and check that the first column caps, the three-dots menu is clickable, and the table scrolls horizontally.

Verified in a running instance: tracks resolve to `320px 320px 109 111 320 206 40`, first column pinned at the cap, horizontal scroll active, ellipsis rendering, and hit-testing confirms the action button is the topmost element at its centre point.

## Impact & rollout

- **Backward compatibility:** none needed — presentation only.
- **Performance:** no measurable change; CSS-only, no new renders or state.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/9743.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change) — n/a, no documented behaviour changes
- [ ] Internal .md docs updated — see note below
- [x] I have reviewed AI generated content

---

### Follow-ups deliberately not in this PR

- `BranchesDataTable` duplicates `DataTable` almost entirely; consolidating is a behaviour-preserving refactor that shouldn't ride along with a bug fix.
- The `gridTemplateColumns: (count) => string` escape hatch lets a future caller hand back uncapped CSS. No caller does today; a `columnWidths` prop would close it.
- ~10 hand-rolled `className="truncate"` call sites could become one `<CellText>` wrapper.

The "grid tracks + `min-w-0` + `text-overflow` on flex containers" interaction is subtle enough to be worth a `dev/knowledge/frontend/` note; happy to add it here or as a follow-up, reviewer's preference.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


