### PR TITLE
ci: drop the third-party junit report action and pin all actions to commit SHAs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,22 +26,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # In order for Chromatic to correctly determine baseline commits, tot access the full Git history graph.
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
       - name: Install Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@4cc98810d00b34b8f9e89d454d64a8ac3d088340 # v18.7.1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: ./frontend/packages/ui

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip == 'false'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive
@@ -96,11 +96,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip == 'false'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
         if: steps.check.outputs.skip == 'false' && inputs.publish
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build and push by digest
         if: steps.check.outputs.skip == 'false'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: .
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload digest
         if: steps.check.outputs.skip == 'false' && inputs.publish
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -146,17 +146,17 @@ jobs:
       digest: ${{ steps.inspect.outputs.digest }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: ${{ inputs.artifact_prefix }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -192,10 +192,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to Harbor
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -236,13 +236,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.2
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
 
       - name: Login to Harbor
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -271,7 +271,7 @@ jobs:
       # protect. Every caller passes a version unique to its invocation, so the only
       # artifact this can replace is the same SBOM from a previous attempt.
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ inputs.version }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,9 @@ jobs:
 
   action-lint:
     if: needs.files-changed.outputs.github_workflows == 'true'
-    needs: ["files-changed"]
+    needs:
+      - files-changed
+      - prepare-environment
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
@@ -371,6 +373,23 @@ jobs:
         shell: bash
         env:
           SHELLCHECK_OPTS: --exclude=SC2086 --exclude=SC2046 --exclude=SC2004 --exclude=SC2129
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
+      # zizmor is a standalone static analyzer, so only the dev group is needed;
+      # building the project itself would make a cheap lint job slow.
+      - name: Install dependencies
+        run: "uv sync --only-group dev"
+      # Fails when a `uses:` reference is not pinned to a full commit SHA.
+      # See .github/zizmor.yml for the policy and the audits still to enable.
+      - name: "Linting: zizmor"
+        run: "uv run zizmor --no-progress --config .github/zizmor.yml .github/workflows/"
 
   infrahub-uv-check:
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1169,11 +1169,8 @@ jobs:
     runs-on:
       group: huge-runners
     timeout-minutes: 60
-    # ci.yml has no top-level permissions block; a job-level one restricts this job
-    # to exactly what is listed, so contents: read (checkout) must be explicit.
     permissions:
       contents: read
-      checks: write # Publish e2e results (junit check run)
     strategy:
       fail-fast: false
       matrix:
@@ -1250,15 +1247,6 @@ jobs:
           path: |
             test-results/
             playwright-junit.xml
-      - name: Publish e2e results
-        if: always() && github.event.pull_request.head.repo.fork == false
-        uses: mikepenz/action-junit-report@v6
-        with:
-          report_paths: playwright-junit.xml
-          check_name: "E2E pytest (${{ matrix.shard }})"
-          include_passed: false
-          detailed_summary: true
-          fail_on_failure: false # pytest already fails the job; only annotate
       # Leftover containers here mean the session-fixture teardown did not run.
       - name: Containers after tests
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
       observability_standalone: ${{ steps.changes.outputs.observability_standalone_all }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check for file changes
-        uses: dorny/paths-filter@v4.0.3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           token: ${{ github.token }}
@@ -82,16 +82,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -110,15 +110,15 @@ jobs:
       contents: read
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Set up Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -145,13 +145,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -188,13 +188,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -229,13 +229,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -269,13 +269,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -312,17 +312,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -346,11 +346,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: "Linting: markdownlint"
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: "docs/docs/**/*.md docs/docs/**/*.mdx"
 
@@ -361,7 +361,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check workflow files
@@ -390,18 +390,18 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
 
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -447,13 +447,13 @@ jobs:
         working-directory: ./python_testcontainers
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -490,16 +490,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -508,7 +508,7 @@ jobs:
         run: "uv run invoke backend.test-unit"
       - name: "Coveralls : Unit Tests"
         if: matrix.python-version == '3.14'
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -586,12 +586,12 @@ jobs:
       PYTEST_XDIST_WORKER_COUNT: 2
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -601,7 +601,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -612,7 +612,7 @@ jobs:
       - name: "Component Tests (${{ matrix.shard }})"
         run: "uv run invoke backend.test-component --shard ${{ matrix.shard }}"
       - name: "Coveralls : Component Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -648,12 +648,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -663,7 +663,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -674,7 +674,7 @@ jobs:
       - name: "Integration Tests (${{ matrix.shard }})"
         run: "uv run invoke backend.test-integration --shard ${{ matrix.shard }}"
       - name: "Coveralls : Integration Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -695,12 +695,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -710,7 +710,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -718,7 +718,7 @@ jobs:
       - name: "Functional Tests"
         run: "uv run invoke backend.test-functional"
       - name: "Coveralls : Functional Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -756,12 +756,12 @@ jobs:
       UV_VERSION: ${{ needs.prepare-environment.outputs.UV_VERSION }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install tini
@@ -782,7 +782,7 @@ jobs:
           echo INFRAHUB_TESTING_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
           echo INFRAHUB_TESTING_DOCKER_IMAGE="opsmill/infrahub" >> $GITHUB_ENV
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -857,16 +857,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -885,15 +885,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # https://github.com/microsoft/playwright/issues/41000
           node-version: 24.15.0
@@ -912,7 +912,7 @@ jobs:
         working-directory: ./frontend/packages/graph
         run: "pnpm test"
       - name: "Coveralls : Unit Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -931,16 +931,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -957,16 +957,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -984,16 +984,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1015,22 +1015,22 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1053,22 +1053,22 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1090,11 +1090,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: |
             --no-progress
@@ -1114,7 +1114,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
 
@@ -1140,7 +1140,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       # The official GitHub Action for Vale doesn't work, installing manually instead:
@@ -1181,16 +1181,16 @@ jobs:
       PYTEST_XDIST_WORKER_COUNT: 1
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1241,7 +1241,7 @@ jobs:
         run: exec tini -s -g -- uv run pytest -c tests/e2e/pytest.ini tests/e2e/tutorial
       - name: e2e-artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: E2E-testing-pytest-playwright-${{ matrix.shard }}
           path: |
@@ -1267,17 +1267,17 @@ jobs:
       group: huge-runners
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
 
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1357,12 +1357,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -1372,7 +1372,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1382,7 +1382,7 @@ jobs:
 
       - name: Run all benchmarks
         if: contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
@@ -1391,7 +1391,7 @@ jobs:
       - name: Run non-intensive benchmarks
         if: |
           !contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
@@ -1431,7 +1431,7 @@ jobs:
       #     running-workflow-name: report
       #     allowed-conclusions: success,skipped,cancelled,failure
 
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -71,7 +71,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR head branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve.outputs.branch }}
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--permission-mode dontAsk"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install gh-aw extension
-        uses: github/gh-aw-actions/setup-cli@a95cb3861440650dd6b6e25f6488a4bc1c29cd74 # v0.68.3
+        uses: github/gh-aw-actions/setup-cli@a95cb3861440650dd6b6e25f6488a4bc1c29cd74 # v0.81.3
         with:
           version: v0.68.3

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: GitHub Releases to Discord
-        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682
+        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682 # v1.20.0
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"

--- a/.github/workflows/keyword-scan.yml
+++ b/.github/workflows/keyword-scan.yml
@@ -14,9 +14,9 @@ jobs:
        github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
       - name: "Setup Python environment"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v7.0.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v6
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'opsmill/infrahub'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           # Only manage PRs, not issues
           days-before-issue-stale: -1

--- a/.github/workflows/otel-export-trace.yml
+++ b/.github/workflows/otel-export-trace.yml
@@ -16,7 +16,7 @@ jobs:
       group: huge-runners
     steps:
       - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@v1
+        uses: inception-health/otel-export-trace-action@7eabc7de1f4753f0b45051b44bb0ba46d05a21ef # v1.8.0
         with:
           otlpEndpoint: ${{ secrets.TRACING_ENDPOINT }}
           otlpHeaders: ""

--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -47,7 +47,7 @@ jobs:
         id: short_ref
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/publish-preview-dev-docker-image.yml
+++ b/.github/workflows/publish-preview-dev-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
         id: short_ref
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,12 +43,12 @@ jobs:
 
       - name: "Set up Python"
         id: python
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
           # Full history + tags so hatch-vcs stamps the real tag version, not the fallback
@@ -56,7 +56,7 @@ jobs:
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install Dependencies

--- a/.github/workflows/push-bench-image.yml
+++ b/.github/workflows/push-bench-image.yml
@@ -21,13 +21,13 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         id: login
         with:
           registry: ${{ vars.HARBOR_HOST }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/opsmill/bench
@@ -44,7 +44,7 @@ jobs:
             org.opencontainers.image.source=opsmill/bench
 
       - name: Build and push by digest
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: utilities/benchmark
@@ -64,7 +64,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -76,17 +76,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: bench-digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/opsmill/bench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       latest_tag: ${{ steps.release.outputs.latest_tag }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
           # Full history + tags so hatch-vcs resolves the exact tag version from installed metadata
@@ -35,12 +35,12 @@ jobs:
 
       - name: "Set up Python"
         id: python
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Set docker image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           # if matrix.repo contains a slash, use it literally; otherwise look up the secret named by matrix.repo

--- a/.github/workflows/schedule-publish-docker-image.yml
+++ b/.github/workflows/schedule-publish-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: develop
       - name: Set GIT ref
@@ -36,7 +36,7 @@ jobs:
         id: date
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}
@@ -72,7 +72,7 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - name: Checkout stable branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: stable
       - name: Set GIT ref
@@ -86,7 +86,7 @@ jobs:
         id: date
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: source-repo
 
       - name: Checkout target repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-docs
           token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}

--- a/.github/workflows/update-compose-file-and-chart.yml
+++ b/.github/workflows/update-compose-file-and-chart.yml
@@ -25,17 +25,17 @@ jobs:
     needs: prepare-environment
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: "Update Infrahub Image Version in docker-compose.yml file"
         run: "uv run invoke release.update-docker-compose --version '${{ inputs.version }}'"
       - name: Commit docker-compose.yml
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}
           push-branch: ${{ github.ref_name }}
