### PR TITLE
ci: gate huge-runner jobs on every cheap check, debounce on push

### DIFF
--- a/.agents/commands/pre-ci.md
+++ b/.agents/commands/pre-ci.md
@@ -133,6 +133,9 @@ Steps 2–4 are CI's `python-lint` job verbatim, and repo-wide — the `invoke` 
 
 1. `uv run yamllint -s .` — CI's `yaml-lint` job. Call it directly, not via
    `uv run invoke lint`, which bundles unrelated steps.
+2. `uv run invoke ci.validate-huge-runner-gate` — the `yaml-lint` job's second step. Every
+   huge-runner job in `ci.yml` must depend on `huge-runner-gate`, and the gate on every
+   GitHub-hosted job; this fails when a new job is not wired in.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       release: ${{ steps.changes.outputs.release_all }}
       frontend: ${{ steps.changes.outputs.frontend_all }}
       e2e: ${{ steps.changes.outputs.e2e_all }}
+      demo: ${{ steps.changes.outputs.demo_files }}
       python: ${{ steps.changes.outputs.python_all }}
       javascript: ${{ steps.changes.outputs.javascript_all }}
       yaml: ${{ steps.changes.outputs.yaml_all }}
@@ -97,6 +98,8 @@ jobs:
         run: "uv sync --all-groups"
       - name: "Linting: yamllint"
         run: "uv run yamllint -s ."
+      - name: "Validate huge-runner gate wiring"
+        run: "uv run invoke ci.validate-huge-runner-gate"
 
   frontend-lint:
     defaults:
@@ -513,13 +516,60 @@ jobs:
           flag-name: backend-unit
           parallel: true
 
+  # ------------------------------------------ Huge-runner gate ------------------------------------------
+  huge-runner-gate:
+    name: Gate for huge-runner jobs
+    if: always() && !cancelled()
+    needs:
+      - prepare-environment
+      - files-changed
+      - yaml-lint
+      - frontend-lint
+      - frontend-validate-openapi-types
+      - frontend-validate-error-catalogue
+      - frontend-validate-graphql-types
+      - validate-observability-standalone
+      - python-lint
+      - markdown-lint
+      - action-lint
+      - infrahub-uv-check
+      - infrahub-testcontainers-check
+      - backend-testcontainers-unit
+      - infrahub-testcontainers-uv-check
+      - backend-tests-unit
+      - backend-validate-generated
+      - frontend-tests
+      - graphql-schema
+      - json-schema
+      - validate-docker-compose-env-vars
+      - documentation
+      - validate-generated-documentation
+      - validate-dev-guideline-links
+      - validate-documentation-style
+      - validate-release-notes-style
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PUSH_DEBOUNCE_SECONDS: 600
+    steps:
+      - name: Fail when a GitHub-hosted check failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "Skipping the huge-runner jobs, these checks did not pass:"
+          jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "  \(.key): \(.value.result)"' <<< "$NEEDS"
+          exit 1
+      - name: Debounce push events
+        if: github.event_name == 'push'
+        run: sleep "$PUSH_DEBOUNCE_SECONDS"
+
   backend-tests-component:
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "backend-tests-unit", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "huge-runner-gate"]
     strategy:
       fail-fast: false
       matrix:
@@ -581,11 +631,10 @@ jobs:
 
   backend-tests-integration:
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "backend-tests-unit", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "huge-runner-gate"]
     strategy:
       fail-fast: false
       matrix:
@@ -635,11 +684,10 @@ jobs:
 
   backend-tests-functional:
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "backend-tests-unit", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "huge-runner-gate"]
     runs-on:
       group: "huge-runners"
     timeout-minutes: 30
@@ -680,12 +728,11 @@ jobs:
 
   backend-docker-integration:
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       (needs.files-changed.outputs.backend == 'true' ||
       needs.files-changed.outputs.testcontainers == 'true')
-    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "backend-tests-unit"]
+    needs: ["prepare-environment", "files-changed", "huge-runner-gate"]
     strategy:
       fail-fast: false
       matrix:
@@ -1114,14 +1161,10 @@ jobs:
     needs:
       - prepare-environment
       - files-changed
-      - yaml-lint
-      - python-lint
-      - backend-tests-unit
-      - infrahub-testcontainers-check
+      - huge-runner-gate
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       needs.files-changed.outputs.e2e == 'true'
     runs-on:
       group: huge-runners
