### PR TITLE
chore(deps): upgrade gitpython to 3.1.61

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1057,14 +1057,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Lock-only bump of gitpython, 3.1.58 → 3.1.61. `pyproject.toml` is untouched — the existing `gitpython>=3.1.50,<4` constraint already admits 3.1.61, so the diff is three lines in `uv.lock`.

## Why

- **3.1.59** and **3.1.60** are security releases, 8 advisories between them.
- **3.1.61** is a fixup that restores `Actor.name_email_regex` as a deprecated descriptor instead of removing it outright.

## Impact on this codebase

The hardening lands in paths Infrahub uses, so each was checked against the real call sites rather than taken from the changelog:

| Upstream change | Call site here | Verdict |
|---|---|---|
| `Repo.__init__` + `repo/fun.py` `is_git_dir` / `find_worktree_git_dir` rewritten | `InfrahubRepositoryBase.get_git_repo_worktree` builds a `Repo` from a **linked worktree** dir (`backend/infrahub/git/base.py:303`) — the reordered branch | No change, probed (below) |
| `Diffable.diff` / `IndexFile.diff` / `Repo.blame` now check new `unsafe_git_diff_options` / `unsafe_git_blame_options` — `--no-index`, `-O`, `--orderfile`, `--contents`, `-S`, `--ignore-revs-file` newly raise `UnsafeOptionError` | No call site passes any of them; no `.blame` usage at all | Not hit |
| `--exec` added to unsafe ls-remote options | The one `ls_remote` call (`git/base.py:1105`) passes no options | Not hit |
| `--separate-git-dir` added to unsafe clone options | No call site passes it | Not hit |
| Config writes now quote values containing whitespace or ``\n\t\b\\"#;``, and raise `ValueError` on CR/NUL | `config_writer` appears only in tests | Not hit |
| `Actor.name_only_regex` removed, `name_email_regex` warns on access | Neither is referenced | Not hit |

Because the worktree-discovery rewrite is the one change that touches a hot path, I probed it directly instead of relying on the test suite: an origin repo plus branch and commit worktrees laid out the way `repositories/<id>/{branches,commits}` is, opened under both versions. `git_dir`, `common_dir`, `working_dir`, resolved HEAD and `worktree list --porcelain` output are identical on 3.1.58 and 3.1.61.

## Checks run

Against 3.1.61 in a synced env:

- `backend/tests/unit/git` — 198 passed
- `backend/tests/component/git` — 108 passed, 1 xfailed
- `backend/tests/functional/git` — 3 passed
- `uv lock --check` — clean

## Notes

- The re-resolve initially also rewrote an unrelated `pendulum` marker hunk; that was reverted so the diff is gitpython-only, and `uv lock --check` still passes.
- No changelog fragment, matching the precedent for lock-only dependency bumps (e.g. df5de166f, the last gitpython bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)