### PR TITLE
docs: clarify the default_branch description on repositories

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/repository.py
+++ b/backend/infrahub/core/schema/definitions/core/repository.py
@@ -41,7 +41,7 @@ core_repository = NodeSchema(
         Attr(
             name="default_branch",
             kind="Text",
-            description="Default branch name in the Git repository",
+            description="Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch.",
             default_value="main",
             order_weight=6000,
         ),

--- a/changelog/+repository-default-branch-description.changed.md
+++ b/changelog/+repository-default-branch-description.changed.md
@@ -1,0 +1,1 @@
+Clarified the description of the `default_branch` attribute on repositories. It now states that the value is the remote branch Infrahub maps onto its own default branch, and that it does not have to be the remote's default branch.

--- a/frontend/app/src/shared/api/graphql/generated/types.ts
+++ b/frontend/app/src/shared/api/graphql/generated/types.ts
@@ -296,14 +296,14 @@ export type BranchCreate = {
 };
 
 export type BranchCreateInput = {
-  /** @deprecated branched_from is set by the server and cannot be provided */
+  /** @deprecated branched_from is set by the server and cannot be provided. Will be removed after version 1.12. */
   branched_from?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
-  /** @deprecated Non isolated mode is not supported anymore */
+  /** @deprecated Non-isolated mode is not supported anymore. Will be removed after version 1.12. */
   is_isolated?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
-  /** @deprecated Branches can only be created from the default branch */
+  /** @deprecated Branches can only be created from the default branch. Will be removed after version 1.12. */
   origin_branch?: InputMaybe<Scalars['String']['input']>;
   sync_with_git?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -12758,7 +12758,7 @@ export type CoreRepository = CoreGenericRepository & CoreNode & CoreTaskTarget &
   /** Current commit hash being tracked */
   commit: Maybe<TextAttribute>;
   credential: NestedEdgedCoreCredential;
-  /** Default branch name in the Git repository */
+  /** Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch. */
   default_branch: Maybe<TextAttribute>;
   /** Description of the repository */
   description: Maybe<TextAttribute>;
@@ -13142,7 +13142,7 @@ export type CoreRepositoryCreateInput = {
   /** Current commit hash being tracked */
   commit?: InputMaybe<TextAttributeCreate>;
   credential?: InputMaybe<RelatedNodeInput>;
-  /** Default branch name in the Git repository */
+  /** Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch. */
   default_branch?: InputMaybe<TextAttributeCreate>;
   /** Description of the repository */
   description?: InputMaybe<TextAttributeCreate>;
@@ -13406,7 +13406,7 @@ export type CoreRepositoryUpdateInput = {
   /** Current commit hash being tracked */
   commit?: InputMaybe<TextAttributeUpdate>;
   credential?: InputMaybe<RelatedNodeInput>;
-  /** Default branch name in the Git repository */
+  /** Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch. */
   default_branch?: InputMaybe<TextAttributeUpdate>;
   /** Description of the repository */
   description?: InputMaybe<TextAttributeUpdate>;
@@ -13443,7 +13443,7 @@ export type CoreRepositoryUpsertInput = {
   /** Current commit hash being tracked */
   commit?: InputMaybe<TextAttributeUpdate>;
   credential?: InputMaybe<RelatedNodeInput>;
-  /** Default branch name in the Git repository */
+  /** Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch. */
   default_branch?: InputMaybe<TextAttributeUpdate>;
   /** Description of the repository */
   description?: InputMaybe<TextAttributeUpdate>;

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -5765,7 +5765,9 @@ type CoreRepository implements CoreGenericRepository & CoreNode & CoreTaskTarget
   """Current commit hash being tracked"""
   commit: TextAttribute
   credential: NestedEdgedCoreCredential!
-  """Default branch name in the Git repository"""
+  """
+  Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch.
+  """
   default_branch: TextAttribute
   """Description of the repository"""
   description: TextAttribute
@@ -5804,7 +5806,9 @@ input CoreRepositoryCreateInput {
   """Current commit hash being tracked"""
   commit: TextAttributeCreate
   credential: RelatedNodeInput
-  """Default branch name in the Git repository"""
+  """
+  Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch.
+  """
   default_branch: TextAttributeCreate
   """Description of the repository"""
   description: TextAttributeCreate
@@ -5940,7 +5944,9 @@ input CoreRepositoryUpdateInput {
   """Current commit hash being tracked"""
   commit: TextAttributeUpdate
   credential: RelatedNodeInput
-  """Default branch name in the Git repository"""
+  """
+  Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch.
+  """
   default_branch: TextAttributeUpdate
   """Description of the repository"""
   description: TextAttributeUpdate
@@ -5976,7 +5982,9 @@ input CoreRepositoryUpsertInput {
   """Current commit hash being tracked"""
   commit: TextAttributeUpdate
   credential: RelatedNodeInput
-  """Default branch name in the Git repository"""
+  """
+  Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch.
+  """
   default_branch: TextAttributeUpdate
   """Description of the repository"""
   description: TextAttributeUpdate


### PR DESCRIPTION
# Why

The `default_branch` attribute on `CoreRepository` was described as "Default branch name in the Git repository", which reads as the remote's own default branch. It is not that: it is the remote branch Infrahub maps onto its own default branch, and it is free to point at any remote branch.

That wording surfaces in the GraphQL schema and as the field's help text in the UI, so the ambiguity reaches users directly and has caused confusion about which branch the value refers to.

## What changed

Behavioral changes:

- The `default_branch` description now reads "Remote branch that Infrahub maps onto its own default branch. Need not be the remote default branch." Visible in the GraphQL schema (`CoreRepository` and its Create/Update/Upsert inputs) and as the field help in the UI.

Implementation notes:

- No migration is needed. `description` carries `json_schema_extra={"update": "allowed"}` on `AttributeSchema`, so the new value applies on schema load.
- The new string is 100 characters, within the `max_length=128` limit on that field.
- Generated files regenerated: `schema/schema.graphql` (`uv run invoke schema.generate-graphqlschema`) and `frontend/app/src/shared/api/graphql/generated/types.ts` (`pnpm codegen`). The GraphQL output now wraps the description into a multi-line `"""` block because of its length.
- The `types.ts` regen also picked up three pre-existing stale lines in `BranchCreate` (deprecation reasons that already carried "Will be removed after version 1.12." in the committed `schema.graphql` but had never been regenerated). That file is not covered by a CI staleness check, which is how it drifted.

What stayed the same:

- No schema structure change, no new or removed fields, no default value change. Only the attribute's description text.
- `schema/openapi.json` and the generated reference docs are unaffected (verified by regenerating both: no diff).

## How to review

- `backend/infrahub/core/schema/definitions/core/repository.py` is the only hand-written change; everything else is generated output.
- Worth a second opinion on the wording itself, since it lands in the public GraphQL schema.

## How to test

```bash
uv run invoke schema.generate-graphqlschema
cd frontend/app && pnpm codegen
git diff --exit-code    # should be clean
```

## Impact & rollout

- **Backward compatibility:** no breaking change. Description text only.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] Tests added/updated (n/a - description text only)
- [x] Changelog entry added (`changelog/+repository-default-branch-description.changed.md`)
- [ ] External docs updated (n/a)
- [ ] Internal .md docs updated (n/a)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

