### PR TITLE
fix: keep watching a flow run through its retry wait [#10338]

### DIFF
--- a/backend/infrahub/trigger/system.py
+++ b/backend/infrahub/trigger/system.py
@@ -11,12 +11,27 @@ from prefect.client.schemas.objects import StateType
 from infrahub.trigger.models import ChangeFlowRunStateAction, ProactiveEventTrigger, SystemTriggerDefinition
 from infrahub.webhook.constants import WEBHOOK_SEND_RETRY_DELAY_SECONDS
 
-# A proactive trigger keeps a per-run countdown: every expected event restarts it, and the
-# action fires when the countdown lapses. A run waiting out a retry backoff emits nothing at
-# all, so the window must outlast the longest configured backoff or every such wait is
-# mistaken for a dead process. The retry-wait transition is an expected event so the countdown
-# is anchored at the start of the silence it explains. The margin absorbs event-propagation
-# and scheduler jitter between the retry-wait transition and the resumed run's next heartbeat.
+# The two event sets below do opposite things. An event in `after` restarts the per-run countdown;
+# an event that is only expected satisfies the window instead, so it expires without firing and
+# the run is left unwatched. Ending the watch that way is only ever right for a finished run.
+ZOMBIE_WATCH_ENDING_EVENTS: set[str] = {
+    "prefect.flow-run.Completed",
+    "prefect.flow-run.Failed",
+    "prefect.flow-run.Cancelled",
+    "prefect.flow-run.Crashed",
+}
+
+# Every other expected event means the run is still alive and must renew the countdown. A retry
+# wait is silent for its whole duration -- the engine tears down its heartbeat thread before it
+# sleeps out the delay -- so the transition anchors the countdown at the start of that silence.
+ZOMBIE_WATCH_RENEWING_EVENTS: set[str] = {
+    "prefect.flow-run.heartbeat",
+    "prefect.flow-run.AwaitingRetry",
+}
+
+# The window must outlast the longest configured backoff or a legitimate retry wait is mistaken
+# for a dead process. The margin absorbs propagation and scheduler jitter before the resumed
+# run's first heartbeat.
 ZOMBIE_DETECTION_MARGIN = timedelta(seconds=60)
 ZOMBIE_HEARTBEAT_WINDOW = timedelta(seconds=WEBHOOK_SEND_RETRY_DELAY_SECONDS) + ZOMBIE_DETECTION_MARGIN
 
@@ -24,15 +39,8 @@ TRIGGER_CRASH_ZOMBIE_FLOWS = SystemTriggerDefinition(
     name="crash-zombie-flows",
     description="Crashes flow runs that have stopped sending heartbeats",
     trigger=ProactiveEventTrigger(
-        after={"prefect.flow-run.heartbeat"},
-        events={
-            "prefect.flow-run.heartbeat",
-            "prefect.flow-run.AwaitingRetry",
-            "prefect.flow-run.Completed",
-            "prefect.flow-run.Failed",
-            "prefect.flow-run.Cancelled",
-            "prefect.flow-run.Crashed",
-        },
+        after=ZOMBIE_WATCH_RENEWING_EVENTS,
+        events=ZOMBIE_WATCH_RENEWING_EVENTS | ZOMBIE_WATCH_ENDING_EVENTS,
         match={"prefect.resource.id": ["prefect.flow-run.*"]},
         for_each={"prefect.resource.id"},
         threshold=1,

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -101,7 +101,7 @@ async def test_wait_that_never_resumes_is_marked_crashed(
 async def test_wait_that_resumes_is_left_alone(prefect_client: PrefectClient, scaled_zombie_automation: None) -> None:
     """A retry wait that resumes is a live process and must survive the countdown.
 
-    The run goes silent for most of a window while it waits out its backoff -- the engine stops
+    The run goes silent for over half a window while it waits out its backoff -- the engine stops
     heartbeating for the whole delay -- and then resumes. The resumed run's first heartbeat has to
     renew the countdown, so the run is still untouched well past the expiry the retry-wait
     transition had armed.
@@ -110,8 +110,11 @@ async def test_wait_that_resumes_is_left_alone(prefect_client: PrefectClient, sc
     await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
     await emit_flow_run_event("prefect.flow-run.AwaitingRetry", flow_run_id)
 
-    # The backoff: silent for most of the window the transition armed.
-    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.8)
+    # The backoff: silent for over half the window the transition armed. The heartbeat is emitted
+    # early enough in that window that a lagging event pipeline still ingests it before the
+    # armed expiry -- a heartbeat that lands after the proactive tick has already fired cannot
+    # undo the crash.
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.6)
     await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
 
     # Now past the transition's expiry but short of the resumed heartbeat's: crashed here means

--- a/backend/tests/component/trigger/test_zombie_detection.py
+++ b/backend/tests/component/trigger/test_zombie_detection.py
@@ -98,6 +98,30 @@ async def test_wait_that_never_resumes_is_marked_crashed(
     )
 
 
+async def test_wait_that_resumes_is_left_alone(prefect_client: PrefectClient, scaled_zombie_automation: None) -> None:
+    """A retry wait that resumes is a live process and must survive the countdown.
+
+    The run goes silent for most of a window while it waits out its backoff -- the engine stops
+    heartbeating for the whole delay -- and then resumes. The resumed run's first heartbeat has to
+    renew the countdown, so the run is still untouched well past the expiry the retry-wait
+    transition had armed.
+    """
+    flow_run_id = await create_waiting_run(prefect_client)
+    await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
+    await emit_flow_run_event("prefect.flow-run.AwaitingRetry", flow_run_id)
+
+    # The backoff: silent for most of the window the transition armed.
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.8)
+    await emit_flow_run_event("prefect.flow-run.heartbeat", flow_run_id)
+
+    # Now past the transition's expiry but short of the resumed heartbeat's: crashed here means
+    # the resumed run's heartbeat did not renew the countdown.
+    await asyncio.sleep(SCALED_WINDOW.total_seconds() * 0.7)
+    run = await prefect_client.read_flow_run(flow_run_id)
+    assert run.state is not None
+    assert run.state.type == StateType.SCHEDULED
+
+
 async def test_wait_transition_restarts_the_countdown(
     prefect_client: PrefectClient, scaled_zombie_automation: None
 ) -> None:

--- a/backend/tests/unit/trigger/test_catalogue.py
+++ b/backend/tests/unit/trigger/test_catalogue.py
@@ -6,6 +6,14 @@ import pytest
 
 from infrahub.trigger import catalogue
 from infrahub.trigger.catalogue import builtin_triggers
+from infrahub.trigger.models import ProactiveEventTrigger
+from infrahub.trigger.system import (
+    TRIGGER_CRASH_ZOMBIE_FLOWS,
+    ZOMBIE_HEARTBEAT_WINDOW,
+    ZOMBIE_WATCH_ENDING_EVENTS,
+    ZOMBIE_WATCH_RENEWING_EVENTS,
+)
+from infrahub.webhook.constants import WEBHOOK_SEND_RETRY_DELAY_SECONDS
 
 if TYPE_CHECKING:
     from infrahub.trigger.models import TriggerDefinition
@@ -21,3 +29,27 @@ def test_builtin_triggers_sorted() -> None:
     names = sorted(name for name in dir(catalogue) if name.isupper())
     ordered_triggers = [getattr(catalogue, name) for name in names]
     assert ordered_triggers == builtin_triggers, "The list of triggers isn't sorted alphabetically"
+
+
+def test_zombie_watch_only_ends_on_a_terminal_state() -> None:
+    """Every event that does not end the zombie watch must renew the countdown.
+
+    A proactive trigger only restarts its countdown for an event listed in `after`. An event that
+    is merely expected satisfies the window instead, so it expires without firing and the run is
+    left unwatched. That is the right outcome for a run that has finished and wrong for any event
+    that means the run is still alive, so the expected set may only ever add terminal states on
+    top of the renewing ones.
+    """
+    trigger = TRIGGER_CRASH_ZOMBIE_FLOWS.trigger
+    assert isinstance(trigger, ProactiveEventTrigger)
+
+    assert trigger.after == ZOMBIE_WATCH_RENEWING_EVENTS
+    assert trigger.events - ZOMBIE_WATCH_ENDING_EVENTS == trigger.after, (
+        "an expected event that is not terminal must also be in `after`, or it permanently "
+        "disarms zombie detection for that run"
+    )
+
+
+def test_zombie_watch_window_outlasts_the_longest_retry_backoff() -> None:
+    """The countdown must not lapse while a run legitimately waits out its retry backoff."""
+    assert ZOMBIE_HEARTBEAT_WINDOW.total_seconds() > WEBHOOK_SEND_RETRY_DELAY_SECONDS

--- a/changelog/10338.fixed.md
+++ b/changelog/10338.fixed.md
@@ -1,0 +1,1 @@
+Fixed flow runs that stopped being watched for crashes once they entered a retry wait. A run whose process died while waiting out a retry backoff, such as a webhook delivery between attempts, stayed scheduled forever instead of being marked as crashed.

--- a/dev/knowledge/backend/async-tasks.md
+++ b/dev/knowledge/backend/async-tasks.md
@@ -350,9 +350,27 @@ Because the discriminant is intrinsic to every run, historical runs type correct
 
 ## Liveness and zombie detection
 
-A running flow emits a `prefect.flow-run.heartbeat` event on a fixed interval while it executes. The `crash-zombie-flows` system automation watches for the absence of these events: it keeps a per-run countdown that every expected event restarts, and marks a run `CRASHED` once the countdown lapses. This reaps runs whose worker process died without recording a terminal state, which would otherwise stay `RUNNING` indefinitely.
+A running flow emits a `prefect.flow-run.heartbeat` event on a fixed interval while it executes. The `crash-zombie-flows` system automation watches for the absence of these events and marks a run `CRASHED` once its countdown lapses. This reaps runs whose worker process died without recording a terminal state, which would otherwise stay `RUNNING` indefinitely.
 
-A run waiting out a retry backoff emits nothing while it waits. The retry-wait transition is therefore registered as an expected event, anchoring the countdown at the start of that silence, and the detection window is sized above the longest configured retry backoff so a run waiting between attempts is not mistaken for a dead process. The window is derived from the webhook send retry delay plus a margin rather than hardcoded, so the relationship holds if the backoff changes. A run whose process genuinely died still lapses the window and is crashed, at the cost of the widened detection latency.
+### An event either renews the countdown or ends the watch
+
+A Prefect proactive trigger has two event sets, and they do opposite things. This is the single most important thing to know before editing the trigger, because the two are easy to confuse and the failure mode is silent:
+
+- an event in **`after`** opens or restarts the per-run countdown;
+- an event that is only in **`expect`** *satisfies* the window instead. It pushes the bucket's count to the threshold, so at expiry the proactive `count < threshold` test fails, the action never fires, and the bucket is then deleted. The run is left unwatched until an `after` event opens a new one.
+
+So "expected" does not mean "renews". Ending the watch is the correct outcome only for the terminal states, where the run has finished and must stop being watched. Any other event the trigger expects means the run is still alive, so it must appear in **both** sets. A unit test asserts that the expected set only ever adds terminal states on top of the renewing ones, because getting this wrong disarms detection for the affected run rather than producing an obvious error.
+
+### Retry waits
+
+A run waiting out a retry backoff is silent for the whole wait: the flow engine tears down its heartbeat thread before it sleeps out the delay, and Prefect excludes in-process retries (`empirical_policy.retry_type == "in_process"`) from the worker scheduled-run query, so nothing else reports on the run either. Two consequences:
+
+- The retry-wait transition renews the countdown, anchoring it at the start of the silence it explains, so the whole window is available to the backoff. Were it merely expected, it would end the watch and a run whose process died inside the wait would never be crashed.
+- The window is sized above the longest configured retry backoff so a legitimate wait is not mistaken for a dead process. It is derived from the webhook send retry delay plus a margin rather than hardcoded, so the relationship holds if the backoff changes.
+
+Because a dead in-process retry wait is never re-submitted by a worker, crashing it has no false-positive path: the run has no way forward other than the process that just died. The cost of the widened window is detection latency, not correctness.
+
+Note when reasoning about which events fire: on resume, Prefect renames the state, so the event is `prefect.flow-run.Retrying`, not `...Running`. The client-side return value of a state proposal keeps the locally-proposed name, so it is not a reliable guide to the emitted event.
 
 ## Key Locations
 


### PR DESCRIPTION
Fixes #10338.

## Problem

`crash-zombie-flows` stopped watching a flow run the moment it entered a retry wait. A run whose process died mid-wait — a webhook delivery killed between attempts, for instance — was never declared crashed and stayed `SCHEDULED/AwaitingRetry` forever.

A Prefect proactive trigger has two event sets that do **opposite** things:

- an event in `after` opens or restarts the per-run countdown;
- an event that is only in `expect` *satisfies* the window. It pushes the bucket's count to the threshold, so at expiry the proactive `count < threshold` test fails, the action never fires, and the bucket is deleted (`prefect/server/events/triggers.py`).

So "expected" does not mean "renews" — it means "stop watching". That is right for the terminal states and wrong for anything meaning the run is still alive. `prefect.flow-run.AwaitingRetry` was expected only.

Nothing re-armed detection during the wait, because the wait is genuinely silent:

- the flow engine's `_send_heartbeats` context exits before `handle_exception` runs, so the `time.sleep(retry_delay)` inside `propose_state_sync`'s WAIT loop happens with **no heartbeat thread alive**. Probed with `retry_delay_seconds=75` / heartbeat 30s: beats at 3.2s and 78.3s only, the second being the resume itself — zero beats across the wait;
- Prefect excludes in-process retries from worker pickup (`empirical_policy.retry_type == "in_process"`, filtered out in both `get-runs-from-worker-queues.sql.jinja` dialects), so no worker reports on the run either.

The window sizing (`120s` backoff + `60s` margin) was already correct and is unchanged; the countdown was being cancelled, not out-run.

## Change

Split the trigger's events into two named sets by the role they play, and put the retry-wait transition in **both** — so it anchors the countdown at the start of the silence it explains:

```python
after=ZOMBIE_WATCH_RENEWING_EVENTS,
events=ZOMBIE_WATCH_RENEWING_EVENTS | ZOMBIE_WATCH_ENDING_EVENTS,
```

Naming the sets by role is the point: the previous shape made it possible to add an expected event without noticing it silently ends the watch. A unit test now enforces that the expected set only ever adds terminal states on top of the renewing ones.

Because a dead in-process retry wait is never re-submitted by a worker, crashing it has no false-positive path — the run has no way forward other than the process that just died.

### Considered and rejected

Deleting `AwaitingRetry` from the expected set also fixes the bug, but it anchors the countdown at the last heartbeat rather than the transition. That cuts the slack for a healthy wait from a full window to ~30s (heartbeat interval), and it fails `test_wait_transition_restarts_the_countdown` — correctly, since the transition would no longer protect anything.

## Also fixes a flaky test

This removes the delivery-order race behind `test_wait_that_never_resumes_is_marked_crashed`, which has failed **25 times across 21 CI runs** on unrelated PRs since W32 (most recently [run 32952205385](https://github.com/opsmill/infrahub/actions/runs/32952205385/job/98126276106), on the stable→develop merge PR).

The test emits `heartbeat` then `AwaitingRetry` ~5ms apart on two websocket clients. It passed **only** when Prefect happened to drop the second event (losing the race against the bucket INSERT); once the event was delivered and counted, detection was disarmed and the run was never crashed. The green outcome was the false positive. With the transition in `after` it creates-or-restarts the bucket either way, so ordering no longer matters.

## Testing

| | before | after |
|---|---|---|
| `test_zombie_detection.py`, 5ms gap (forced losing side) | 1 failed, 1 passed (76s) | **3 passed** |
| `test_zombie_detection.py`, 0ms gap (the CI condition) | flaky | **3 passed** |
| `test_zombie_detection.py`, reversed emit order | — | **passed** |
| `unit/trigger/test_catalogue.py` | — | **16 passed** (0.15s) |

New tests:

- `test_zombie_watch_only_ends_on_a_terminal_state` — definition-level invariant, fails in 0.19s against the old wiring with the reason spelled out. Deterministic; no delivery race to lose.
- `test_zombie_watch_window_outlasts_the_longest_retry_backoff` — locks the window/backoff relationship.
- `test_wait_that_resumes_is_left_alone` — the healthy half of the contract (silent through the backoff, then resumes → left alone), previously uncovered.

Local gates: `invoke format`, `ruff check . --exclude python_sdk`, `uv lock --check`, `invoke backend.lint` (ty + mypy over 1634 files), `invoke backend.validate-generated`, `invoke docs.validate`, `invoke docs.lint`, `invoke backend.test-unit` — all clean, no generated-file drift. Frontend checks skipped (backend-only change).

## Docs

Corrected the "Liveness and zombie detection" section of `dev/knowledge/backend/async-tasks.md`, which documented the `every expected event restarts it` reading that produced this bug, and now explains the `after` vs `expect` split, why a retry wait is silent, and that on resume the event is `prefect.flow-run.Retrying` (not `...Running`) while the client-side state name still says `Running`.

## Not addressed

#10201 (the automation firing against terminal cron-scheduled runs) is a separate defect in the same automation and is untouched here — `AwaitingRetry` never occurs for the cron runs that cause it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

