### PR TITLE
Report children on a hierarchy attach

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, PrivateAttr, computed_field, field_validator, model_validator
 
 from infrahub.core.constants import NULL_VALUE, DiffAction, RelationshipCardinality, RelationshipKind
+from infrahub.log import get_logger
 
 if TYPE_CHECKING:
     from infrahub.core.attribute import BaseAttribute
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
+
+log = get_logger()
 
 
 class PropertyChangelog(BaseModel):
@@ -451,6 +454,30 @@ class ChangelogRelationshipMapper:
                 return self.cardinality_many_relationship
 
 
+def peer_relationships(peer_schema: MainSchemaTypes, rel_schema: RelationshipSchema) -> list[RelationshipSchema]:
+    """Return the peer's side of ``rel_schema``.
+
+    A hierarchy declares ``parent`` and ``children`` under one identifier, so only the mirrored
+    direction tells them apart. When no candidate mirrors the direction the whole set is returned
+    and logged: the answer is a guess, but dropping it would hide a change that did happen.
+    """
+    candidates = peer_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
+    mirrored = [candidate for candidate in candidates if candidate.direction == rel_schema.direction.neighbor_direction]
+    if mirrored:
+        return mirrored
+
+    if candidates:
+        log.warning(
+            "No peer relationship mirrors the direction, reporting every candidate",
+            peer_kind=peer_schema.kind,
+            identifier=rel_schema.get_identifier(),
+            direction=rel_schema.direction.value,
+            candidates=[candidate.name for candidate in candidates],
+        )
+
+    return candidates
+
+
 class RelationshipChangelogGetter:
     def __init__(self, db: InfrahubDatabase, branch: Branch) -> None:
         self._db = db
@@ -520,9 +547,10 @@ class RelationshipChangelogGetter:
                     primary_changelog=primary_changelog,
                 )
             )
+            previous_peer_schema = schema_branch.get(name=str(relationship.peer_kind_previous), duplicate=False)
             secondaries.extend(
                 self._process_removed_peers(
-                    peer_schema=peer_schema,
+                    peer_schema=previous_peer_schema,
                     peer_id=str(relationship.peer_id_previous),
                     peer_kind=str(relationship.peer_kind_previous),
                     rel_schema=rel_schema,
@@ -582,23 +610,6 @@ class RelationshipChangelogGetter:
 
         return secondaries
 
-    def _peer_relationships(
-        self, peer_schema: MainSchemaTypes, rel_schema: RelationshipSchema
-    ) -> list[RelationshipSchema]:
-        """Return the peer's side of ``rel_schema``.
-
-        A hierarchy declares `parent` and `children` under one identifier, so only the mirrored
-        direction tells them apart. An unresolved direction keeps every candidate rather than guess.
-        """
-        candidates = peer_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
-        if len(candidates) < 2:
-            return candidates
-
-        mirrored = [
-            candidate for candidate in candidates if candidate.direction == rel_schema.direction.neighbor_direction
-        ]
-        return mirrored or candidates
-
     def _process_added_peers(
         self,
         peer_id: str,
@@ -608,7 +619,7 @@ class RelationshipChangelogGetter:
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
         node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
-        for peer_relation in self._peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
+        for peer_relation in peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
             if peer_relation.cardinality == RelationshipCardinality.ONE:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
                     name=peer_relation.name,
@@ -638,7 +649,7 @@ class RelationshipChangelogGetter:
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
         node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
-        for peer_relation in self._peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
+        for peer_relation in peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
             if peer_relation.cardinality == RelationshipCardinality.ONE:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
                     name=peer_relation.name,

--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -582,6 +582,23 @@ class RelationshipChangelogGetter:
 
         return secondaries
 
+    def _peer_relationships(
+        self, peer_schema: MainSchemaTypes, rel_schema: RelationshipSchema
+    ) -> list[RelationshipSchema]:
+        """Return the peer's side of ``rel_schema``.
+
+        A hierarchy declares `parent` and `children` under one identifier, so only the mirrored
+        direction tells them apart. An unresolved direction keeps every candidate rather than guess.
+        """
+        candidates = peer_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
+        if len(candidates) < 2:
+            return candidates
+
+        mirrored = [
+            candidate for candidate in candidates if candidate.direction == rel_schema.direction.neighbor_direction
+        ]
+        return mirrored or candidates
+
     def _process_added_peers(
         self,
         peer_id: str,
@@ -590,17 +607,14 @@ class RelationshipChangelogGetter:
         rel_schema: RelationshipSchema,
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
-        secondaries: list[NodeChangelog] = []
-        peer_relation = peer_schema.get_relationship_by_identifier(id=str(rel_schema.identifier), raise_on_error=False)
-        if peer_relation:
-            node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
+        node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
+        for peer_relation in self._peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
             if peer_relation.cardinality == RelationshipCardinality.ONE:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
                     name=peer_relation.name,
                     peer_id=primary_changelog.node_id,
                     peer_kind=primary_changelog.node_kind,
                 )
-                secondaries.append(node_changelog)
             elif peer_relation.cardinality == RelationshipCardinality.MANY:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityManyChangelog(
                     name=peer_relation.name,
@@ -612,9 +626,8 @@ class RelationshipChangelogGetter:
                         )
                     ],
                 )
-                secondaries.append(node_changelog)
 
-        return secondaries
+        return [node_changelog] if node_changelog.relationships else []
 
     def _process_removed_peers(
         self,
@@ -624,17 +637,14 @@ class RelationshipChangelogGetter:
         rel_schema: RelationshipSchema,
         primary_changelog: NodeChangelog,
     ) -> list[NodeChangelog]:
-        secondaries: list[NodeChangelog] = []
-        peer_relation = peer_schema.get_relationship_by_identifier(id=str(rel_schema.identifier), raise_on_error=False)
-        if peer_relation:
-            node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
+        node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
+        for peer_relation in self._peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
             if peer_relation.cardinality == RelationshipCardinality.ONE:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
                     name=peer_relation.name,
                     peer_id_previous=primary_changelog.node_id,
                     peer_kind_previous=primary_changelog.node_kind,
                 )
