### PR TITLE
feat(frontend): reveal row metadata icon on hover

### DIFF
--- a/changelog/+metadata-icon-hover-reveal.changed.md
+++ b/changelog/+metadata-icon-hover-reveal.changed.md
@@ -1,0 +1,1 @@
+Showed the attribute and relationship metadata icon only on row hover, after the protected-status lock icon

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-attribute-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-attribute-row.tsx
@@ -36,10 +36,13 @@ export function ObjectAttributeRow({
         <>
           <ObjectAttributeValue attributeSchema={attributeSchema} attributeData={attributeData} />
 
+          {attributeData.is_protected && <LockIcon className="size-3.5 text-foreground-muted" />}
+
           <MetaDetailsTooltip
             updatedAt={attributeData.updated_at}
             source={attributeData.source}
             owner={attributeData.owner}
+            triggerClassName="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
             isProtected={attributeData.is_protected}
             header={
               !attributeSchema.read_only && (
@@ -65,8 +68,6 @@ export function ObjectAttributeRow({
               )
             }
           />
-
-          {attributeData.is_protected && <LockIcon className="size-3.5 text-foreground-muted" />}
 
           {attributeSchema.display === "extra" && <ExtraFieldIndicator className="ml-auto" />}
         </>

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
@@ -30,7 +30,7 @@ export function ObjectDataRow({ value, className, objectKind, fieldSchema }: Obj
   const defaultTab = isRelationship ? "relationships" : "attributes";
 
   return (
-    <div className={classNames("grid grid-cols-[200px_auto] gap-4 px-3 py-2 text-sm", className)}>
+    <div className={classNames("group grid grid-cols-[200px_auto] gap-4 px-3 py-2 text-sm", className)}>
       <dt className="flex h-8 items-center font-medium text-foreground-muted">
         {schema ? (
           <DialogTrigger>

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-data-row.tsx
@@ -30,7 +30,9 @@ export function ObjectDataRow({ value, className, objectKind, fieldSchema }: Obj
   const defaultTab = isRelationship ? "relationships" : "attributes";
 
   return (
-    <div className={classNames("group grid grid-cols-[200px_auto] gap-4 px-3 py-2 text-sm", className)}>
+    <div
+      className={classNames("group grid grid-cols-[200px_auto] gap-4 px-3 py-2 text-sm", className)}
+    >
       <dt className="flex h-8 items-center font-medium text-foreground-muted">
         {schema ? (
           <DialogTrigger>

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-relationship-row.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-data-display/object-relationship-row.tsx
@@ -91,11 +91,15 @@ function RelationshipOneRow({
 
           {relationshipProperties && (
             <>
+              {relationshipProperties.is_protected && (
+                <LockIcon className="size-3.5 text-foreground-muted" />
+              )}
               <MetaDetailsTooltip
                 updatedAt={relationshipProperties.updated_at}
                 source={relationshipProperties.source}
                 owner={relationshipProperties.owner}
                 isProtected={relationshipProperties.is_protected}
+                triggerClassName="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
                 header={
                   onClickMetadata && (
                     <div className="flex items-center justify-between border-b p-1 pt-0 pl-2">
@@ -119,9 +123,6 @@ function RelationshipOneRow({
                   )
                 }
               />
-              {relationshipProperties.is_protected && (
-                <LockIcon className="size-3.5 text-foreground-muted" />
-              )}
             </>
           )}
 
@@ -162,7 +163,7 @@ function RelationshipManyRow({
       objectKind={objectKind}
       value={
         <>
-          <dl className="flex flex-col">
+          <dl className="flex w-full flex-col">
             {relatedNodeEdges.map((edge) => {
               const relatedNode = edge.node;
               const edgeProperties = edge.properties;
@@ -170,22 +171,23 @@ function RelationshipManyRow({
               if (!relatedNode) return null;
 
               return (
-                <Row key={relatedNode.id}>
+                <Row key={relatedNode.id} className="group/edge w-full">
                   <Link to={getObjectDetailsUrl(relatedNode.__typename, relatedNode.id)}>
                     {getNodeLabel(relatedNode)}
                   </Link>
 
                   {edgeProperties && (
                     <>
+                      {edgeProperties.is_protected && (
+                        <LockIcon className="size-3.5 text-foreground-muted" />
+                      )}
                       <MetaDetailsTooltip
                         updatedAt={edgeProperties.updated_at}
                         source={edgeProperties.source}
                         owner={edgeProperties.owner}
                         isProtected={edgeProperties.is_protected}
+                        triggerClassName="opacity-0 transition-opacity group-hover/edge:opacity-100 focus-visible:opacity-100"
                       />
-                      {edgeProperties.is_protected && (
-                        <LockIcon className="size-3.5 text-foreground-muted" />
-                      )}
                     </>
                   )}
                 </Row>

--- a/frontend/app/src/shared/components/display/meta-details-tooltips.tsx
+++ b/frontend/app/src/shared/components/display/meta-details-tooltips.tsx
@@ -8,6 +8,7 @@ import { PropertyList } from "@/shared/components/table/property-list";
 import { Badge } from "@/shared/components/ui/badge";
 import { Link } from "@/shared/components/ui/link";
 import { useFormatDate } from "@/shared/context/date-preferences-context";
+import { classNames } from "@/shared/utils/common";
 
 import type { NodeCore } from "@/entities/nodes/object/domain/model/node";
 import { getNodeLabel } from "@/entities/nodes/object/domain/rules/get-node-label";
@@ -20,6 +21,7 @@ interface MetaDetailsTooltipProps {
   source?: NodeCore | null;
   owner?: NodeCore | null;
   isProtected: AnyAttribute["is_protected"];
+  triggerClassName?: string;
 }
 
 export default function MetaDetailsTooltip({
@@ -28,6 +30,7 @@ export default function MetaDetailsTooltip({
   source,
   owner,
   isProtected,
+  triggerClassName,
 }: MetaDetailsTooltipProps) {
   const { isProfile, isTemplate } = useSchema(source?.__typename);
   const { formatDate } = useFormatDate();
@@ -81,7 +84,7 @@ export default function MetaDetailsTooltip({
         size="xs"
         shape="circle"
         variant="ghost"
-        className="text-foreground-muted"
+        className={classNames("text-foreground-muted", triggerClassName)}
         data-testid="view-metadata-button"
       >
         <Icon icon="mdi:information-slab-circle-outline" />


### PR DESCRIPTION
I used this change to facilitate my learning of the front end of Infrahub. This is by no means a fully vetted PR. Claude helped me greatly with this. If this is something the frontend team feels makes sense for Infrahub, I'd love to have it vetted further. If not, happy to close it.

## Dyanmic ToolTip
<img width="1489" height="830" alt="2026-08-31 17 34 58" src="https://github.com/user-attachments/assets/ced31f5c-44d2-4b78-a258-cada6edcd280" />

---
# Why

Metadata icons (source/owner/updated-at) were always visible on every attribute and relationship row in the object detail view, adding visual clutter.

Goal: show the icon only on row hover, consistent with the existing hover-reveal pattern already used elsewhere on the page (the field-label schema icon, the profile/group edit pencil). This gives the customer a less chaotic UI but still allows them to see the Metadata if they'd like. 

## What changed

- Attribute and relationship rows now reveal their metadata icon on hover instead of always.
- Icon order is now value → protected-lock icon → metadata icon.
- Many-cardinality relationship list items (e.g. Tags) each get an independent hover scope spanning the full row width — hovering one tag's line reveals only that tag's icon, and hovering anywhere along the line (not just pinpoint on the icon) reveals it.

## How to review

- `meta-details-tooltips.tsx` — new optional `triggerClassName` prop, passed through to the trigger button.
- `object-data-row.tsx` — added `group` to the row wrapper.
- `object-attribute-row.tsx` / `object-relationship-row.tsx` — reordered icons, wired the hover class, widened per-item relationship rows to `w-full`.

## Impact & rollout

- **Backward compatibility:** none — pure UI/CSS behavior change.
- **Config/env changes:** none.

## Checklist

- [ ] Tests added/updated — none; this is hover/layout CSS behavior, verified manually in a live browser session
- [x] Changelog entry added
- [ ] External docs updated — not applicable
- [ ] Internal .md docs updated — not applicable

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