@@ -1225,16 +1268,11 @@ jobs:
   E2E-testing-invoke-demo-start:
     needs:
       - prepare-environment
-      - frontend-lint
       - files-changed
-      - yaml-lint
-      - python-lint
-      - backend-tests-unit
-      - infrahub-testcontainers-check
+      - huge-runner-gate
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       github.base_ref == 'stable' &&
       needs.files-changed.outputs.e2e == 'true'
     runs-on:
@@ -1305,17 +1343,13 @@ jobs:
   # ------------------------------------------ E2E version upgrade ------------------------------------------------
   E2E-testing-version-upgrade:
     needs:
-      - frontend-lint
       - files-changed
-      - yaml-lint
-      - python-lint
-      - backend-tests-unit
-      - infrahub-testcontainers-check
+      - huge-runner-gate
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      (needs.files-changed.outputs.e2e == 'true' ||
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
+      (needs.files-changed.outputs.backend == 'true' ||
+      needs.files-changed.outputs.demo == 'true' ||
       needs.files-changed.outputs.version_upgrade_workflow == 'true')
     uses: ./.github/workflows/version-upgrade.yml
 
@@ -1323,16 +1357,11 @@ jobs:
   backend-benchmark:
     needs:
       - prepare-environment
-      - frontend-lint
       - files-changed
-      - yaml-lint
-      - python-lint
-      - backend-tests-unit
-      - infrahub-testcontainers-check
+      - huge-runner-gate
     if: |
-      always() && !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !cancelled() &&
+      needs.huge-runner-gate.result == 'success' &&
       needs.files-changed.outputs.backend == 'true'
     runs-on:
       group: huge-runners

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -2,7 +2,7 @@
 
 from invoke import Collection, Context, task
 
-from . import backend, demo, dev, docs, frontend, main, performance, release, schema, sdk
+from . import backend, ci, demo, dev, docs, frontend, main, performance, release, schema, sdk
 from .utils import ESCAPED_REPO_PATH
 
 ns = Collection()
@@ -16,6 +16,7 @@ ns.add_collection(demo)
 ns.add_collection(main)
 ns.add_collection(schema)
 ns.add_collection(release)
+ns.add_collection(ci)
 
 
 @task

--- a/tasks/ci.py
+++ b/tasks/ci.py
@@ -1,0 +1,246 @@
+"""Invoke tasks that validate the wiring of the GitHub Actions CI workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from invoke import Context, Exit, task
+
+from .utils import REPO_BASE
+
+CI_WORKFLOW = Path(".github/workflows/ci.yml")
+HUGE_RUNNER_GROUP = "huge-runners"
+GATE_JOB = "huge-runner-gate"
+REPORTER_JOBS: frozenset[str] = frozenset({"coverall-report"})
+"""Jobs that aggregate huge-runner results: they run after the huge-runner jobs, so they cannot feed the gate."""
+
+
+@dataclass(frozen=True)
+class JobWiring:
+    """The parts of a workflow job the gate check reasons about."""
+
+    name: str
+    """Job id, the key under ``jobs:``."""
+
+    needs: frozenset[str]
+    """Job ids listed under ``needs``."""
+
+    runner_groups: frozenset[str]
+    """Runner groups the job runs on, including those of a local reusable workflow it calls."""
+
+    condition: str
+    """The job-level ``if`` expression, empty when absent."""
+
+    @property
+    def on_huge_runners(self) -> bool:
+        """Whether the job, or the reusable workflow it calls, takes a huge runner."""
+        return HUGE_RUNNER_GROUP in self.runner_groups
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    import yaml  # tasks modules load on every invoke command; keep non-stdlib imports function-local
+
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _runner_groups(job: dict[str, Any], repo_root: Path) -> frozenset[str]:
+    runs_on = job.get("runs-on")
+    if isinstance(runs_on, dict) and "group" in runs_on:
+        return frozenset({str(runs_on["group"])})
+    uses = job.get("uses")
+    if isinstance(uses, str) and uses.startswith("./"):
+        called = _load_yaml(path=repo_root / uses)
+        return frozenset().union(
+            *(_runner_groups(job=called_job, repo_root=repo_root) for called_job in called.get("jobs", {}).values())
+        )
+    return frozenset()
+
+
+def load_job_wiring(workflow_path: Path, repo_root: Path) -> dict[str, JobWiring]:
+    """Read the jobs of a workflow into the shape the gate check reasons about.
+
+    Args:
+        workflow_path: Workflow file, relative to ``repo_root``.
+        repo_root: Repository root, used to resolve ``uses: ./.github/workflows/...`` calls.
+
+    Returns:
+        The jobs keyed by job id.
+
+    """
+    workflow = _load_yaml(path=repo_root / workflow_path)
+    wiring: dict[str, JobWiring] = {}
+    for name, job in workflow.get("jobs", {}).items():
+        needs = job.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        wiring[name] = JobWiring(
+            name=name,
+            needs=frozenset(needs),
+            runner_groups=_runner_groups(job=job, repo_root=repo_root),
+            condition=str(job.get("if", "")),
+        )
+    return wiring
+
+
+def _closes_at_end(text: str) -> bool:
+    """Whether ``text`` is a single parenthesised group, ``(`` first and its matching ``)`` last."""
+    if not text.startswith("(") or not text.endswith(")"):
+        return False
+    depth = 0
+    in_string = False
+    for index, char in enumerate(text):
+        if in_string:
+            in_string = char != "'"
+        elif char == "'":
+            in_string = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index == len(text) - 1
+    return False
+
+
+def _top_level_conjuncts(expression: str) -> list[str] | None:
+    """Split a GitHub Actions expression on its top-level ``&&`` operators.
+
+    The ``${{ }}`` wrapper, parentheses enclosing a whole conjunct and all whitespace are
+    dropped, so equivalent spellings of the same check compare equal.
+
+    Args:
+        expression: The ``if`` expression, possibly spanning several lines.
+
+    Returns:
+        The normalised conjuncts, or ``None`` when a top-level ``||`` makes the expression a
+        disjunction that no single conjunct can guard.
+
+    """
+    expression = expression.strip()
+    if expression.startswith("${{") and expression.endswith("}}"):
+        expression = expression[3:-2]
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    in_string = False
+    index = 0
+    while index < len(expression):
+        char = expression[index]
+        if in_string:
+            in_string = char != "'"
+        elif char == "'":
+            in_string = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth == 0 and expression.startswith("||", index):
+            return None
+        elif depth == 0 and expression.startswith("&&", index):
+            parts.append("".join(current).strip())
+            current = []
+            index += 2
+            continue
+        current.append(char)
+        index += 1
+    parts.append("".join(current).strip())
+
+    conjuncts: list[str] = []
+    for part in parts:
+        nested = _top_level_conjuncts(expression=part[1:-1]) if _closes_at_end(text=part) else None
+        if nested is None:
+            # Either a plain conjunct or a parenthesised disjunction, which stays one opaque atom.
+            conjuncts.append("".join(part.split()))
+        else:
+            conjuncts.extend(nested)
+    return conjuncts
+
+
+def find_gate_violations(
+    jobs: dict[str, JobWiring], gate: str = GATE_JOB, reporters: frozenset[str] = REPORTER_JOBS
+) -> list[str]:
+    """Check that every huge-runner job waits for the gate and that the gate waits for every other job.
+
+    Args:
+        jobs: The workflow jobs, as returned by ``load_job_wiring``.
+        gate: Id of the fan-in job the huge-runner jobs depend on.
+        reporters: Jobs that run after the huge-runner jobs and therefore cannot feed the gate.
+
+    Returns:
+        One message per violation, empty when the wiring is correct.
+
+    """
+    gate_job = jobs.get(gate)
+    if gate_job is None:
+        return [f"job '{gate}' is missing from the workflow"]
+
+    violations: list[str] = []
+    if gate_job.on_huge_runners:
+        violations.append(
+            f"'{gate}' must not run on {HUGE_RUNNER_GROUP}: it only fans in results, so keep it on a GitHub-hosted runner"
+        )
+    gate_conjuncts = _top_level_conjuncts(expression=gate_job.condition)
+    if gate_conjuncts is None or not {"always()", "!cancelled()"} <= set(gate_conjuncts):
+        violations.append(
+            f"'{gate}' must have always() and !cancelled() as top-level conjuncts of its condition: a path-filtered "
+            "job is skipped, and without always() a skipped need would skip the gate and every huge-runner job behind "
+            "it, while !cancelled() keeps it from running on a cancelled workflow"
+        )
+    violations.extend(f"'{gate}' depends on the unknown job '{name}'" for name in sorted(gate_job.needs - jobs.keys()))
+
+    for job in jobs.values():
+        if job.name == gate:
+            continue
+        if job.on_huge_runners:
+            if gate not in job.needs:
+                violations.append(f"'{job.name}' runs on {HUGE_RUNNER_GROUP} but does not list '{gate}' in its needs")
+            conjuncts = _top_level_conjuncts(expression=job.condition)
+            if conjuncts is None:
+                violations.append(
+                    f"'{job.name}' joins its condition with a top-level ||, so one branch can run it after '{gate}' "
+                    "failed; keep the whole condition a conjunction and put alternatives inside parentheses"
+                )
+            else:
+                if f"needs.{gate}.result=='success'" not in conjuncts:
+                    violations.append(
+                        f"'{job.name}' must have needs.{gate}.result == 'success' as a top-level conjunct of its "
+                        "condition: it is the only thing that stops a status function such as always() or failure() "
+                        f"from running it after '{gate}' failed"
+                    )
+                if "!cancelled()" not in conjuncts:
+                    violations.append(
+                        f"'{job.name}' must have !cancelled() as a top-level conjunct of its condition: without a status "
+                        f"function the implicit success() skips it whenever a path-filtered job upstream of '{gate}' was "
+                        "skipped, even though the gate passed"
+                    )
+            if job.name in gate_job.needs:
+                violations.append(f"'{gate}' must not depend on the {HUGE_RUNNER_GROUP} job '{job.name}'")
+        elif job.name in reporters:
+            if job.name in gate_job.needs:
+                violations.append(
+                    f"'{gate}' must not depend on '{job.name}': it reports on the huge-runner jobs and runs after them"
+                )
+        elif job.name not in gate_job.needs:
+            violations.append(
+                f"'{job.name}' is missing from the needs of '{gate}'; add it there so the huge-runner jobs wait "
+                "for it, or add it to REPORTER_JOBS in tasks/ci.py if it aggregates huge-runner results"
+            )
+    return violations
+
+
+@task(name="validate-huge-runner-gate")
+def validate_huge_runner_gate(context: Context) -> None:  # noqa: ARG001
+    """Verify that ci.yml routes every huge-runner job through the gate job and the gate through every cheap job.
+
+    Raises:
+        Exit: If the wiring has violations; each one is listed in the message.
+
+    """
+    violations = find_gate_violations(jobs=load_job_wiring(workflow_path=CI_WORKFLOW, repo_root=REPO_BASE))
+    if violations:
+        details = "\n".join(f"  - {violation}" for violation in violations)
+        raise Exit(f"{CI_WORKFLOW}: huge-runner gate wiring is broken:\n{details}", code=1)
+    print(f"{CI_WORKFLOW}: huge-runner gate wiring is valid")


### PR DESCRIPTION
## Summary

The huge-runner jobs (16 to 17 per backend run, on a self-hosted pool of 24 slots) waited only for lint and the unit tests. A failing frontend test, generated-file validator or Vale check still let all of them run on a run that could not merge, and merge bursts on `stable` cancelled push runs after they had already taken runners. This PR routes every huge-runner job through a single gate that waits for every GitHub-hosted check, holds that gate for 10 minutes on push events, and stops running the version-upgrade migration test on frontend-only changes. Pull requests pay no latency for it: the cheap checks all finish before the unit tests do.

Based on the 280 CI runs on `stable` between 2026-08-19 and 2026-09-02 (40 push runs, 240 PR runs):

| Where huge-runner minutes went without a merge signal | Minutes | Share | This PR |
|---|---|---|---|
| a cheap non-gating job failed while the huge-runner jobs ran | 2,552 | 8% | fixed by the gate |
| push runs cancelled by `concurrency` after taking runners (10 of 40) | 934 | 18% of push minutes | ~570 avoided by the hold |
| version-upgrade on frontend-only changes (26 runs) | 253 | 1% | fixed by the trigger change |
| runs on PRs that were still drafts | 4,715 | 15% | follow-up |
| passing jobs alongside one flaky huge job (46 of 54 failures are a single group) | ~6,700 | 21% | not addressable by gating |

The pool peaked at 24 of 24 slots and 18% of huge-runner jobs queued for more than 5 minutes, so every avoided job shortens someone else's queue.

## Key changes

- **`huge-runner-gate` fan-in job.** Needs all 26 GitHub-hosted jobs, runs with `always() && !cancelled()` so a path-skipped job does not skip it, and fails when any need is `failure` or `cancelled`, listing which. Every huge-runner job now needs only `prepare-environment`, `files-changed` and the gate, and its condition is `!cancelled() && needs.huge-runner-gate.result == 'success' && <path filter>`: the status function stops GitHub's skip propagation (a path-skipped job upstream of the gate otherwise skips everything behind it, which the first run on this PR demonstrated), and the explicit gate check is what keeps a failed gate from being bypassed.
- **Self-enforcing wiring.** `invoke ci.validate-huge-runner-gate` (new `tasks/ci.py`) parses `ci.yml`, resolves local reusable workflows to their runner groups, and fails when a huge-runner job does not need the gate, lacks the gate-result check or `!cancelled()` as top-level conjuncts of its condition, or joins its condition with a top-level `||`; when the gate runs on `huge-runners` or lacks `always()`; when a GitHub-hosted job is missing from the gate's `needs`; or when the gate depends on a huge-runner, reporter or unknown job. The `yaml-lint` job runs it, and `/pre-ci` lists it. Adding a cheap job means adding one line to the gate; forgetting fails CI.
- **Push debounce.** The gate sleeps 600 s on `push` events before the huge-runner jobs may start, so the concurrency cancellation from the next merge lands first. Nobody waits on a post-merge run and GitHub-hosted minutes are free for this repository.
- **Version-upgrade trigger.** Keys on `backend`, the new `demo` output (`models/**`, which that test loads into the old release) or the workflow file, instead of the wide `e2e` filter.

## Test plan

- [x] `yamllint -s .`, actionlint (with the CI's shellcheck exclusions), `ruff check`/`ruff format --check` repo-wide, `ty check .`
- [x] `uv run invoke ci.validate-huge-runner-gate` passes on the real workflow
- [x] The validator's violation paths were exercised against synthetic wirings (valid wiring, missing gate, gate on huge runners or without `always()`/`!cancelled()`, gate dependencies on huge/reporter/unknown jobs, huge job bypassing the gate, every condition shape including the `||` escape hatches, the `${{ }}` wrapper, redundant parentheses and unspaced operators, the conjunct splitter, reusable-workflow runner resolution). Those tests are not committed: importing the repo-root `tasks` package from a backend test needed a pytest `pythonpath` entry and a mypy override, which the maintainers preferred not to carry; the validator runs against the real workflow in the `yaml-lint` job.
- [x] On this PR's run: `huge-runner-gate` completes right after the last cheap job, and every huge-runner job starts only after it (run 33654364036: gate done 16:25:45, all 17 huge-runner jobs started 16:25:51; the very first run had skipped them all until the explicit gate-result check was added)
- [ ] On the first `stable` push after merge: the gate holds for ~10 minutes, then the huge-runner jobs start

## Follow-ups not in this PR

- Skip huge-runner jobs on draft PRs (`!github.event.pull_request.draft`, add `ready_for_review` to the trigger types, label opt-in): ~15% of minutes.
- Move `otel-export-trace` off `huge-runners` if the endpoint is reachable from GitHub-hosted runners: it takes a slot after every CI run.
- Reconsider the unit-test gate: it fired 0 times in the 41 runs since it landed and adds ~3.3 min to every backend run; python-lint plus the validators (done by 2.4 min) would keep most of the protection.

## Draft: tiering the huge-runner jobs behind a fast smoke job

Written as requested for discussion; nothing below is implemented.

### What a smoke can and cannot catch

The gate covers lint, type checks, unit tests and generated-file drift. What is still unproven when the huge-runner jobs start is the stack: the Docker image build (including the frontend build inside it), server boot against Neo4j / RabbitMQ / Redis / Prefect, schema load on a fresh database, and the first API round-trip. That is the failure class that breaks everything at once, and the only one a smoke predicts.

| Shape of the 54 runs with a huge-runner failure | Runs | Smoke would have caught it |
|---|---|---|
| exactly one job group failed (component 20, e2e 7, integration 4, docker 3, functional 2, ...) | 46 | no: test-level flakes or real failures in one suite, the stack booted |
| several groups failed together (boot / image / migration class) | 8 | 3 or 4 of them |

Collateral in a smoke-detectable run is 150 to 200 passing huge-runner minutes, so the ceiling is roughly 500 to 700 minutes per two weeks, about 2% of the total. The 21% flake-collateral bucket is out of reach: the stack was healthy in those runs.

### Why a strict tier is a bad trade on this pool

A strict tier (smoke, then everything else) costs every backend run twice: the smoke itself (image build 0.3 min from the layer cache, `compose up --wait`, schema load, one query: 3 to 4 min plus checkout and `uv sync`), and a second pass through the huge-runner queue. Huge-runner jobs already wait p90 10 min at peak; with a tier the smoke waits for a slot and then 16 jobs wait again. Expected saving is ~5 huge-runner minutes per run against 4 to 5 minutes of wall clock on every run, more at peak. On push runs nobody waits, but the PR just proved the stack and the debounce already holds those jobs, so the saving there rounds to zero.

### Proposal: concurrent smoke with cancel-on-failure

Run the smoke alongside the other huge-runner jobs and have it cancel the run when it fails. The siblings have burned 3 to 5 of their 10 to 20 minutes by then, so this captures roughly two thirds of the collateral at zero added latency.

```yaml
  huge-runner-smoke:
    name: Smoke (image build + stack boot)
    needs: ["prepare-environment", "files-changed", "huge-runner-gate"]
    if: |
      !cancelled() &&
      needs.huge-runner-gate.result == 'success' &&
      needs.files-changed.outputs.e2e == 'true' # anything that can change the image or the stack
    runs-on:
      group: huge-runners
    timeout-minutes: 10
    permissions:
      contents: read
      actions: write # cancel this run when the stack does not boot
    env:
      INFRAHUB_DB_TYPE: neo4j
      PYTEST_XDIST_WORKER_COUNT: 1
    steps:
      # checkout, setup-python, setup-uv, uv sync, tini and the image-version env vars:
      # the same preamble as E2E-testing-pytest-playwright
      - name: Build image
        run: uv run invoke dev.build
      - name: Boot the stack and load the schema
        run: exec tini -s -g -- uv run pytest -c tests/e2e/pytest.ini tests/e2e/smoke
      - name: Stop the sibling huge-runner jobs
        if: failure() && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
        env:
          GH_TOKEN: ${{ github.token }}
        run: |
          echo "::error::The stack did not boot; cancelling the run so the other huge-runner jobs stop."
          gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel"
```

- GitHub has no per-job cancel, only run cancel: the run conclusion becomes `cancelled`, the smoke job's own `failure` and its `::error::` annotation stay visible and name the cause, and branch protection treats `cancelled` as not passing.
- Fork and Dependabot PRs get a read-only token, so the cancel step is skipped there and the smoke simply fails the run.
- `ci.validate-huge-runner-gate` accepts this job as is (it runs on `huge-runners` and needs the gate). A strict tier would need one extra rule ("every huge-runner job except the smoke needs the smoke") and a `TIER1_JOBS` constant.

The smoke test itself: `tests/e2e/smoke/test_stack_boots.py`, requesting only the session fixtures that boot the stack through infrahub-testcontainers and load the base schema (no dataset, no browser), with one SDK query asserting the default branch reports a schema hash. Cost is boot plus schema load, about 2 minutes today. Keep it out of the shard runs: no shard marker, and `--ignore=tests/e2e/smoke` on the shard command line.

### The risk that decides it

A flaky smoke is worse than none: every false cancel throws away a full run (~180 huge-runner minutes plus a developer retry), so break-even is near a 2% flake rate, and the boot path has a history of CI-only readiness failures. Rollout: land the smoke as a plain job without the cancel step, measure its failure rate for two weeks (a smoke failure with green e2e shards is a smoke flake), and add the cancel step only below 0.5%.

### Recommendation

No strict tier. Try the concurrent smoke only with the two-week measurement first. The larger remaining lever is the component suite: it fails in 15.7% of the runs it appears in, its `other` shard is the longest job in CI at 19.6 min p50, and it is the biggest single source of both re-runs and passing-job collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
