### PR TITLE
fix(regeneration): treat display_label / human_friendly_id reads as imprecise (IFC-3071)

### DIFF
--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -53,12 +53,12 @@ def reads_unscopable_derived_field(
     readable_fields_by_kind: Mapping[str, set[str]],
     get_node_schema: Callable[[str], MainSchemaTypes | None],
 ) -> bool:
-    """Whether the query reads a display_label / human_friendly_id composed from a related peer.
+    """Whether the query reads a computed field whose value is composed from a related peer.
 
     Such a read cannot be narrowed: the change that moves the value lands on a peer the read set
     never names, so the field-level match cannot see it, and the query has to fall back to every
-    target. A read of a derived field with no declared path, or on a kind absent from the schema,
-    is treated the same way -- conservatively, so scopability that cannot be verified widens rather
+    target. A read whose value has no declared path, or on a kind absent from the schema, is
+    treated the same way -- conservatively, so scopability that cannot be verified widens rather
     than raises.
     """
     for kind, fields in readable_fields_by_kind.items():

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -21,12 +21,12 @@ from .models import TargetSelection
 log = get_logger()
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Mapping
 
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
-    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.schema_branch import SchemaBranch
 
 
 GATHER_GRAPHQL_QUERY_SUBSCRIBERS = """
@@ -51,7 +51,7 @@ query GatherGraphQLQuerySubscribers($members: [ID!]) {
 
 def reads_unscopable_derived_field(
     readable_fields_by_kind: Mapping[str, set[str]],
-    get_node_schema: Callable[[str], MainSchemaTypes | None],
+    schema_branch: SchemaBranch,
 ) -> bool:
     """Whether the query reads a computed field whose value is composed from a related peer.
 
@@ -65,8 +65,10 @@ def reads_unscopable_derived_field(
         derived_reads = fields & IMPRECISE_READ_FIELDS
         if not derived_reads:
             continue
-        node_schema = get_node_schema(kind)
-        if node_schema is None or any(
+        if not schema_branch.has(name=kind):
+            return True
+        node_schema = schema_branch.get(name=kind, duplicate=False)
+        if any(
             not derived_read_is_scopable(node_schema=node_schema, field_name=field_name) for field_name in derived_reads
         ):
             return True
@@ -115,9 +117,7 @@ async def get_field_level_impacted_subscribers(
         readable_fields_by_kind=readable_fields_by_kind,
         depends_on_everything=reads_unscopable_derived_field(
             readable_fields_by_kind=readable_fields_by_kind,
-            get_node_schema=lambda kind: (
-                query_schema_branch.get(name=kind, duplicate=False) if query_schema_branch.has(name=kind) else None
-            ),
+            schema_branch=query_schema_branch,
         ),
     )
     assessment = classifier.assess(diff_summary=diff_summary)

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -4,6 +4,10 @@ from typing import TYPE_CHECKING, assert_never
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.schema.schema_branch_computed.python_transform import (
+    IMPRECISE_READ_FIELDS,
+    derived_read_is_scopable,
+)
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -17,8 +21,12 @@ from .models import TargetSelection
 log = get_logger()
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
+
+    from infrahub.core.schema import MainSchemaTypes
 
 
 GATHER_GRAPHQL_QUERY_SUBSCRIBERS = """
@@ -39,6 +47,23 @@ query GatherGraphQLQuerySubscribers($members: [ID!]) {
   }
 }
 """
+
+
+def reads_unscopable_derived_field(
+    readable_fields_by_kind: Mapping[str, set[str]],
+    get_node_schema: Callable[[str], MainSchemaTypes],
+) -> bool:
+    """Whether the query reads a display_label / human_friendly_id composed from a related peer.
+
+    Such a read cannot be narrowed: the change that moves the value lands on a peer the read set
+    never names, so the field-level match cannot see it, and the query has to fall back to every
+    target. A read of a derived field with no declared path is treated the same way, conservatively.
+    """
+    for kind, fields in readable_fields_by_kind.items():
+        for field_name in fields & IMPRECISE_READ_FIELDS:
+            if not derived_read_is_scopable(node_schema=get_node_schema(kind), field_name=field_name):
+                return True
+    return False
 
 
 async def get_field_level_impacted_subscribers(
@@ -81,6 +106,10 @@ async def get_field_level_impacted_subscribers(
         only_has_unique_targets=query_report.only_has_unique_targets,
         traversed_kinds=query_report.traversed_kinds,
         readable_fields_by_kind=readable_fields_by_kind,
+        depends_on_everything=reads_unscopable_derived_field(
+            readable_fields_by_kind=readable_fields_by_kind,
+            get_node_schema=lambda kind: query_schema_branch.get(name=kind, duplicate=False),
+        ),
     )
     assessment = classifier.assess(diff_summary=diff_summary)
 

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -51,18 +51,25 @@ query GatherGraphQLQuerySubscribers($members: [ID!]) {
 
 def reads_unscopable_derived_field(
     readable_fields_by_kind: Mapping[str, set[str]],
-    get_node_schema: Callable[[str], MainSchemaTypes],
+    get_node_schema: Callable[[str], MainSchemaTypes | None],
 ) -> bool:
     """Whether the query reads a display_label / human_friendly_id composed from a related peer.
 
     Such a read cannot be narrowed: the change that moves the value lands on a peer the read set
     never names, so the field-level match cannot see it, and the query has to fall back to every