-                secondaries.append(node_changelog)
             elif peer_relation.cardinality == RelationshipCardinality.MANY:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityManyChangelog(
                     name=peer_relation.name,
@@ -646,6 +656,5 @@ class RelationshipChangelogGetter:
                         )
                     ],
                 )
-                secondaries.append(node_changelog)
 
-        return secondaries
+        return [node_changelog] if node_changelog.relationships else []

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -1468,14 +1468,17 @@ class RelationshipDeleteAllQuery(Query):
     def get_deleted_relationships_changelog(
         self, node_schema: NodeSchema
     ) -> list[RelationshipCardinalityOneChangelog | RelationshipCardinalityManyChangelog]:
-        rel_identifier_to_changelog_mapper: dict[str, ChangelogRelationshipMapper] = {}
+        # Both sides of a hierarchy share one identifier, so it cannot be the key.
+        rel_name_to_changelog_mapper: dict[str, ChangelogRelationshipMapper] = {}
 
         for item in self.get_data():
             if item.uuid == self.node_id:
                 continue
 
             deleted_rel_schemas = [
-                rel_schema for rel_schema in node_schema.relationships if rel_schema.identifier == item.rel_identifier
+                rel_schema
+                for rel_schema in node_schema.relationships
+                if rel_schema.get_identifier() == item.rel_identifier
             ]
 
             if len(deleted_rel_schemas) == 0:
@@ -1497,14 +1500,14 @@ class RelationshipDeleteAllQuery(Query):
                 deleted_rel_schema = deleted_rel_schemas[0]
 
             try:
-                changelog_mapper = rel_identifier_to_changelog_mapper[item.rel_identifier]
+                changelog_mapper = rel_name_to_changelog_mapper[deleted_rel_schema.name]
             except KeyError:
                 changelog_mapper = ChangelogRelationshipMapper(schema=deleted_rel_schema)
-                rel_identifier_to_changelog_mapper[item.rel_identifier] = changelog_mapper
+                rel_name_to_changelog_mapper[deleted_rel_schema.name] = changelog_mapper
 
             changelog_mapper.delete_relationship(peer_id=item.uuid, peer_kind=item.kind, rel_schema=deleted_rel_schema)
 
