### PR TITLE
refactor: type artifact and transform lookups with SDK protocols [IFC-3075]

### DIFF
--- a/backend/infrahub/artifacts/tasks.py
+++ b/backend/infrahub/artifacts/tasks.py
@@ -1,7 +1,8 @@
+from infrahub_sdk.protocols import CoreArtifactCheck, CoreArtifactValidator
 from prefect import flow
 
 from infrahub.artifacts.models import CheckArtifactCreate
-from infrahub.core.constants import InfrahubKind, ValidatorConclusion
+from infrahub.core.constants import ValidatorConclusion
 from infrahub.core.timestamp import Timestamp
 from infrahub.git.repository import get_initialized_repo
 from infrahub.tasks.artifact import define_artifact
@@ -16,7 +17,7 @@ async def create(model: CheckArtifactCreate) -> ValidatorConclusion:
     client = get_client()
     client.request_context = model.context.to_request_context()
 
-    validator = await client.get(kind=InfrahubKind.ARTIFACTVALIDATOR, id=model.validator_id, include=["checks"])
+    validator = await client.get(kind=CoreArtifactValidator, id=model.validator_id, include=["checks"])
 
     repo = await get_initialized_repo(
         client=client,
@@ -56,9 +57,7 @@ async def create(model: CheckArtifactCreate) -> ValidatorConclusion:
 
     check = None
     check_name = f"{model.artifact_name}: {model.target_name}"
-    existing_check = await client.filters(
-        kind=InfrahubKind.ARTIFACTCHECK, validator__ids=validator.id, name__value=check_name
-    )
+    existing_check = await client.filters(kind=CoreArtifactCheck, validator__ids=validator.id, name__value=check_name)
     if existing_check:
         check = existing_check[0]
 
@@ -73,7 +72,7 @@ async def create(model: CheckArtifactCreate) -> ValidatorConclusion:
         await check.save()
     else:
         check = await client.create(
-            kind=InfrahubKind.ARTIFACTCHECK,
+            kind=CoreArtifactCheck,
             data={
                 "name": check_name,
                 "origin": model.repository_id,

--- a/backend/infrahub/computed_attribute/transform_recompute.py
+++ b/backend/infrahub/computed_attribute/transform_recompute.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
-from infrahub.core.constants import InfrahubKind
+from infrahub_sdk.protocols import CoreTransformPython
+
 from infrahub.core.registry import registry
 from infrahub.log import get_logger
 from infrahub.workflows.catalogue import TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES
@@ -11,8 +12,6 @@ from infrahub.workflows.constants import WorkflowTag
 from .recompute_resolution import RecomputeResolver
 
 if TYPE_CHECKING:
-    from infrahub_sdk.node import InfrahubNode
-
     from infrahub.events.models import EventContext
     from infrahub.services.adapters.workflow import InfrahubWorkflow
 
@@ -22,7 +21,9 @@ log = get_logger()
 class TransformFetcher(Protocol):
     """Fetches a Python transform node by id, returning ``None`` when it is gone."""
 
-    async def get(self, *, kind: str, id: str, branch: str, raise_when_missing: bool) -> InfrahubNode | None: ...
+    async def get(
+        self, *, kind: type[CoreTransformPython], id: str, branch: str, raise_when_missing: bool
+    ) -> CoreTransformPython | None: ...
 
 
 class TransformRecomputeSubmitter:
@@ -41,7 +42,7 @@ class TransformRecomputeSubmitter:
         A transform that no longer resolves (branch race, or an already-landed delete) returns 0.
         """
         transform = await self._client.get(
-            kind=InfrahubKind.TRANSFORMPYTHON, id=transform_id, branch=branch_name, raise_when_missing=False
+            kind=CoreTransformPython, id=transform_id, branch=branch_name, raise_when_missing=False
         )
         if transform is None:
             log.warning(f"Transform {transform_id} not found on {branch_name}; skipping recompute")

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -1,26 +1,25 @@
-from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.protocols import CoreArtifact
 from prefect import task
 from prefect.cache_policies import NONE
 
 from infrahub import lock
 from infrahub.artifacts.models import CheckArtifactCreate
-from infrahub.core.constants import InfrahubKind
 from infrahub.git.models import RequestArtifactGenerate
 from infrahub.workers.dependencies import get_client
 
 
 @task(name="define-artifact", task_run_name="Define Artifact", cache_policy=NONE)
-async def define_artifact(model: CheckArtifactCreate | RequestArtifactGenerate) -> tuple[InfrahubNode, bool]:
+async def define_artifact(model: CheckArtifactCreate | RequestArtifactGenerate) -> tuple[CoreArtifact, bool]:
     """Return an artifact together with a flag to indicate if the artifact is created now or already existed."""
     client = get_client()
     client.request_context = model.context.to_request_context()
     created = False
     if model.artifact_id:
-        artifact = await client.get(kind=InfrahubKind.ARTIFACT, id=model.artifact_id, branch=model.branch_name)
+        artifact = await client.get(kind=CoreArtifact, id=model.artifact_id, branch=model.branch_name)
     else:
         async with lock.registry.get(f"{model.target_id}-{model.artifact_definition}", namespace="artifact"):
             artifacts = await client.filters(
-                kind=InfrahubKind.ARTIFACT,
+                kind=CoreArtifact,
                 branch=model.branch_name,
                 definition__ids=[model.artifact_definition],
                 object__ids=[model.target_id],
@@ -29,7 +28,7 @@ async def define_artifact(model: CheckArtifactCreate | RequestArtifactGenerate) 
                 artifact = artifacts[0]
             else:
                 artifact = await client.create(
-                    kind=InfrahubKind.ARTIFACT,
+                    kind=CoreArtifact,
                     branch=model.branch_name,
                     data={
                         "name": model.artifact_name,

--- a/backend/tests/unit/computed_attribute/test_transform_recompute.py
+++ b/backend/tests/unit/computed_attribute/test_transform_recompute.py
@@ -18,7 +18,7 @@ from infrahub.workflows.constants import WorkflowTag
 from tests.adapters.workflow import WorkflowRecorder
 
 if TYPE_CHECKING:
-    from infrahub_sdk.node import InfrahubNode
+    from infrahub_sdk.protocols import CoreTransformPython
 
 BRANCH = "main"
 TRANSFORM_NAME = "transform_a"
@@ -48,11 +48,11 @@ class _FetcherReturning:
     async def get(
         self,
         *,
-        kind: str,
+        kind: type[CoreTransformPython],
         id: str,
         branch: str,
         raise_when_missing: bool,
-    ) -> InfrahubNode | None:
+    ) -> CoreTransformPython | None:
         self.requested_ids.append(id)
         return self._transform  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1158,7 +1158,6 @@ invalid-return-type = "ignore"
 invalid-type-form = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
-possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unresolved-reference = "ignore"
 unsupported-operator = "ignore"
@@ -1199,8 +1198,6 @@ include = ["models/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-argument-type = "ignore"
-invalid-assignment = "ignore"
-missing-argument = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
 unresolved-attribute = "ignore"
@@ -1216,7 +1213,6 @@ include = ["python_testcontainers/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-assignment = "ignore"
-possibly-missing-attribute = "ignore"
 possibly-missing-submodule = "ignore"
 too-many-positional-arguments = "ignore"
 unresolved-attribute = "ignore"
@@ -1316,15 +1312,6 @@ include = [
 
 [tool.ty.overrides.rules]
 invalid-return-type = "ignore"
-
-[[tool.ty.overrides]]
-include = [
-    "backend/infrahub/core/diff/coordinator.py",
-    "backend/infrahub/core/relationship/model.py",
-]
-
-[tool.ty.overrides.rules]
-no-matching-overload = "ignore"
 
 [[tool.ty.overrides]]
 include = [
@@ -1730,7 +1717,6 @@ include = ["backend/infrahub/computed_attribute/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 no-matching-overload = "ignore"
-unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1772,9 +1758,6 @@ include = ["backend/infrahub/message_bus/**"]
 # The ignored rules below should be removed once the code has been updated, they are included    #
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
-call-top-callable = "ignore"
-invalid-await = "ignore"
-no-matching-overload = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1787,18 +1770,6 @@ include = ["backend/infrahub/message_bus/operations/__init__.py"]
 # message_bus/ stays enforced.                                                                    #
 ##################################################################################################
 invalid-argument-type = "ignore"
-
-[[tool.ty.overrides]]
-include = ["backend/infrahub/artifacts/tasks.py"]
-
-[tool.ty.overrides.rules]
-##################################################################################################
-# The ignored rules below should be removed once the code has been updated, they are included    #
-# like this so that we can reactivate them one by one.                                           #
-##################################################################################################
-invalid-argument-type = "ignore"
-invalid-assignment = "ignore"
-unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
 include = ["backend/infrahub/artifacts/**"]
@@ -1819,7 +1790,6 @@ include = ["backend/infrahub/tasks/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 missing-argument = "ignore"
-unknown-argument = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -1854,7 +1824,6 @@ include = ["backend/infrahub/api/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 invalid-return-type = "ignore"
-unresolved-attribute = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 
 [[tool.ty.overrides]]
@@ -2010,7 +1979,6 @@ missing-argument = "ignore"
 no-matching-overload = "ignore"
 not-subscriptable = "ignore"
 not-iterable = "ignore"
-unknown-argument = "ignore"
 unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
 unused-awaitable = "ignore"
@@ -2058,7 +2026,6 @@ invalid-assignment = "ignore"
 invalid-return-type = "ignore"
 no-matching-overload = "ignore"
 not-iterable = "ignore"
-unknown-argument = "ignore"
 unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments


### PR DESCRIPTION
# Why

IFC-3054 made the generated SDK protocols carry the peer type of every relationship. Nothing benefits from that yet: call sites still pass kind strings, so the client returns a bare `InfrahubNode`, attribute access goes through `__getattr__`, and the type checkers see the `Attribute | RelationshipManager | RelatedNode` union. The `pyproject.toml` suppressions are what hides the result.

Goal: convert the call sites where the swap is mechanical, and delete the suppressions they were carrying.

Non-goals: `generators/`, `proposed_change/`, `git/`, `webhook/` and `git_credential/`. The first three are blocked on an SDK gap (`extract` is missing from `CoreNodeBase`); the last two need runtime narrowing helpers that are worth deciding on separately.

Part of IFC-3075.

## What changed

Behavioral changes: none. Passing a protocol class instead of a kind string changes what the type checker sees, not what the client sends.

- `define_artifact` now returns `tuple[CoreArtifact, bool]`, and the artifact, artifact-validator and artifact-check lookups take protocol classes.
- The Python-transform lookup in `transform_recompute` takes `CoreTransformPython`, and the local `TransformFetcher` protocol and its test double follow.

15 ty suppressions removed, 1 override block deleted:

- 12 were already dead on `develop` - removing them changes no output.
- `artifacts/tasks.py` drops `invalid-argument-type` + `invalid-assignment`; its block is now empty and gone.
- `computed_attribute/**` drops `unresolved-attribute`.

What stayed the same: no schema changes, no API changes, no runtime behavior change. No changelog fragment - this is a code-only change with no user-visible effect.

## How to review

`pyproject.toml` is the point of the PR; the source diff is what earns it.

Worth knowing while reviewing: `ty` reports `useless-overrides-section` when a block empties out, so the config cannot silently drift out of sync with the code.

## How to test

```bash
uv run ty check
uv run mypy --show-error-codes backend
uv run ruff check . --exclude python_sdk
uv run pytest backend/tests/unit -q --no-cov
```

All green locally; unit suite 2468 passed.

## Impact & rollout

- **Backward compatibility:** no breaking changes.
- **Performance:** unaffected.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added
- [ ] External docs updated
- [ ] Internal .md docs updated
- [ ] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