-    target. A read of a derived field with no declared path is treated the same way, conservatively.
+    target. A read of a derived field with no declared path, or on a kind absent from the schema,
+    is treated the same way -- conservatively, so scopability that cannot be verified widens rather
+    than raises.
     """
     for kind, fields in readable_fields_by_kind.items():
-        for field_name in fields & IMPRECISE_READ_FIELDS:
-            if not derived_read_is_scopable(node_schema=get_node_schema(kind), field_name=field_name):
-                return True
+        derived_reads = fields & IMPRECISE_READ_FIELDS
+        if not derived_reads:
+            continue
+        node_schema = get_node_schema(kind)
+        if node_schema is None or any(
+            not derived_read_is_scopable(node_schema=node_schema, field_name=field_name) for field_name in derived_reads
+        ):
+            return True
     return False
 
 
@@ -108,7 +115,9 @@ async def get_field_level_impacted_subscribers(
         readable_fields_by_kind=readable_fields_by_kind,
         depends_on_everything=reads_unscopable_derived_field(
             readable_fields_by_kind=readable_fields_by_kind,
-            get_node_schema=lambda kind: query_schema_branch.get(name=kind, duplicate=False),
+            get_node_schema=lambda kind: (
+                query_schema_branch.get(name=kind, duplicate=False) if query_schema_branch.has(name=kind) else None
+            ),
         ),
     )
     assessment = classifier.assess(diff_summary=diff_summary)

--- a/backend/infrahub/core/regeneration/impact_classifier.py
+++ b/backend/infrahub/core/regeneration/impact_classifier.py
@@ -48,12 +48,17 @@ class QueryImpactClassifier:
     A kind read both at a root and through a relationship counts as traversed. The two read paths
     are indistinguishable once a change is in hand, so treating it as mappable would narrow away the
     members reached only by the relationship.
+
+    ``depends_on_everything`` marks a query whose read surface cannot be pinned down at all -- a read
+    of a derived value composed from a peer the read set never names -- so any relevant change widens
+    to every target.
     """
 
     query_branch: str
     only_has_unique_targets: bool
     traversed_kinds: set[str]
     readable_fields_by_kind: dict[str, set[str]]
+    depends_on_everything: bool = False
 
     def assess(self, diff_summary: list[NodeDiff]) -> ImpactAssessment:
         changed_node_ids = self._changed_node_ids(diff_summary=diff_summary, kinds=self.readable_fields_by_kind)
@@ -63,9 +68,9 @@ class QueryImpactClassifier:
         return ChangedNodes(node_ids=changed_node_ids)
 
     def _must_widen(self, *, diff_summary: list[NodeDiff], changed_node_ids: list[str]) -> bool:
