### PR TITLE
test(backend): report the Prefect test server's stacks when a component test times out

### DIFF
--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -81,7 +81,7 @@ from tests.helpers.constants import (
     PREFECT_TEST_SERVER_PORT_RANGE,
 )
 from tests.helpers.file_repo import FileRepo
-from tests.helpers.prefect_diagnostics import register_prefect_test_server
+from tests.helpers.prefect_diagnostics import register_prefect_test_server, timeout_diagnostics_section
 from tests.helpers.test_client import dummy_async_request
 from tests.helpers.utils import find_available_prefect_port
 from tests.test_data import dataset01 as ds01
@@ -106,6 +106,25 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         if list(item.iter_markers("httpx_mock")):
             continue
         item.add_marker(default_marker)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo[None]
+) -> Generator[None, pytest.TestReport, pytest.TestReport]:
+    """Make a test the Prefect server wedged carry that server's stacks into the failure.
+
+    A wedged server takes its whole worker down through timeouts that describe nothing but the
+    test they killed. The report has to be added here, before the report is logged: xdist ships
+    it to the controller at that point, and anything attached later never leaves the worker.
+    """
+    report = yield
+    section = timeout_diagnostics_section(
+        nodeid=item.nodeid, when=call.when, exception=call.excinfo.value if call.excinfo else None
+    )
+    if section is not None:
+        report.sections.append(section)
+    return report  # noqa: B901 - a pytest wrapper hook yields, then returns the result it wrapped
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/backend/tests/helpers/prefect_diagnostics.py
+++ b/backend/tests/helpers/prefect_diagnostics.py
@@ -100,6 +100,13 @@ def timeout_diagnostics_section(nodeid: str, when: str, exception: BaseException
 
     Any other failure is left alone. The report costs the server a signal, the run a two second
     wait and the log three hundred lines, which only a suspected wedge earns.
+
+    The message is the only mark pytest-timeout leaves on the failure, so a test failing itself
+    with one that opens the same way would be reported on too. That is the right way round to be
+    wrong: a false positive costs an already-failing test two seconds and a log tail, and the
+    server survives being asked what it is doing, while matching on the plugin's own frames
+    instead would stop reporting the day its internals change — silently, and back to a wedge
+    that CI cannot describe.
     """
     if not isinstance(exception, pytest.fail.Exception) or not str(exception).startswith(TIMEOUT_MESSAGE_PREFIX):
         return None

--- a/backend/tests/helpers/prefect_diagnostics.py
+++ b/backend/tests/helpers/prefect_diagnostics.py
@@ -10,18 +10,25 @@ to. Code that gives up on a Prefect call then asks every registered server for t
 its threads (SIGUSR1) and prints the tail of its log. pytest captures that as part of the failing
 test, so the report travels with the failure into the CI log.
 
+Only code that knows it is waiting on Prefect can report the wedge itself; pytest-timeout kills
+everything else from the outside, wherever it happens to be. ``timeout_diagnostics_section``
+covers that case, so a test the timeout killed carries the same report.
+
 Nothing here raises: it runs on a path that is already failing, and a broken diagnostic must not
 replace the original error.
 """
 
 from __future__ import annotations
 
+import io
 import signal
 import sys
 import time
 import traceback
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TextIO
+
+import pytest
 
 if TYPE_CHECKING:
     import subprocess  # noqa: S404 - the server being reported on is a subprocess
@@ -35,6 +42,9 @@ LOG_TAIL_LINES = 300
 # synchronously from the signal handler, so this only covers signal delivery.
 STACK_DUMP_TIMEOUT_SECONDS = 2.0
 STACK_DUMP_POLL_SECONDS = 0.05
+
+# How pytest-timeout words the failure it raises: ``pytest.fail("Timeout >%ss" % timeout)``.
+TIMEOUT_MESSAGE_PREFIX = "Timeout >"
 
 
 @dataclass(frozen=True)
@@ -80,6 +90,27 @@ def dump_prefect_test_server_diagnostics(reason: str, stream: TextIO | None = No
     except Exception:
         print("Failed to report on the Prefect test server:", file=out)
         traceback.print_exc(file=out)
+
+
+def timeout_diagnostics_section(nodeid: str, when: str, exception: BaseException | None) -> tuple[str, str] | None:
+    """A report section on every registered server, for a test pytest-timeout killed. Else ``None``.
+
+    Attach it to the test report rather than printing it: under xdist a worker's own stdout goes
+    nowhere, and only what the report carries reaches the CI log.
+
+    Any other failure is left alone. The report costs the server a signal, the run a two second
+    wait and the log three hundred lines, which only a suspected wedge earns.
+    """
+    if not isinstance(exception, pytest.fail.Exception) or not str(exception).startswith(TIMEOUT_MESSAGE_PREFIX):
+        return None
+
+    out = io.StringIO()
+    reason = f"{nodeid} was killed by pytest-timeout during {when}: {exception}"
+    dump_prefect_test_server_diagnostics(reason, stream=out)
+    reported = out.getvalue()
+    if not reported:
+        return None
+    return f"Prefect test server diagnostics ({when})", reported
 
 
 def _dump_server(server: PrefectTestServerProcess, out: TextIO) -> None:

--- a/backend/tests/unit/helpers/test_prefect_diagnostics.py
+++ b/backend/tests/unit/helpers/test_prefect_diagnostics.py
@@ -17,6 +17,7 @@ from tests.helpers.prefect_diagnostics import (
     clear_prefect_test_servers,
     dump_prefect_test_server_diagnostics,
     register_prefect_test_server,
+    timeout_diagnostics_section,
 )
 from tests.helpers.prefect_test_server import enable_stack_dump_on_signal
 
@@ -154,3 +155,51 @@ def test_only_the_tail_of_a_long_log_is_reported(exited_server: tuple[subprocess
     assert f"... 10 earlier lines in {log_path}" in reported
     assert "line 9\n" not in reported
     assert f"line {LOG_TAIL_LINES + 9}\n" in reported
+
+
+def _timeout_failure() -> BaseException:
+    """The exception pytest-timeout raises when it kills a test."""
+    return pytest.fail.Exception("Timeout >300.0s")
+
+
+def test_a_timed_out_test_gets_a_section_holding_the_server_stacks(
+    idle_server: tuple[subprocess.Popen[bytes], Path],
+) -> None:
+    process, log_path = idle_server
+    register_prefect_test_server(port=4242, process=process, log_path=log_path)
+
+    section = timeout_diagnostics_section(
+        nodeid="tests/component/trigger/test_tasks.py::test_setup_triggers",
+        when="teardown",
+        exception=_timeout_failure(),
+    )
+
+    assert section is not None
+    title, reported = section
+    assert title == "Prefect test server diagnostics (teardown)"
+    assert "tests/component/trigger/test_tasks.py::test_setup_triggers" in reported
+    assert "Timeout >300.0s" in reported
+    assert f"Prefect test server on port 4242 (pid {process.pid})" in reported
+    assert "Current thread" in reported
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(None, id="passed"),
+        pytest.param(AssertionError("assert 1 == 2"), id="ordinary failure"),
+        pytest.param(pytest.fail.Exception("this test is not ready"), id="deliberate fail()"),
+    ],
+)
+def test_only_a_timeout_is_worth_signalling_the_server_for(
+    exception: BaseException | None, idle_server: tuple[subprocess.Popen[bytes], Path]
+) -> None:
+    process, log_path = idle_server
+    register_prefect_test_server(port=4242, process=process, log_path=log_path)
+
+    assert timeout_diagnostics_section(nodeid="test_something", when="call", exception=exception) is None
+
+
+def test_a_timeout_reports_nothing_when_no_server_is_registered() -> None:
+    """Every suite that runs no Prefect server still times out for its own reasons."""
+    assert timeout_diagnostics_section(nodeid="test_something", when="call", exception=_timeout_failure()) is None

--- a/changelog/+prefect-test-server-diagnostics-on-timeout.housekeeping.md
+++ b/changelog/+prefect-test-server-diagnostics-on-timeout.housekeeping.md
@@ -1,1 +1,0 @@
-Report the Prefect test server's own thread stacks on a component test killed by pytest-timeout, so a wedged server is diagnosable from the CI log instead of only showing up as timeouts in unrelated tests.

--- a/changelog/+prefect-test-server-diagnostics-on-timeout.housekeeping.md
+++ b/changelog/+prefect-test-server-diagnostics-on-timeout.housekeeping.md
@@ -1,0 +1,1 @@
+Report the Prefect test server's own thread stacks on a component test killed by pytest-timeout, so a wedged server is diagnosable from the CI log instead of only showing up as timeouts in unrelated tests.


### PR DESCRIPTION
## Problem

An ephemeral Prefect test server occasionally wedges mid-session on one xdist worker of
`backend-tests-component`: automations/deployments reads and the events websocket stop answering
while other endpoints keep working. Every later test on that worker then burns its full 300s
pytest-timeout, and the abandoned coroutines poison the tests after it.

Five occurrences so far (2026-08-21, 08-25 ×2, 08-26, 08-28), each with a different victim. The
latest, [run 33177588829](https://github.com/opsmill/infrahub/actions/runs/33177588829/job/98870387704)
on the SDK-bump PR #10448: `trigger/test_tasks.py::test_setup_triggers` passed, then its
`cleanup_automation` teardown hung for 300s, the abandoned task died with
`RuntimeError('Cannot send a request, as the client has been closed')`, and the next test on gw0
(`webhook/test_cancel_during_retry_wait.py`) burned another 300s in the 60s-timeout retry loop.

**Why the server wedges is still unknown, and CI cannot tell us.** The SIGUSR1 stack-dump
diagnostics added in `d80c11b9c` are wired only into `TaskManagerSetup.run_once`'s
`report_failure`, so nothing fires when the wedge is hit anywhere else — and the per-port server
log lives in pytest's basetemp, which CI never uploads. That run carries zero server-side evidence.

## Change

Attach the existing diagnostics report — every registered server's thread stacks (SIGUSR1) plus the
tail of its log — as a report section on any component test pytest-timeout kills.

- `tests/helpers/prefect_diagnostics.py`: new `timeout_diagnostics_section()`, returning the section
  for a `Failed: Timeout >…` and `None` for every other outcome (the report costs the server a
  signal, the run a 2s wait and the log 300 lines, so only a suspected wedge earns it).
- `tests/component/conftest.py`: a `pytest_runtest_makereport` wrapper attaches it. It has to happen
  there, before the report is logged: that is when xdist ships the report to the controller, and
  anything attached later (e.g. from `pytest_exception_interact`) never leaves the worker.

No production code touched; component tests that pass are unaffected.

## Validation

- `backend/tests/unit/helpers/test_prefect_diagnostics.py` — 11 passed, incl. 5 new covering the
  section, the non-timeout outcomes it ignores, and the no-server case.
- End to end against the real ephemeral server: a probe test made to hang under `-n 2 --timeout=20`
  fails with the section rendered in its report, carrying the server's uvicorn loop and aiosqlite
  worker stacks. (Probe not committed.)
- `ruff check . --exclude python_sdk`, `ruff format`, `mypy` on the changed files — clean.

## Next time it happens

The failing test's output will name the server, its pid and its threads' stacks, which is what the
standing question — *why* does it wedge — needs and has never had.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