-        return [changelog_mapper.changelog for changelog_mapper in rel_identifier_to_changelog_mapper.values()]
+        return [changelog_mapper.changelog for changelog_mapper in rel_name_to_changelog_mapper.values()]
 
 
 class GetAllPeersIds(Query):

--- a/backend/tests/component/core/changelog/test_models.py
+++ b/backend/tests/component/core/changelog/test_models.py
@@ -480,3 +480,46 @@ async def test_node_changelog_parent(db: InfrahubDatabase, default_branch: Branc
     await car1_delete1.delete(db=db)
     assert car1_delete1.node_changelog.parent.node_id == person2.id
     assert car1_delete1.node_changelog.parent.node_kind == "TestPerson"
+
+
+async def test_secondary_changelog_names_the_hierarchy_children_relationship(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple: SchemaRoot
+) -> None:
+    """A hierarchy peer must be told that `children` moved, not that its own `parent` did."""
+    region = await Node.init(db=db, schema="LocationRegion", branch=default_branch)
+    await region.new(db=db, name="region-1")
+    await region.save(db=db)
+
+    site = await Node.init(db=db, schema="LocationSite", branch=default_branch)
+    await site.new(db=db, name="site-1", parent=region)
+    await site.save(db=db)
+
+    rack = await Node.init(db=db, schema="LocationRack", branch=default_branch)
+    await rack.new(db=db, name="rack-1", parent=site)
+    await rack.save(db=db)
+
+    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    attached = await getter.get_changelogs(primary_changelog=rack.node_changelog)
+
+    assert [changelog.node_id for changelog in attached] == [site.id]
+    assert attached[0].node_kind == "LocationSite"
+    assert attached[0].relationships == {
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.ADDED)],
+        )
+    }
+
+    to_delete = await NodeManager.get_one(id=rack.id, db=db, raise_on_error=True)
+    await to_delete.delete(db=db)
+    detached = await getter.get_changelogs(primary_changelog=to_delete.node_changelog)
+
+    assert [changelog.node_id for changelog in detached] == [site.id]
+    assert detached[0].relationships == {
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[
+                RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.REMOVED)
+            ],
+        )
+    }