-        if not self.only_has_unique_targets:
-            # Any number of objects can answer the query, so a changed node cannot be traced back to
-            # the targets reading it.
+        if self.depends_on_everything or not self.only_has_unique_targets:
+            # A changed node cannot be traced back to the targets reading it: the query answers from
+            # an unbounded set, or reads a derived value moved by a peer the read set cannot name.
             return bool(changed_node_ids)
 
         traversed_fields_by_kind = {

--- a/backend/infrahub/core/regeneration/predicates.py
+++ b/backend/infrahub/core/regeneration/predicates.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.constants import DiffAction
+from infrahub.core.schema.schema_branch_computed.python_transform import IMPRECISE_READ_FIELDS
 from infrahub.exceptions import NodeNotFoundError
 from infrahub.git.closure_builder.canonicalizer import canonicalize_path
 
@@ -72,6 +73,11 @@ def relevant_node_changes(
     -- is excluded. `readable_fields_by_kind` maps each kind the query reads to the set of its
     attribute and relationship names that the query selects.
 
+    A read of a computed/derived field never intersects a change by name: the field that moved the
+    value is reported under a backing field the read set cannot name. A read set holding such a
+    field is therefore imprecise for its kind -- any change to that kind counts -- since narrowing
+    it away would leave the reader stale.
+
     Only entries marked unchanged are skipped, at both the node and the element level: a diff can
     carry a node purely as hierarchical context, and can hang an unchanged parent relationship off
     a node that did change, neither of which makes a reader stale. A removed node is deliberately
@@ -85,7 +91,8 @@ def relevant_node_changes(
         if not readable_fields:
             continue
         updated_fields = {element["name"] for element in node_diff["elements"] if not _is_unchanged(element["action"])}
-        if updated_fields & readable_fields:
+        imprecise_read = bool(readable_fields & IMPRECISE_READ_FIELDS)
+        if updated_fields and (imprecise_read or (updated_fields & readable_fields)):
             relevant_node_ids.append(node_diff["id"])
     return relevant_node_ids
 

--- a/backend/tests/component/core/regeneration/test_impact.py
+++ b/backend/tests/component/core/regeneration/test_impact.py
@@ -36,6 +36,21 @@ query GetImpactCar($ids: [ID!]!) {
 }
 """
 
+# The query reads only the car's ``display_label``, a computed value built from the car's own
+# ``name`` and ``color``. A change to ``name`` moves the label but is reported under ``name``, which
+# an exact-name match against the read set never sees.
+QUERY_CAR_DISPLAY_LABEL = """
+query GetImpactCarLabel($ids: [ID!]!) {
+    TestingCar(ids: $ids) {
+        edges {
+            node {
+                display_label
+            }
+        }
+    }
+}
+"""
+
 # The car is the group member; the tag stands in for an artifact or generator definition. The impact
 # mapping reads only the subscriber's id and typename, so a plain kind keeps the fixture free of the
 # transformation and repository wiring a real definition would demand.
@@ -148,6 +163,35 @@ class TestFieldLevelImpact(TestInfrahubApp):
                     field_names=["name"],
                 )
             ],
+        )
+        assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)
+
+    async def test_display_label_backing_change_selects_subscriber(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        client: InfrahubClient,
+    ) -> None:
+        """A change to a backing field that moves a read display_label selects the subscriber.
+
+        The query reads only the car's display_label; the diff reports the backing ``name``. An
+        exact-name match would drop it and leave the artifact stale. The label is built from the
+        car's own attributes, so the routing narrows to the car's subscriber rather than widening.
+        """
+        resolved = await get_field_level_impacted_subscribers(
+            query_payload=QUERY_CAR_DISPLAY_LABEL,
+            diff_summary=[
+                node_diff(
+                    node_id=dataset["car_id"],
+                    kind=TestKind.CAR,
+                    branch=default_branch.name,
+                    field_names=["name"],
+                )
+            ],
+            query_branch=default_branch.name,
+            subscriber_kind=SUBSCRIBER_KIND,
+            every_target=[dataset["subscriber_id"]],
+            client=client,
         )
         assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)
 

--- a/backend/tests/unit/core/regeneration/test_impact.py
+++ b/backend/tests/unit/core/regeneration/test_impact.py
@@ -81,7 +81,7 @@ def test_reads_unscopable_derived_field(case: UnscopableCase) -> None:
     assert (
         reads_unscopable_derived_field(
             readable_fields_by_kind=case.readable_fields_by_kind,
-            get_node_schema=lambda kind: case.schemas.get(kind),
+            get_node_schema=case.schemas.get,
         )
         is case.expected
     )

--- a/backend/tests/unit/core/regeneration/test_impact.py
+++ b/backend/tests/unit/core/regeneration/test_impact.py
@@ -67,6 +67,12 @@ UNSCOPABLE_CASES = [
         },
         expected=True,
     ),
+    UnscopableCase(
+        name="derived_read_on_a_kind_absent_from_the_schema_widens",
+        readable_fields_by_kind={"TestGone": {"display_label"}},
+        schemas={},
+        expected=True,
+    ),
 ]
 
 
@@ -75,7 +81,7 @@ def test_reads_unscopable_derived_field(case: UnscopableCase) -> None:
     assert (
         reads_unscopable_derived_field(
             readable_fields_by_kind=case.readable_fields_by_kind,
-            get_node_schema=lambda kind: case.schemas[kind],
+            get_node_schema=lambda kind: case.schemas.get(kind),
         )
         is case.expected
     )

--- a/backend/tests/unit/core/regeneration/test_impact.py
+++ b/backend/tests/unit/core/regeneration/test_impact.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub.core.regeneration.impact import reads_unscopable_derived_field
+from infrahub.core.schema.schema_branch import SchemaBranch
 from tests.helpers.schema.car import CAR
 
 if TYPE_CHECKING:
@@ -18,6 +19,13 @@ def _car_with(**overrides: object) -> NodeSchema:
     for name, value in overrides.items():
         setattr(car, name, value)
     return car
+
+
+def _schema_branch(schemas: dict[str, MainSchemaTypes]) -> SchemaBranch:
+    branch = SchemaBranch(cache={}, name="test")
+    for kind, schema in schemas.items():
+        branch.set(name=kind, schema=schema)
+    return branch
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -81,7 +89,7 @@ def test_reads_unscopable_derived_field(case: UnscopableCase) -> None:
     assert (
         reads_unscopable_derived_field(
             readable_fields_by_kind=case.readable_fields_by_kind,
-            get_node_schema=case.schemas.get,
+            schema_branch=_schema_branch(case.schemas),
         )
         is case.expected
     )

--- a/backend/tests/unit/core/regeneration/test_impact.py
+++ b/backend/tests/unit/core/regeneration/test_impact.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core.regeneration.impact import reads_unscopable_derived_field
+from tests.helpers.schema.car import CAR
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes, NodeSchema
+
+
+def _car_with(**overrides: object) -> NodeSchema:
+    car = deepcopy(CAR)
+    for name, value in overrides.items():
+        setattr(car, name, value)
+    return car
+
+
+@dataclass(frozen=True, kw_only=True)
+class UnscopableCase:
+    name: str
+    readable_fields_by_kind: dict[str, set[str]]
+    schemas: dict[str, MainSchemaTypes] = field(default_factory=dict)
+    expected: bool
+
+
+UNSCOPABLE_CASES = [
+    UnscopableCase(
+        name="no_derived_read_is_scopable",
+        readable_fields_by_kind={"TestCar": {"name"}},
+        expected=False,
+    ),
+    UnscopableCase(
+        name="display_label_from_own_attribute_is_scopable",
+        readable_fields_by_kind={"TestCar": {"display_label"}},
+        schemas={"TestCar": CAR},
+        expected=False,
+    ),
+    UnscopableCase(
+        name="hfid_from_own_attribute_is_scopable",
+        readable_fields_by_kind={"TestCar": {"human_friendly_id"}},
+        schemas={"TestCar": _car_with(human_friendly_id=["name__value"])},
+        expected=False,
+    ),
+    UnscopableCase(
+        name="hfid_composed_from_a_peer_is_unscopable",
+        readable_fields_by_kind={"TestCar": {"human_friendly_id"}},
+        schemas={"TestCar": _car_with(human_friendly_id=["owner__name__value", "name__value"])},
+        expected=True,
+    ),
+    UnscopableCase(
+        name="display_label_crossing_a_relationship_is_unscopable",
+        readable_fields_by_kind={"TestCar": {"display_label"}},
+        schemas={"TestCar": _car_with(display_labels=["owner__name__value"])},
+        expected=True,
+    ),
+    UnscopableCase(
+        name="one_unscopable_read_among_scopable_ones_widens",
+        readable_fields_by_kind={"TestCar": {"display_label"}, "TestOwner": {"human_friendly_id"}},
+        schemas={
+            "TestCar": CAR,
+            "TestOwner": _car_with(human_friendly_id=["owner__name__value"]),
+        },
+        expected=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", UNSCOPABLE_CASES, ids=lambda case: case.name)
+def test_reads_unscopable_derived_field(case: UnscopableCase) -> None:
+    assert (
+        reads_unscopable_derived_field(
+            readable_fields_by_kind=case.readable_fields_by_kind,
+            get_node_schema=lambda kind: case.schemas[kind],
+        )
+        is case.expected
+    )

--- a/backend/tests/unit/core/regeneration/test_impact_classifier.py
+++ b/backend/tests/unit/core/regeneration/test_impact_classifier.py
@@ -111,6 +111,36 @@ ASSESS_CASES = [
         ],
         expected=ChangedNodes(node_ids=[]),
     ),
+    # display_label / human_friendly_id are computed: a read records the computed field name, but a
+    # change to the backing field that moves the value is reported under the backing field's name.
+    # Such a read must be treated as imprecise for its kind -- any change to the kind is relevant --
+    # or the reader is left stale.
+    AssessCase(
+        name="unique_targets_display_label_root_change_narrows_to_that_node",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["name"])],
+        expected=ChangedNodes(node_ids=["dev1"]),
+        traversed_kinds=set(),
+        readable_fields_by_kind={"TestDevice": {"display_label"}},
+    ),
+    AssessCase(
+        name="unique_targets_display_label_change_on_several_nodes_narrows_to_each",
+        only_has_unique_targets=True,
+        diff_summary=[
+            node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["name"]),
+            node_diff(node_id="dev2", kind="TestDevice", branch=BRANCH, field_names=["name"]),
+        ],
+        expected=ChangedNodes(node_ids=["dev1", "dev2"]),
+        traversed_kinds=set(),
+        readable_fields_by_kind={"TestDevice": {"display_label"}},
+    ),
+    AssessCase(
+        name="unique_targets_display_label_read_through_a_relationship_widens",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="intf1", kind="TestInterface", branch=BRANCH, field_names=["name"])],
+        readable_fields_by_kind={"TestDevice": {"name"}, "TestInterface": {"display_label"}},
+        expected=EveryTarget(),
+    ),
 ]
 
 

--- a/backend/tests/unit/core/regeneration/test_impact_classifier.py
+++ b/backend/tests/unit/core/regeneration/test_impact_classifier.py
@@ -33,6 +33,7 @@ class AssessCase:
     expected: ImpactAssessment
     traversed_kinds: set[str] = field(default_factory=lambda: set(TRAVERSED_KINDS))
     readable_fields_by_kind: dict[str, set[str]] = field(default_factory=lambda: dict(READABLE_FIELDS))
+    depends_on_everything: bool = False
 
 
 ASSESS_CASES = [
@@ -141,6 +142,24 @@ ASSESS_CASES = [
         readable_fields_by_kind={"TestDevice": {"name"}, "TestInterface": {"display_label"}},
         expected=EveryTarget(),
     ),
+    # A query that reads a derived value composed from a peer the read set cannot name cannot be
+    # narrowed, so any relevant change widens to every target, and no relevant change selects nothing.
+    AssessCase(
+        name="depends_on_everything_relevant_change_widens",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["name"])],
+        readable_fields_by_kind={"TestDevice": {"display_label"}},
+        depends_on_everything=True,
+        expected=EveryTarget(),
+    ),
+    AssessCase(
+        name="depends_on_everything_unread_change_selects_nothing",
+        only_has_unique_targets=True,
+        diff_summary=[node_diff(node_id="dev1", kind="TestDevice", branch=BRANCH, field_names=["description"])],
+        readable_fields_by_kind={"TestDevice": {"name"}},
+        depends_on_everything=True,
+        expected=ChangedNodes(node_ids=[]),
+    ),
 ]
 
 
@@ -151,6 +170,7 @@ def test_assess(case: AssessCase) -> None:
         only_has_unique_targets=case.only_has_unique_targets,
         traversed_kinds=case.traversed_kinds,
         readable_fields_by_kind=case.readable_fields_by_kind,
+        depends_on_everything=case.depends_on_everything,
     )
 
     assessment = classifier.assess(diff_summary=case.diff_summary)

--- a/changelog/+selective-regen-display-label-hfid.fixed.md
+++ b/changelog/+selective-regen-display-label-hfid.fixed.md
@@ -1,0 +1,1 @@
+Fixed selective regeneration skipping generators and artifacts whose query reads an object's display label or human-friendly ID when a change to a backing field moved that value, leaving them stale after a merge; they are now regenerated.

--- a/changelog/+selective-regen-display-label-hfid.fixed.md
+++ b/changelog/+selective-regen-display-label-hfid.fixed.md
@@ -1,1 +1,1 @@
-Fixed selective regeneration skipping Generators and artifacts whose query reads an object's display label or human-friendly ID when a change to a backing field moved that value, leaving them stale after a merge; they are now regenerated.
+Artifacts and Generators whose query reads an object's display label or human-friendly ID are now regenerated when a change to a backing field moves that value, instead of being skipped and left stale after a merge.

--- a/changelog/+selective-regen-display-label-hfid.fixed.md
+++ b/changelog/+selective-regen-display-label-hfid.fixed.md
@@ -1,1 +1,1 @@
-Fixed selective regeneration skipping generators and artifacts whose query reads an object's display label or human-friendly ID when a change to a backing field moved that value, leaving them stale after a merge; they are now regenerated.
+Fixed selective regeneration skipping Generators and artifacts whose query reads an object's display label or human-friendly ID when a change to a backing field moved that value, leaving them stale after a merge; they are now regenerated.


### PR DESCRIPTION
Closes #10471

## Summary

Selective regeneration (run on merge and proposed-change follow-up) decides which generators/artifacts to regenerate by intersecting each changed field against the fields a definition's query reads, **by exact name**. `display_label` and `human_friendly_id` are computed and never appear as diff elements, so a change to a backing field that moves them was dropped and the reader left stale after a merge — under-execution, which the package invariant forbids. Ref: [IFC-3071](https://opsmill.atlassian.net/browse/IFC-3071).

The selective path is on by default (`INFRAHUB_SELECTIVE_EXECUTION_AFTER_MERGE=true`), so this bug is exposed in default deployments; disabling the flag re-executes everything and masks it.

## Fix (two parts)

1. **Imprecise read** (`predicates.py`) — a read set holding a computed field (`display_label` / `human_friendly_id`) is imprecise for its kind: any change to that kind counts. Purely additive widening; reuses the existing `IMPRECISE_READ_FIELDS`.

2. **Peer-composed labels** (`impact.py`) — a label/hfid can be composed from a **related node's** field (e.g. `hfid = parent__name`); a change to that peer moves the value but the peer's kind is never in the read set. When a read of such a derived field is **not scopable** to the reading kind's own attributes (checked via `derived_read_is_scopable`), the query can no longer be narrowed and widens to every target. Scopable reads (value comes only from the kind's own attributes) keep narrowing precisely.

This closes the residual under-execution safely on the released branch. It resolves the Cubic P2 review comment — the scopability guard lives in `impact.py` (which holds the schema) rather than the pure `predicates.py`.

## Scope of what regenerates

| Read | Change | Result |
| --- | --- | --- |
| `Device.display_label` (= own `name`) | `name` on dev1 | narrows to dev1 |
| `Device.display_label` (= own `name`) | `name` on dev1 + dev2 | narrows to each |
| `Interface.display_label` read via traversal | change on an interface | widens to every target |
| label/hfid composed from a peer (non-scopable) | any relevant change | widens to every target |

## Follow-up

A precise resolution of peer-composed labels — walking the derived-field path back to the owning member via the dependent-node resolver instead of widening — is tracked for **1.12** (develop only; the reached-path machinery does not exist on stable).

## Tests

- Unit — `test_impact_classifier.py` (imprecise-read + `depends_on_everything`) and `test_impact.py` (`reads_unscopable_derived_field` scopable vs peer-composed).
- Component (end-to-end, real DB + schema + server) — `test_impact.py::TestFieldLevelImpact::test_display_label_backing_change_selects_subscriber`.

## How to test

The component test reproduces the bug against a real Infrahub stack: a query that reads a car's `display_label` and a diff that changes the backing `name`. It runs from `backend/`:

```bash
cd backend && INFRAHUB_TESTING_TASKMGR_BACKGROUND_SVC_REPLICAS=1 \
  uv run pytest tests/component/core/regeneration/test_impact.py -v
```

Verified end-to-end: with the fix the subscriber is selected — `TargetSelection(ids=[<subscriber>], widened=False)`; reverting the imprecise-read handling in `predicates.py` drops it back to `ids=[]` (the stale-artifact bug), so the test genuinely reproduces the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[IFC-3071]: https://opsmill.atlassian.net/browse/IFC-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