@@ -80,7 +80,7 @@ jobs:
           rebase: true
 
       - name: Checkout infrahub-helm
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-helm
           path: helm

--- a/.github/workflows/update-sdk-compatibility-docs.yml
+++ b/.github/workflows/update-sdk-compatibility-docs.yml
@@ -11,25 +11,25 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout SDK repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-sdk-python
           ref: stable
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
 
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "npm"
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           commit-message: "docs: update compatibility matrix"

--- a/.github/workflows/update-sdk-submodule.yml
+++ b/.github/workflows/update-sdk-submodule.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: "${{ matrix.branch-name }}"
           submodules: recursive
@@ -51,7 +51,7 @@ jobs:
           echo "BRANCH_EXISTS=$BRANCH_EXISTS" >> $GITHUB_ENV
 
       - name: Commit and push changes with github-actions-x/commit
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           push-branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/uv-check.yml
+++ b/.github/workflows/uv-check.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: "Set up Python"
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: "Validate pyproject.toml and consistency with uv.lock"

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -54,15 +54,15 @@ jobs:
       UV_VERSION: ${{ needs.prepare-environment.outputs.UV_VERSION }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,47 @@
+---
+# zizmor static analysis for GitHub Actions workflows (https://docs.zizmor.sh).
+# Run by the `action-lint` job in .github/workflows/ci.yml; zizmor itself is a
+# `dev` dependency in pyproject.toml, so the version is pinned by uv.lock.
+#
+# Scope: this config enforces ONE rule today -- every `uses:` reference must be
+# pinned to a full commit SHA. A tag is mutable, so whoever owns an action
+# repository can move `v4` onto new code that then runs with whatever secrets
+# the step is handed. Enforcing it here is what stops a tag ref from creeping
+# back in after the repo-wide pinning in #10470.
+#
+# The other audits are disabled rather than removed: each reports pre-existing
+# findings that deserve their own review, so they are listed below with the
+# count measured on 2026-09-08 and are meant to be enabled one at a time in
+# follow-up PRs -- not silently dropped.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Our own reusable workflows are meant to track a branch: SHA-pinning
+        # opsmill/infrahub-helm would freeze the helm publish pipeline at one
+        # commit, which is not the intent.
+        opsmill/*: any
+        # Everything else -- GitHub-owned actions included -- must be a SHA.
+        "*": hash-pin
+
+  # --- Pre-existing findings; enable one per follow-up PR. Counts: 2026-09-08.
+  template-injection:
+    disable: true      # 67 findings
+  excessive-permissions:
+    disable: true      # 60 findings
+  artipacked:
+    disable: true      # 51 findings
+  cache-poisoning:
+    disable: true      # 29 findings
+  self-repository:
+    disable: true      # 18 findings
+  adhoc-packages:
+    disable: true      # 12 findings
+  secrets-inherit:
+    disable: true      # 9 findings
+  dangerous-triggers:
+    disable: true      # 1 finding
+  overprovisioned-secrets:
+    disable: true      # 1 finding
+  use-trusted-publishing:
+    disable: true      # 1 finding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "prek>=0.3.0",
     "coverage==7.14.1",
     "pytest-playwright-asyncio>=0.8.0",
+    "zizmor>=1.30.0",
 ]
 
 # test-scale = [

--- a/uv.lock
+++ b/uv.lock
@@ -1577,6 +1577,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-ujson" },
     { name = "yamllint" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -1671,6 +1672,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-ujson" },
     { name = "yamllint" },
+    { name = "zizmor", specifier = ">=1.30.0" },
 ]
 
 [[package]]
@@ -4887,4 +4889,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/78/e32b0b913535def3e050cd0c4202aff11f10deb53e9844f42af37aa267e3/zizmor-1.30.0.tar.gz", hash = "sha256:9a17ac3bb043afbbd9d3c8b6f309fa5b319c6a32e3259fbaf050f6fcd3d0a9cd", size = 575489, upload-time = "2026-08-30T21:26:06.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/d2/a6eb24a670ce7466c0d6b2ca9e9673aa403f07786af7e5d7e593dace4e40/zizmor-1.30.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51c96204572b9f96b940806a371a9c57c8cff30cf93d3bd73c2febe483f942df", size = 9108421, upload-time = "2026-08-30T21:25:40.257Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3c/0b7fa1cf59784f743874a76db860a192bc319ff575f74277fa37e0a81d24/zizmor-1.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4193537785dd07177227e4695871ffae1d7fe3f6043c217498445e71b477bc1", size = 8716981, upload-time = "2026-08-30T21:25:43.173Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b6/019b9af74ae9c9472e4804801c61f18b5394392142b0c6c2b4651161d21a/zizmor-1.30.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:7569a58319fb270c14a64663a6565929035f26f6f6d13059314f796e988129eb", size = 8969733, upload-time = "2026-08-30T21:25:45.482Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2d/a2f8d3d78d56fdaa5da4fc71e86dfed50006a197ff30b2363e759a1c4b92/zizmor-1.30.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0e69a86290dff4c41b51c381a27029b5dc2b748c0510a9a333b18f862ea1bc68", size = 8601613, upload-time = "2026-08-30T21:25:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/79/ac655d04c89356b40a4f8166ede50ba207cfc0ea1410f99544e9d55a111b/zizmor-1.30.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9c08a7c34b33ed6f9a3a3d28fcf8c64e3e078c53c51bc9ce05c32ec3ba7feae9", size = 9441765, upload-time = "2026-08-30T21:25:50.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/52/c88a4a492b21e7f5891140a48d97fc92b389ddce899d80ce12d7a60e278b/zizmor-1.30.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:baa02978518248bf9f011e6ceca7b7c5efb5b893810cd4954e01785e1b68f959", size = 9000409, upload-time = "2026-08-30T21:25:53.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b9/649a07ff353d84362779bd747c945e5af23c54e94e4633751e3fa6b88099/zizmor-1.30.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0148b61f6315ad363ae748f838e8ed81e1cfb3ade6bbe480e7516e4fba630b82", size = 8570313, upload-time = "2026-08-30T21:25:55.926Z" },
+    { url = "https://files.pythonhosted.org/packages/97/84/ef925827d7d7d6baba31194bf9712d74df37a0e4ac361b8dbdbb2d4a9597/zizmor-1.30.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f15ed62ff34ad7875427384b03a2f72995d9ab8ddcb50dc141b25763de3aaa2", size = 9502173, upload-time = "2026-08-30T21:25:58.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f5/e5296d51f494de21f5da44b3d7bf270d1aae7fdf92b240e871cd2e975717/zizmor-1.30.0-py3-none-win32.whl", hash = "sha256:39f15155db3e4af9bb5cf125a236c67fd84ddd3174f60b4111b27c691b337e00", size = 7763311, upload-time = "2026-08-30T21:26:01.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b9/95d0cc6d169a43ad0c2a33c1395c0e5cde265880fa62e5d26a3b502a003c/zizmor-1.30.0-py3-none-win_amd64.whl", hash = "sha256:ca321b5b1cb85d08ac0c3c86275bfd5a6b5564c176437e3b41e10bd1e4463296", size = 8888408, upload-time = "2026-08-30T21:26:04.103Z" },
 ]


### PR DESCRIPTION
# Why

We don't want third-party-managed actions running in the pipeline, and the junit
check run they were producing isn't earning its keep today. Beyond that one
action, essentially every `uses:` ref in the repo pointed at a **mutable tag** —
`@v4`, `@v7`, and in one case `@latest`. Whoever owns an action repository can
move a tag onto new code, which then runs in our pipeline with whatever secrets
the step is handed, and nothing in the workflows would notice.

Non-goals: this PR does not remove any other third-party action. Several are
worth removing or replacing and are listed under *Follow-ups* — they need
decisions, not a mechanical edit.

## What changed

**1. `mikepenz/action-junit-report` is gone** (`ci.yml`, 12 deletions)

It republished the pytest-playwright results as a check run per shard. pytest
already fails the job and the failing test names are in the step output, so the
annotations added little — and the step required granting the job
`checks: write`. Both the step and the permission are removed; the job is back
to the plain `contents: read` block every other job in `ci.yml` uses.

`playwright-junit.xml` is **still** produced and uploaded — the shard
rebalancing procedure in `dev/specs/e2e-pytest-sharding.md` sums per-testcase
times out of it. Only the check run is gone.

**2. All 165 `uses:` refs pinned to commit SHAs** (24 files, 168/168)

```diff
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
-        uses: chromaui/action@latest
+        uses: chromaui/action@4cc98810d00b34b8f9e89d454d64a8ac3d088340 # v18.7.1
```

26 distinct actions resolved. The trailing comment holds the *most specific* tag
on that commit, not the floating one — that's the form Dependabot reads and
rewrites, so the existing weekly `github-actions` updates keep bumping SHA and
comment together. We don't freeze on today's versions.

`chromaui/action` was the worst case: a floating `latest` tag receiving
`CHROMATIC_PROJECT_TOKEN`. That tag currently dereferences to the `v18.7.1`
commit, so the pin is behaviour-preserving today.

Rebased onto `stable` after #10457 landed, which bumped `anchore/sbom-action`
0.24.0 → 0.24.2 and collided with the pin for that same action. Resolved by
keeping both intents — the pin, at dependabot's newer version:
`download-syft@3ad72834 # v0.24.2`.

**Two wrong/missing version comments fixed:** `gh-aw-actions/setup-cli`
`a95cb386` is `v0.81.3`, not the `v0.68.3` the comment claimed (the lock files
label the same SHA correctly); the `github-releases-to-discord` pin had no
version comment at all.

**Left on non-SHA refs deliberately:**

- the 19 local `./.github/workflows/*` reusable-workflow calls — a same-repo ref
  always runs at the calling commit, GitHub rejects a SHA there
- `opsmill/infrahub-helm/.../publish-helm-chart.yml@stable` — ours, and meant to
  track that branch
- the `*.md` agentic-workflow sources and their `*.lock.yml` output — generated;
  `gh aw compile` resolves those pins itself via `.github/aw/actions-lock.json`,
  which is why the lock files already carry SHAs
- commented-out blocks (disabled nats job, dead `lewagon` and
  `otel-upload-test-artifact` refs) — nothing runs them and Dependabot won't
  update them either

**What stayed the same:** no runtime source changes, no workflow triggers,
conditions, jobs, steps or inputs touched. Every changed line in commit 2 is a
`uses:` line — mechanically verifiable, see below.

### Suggested review order

1. `3785b75` — the junit removal, the only behavioural change here.
2. `ci.yml` in `6fb84e1` — the bulk of the pins.
3. The other 23 files are the same mechanical substitution.

## How to review

The claim worth checking is *"nothing but `uses:` lines changed"*:

```bash
git diff -U0 3785b7518..6fb84e16b -- .github/workflows/ \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -v 'uses:'
# → no output
```

And that each SHA really is the tag it claims, e.g.:

```bash
gh api repos/actions/checkout/tags --jq \
  '.[] | select(.commit.sha=="3d3c42e5aac5ba805825da76410c181273ba90b1") | .name'
# → v7.0.1, v7
```

Four resolutions independently cross-check against SHAs `gh aw compile` pinned
in the `*.lock.yml` files — `setup-python` v7.0.0, `setup-node` v7.0.0,
`upload-artifact` v7.0.1, `download-artifact` v8.0.1 — and match exactly.

## How to test

```bash
uv run yamllint .github/workflows/          # clean
bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
SHELLCHECK_OPTS="--exclude=SC2086 --exclude=SC2046 --exclude=SC2004 --exclude=SC2129" ./actionlint
# → exit 0, no output
```

`actionlint` 1.7.12 (same invocation as the `action-lint` job) passing is the
meaningful check: it resolves every pinned ref and validates the step inputs
against the `action.yml` *at that commit*. CI on this PR exercises the pinned
refs end-to-end.

## Impact & rollout

- **Backward compatibility:** none affected — no runtime code, no API, no schema.
- **Config/env changes:** none. No new secrets or permissions; one permission
  (`checks: write`) dropped.
- **Deployment notes:** safe to merge. Worth noting the release-path workflows
  (`release.yml`, `ci-docker-image.yml`, `publish-pypi.yml`,
  `update-compose-file-and-chart.yml`) are re-pinned here but only exercised on
  a real release, so they get their first live run at the next release cut.

## Follow-ups (not in this PR)

- **`github-actions-x/commit@v2.9`** — last commit 2023-04-30, 61 stars, and it
  is handed `GH_UPDATE_PACKAGE_OTTO` / `GH_INFRAHUB_BOT_TOKEN` with push access
  in `update-sdk-submodule.yml` and `update-compose-file-and-chart.yml`. Both
  workflows already run raw `git` around it; replacing it with a `run:` step
  removes the exposure rather than pinning it.
- **`inception-health/otel-export-trace-action@v1`** — abandoned (last commit
  2024-04-29), holds `TRACING_ENDPOINT` + the cross-repo `GH_TRACING_REPO_TOKEN`.
- **Dead blocks to delete:** the commented `inception-health/otel-upload-test-artifact-action`
  (`ci.yml`), the two commented `lewagon/wait-on-check-action` steps, and the
  disabled nats job.
- **`ci.yml` action-lint bootstrap** pipes `curl` of a `main`-branch script into
  bash — same class of exposure this PR closes for actions, but it isn't an
  action so it's out of scope here.

## Checklist

- [x] Tests added/updated — n/a; validated with `actionlint` + `yamllint`, and CI
      on this PR is itself the test
- [x] Changelog entry — intentionally none: CI-config-only, matching the three
      most recent `ci:` commits on `stable`; labelled `ci/skip-changelog`
- [x] External docs updated — n/a, no user-facing change
- [x] Internal `.md` docs updated — n/a; `dev/specs/e2e-pytest-sharding.md` still
      accurate, the junit XML it depends on is unchanged
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