--- a/backend/tests/component/core/changelog/test_models.py
+++ b/backend/tests/component/core/changelog/test_models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import (
@@ -9,7 +11,7 @@ from infrahub.core.changelog.models import (
     RelationshipChangelogGetter,
     RelationshipPeerChangelog,
 )
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import DiffAction, InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
@@ -521,5 +523,209 @@ async def test_secondary_changelog_names_the_hierarchy_children_relationship(
             peers=[
                 RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.REMOVED)
             ],
+        )
+    }
+
+
+async def test_deleted_middle_node_reports_both_hierarchy_sides(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+) -> None:
+    """Deleting a node with a parent and a child must report both sides, each on its own relationship."""
+    top = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP, branch=default_branch)
+    await top.new(db=db, name="top")
+    await top.save(db=db)
+
+    mid = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP, branch=default_branch)
+    await mid.new(db=db, name="mid", parent=top)
+    await mid.save(db=db)
+
+    leaf = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP, branch=default_branch)
+    await leaf.new(db=db, name="leaf", parent=mid)
+    await leaf.save(db=db)
+
+    to_delete = await NodeManager.get_one(id=mid.id, db=db, raise_on_error=True)
+    await to_delete.delete(db=db)
+
+    assert to_delete.node_changelog.relationships == {
+        "parent": RelationshipCardinalityOneChangelog(
+            name="parent", peer_id_previous=top.id, peer_kind_previous=InfrahubKind.STANDARDGROUP
+        ),
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=leaf.id, peer_kind=InfrahubKind.STANDARDGROUP, peer_status=DiffAction.REMOVED
+                )
+            ],
+        ),
+    }
+
+    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    secondaries = await getter.get_changelogs(primary_changelog=to_delete.node_changelog)
+
+    by_node = {changelog.node_id: changelog for changelog in secondaries}
+    assert sorted(by_node) == sorted([top.id, leaf.id])
+    assert by_node[top.id].relationships == {
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=mid.id, peer_kind=InfrahubKind.STANDARDGROUP, peer_status=DiffAction.REMOVED
+                )
+            ],
+        )
+    }
+    assert by_node[leaf.id].relationships == {
+        "parent": RelationshipCardinalityOneChangelog(
+            name="parent", peer_id_previous=mid.id, peer_kind_previous=InfrahubKind.STANDARDGROUP
+        )
+    }
+
+
+async def test_secondary_changelog_hierarchy_move_reports_both_parents(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple: SchemaRoot
+) -> None:
+    """Moving a rack must tell the old site and the new site that `children` changed."""
+    region = await Node.init(db=db, schema="LocationRegion", branch=default_branch)
+    await region.new(db=db, name="region-1")
+    await region.save(db=db)
+
+    site_1 = await Node.init(db=db, schema="LocationSite", branch=default_branch)
+    await site_1.new(db=db, name="site-1", parent=region)
+    await site_1.save(db=db)
+
+    site_2 = await Node.init(db=db, schema="LocationSite", branch=default_branch)
+    await site_2.new(db=db, name="site-2", parent=region)
+    await site_2.save(db=db)
+
+    rack = await Node.init(db=db, schema="LocationRack", branch=default_branch)
+    await rack.new(db=db, name="rack-1", parent=site_1)
+    await rack.save(db=db)
+
+    moved = await NodeManager.get_one(id=rack.id, db=db, raise_on_error=True)
+    await moved.parent.update(data=site_2, db=db)
+    await moved.save(db=db)
+
+    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    secondaries = await getter.get_changelogs(primary_changelog=moved.node_changelog)
+
+    by_node = {changelog.node_id: changelog for changelog in secondaries}
+    assert sorted(by_node) == sorted([site_1.id, site_2.id])
+    assert by_node[site_1.id].relationships == {
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[
+                RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.REMOVED)
+            ],
+        )
+    }
+    assert by_node[site_2.id].relationships == {
+        "children": RelationshipCardinalityManyChangelog(
+            name="children",
+            peers=[RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.ADDED)],
+        )
+    }
+
+
+# A generic whose two members name their side of `shared__link` differently.
+DIFFERING_PEER_NAMES: dict[str, Any] = {
+    "generics": [
+        {
+            "name": "Place",
+            "namespace": "Zzz",
+            "default_filter": "name__value",
+            "display_label": "name__value",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+        }
+    ],
+    "nodes": [
+        {
+            "name": "Device",
+            "namespace": "Zzz",
+            "default_filter": "name__value",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+            "relationships": [
+                {
+                    "name": "location",
+                    "peer": "ZzzPlace",
+                    "cardinality": "one",
+                    "identifier": "shared__link",
+                    "optional": True,
+                }
+            ],
+        },
+        {
+            "name": "Site",
+            "namespace": "Zzz",
+            "inherit_from": ["ZzzPlace"],
+            "relationships": [
+                {
+                    "name": "devices",
+                    "peer": "ZzzDevice",
+                    "cardinality": "many",
+                    "identifier": "shared__link",
+                    "optional": True,
+                }
+            ],
+        },
+        {
+            "name": "Rack",
+            "namespace": "Zzz",
+            "inherit_from": ["ZzzPlace"],
+            "relationships": [
+                {
+                    "name": "equipment",
+                    "peer": "ZzzDevice",
+                    "cardinality": "many",
+                    "identifier": "shared__link",
+                    "optional": True,
+                }
+            ],
+        },
+    ],
+}
+
+
+async def test_secondary_changelog_names_the_previous_peer_own_relationship(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, data_schema: None
+) -> None:
+    """A moved peer must be described by its own schema, not by the schema of the new peer."""
+    registry.schema.register_schema(schema=SchemaRoot(**DIFFERING_PEER_NAMES), branch=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    site = await Node.init(db=db, schema="ZzzSite", branch=default_branch)
+    await site.new(db=db, name="site-1")
+    await site.save(db=db)
+
+    rack = await Node.init(db=db, schema="ZzzRack", branch=default_branch)
+    await rack.new(db=db, name="rack-1")
+    await rack.save(db=db)
+
+    device = await Node.init(db=db, schema="ZzzDevice", branch=default_branch)
+    await device.new(db=db, name="device-1", location=site)
+    await device.save(db=db)
+
+    moved = await NodeManager.get_one(id=device.id, db=db, raise_on_error=True)
+    await moved.location.update(data=rack, db=db)
+    await moved.save(db=db)
+
+    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    by_node = {
+        changelog.node_id: changelog
+        for changelog in await getter.get_changelogs(primary_changelog=moved.node_changelog)
+    }
+
+    assert sorted(by_node) == sorted([site.id, rack.id])
+    assert by_node[site.id].relationships == {
+        "devices": RelationshipCardinalityManyChangelog(
+            name="devices",
+            peers=[RelationshipPeerChangelog(peer_id=device.id, peer_kind="ZzzDevice", peer_status=DiffAction.REMOVED)],
+        )
+    }
+    assert by_node[rack.id].relationships == {
+        "equipment": RelationshipCardinalityManyChangelog(
+            name="equipment",
+            peers=[RelationshipPeerChangelog(peer_id=device.id, peer_kind="ZzzDevice", peer_status=DiffAction.ADDED)],
         )
     }

--- a/backend/tests/unit/core/changelog/test_models.py
+++ b/backend/tests/unit/core/changelog/test_models.py
@@ -124,8 +124,9 @@ HIERARCHY_PEER_SCHEMA = NodeSchema(
     ],
 )
 
