### PR TITLE
refactor(regeneration): consume SubscriberRef directly, drop ProposedChangeSubscriber (IFC-3070)

### DIFF
--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -8,7 +8,6 @@ from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.message_bus.types import ProposedChangeSubscriber
 from infrahub.workers.dependencies import get_database
 
 from .impact_classifier import ChangedNodes, EveryTarget, QueryImpactClassifier, RelationshipReachedChanges
@@ -74,8 +73,8 @@ async def get_field_level_impacted_subscribers(
         case _ as unreachable:
             assert_never(unreachable)
 
-    subscribers = await _get_subscribers_for_nodes(node_ids=member_ids, branch=query_branch, client=client)
-    ids = [subscriber.subscriber_id for subscriber in subscribers if subscriber.kind == subscriber_kind]
+    subscribers = await fetch_subscriber_refs(client=client, node_ids=member_ids, branch=query_branch)
+    ids = [subscriber.id for subscriber in subscribers if subscriber.kind == subscriber_kind]
     return TargetSelection(ids=ids, widened=False)
 
 
@@ -106,10 +105,3 @@ class ReachedMemberResolver:
                     )
                 members |= peer_uuids
         return members
-
-
-async def _get_subscribers_for_nodes(
-    node_ids: list[str], branch: str, client: InfrahubClient
-) -> list[ProposedChangeSubscriber]:
-    refs = await fetch_subscriber_refs(client=client, node_ids=node_ids, branch=branch)
-    return [ProposedChangeSubscriber(subscriber_id=ref.id, kind=ref.kind) for ref in refs]

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -93,11 +93,6 @@ class ProposedChangeRepository(BaseModel):
         return bool(self.files_added + self.files_changed + self.files_removed)
 
 
-class ProposedChangeSubscriber(BaseModel):
-    subscriber_id: str
-    kind: str
-
-
 class ProposedChangeArtifactDefinition(BaseModel):
     definition_id: str
     definition_name: str


### PR DESCRIPTION
## Summary

Internal cleanup in the artifact/generator regeneration engine. Ref: [IFC-3070](https://opsmill.atlassian.net/browse/IFC-3070).

The field-level impact path fetched `SubscriberRef`s from the query-group subscriber lookup, converted each into a `message_bus.types.ProposedChangeSubscriber` (renaming `id` → `subscriber_id`), then destructured it straight back to `id`/`kind` on the next line. The conversion added nothing but a `message_bus` dependency inside a regeneration internal.

## Changes

- `core/regeneration/impact.py` — consume `SubscriberRef` directly: call `fetch_subscriber_refs` and read `ref.id` / `ref.kind`. Dropped the one-line `_get_subscribers_for_nodes` wrapper and the `message_bus` import.
- `message_bus/types.py` — deleted `ProposedChangeSubscriber`, now unreferenced.

## Behavior

No behavior change. The same subscriber refs flow through, still un-deduplicated, still filtered by `subscriber_kind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-3070]: https://opsmill.atlassian.net/browse/IFC-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