-# A hierarchical node whose own children relationship uses a different identifier, so it holds
-# only one side under `parent__child`.
+# A node that inherits a hierarchy but declares its own `children` under another identifier keeps
+# only `parent` under `parent__child`, because the generated `children` is then skipped. Schema
+# validation accepts it.
 ONE_SIDED_PEER_SCHEMA = NodeSchema(
     name="Room",
     namespace="Loc",

--- a/backend/tests/unit/core/changelog/test_models.py
+++ b/backend/tests/unit/core/changelog/test_models.py
@@ -3,8 +3,10 @@ from typing import Any
 
 import pytest
 
-from infrahub.core.changelog.models import AttributeChangelog
-from infrahub.core.constants import DiffAction
+from infrahub.core.changelog.models import AttributeChangelog, peer_relationships
+from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants.schema import PARENT_CHILD_IDENTIFIER
+from infrahub.core.schema import NodeSchema, RelationshipSchema
 
 
 @dataclass
@@ -99,3 +101,112 @@ def test_sensitive_attribute_update_status(test_case: SensitiveAttributeTestCase
 
     assert attr.value_update_status == test_case.expected_status
     assert attr.has_updates == test_case.expected_has_updates
+
+
+HIERARCHY_PEER_SCHEMA = NodeSchema(
+    name="Site",
+    namespace="Loc",
+    relationships=[
+        RelationshipSchema(
+            name="parent",
+            peer="LocRegion",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.OUTBOUND,
+        ),
+        RelationshipSchema(
+            name="children",
+            peer="LocRack",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.MANY,
+            direction=RelationshipDirection.INBOUND,
+        ),
+    ],
+)
+
+# A hierarchical node whose own children relationship uses a different identifier, so it holds
+# only one side under `parent__child`.
+ONE_SIDED_PEER_SCHEMA = NodeSchema(
+    name="Room",
+    namespace="Loc",
+    relationships=[
+        RelationshipSchema(
+            name="parent",
+            peer="LocSite",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.OUTBOUND,
+        ),
+    ],
+)
+
+
+@dataclass
+class PeerRelationshipCase:
+    name: str
+    peer: NodeSchema
+    local: RelationshipSchema
+    expected_names: list[str]
+
+
+PEER_RELATIONSHIP_CASES: list[PeerRelationshipCase] = [
+    PeerRelationshipCase(
+        name="the_child_side_resolves_to_children",
+        peer=HIERARCHY_PEER_SCHEMA,
+        local=RelationshipSchema(
+            name="parent",
+            peer="LocSite",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.OUTBOUND,
+        ),
+        expected_names=["children"],
+    ),
+    PeerRelationshipCase(
+        name="the_parent_side_resolves_to_parent",
+        peer=HIERARCHY_PEER_SCHEMA,
+        local=RelationshipSchema(
+            name="children",
+            peer="LocSite",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.MANY,
+            direction=RelationshipDirection.INBOUND,
+        ),
+        expected_names=["parent"],
+    ),
+    PeerRelationshipCase(
+        # Schema validation only checks the peers the pair declares, so it never sees a third kind.
+        name="a_third_kind_reusing_the_identifier_gets_every_candidate",
+        peer=HIERARCHY_PEER_SCHEMA,
+        local=RelationshipSchema(
+            name="site",
+            peer="LocSite",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.BIDIR,
+        ),
+        expected_names=["parent", "children"],
+    ),
+    PeerRelationshipCase(
+        # Nothing mirrors an outbound side on a peer that only declares one. Report it anyway,
+        # so a change that did happen is never dropped.
+        name="a_lone_candidate_is_reported_even_when_it_does_not_mirror",
+        peer=ONE_SIDED_PEER_SCHEMA,
+        local=RelationshipSchema(
+            name="parent",
+            peer="LocRoom",
+            identifier=PARENT_CHILD_IDENTIFIER,
+            cardinality=RelationshipCardinality.ONE,
+            direction=RelationshipDirection.OUTBOUND,
+        ),
+        expected_names=["parent"],
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", [pytest.param(tc, id=tc.name) for tc in PEER_RELATIONSHIP_CASES])
+def test_peer_relationships(test_case: PeerRelationshipCase) -> None:
+    """A hierarchy resolves by direction. When nothing mirrors it, every candidate is reported."""
+    resolved = peer_relationships(peer_schema=test_case.peer, rel_schema=test_case.local)
+
+    assert [relationship.name for relationship in resolved] == test_case.expected_names

--- a/changelog/10485.fixed.md
+++ b/changelog/10485.fixed.md
@@ -1,1 +1,1 @@
-Attaching or removing a child of a hierarchical node now reports the change on the parent's `children` relationship, not on the parent's own `parent`. A computed attribute that reads `children` recomputes again.
+Attaching or removing a child now reports the change on the hierarchical parent's `children` relationship, instead of on its `parent` relationship. A Python transform computed attribute or an action rule that matches `children` now reacts. Deleting a node that has both a parent and a child now reports both sides.

--- a/changelog/10485.fixed.md
+++ b/changelog/10485.fixed.md
@@ -1,0 +1,1 @@
+Attaching or removing a child of a hierarchical node now reports the change on the parent's `children` relationship, not on the parent's own `parent`. A computed attribute that reads `children` recomputes again.

--- a/dev/knowledge/backend/schema-definitions.md
+++ b/dev/knowledge/backend/schema-definitions.md
@@ -41,7 +41,7 @@ core_standard_webhook = NodeSchema(
 | `name` | `str` | *required* | Relationship name (lowercase, 3-64 chars) |
 | `peer` | `str` | *required* | Kind of the peer object (e.g., `InfrahubKind.KEYVALUE`) |
 | `kind` | `RelationshipKind` | `GENERIC` | Relationship type (see below) |
-| `identifier` | `str \| None` | `None` | Unique identifier; auto-generated if omitted |
+| `identifier` | `str \| None` | `None` | Names the shared relationship edge; auto-generated if omitted. Not unique within a node schema, see Direction |
 | `cardinality` | `RelationshipCardinality` | `MANY` | `ONE` or `MANY` |
 | `optional` | `bool` | `True` | Whether the relationship is mandatory |
 | `order_weight` | `int \| None` | `None` | Frontend display ordering (lower = first) |
@@ -71,13 +71,26 @@ When wiring a new cascade, inspect every schema for a mandatory relationship tha
 | `GENERIC` | Standard association between nodes |
 | `ATTRIBUTE` | Peer is semantically part of the parent (e.g., headers on a webhook) |
 | `COMPONENT` | Triggers template generation for the peer (see [Object Templates](templates.md)) |
-| `PARENT` | Hierarchical parent-child relationship |
+| `PARENT` | Marks the peer as the owning parent of this node |
 | `GROUP` | Group membership |
+| `HIERARCHY` | The generated `parent` / `children` pair on a hierarchical node |
+| `PROFILE` | Links a node to its profile |
+| `TEMPLATE` | Links an instance to the object template it came from |
 
 ### Direction
 
 - **`BIDIR`** (default) — traversable both ways. Use when peers are different kinds.
 - **`OUTBOUND`** / **`INBOUND`** — needed when the same model appears on both sides (self-referencing relationships).
+
+Both sides of one relationship share a single `identifier`, so it is not unique within a node
+schema. A hierarchical node carries two relationships under the identifier `parent__child`
+(`PARENT_CHILD_IDENTIFIER` in `core/constants/schema.py`): `parent` (`OUTBOUND`, cardinality
+`ONE`) and `children` (`INBOUND`, cardinality `MANY`). Both come from
+`SchemaBranch.add_hierarchy_node()` and `add_hierarchy_generic()`.
+
+`get_relationship_by_identifier()` therefore cannot resolve a hierarchy. It returns whichever side
+is declared first. Use `get_relationships_by_identifier()` instead and select the side whose
+`direction` equals the local relationship's `direction.neighbor_direction`.
 
 ### Branch Support Auto-Determination
 


### PR DESCRIPTION
# Why

A hierarchical schema declares `parent` and `children` under one identifier, `parent__child`. The peer changelog looked the other side of the edge up by identifier alone and kept the first match, which is `parent`. Attaching a child told its parent that its own `parent` had become the child, and the real change on `children` was never announced.

Every consumer of node events saw the wrong relationship. A computed attribute whose query reads `children` filters events on the fields it reads, so it dropped the event and never recomputed. A user action rule matching `children` never fired.

Closes #10485

## Scope against the issue

The issue lists three scenarios. This PR fixes the first one. The other two need no change.

- **A new peer points its own `parent` at the node.** Fixed and tested.
- **`Update(data: {children: [...]})` from the parent side.** Already worked. The primary changelog names that relationship directly, so it was never ambiguous. I verified the secondary changelog is identical before and after this change, and added a test to hold it.
- **Touching an unrelated attribute does not recompute.** This is the selective recompute design, not a defect. The trigger narrows `infrahub.field.name` to the fields the transform reads.

## What changed

- A hierarchy peer now gets an event naming `children`, with the right cardinality.
- The peer side is resolved by the mirrored direction: `parent` is outbound, so it maps to the inbound `children`.
- Deleting a node that has both a parent and a child now reports both sides. The mapper that builds a deleted node's relationship changelog was keyed on the identifier, so the second hierarchy edge reused the first edge's mapper and overwrote it. A middle node reported a single `parent` entry pointing at its own child.
- A cardinality-one peer that moved described its previous peer with the new peer's schema, so the relationship named for the old peer could be one it does not declare. The removed side is now resolved from the previous peer kind, as the removal branch already did.
- A pair holding one relationship per identifier on each side keeps its current behaviour.

Merge and rebase were never affected. `core/diff/query_parser.py` already disambiguates the same way, so this follows an established pattern rather than a new one. `RelationshipAdd` and `RelationshipRemove` share the fixed function.

## How to review

Start with `peer_relationships` in `backend/infrahub/core/changelog/models.py`, then the mapper key in `backend/infrahub/core/query/relationship.py`.

The fallback deserves the most attention. When no candidate mirrors the local direction, every candidate is returned, and the result is a guess. Two schemas reach it, both accepted by validation:

- A third kind reuses the `parent__child` identifier with the default `bidirectional` direction. Validation only checks the peers the hierarchy pair itself declares, so it never sees this one. Both entries produced are schema-invalid: the changelog names a `peer_kind` the relationship does not allow.
- A hierarchical node declares its own `children` under a different identifier, so it holds only `parent` under `parent__child`. The lone candidate does not mirror, and reporting it reproduces the original bug in a narrow shape.

Returning nothing instead would drop a real event, which is the failure this PR fixes, so the branch keeps every candidate and always logs a warning naming the peer kind, the identifier, the direction and the candidates. A user action rule on a falsely reported name still runs its generator, so that log line is the signal to alert on. Two unit params pin both shapes.

Deciding whether `validate_identifiers` should reject these schemas outright would make the branch dead code. That is a schema-validation change with its own compatibility risk, so it is not in this PR.

## How to test

```bash
INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest backend/tests/component/core/changelog/ backend/tests/unit/core/changelog/ --neo4j
```

The hierarchy tests fail on the parent commit and pass here. Validated on release-1.10 as well: it sends the same wrong event, and only worked because the trigger carried no field filter before 1.11.0.

## Impact & rollout

- **Backward compatibility:** the event payload changes for a hierarchical attach, detach and delete. It was wrong before.
- **Config/env changes:** none.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated (if user-facing or ops-facing change)
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content
