### PR TITLE
fix(backend): set `to_user_id` when closing agnostic edges on aware objects

### DIFF
--- a/backend/infrahub/core/branch/data_deleter.py
+++ b/backend/infrahub/core/branch/data_deleter.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
 from infrahub.core.branch.enums import BranchStatus
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.query.branch import (
     DeleteBranchAgnosticAttributesQuery,
@@ -40,7 +41,7 @@ class BranchDeleteResult:
 class BranchDataDeleterInterface(Protocol):
     """The database side of a branch delete."""
 
-    async def delete(self, branch: Branch) -> BranchDeleteResult: ...
+    async def delete(self, branch: Branch, user_id: str = SYSTEM_USER_ID) -> BranchDeleteResult: ...
 
 
 class LoggerInterface(Protocol):
@@ -62,7 +63,7 @@ class BranchDataDeleter:
         self.batch_size = batch_size
         self.log = log or get_logger()
 
-    async def delete(self, branch: Branch) -> BranchDeleteResult:
+    async def delete(self, branch: Branch, user_id: str = SYSTEM_USER_ID) -> BranchDeleteResult:
         """Remove the branch's data and then the branch itself.
 
         Returns whether the Branch object was actually deleted in case multiple processes try to
@@ -81,7 +82,7 @@ class BranchDataDeleter:
             branch.status = BranchStatus.DELETING
             await branch.save(db=self.db)
 
-        edges_removed = await self.delete_branch_data(branch_name=branch.name)
+        edges_removed = await self.delete_branch_data(branch_name=branch.name, user_id=user_id)
 
         query = await StandardNodeDeleteQuery.init(db=self.db, node=branch)
         await query.execute(db=self.db)
@@ -89,14 +90,14 @@ class BranchDataDeleter:
 
         return BranchDeleteResult(branch_deleted=branch_deleted, edges_removed=edges_removed)
 
-    async def delete_branch_data(self, branch_name: str) -> int:
+    async def delete_branch_data(self, branch_name: str, user_id: str = SYSTEM_USER_ID) -> int:
         """Remove a branch's data without requiring the branch itself to still exist.
 
         Returns the number of edges removed, so a caller whose own logging is the only thing the
         operator can see is able to report progress.
         """
         agnostic_edges_count = await self._delete_agnostic_peers(branch_name=branch_name)
-        await self._retire_agnostic_fields(branch_name=branch_name)
+        await self._retire_agnostic_fields(branch_name=branch_name, user_id=user_id)
         branch_edges_count = await self._delete_edges(branch_name=branch_name)
         return agnostic_edges_count + branch_edges_count
 
@@ -131,7 +132,7 @@ class BranchDataDeleter:
             )
         return edges_removed
 
-    async def _retire_agnostic_fields(self, branch_name: str) -> None:
+    async def _retire_agnostic_fields(self, branch_name: str, user_id: str) -> None:
         """Close the global edges of branch-agnostic fields this branch was the last to retain.
 
         The complement of the agnostic-peer hard-delete: that stage removes the peers of Nodes
@@ -144,7 +145,7 @@ class BranchDataDeleter:
         batch_size = min(self.batch_size, MAX_AGNOSTIC_PEER_BATCH_SIZE)
 
         query = await RetireBranchAgnosticFieldsQuery.init(
-            db=self.db, branch_name=branch_name, at=Timestamp(), batch_size=batch_size
+            db=self.db, branch_name=branch_name, at=Timestamp(), batch_size=batch_size, user_id=user_id
         )
         await query.execute(db=self.db)
 

--- a/backend/infrahub/core/branch/delete_coordinator.py
+++ b/backend/infrahub/core/branch/delete_coordinator.py
@@ -68,7 +68,7 @@ class BranchDeleteOrchestrator:
         # Freezing has to precede the deletion, which takes away the branch name they are found by.
         await self.diff_freezer.freeze_diffs_for_branch(branch_name=branch.name)
 
-        result = await self.data_deleter.delete(branch=branch)
+        result = await self.data_deleter.delete(branch=branch, user_id=context.account.account_id)
 
         if result.branch_deleted:
             await self.workflow.submit_workflow(

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -247,7 +247,11 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                 await user_branch.rebase(db=dbt, user_id=context.account.account_id, at=rebase_at)
                 log.info("Branch graph rebased")
                 await _retire_agnostic_fields_of_base_deletions(
-                    db=dbt, node_uuids=base_deleted_node_uuids, at=rebase_at, log=log
+                    db=dbt,
+                    node_uuids=base_deleted_node_uuids,
+                    at=rebase_at,
+                    user_id=context.account.account_id,
+                    log=log,
                 )
 
             # Only update registry after txn commit. Otherwise, branch status and branched_from
@@ -491,6 +495,7 @@ async def _retire_agnostic_fields_of_base_deletions(
     db: InfrahubDatabase,
     node_uuids: list[str],
     at: Timestamp,
+    user_id: str,
     log: Logger | LoggerAdapter[Logger],
 ) -> None:
     """Re-evaluate branch-agnostic retention for the base-branch deletions this rebase absorbs.
@@ -504,6 +509,7 @@ async def _retire_agnostic_fields_of_base_deletions(
         db: The transaction the rebase itself runs in.
         node_uuids: The nodes the base-branch diff records as removed within the rebased window.
         at: The rebase timestamp; closed edges are stamped with it.
+        user_id: The account the rebase runs as, recorded on the edges the re-evaluation closes.
         log: The flow's run logger.
 
     """
@@ -512,7 +518,9 @@ async def _retire_agnostic_fields_of_base_deletions(
     log.info(f"Re-evaluating branch-agnostic retirement for {len(node_uuids)} deletions absorbed by the rebase")
     for batch_start in range(0, len(node_uuids), RETIREMENT_BATCH_SIZE):
         batch_uuids = node_uuids[batch_start : batch_start + RETIREMENT_BATCH_SIZE]
-        retirement_query = await RetireNodeAgnosticFieldsQuery.init(db=db, node_uuids=batch_uuids, at=at)
+        retirement_query = await RetireNodeAgnosticFieldsQuery.init(
+            db=db, node_uuids=batch_uuids, at=at, user_id=user_id
+        )
         await retirement_query.execute(db=db)
         retired = retirement_query.get_data()
         log.info(

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -16,7 +16,7 @@ from infrahub.core.branch.data_deleter import BranchDataDeleter
 from infrahub.core.branch.delete_coordinator import BranchDeleteOrchestrator
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
-from infrahub.core.constants import DiffAction, MutationAction
+from infrahub.core.constants import SYSTEM_USER_ID, DiffAction, MutationAction
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
 from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRoot, EnrichedDiffRootMetadata
@@ -148,6 +148,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
 
     medium_context = context.model_copy(update={"priority": WorkflowPriority.MEDIUM})
     low_context = context.model_copy(update={"priority": WorkflowPriority.LOW})
+    user_id = context.account.account_id or SYSTEM_USER_ID
 
     async with database.start_session() as db:
         log = get_run_logger()
@@ -244,13 +245,13 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                 pre_rebase_schema = registry.schema.get_schema_branch(name=user_branch.name).duplicate()
 
             async with db.start_transaction() as dbt:
-                await user_branch.rebase(db=dbt, user_id=context.account.account_id, at=rebase_at)
+                await user_branch.rebase(db=dbt, user_id=user_id, at=rebase_at)
                 log.info("Branch graph rebased")
                 await _retire_agnostic_fields_of_base_deletions(
                     db=dbt,
                     node_uuids=base_deleted_node_uuids,
                     at=rebase_at,
-                    user_id=context.account.account_id,
+                    user_id=user_id,
                     log=log,
                 )
 
@@ -283,7 +284,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
                     migrations=migrations,
                     update_db=False,
                     update_registry=True,
-                    user_id=context.account.account_id,
+                    user_id=user_id,
                     manage_rollback=True,
                 )
                 log.info("Migrations completed")

--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import SYSTEM_USER_ID, DiffAction
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.query.bulk_merge import (
     BulkMergeAttributePropertyEdgesQuery,
@@ -61,7 +61,7 @@ class DiffMerger:
         self.rollbacker = rollbacker
         self._merge_started = False
 
-    async def merge_graph(self, at: Timestamp) -> None:
+    async def merge_graph(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         tracking_id = BranchTrackingId(name=self.source_branch.name)
 
         log.info("Querying conflicted node UUIDs")
@@ -135,12 +135,14 @@ class DiffMerger:
             candidates=len(deleted_node_uuids),
         )
         if deleted_node_uuids:
-            await self._retire_agnostic_fields_of_deleted_nodes(node_uuids=deleted_node_uuids, at=at)
+            await self._retire_agnostic_fields_of_deleted_nodes(node_uuids=deleted_node_uuids, at=at, user_id=user_id)
 
         log.info("Graph merge complete")
 
     @retry_db_transaction(name="merge_retire_agnostic_fields")
-    async def _retire_agnostic_fields_of_deleted_nodes(self, node_uuids: list[str], at: Timestamp) -> None:
+    async def _retire_agnostic_fields_of_deleted_nodes(
+        self, node_uuids: list[str], at: Timestamp, user_id: str = SYSTEM_USER_ID
+    ) -> None:
         """Re-evaluate retention for the nodes whose deletion this merge carried to the destination.
 
         The merge itself is never the release trigger: the query re-runs the retention predicate over
@@ -150,7 +152,9 @@ class DiffMerger:
         """
         for i in range(0, len(node_uuids), self.metadata_batch_size):
             batch_uuids = node_uuids[i : i + self.metadata_batch_size]
-            retirement_query = await RetireNodeAgnosticFieldsQuery.init(db=self.db, node_uuids=batch_uuids, at=at)
+            retirement_query = await RetireNodeAgnosticFieldsQuery.init(
+                db=self.db, node_uuids=batch_uuids, at=at, user_id=user_id
+            )
             await retirement_query.execute(db=self.db)
             retired = retirement_query.get_data()
             log.info(

--- a/backend/infrahub/core/merge/graph_merger.py
+++ b/backend/infrahub/core/merge/graph_merger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.exceptions import (
     MergeConflictsUnresolvedError,
@@ -51,7 +52,7 @@ class GraphMerger:
         self.constraint_validator = constraint_validator
         self.log = logger or get_logger()
 
-    async def merge(self, at: Timestamp) -> None:
+    async def merge(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         """Merge the current branch into the default branch.
 
         Raises:
@@ -84,7 +85,7 @@ class GraphMerger:
             await self._validate_constraints()
 
             try:
-                await self.diff_merger.merge_graph(at=at)
+                await self.diff_merger.merge_graph(at=at, user_id=user_id)
             except Exception as exc:
                 # Rollback is handled outside of this class b/c there is more than just the graph changes to revert
                 self.log.exception("Graph merge failed")

--- a/backend/infrahub/core/merge/orchestrator.py
+++ b/backend/infrahub/core/merge/orchestrator.py
@@ -106,7 +106,7 @@ class BranchMergeOrchestrator:
             async with lock.registry.global_graph_lock():
                 self.log.info("Global graph lock acquired for merge")
                 await self._record_merge_start(merge_at=merge_at, user_id=user_id)
-                await self.graph_merger.merge(at=merge_at)
+                await self.graph_merger.merge(at=merge_at, user_id=user_id)
 
             self.log.info("Loading enriched diff for changelog collection")
             branch_diff = await self.diff_repository.get_one(

--- a/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m032_cleanup_orphaned_branch_relationships.py
@@ -87,7 +87,7 @@ class Migration032(ArbitraryMigration):
             deleter = BranchDataDeleter(db=db, batch_size=config.SETTINGS.database.query_size_limit)
             for branch_name in orphaned_branch_names:
                 log.info(f"Cleaning up branch '{branch_name}'...")
-                await deleter.delete_branch_data(branch_name=branch_name)
+                await deleter.delete_branch_data(branch_name=branch_name, user_id=migration_input.user_id)
                 log.info(f"Branch '{branch_name}' cleaned up.")
 
             log.info("Deleting orphaned relationships...")

--- a/backend/infrahub/core/migrations/graph/m075_finish_deleting_branches.py
+++ b/backend/infrahub/core/migrations/graph/m075_finish_deleting_branches.py
@@ -80,7 +80,7 @@ class Migration075(ArbitraryMigration):
             console.log(f"Cleaning up branch '{branch_name}' left in the DELETING state...")
             try:
                 branch = await Branch.get_by_name(db=db, name=branch_name, ignore_deleting=False)
-                delete_result = await deleter.delete(branch=branch)
+                delete_result = await deleter.delete(branch=branch, user_id=migration_input.user_id)
             except Exception as exc:
                 console.log(f"Branch '{branch_name}' could not be deleted: {exc}")
                 errors.append(f"branch '{branch_name}': {exc}")

--- a/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/migration.py
+++ b/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/migration.py
@@ -54,7 +54,7 @@ class Migration078(ArbitraryMigration):
         # Each pass runs whatever the one before it did, but only the repairs decide the outcome.
         try:
             close_query = await CloseUnretainedAgnosticFieldsQuery.init(
-                db=db, at=migration_input.at, batch_size=self.batch_size
+                db=db, at=migration_input.at, batch_size=self.batch_size, user_id=migration_input.user_id
             )
             await close_query.execute(db=db)
         except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
+++ b/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
@@ -101,8 +101,11 @@ CALL (field, retired_at) {
     SET edge_to_close.to = CASE
         WHEN edge_to_close.from > retired_at THEN edge_to_close.from
         ELSE retired_at
-    END
+    END,
+    edge_to_close.to_user_id = $user_id
+    RETURN count(edge_to_close) AS batch_closed_edges
 } IN TRANSACTIONS OF $batch_size ROWS
+RETURN sum(batch_closed_edges) AS edges_closed
 """
 )
 
@@ -144,12 +147,17 @@ class CloseUnretainedAgnosticFieldsQuery(Query):
         self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
         self.params["at"] = self.at.to_string()
         self.params["batch_size"] = self.batch_size
+        self.params["user_id"] = self.user_id
 
         self.add_to_query(_CLOSE_UNRETAINED_AGNOSTIC_FIELDS)
+        self.update_return_labels(["edges_closed"])
 
     def closed_edge_count(self) -> int:
         """How many global edges this run stamped shut. Zero means nothing was left to release."""
-        return sum(stat.properties_set or 0 for stat in self.stats.stats)
+        result = self.get_result()
+        if result is None:
+            return 0
+        return result.get_as_type("edges_closed", int)
 
 
 class DeleteDetachedAgnosticFieldsQuery(Query):

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1284,7 +1284,9 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         query = await NodeDeleteQuery.init(db=db, node=self, at=delete_at, user_id=user_id)
         await query.execute(db=db)
 
-        retirement_query = await RetireNodeAgnosticFieldsQuery.init(db=db, node_uuids=[self.get_id()], at=delete_at)
+        retirement_query = await RetireNodeAgnosticFieldsQuery.init(
+            db=db, node_uuids=[self.get_id()], at=delete_at, user_id=user_id
+        )
         await retirement_query.execute(db=db)
         retired = retirement_query.get_data()
         if retired.edges_closed:

--- a/backend/infrahub/core/query/agnostic_field_closure.py
+++ b/backend/infrahub/core/query/agnostic_field_closure.py
@@ -6,8 +6,8 @@ The candidates are handed in as a list of vertices.
 from infrahub.core.query.agnostic_retention import UNRETAINED_AGNOSTIC_FIELD_PREDICATE
 
 # Expects a list variable `agnostic_candidates` in scope holding the `:Attribute` / `:Relationship`
-# vertices, plus the `$global_branch_name` and `$at` parameters. It writes, but returns no rows,
-# so the composing query's own RETURN is left untouched.
+# vertices, plus the `$global_branch_name`, `$at` and `$user_id` parameters. It writes, but returns
+# no rows, so the composing query's own RETURN is left untouched.
 CLOSE_UNRETAINED_AGNOSTIC_FIELDS = """
 CALL (agnostic_candidates) {
     %(unretained_predicate)s
@@ -17,6 +17,6 @@ CALL (agnostic_candidates) {
     AND unread_edge.status = "active"
     AND unread_edge.from <= $at
     AND unread_edge.to IS NULL
-    SET unread_edge.to = $at
+    SET unread_edge.to = $at, unread_edge.to_user_id = $user_id
 }
 """ % {"unretained_predicate": UNRETAINED_AGNOSTIC_FIELD_PREDICATE}

--- a/backend/infrahub/core/query/branch_agnostic_retirement.py
+++ b/backend/infrahub/core/query/branch_agnostic_retirement.py
@@ -50,8 +50,10 @@ CALL (field) {
       AND edge_to_close.status = "active"
       AND edge_to_close.from <= $at
       AND edge_to_close.to IS NULL
-    SET edge_to_close.to = $at
+    SET edge_to_close.to = $at, edge_to_close.to_user_id = $user_id
+    RETURN count(edge_to_close) AS batch_closed_edges
 } IN TRANSACTIONS OF $batch_size ROWS
+RETURN sum(batch_closed_edges) AS edges_closed
 """
 
 
@@ -82,11 +84,16 @@ class RetireBranchAgnosticFieldsQuery(Query):
         self.params["branch_name"] = self.branch_name
         self.params["at"] = self.at.to_string()
         self.params["batch_size"] = self.batch_size
+        self.params["user_id"] = self.user_id
 
         self.add_to_query(
             _RETIRE_UNRETAINED_FIELDS_OF_BRANCH % {"unretained_predicate": UNRETAINED_AGNOSTIC_FIELD_PREDICATE}
         )
+        self.update_return_labels(["edges_closed"])
 
     def closed_edge_count(self) -> int:
         """How many global edges this run stamped shut. Zero means every field is still retained somewhere."""
-        return self.stats.get_counter("properties_set")
+        result = self.get_result()
+        if result is None:
+            return 0
+        return result.get_as_type("edges_closed", int)

--- a/backend/infrahub/core/query/node_agnostic_retirement.py
+++ b/backend/infrahub/core/query/node_agnostic_retirement.py
@@ -38,7 +38,7 @@ WHERE e.branch = $global_branch_name
   AND e.status = "active"
   AND e.from <= $at
   AND e.to IS NULL
-SET e.to = $at
+SET e.to = $at, e.to_user_id = $user_id
 RETURN count(e) AS edges_closed
 """ % {"unretained_predicate": UNRETAINED_AGNOSTIC_FIELD_PREDICATE}
 
@@ -64,6 +64,7 @@ class RetireNodeAgnosticFieldsQuery(Query):
         self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
         self.params["node_uuids"] = self.node_uuids
         self.params["at"] = self.at.to_string()
+        self.params["user_id"] = self.user_id
 
         self.add_to_query(_RETIRE_UNRETAINED_FIELDS_OF_NODES)
         self.update_return_labels(["edges_closed"])

--- a/backend/tests/component/core/agnostic_retirement/support.py
+++ b/backend/tests/component/core/agnostic_retirement/support.py
@@ -16,6 +16,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.query.branch_agnostic_retirement import RetireBranchAgnosticFieldsQuery
 from infrahub.core.query.node_agnostic_retirement import RetireNodeAgnosticFieldsQuery
 from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode
+from tests.helpers.agnostic_edges import TEST_ACTOR_ID
 
 if TYPE_CHECKING:
     from neo4j import Record
@@ -70,6 +71,8 @@ class FailingBranchRetirementDatabase(FailingRetirementDatabase):
     failing_query_name = RetireBranchAgnosticFieldsQuery.name
 
 
-async def delete_node(db: InfrahubDatabase, node_id: str, branch: Branch, at: Timestamp) -> None:
+async def delete_node(
+    db: InfrahubDatabase, node_id: str, branch: Branch, at: Timestamp, user_id: str = TEST_ACTOR_ID
+) -> None:
     to_delete = await NodeManager.get_one(db=db, id=node_id, branch=branch, raise_on_error=True)
-    await to_delete.delete(db=db, at=at)
+    await to_delete.delete(db=db, at=at, user_id=user_id)

--- a/backend/tests/component/core/agnostic_retirement/test_on_branch_delete.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_branch_delete.py
@@ -27,10 +27,10 @@ from tests.component.core.agnostic_retirement.support import (
     delete_node,
 )
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     assert_attribute_retired_at,
     assert_relationship_retired_at,
     attribute_global_edges,
-    closing_actors,
     create_widget,
     edge_summary,
     open_edge_types,
@@ -94,7 +94,7 @@ class TestAgnosticRetirementOnBranchDelete:
         ), "the branch still reads the object through its fork window, so the delete released nothing"
 
         lower_bound = Timestamp()
-        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch)
+        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch, user_id=TEST_ACTOR_ID)
         upper_bound = Timestamp()
         assert result.branch_deleted
 
@@ -110,8 +110,10 @@ class TestAgnosticRetirementOnBranchDelete:
             "the close carries the branch deletion's own time"
         )
         retired_at = Timestamp(stamp)
-        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=retired_at)
-        assert_relationship_retired_at(after=relationship_after, before=relationship_before, at=retired_at)
+        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=retired_at, by=TEST_ACTOR_ID)
+        assert_relationship_retired_at(
+            after=relationship_after, before=relationship_before, at=retired_at, by=TEST_ACTOR_ID
+        )
 
     async def test_deleting_a_branch_releases_nothing_while_another_branch_retains_the_object(
         self,
@@ -132,7 +134,7 @@ class TestAgnosticRetirementOnBranchDelete:
         assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
 
         await delete_node(db=db, node_id=widget.id, branch=default_branch, at=Timestamp())
-        await BranchDataDeleter(db=db, batch_size=5).delete(branch=doomed)
+        await BranchDataDeleter(db=db, batch_size=5).delete(branch=doomed, user_id=TEST_ACTOR_ID)
 
         assert edge_summary(await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")) == (
             edge_summary(before)
@@ -141,33 +143,11 @@ class TestAgnosticRetirementOnBranchDelete:
         assert on_retainer is not None
         assert on_retainer.get_attribute(name="serial").value == 3200
 
-        await BranchDataDeleter(db=db, batch_size=5).delete(branch=retainer)
+        await BranchDataDeleter(db=db, batch_size=5).delete(branch=retainer, user_id=TEST_ACTOR_ID)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
         assert open_edges(after) == [], "the last retainer's deletion released it"
         assert {edge.status for edge in after} == {"active"}
-
-    async def test_the_release_records_the_account_that_deleted_the_branch(
-        self,
-        db: InfrahubDatabase,
-        default_branch: Branch,
-        agnostic_schema: None,
-    ) -> None:
-        """A branch delete's release is attributed to whoever asked for the delete."""
-        actor_id = "17ce4c8a-6bf1-4b5f-9ec0-5cf6a9d4d1a2"
-        widget = await create_widget(db=db, branch=default_branch, name="released-by-a-named-account", serial=3400)
-        branch = await create_branch(db=db, branch_name="deleted-by-a-named-account")
-
-        await delete_node(db=db, node_id=widget.id, branch=default_branch, at=Timestamp())
-        after_node_delete = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert open_edges(after_node_delete) != [], "the branch still reads the object, so nothing is closed yet"
-
-        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch, user_id=actor_id)
-        assert result.branch_deleted
-
-        after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert open_edges(after) == [], "the last retainer's deletion released it"
-        assert closing_actors(after) == {actor_id}, "every edge the branch delete closed names the deleting account"
 
     async def test_a_retirement_failure_fails_the_branch_delete(
         self,
@@ -199,7 +179,7 @@ class TestAgnosticRetirementOnBranchDelete:
             edge_summary(before)
         ), "the failed run closed nothing"
 
-        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch)
+        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch, user_id=TEST_ACTOR_ID)
         assert result.branch_deleted
         assert await self._branch_vertex_count(db=db, branch_name=branch.name) == 0
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")

--- a/backend/tests/component/core/agnostic_retirement/test_on_branch_delete.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_branch_delete.py
@@ -30,6 +30,7 @@ from tests.helpers.agnostic_edges import (
     assert_attribute_retired_at,
     assert_relationship_retired_at,
     attribute_global_edges,
+    closing_actors,
     create_widget,
     edge_summary,
     open_edge_types,
@@ -145,6 +146,28 @@ class TestAgnosticRetirementOnBranchDelete:
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
         assert open_edges(after) == [], "the last retainer's deletion released it"
         assert {edge.status for edge in after} == {"active"}
+
+    async def test_the_release_records_the_account_that_deleted_the_branch(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        agnostic_schema: None,
+    ) -> None:
+        """A branch delete's release is attributed to whoever asked for the delete."""
+        actor_id = "17ce4c8a-6bf1-4b5f-9ec0-5cf6a9d4d1a2"
+        widget = await create_widget(db=db, branch=default_branch, name="released-by-a-named-account", serial=3400)
+        branch = await create_branch(db=db, branch_name="deleted-by-a-named-account")
+
+        await delete_node(db=db, node_id=widget.id, branch=default_branch, at=Timestamp())
+        after_node_delete = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
+        assert open_edges(after_node_delete) != [], "the branch still reads the object, so nothing is closed yet"
+
+        result = await BranchDataDeleter(db=db, batch_size=5).delete(branch=branch, user_id=actor_id)
+        assert result.branch_deleted
+
+        after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
+        assert open_edges(after) == [], "the last retainer's deletion released it"
+        assert closing_actors(after) == {actor_id}, "every edge the branch delete closed names the deleting account"
 
     async def test_a_retirement_failure_fails_the_branch_delete(
         self,

--- a/backend/tests/component/core/agnostic_retirement/test_on_merge.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_merge.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 from tests.component.core.agnostic_retirement.support import delete_node
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     assert_attribute_retired_at,
     assert_relationship_retired_at,
     attribute_global_edges,
@@ -60,7 +61,7 @@ async def _merge_branch(db: InfrahubDatabase, default_branch: Branch, branch: Br
     await _update_branch_diff(db=db, default_branch=default_branch, branch=branch)
     component_registry = get_component_registry()
     diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
-    await diff_merger.merge_graph(at=at)
+    await diff_merger.merge_graph(at=at, user_id=TEST_ACTOR_ID)
 
 
 class TestAgnosticRetirementOnMerge:
@@ -116,11 +117,13 @@ class TestAgnosticRetirementOnMerge:
             "the merge carried the deletion to the default branch"
         )
         attribute_after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=merged_at)
+        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=merged_at, by=TEST_ACTOR_ID)
         relationship_after = await relationship_global_edges(
             db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER
         )
-        assert_relationship_retired_at(after=relationship_after, before=relationship_before, at=merged_at)
+        assert_relationship_retired_at(
+            after=relationship_after, before=relationship_before, at=merged_at, by=TEST_ACTOR_ID
+        )
 
     async def test_merging_the_deletion_releases_nothing_while_another_branch_retains_the_object(
         self,
@@ -184,7 +187,7 @@ class TestAgnosticRetirementOnMerge:
         assert await NodeManager.get_one(db=db, id=unretained.id, branch=default_branch) is None
 
         unretained_after = await attribute_global_edges(db=db, node_id=unretained.id, attribute_name="serial")
-        assert_attribute_retired_at(after=unretained_after, before=unretained_before, at=merged_at)
+        assert_attribute_retired_at(after=unretained_after, before=unretained_before, at=merged_at, by=TEST_ACTOR_ID)
         assert edge_summary(await attribute_global_edges(db=db, node_id=retained.id, attribute_name="serial")) == (
             edge_summary(retained_before)
         ), "its neighbor's release must not drag the retained node's fields shut with it"

--- a/backend/tests/component/core/agnostic_retirement/test_on_node_delete.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_node_delete.py
@@ -29,6 +29,7 @@ from tests.component.core.agnostic_retirement.support import (
     delete_node,
 )
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     assert_attribute_retired_at,
     assert_relationship_retired_at,
     attribute_global_edges,
@@ -109,7 +110,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=branch, at=deleted_at)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+        assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     async def test_a_field_stays_open_while_the_default_branch_still_holds_the_object(
         self,
@@ -148,7 +149,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+        assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     async def test_a_field_stays_open_for_a_branch_that_forked_between_creation_and_deletion(
         self,
@@ -202,7 +203,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=second, at=last_delete)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=last_delete)
+        assert_attribute_retired_at(after=after, before=before, at=last_delete, by=TEST_ACTOR_ID)
 
     async def test_an_attribute_that_accumulated_value_edges_is_closed_edge_for_edge(
         self,
@@ -232,7 +233,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+        assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     async def test_a_repointed_relationship_is_closed_edge_for_edge(
         self,
@@ -273,7 +274,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
 
         after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
-        assert_relationship_retired_at(after=after, before=before, at=deleted_at)
+        assert_relationship_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     async def test_a_relationship_is_closed_when_its_peers_are_live_on_different_branches(
         self,
@@ -309,7 +310,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=gadget.id, branch=default_branch, at=last_delete)
 
         after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
-        assert_relationship_retired_at(after=after, before=before, at=last_delete)
+        assert_relationship_retired_at(after=after, before=before, at=last_delete, by=TEST_ACTOR_ID)
 
     async def test_a_field_removed_on_the_only_retaining_branch_is_closed_with_the_object(
         self,
@@ -331,7 +332,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
 
         after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+        assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
         owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name="serial")
         assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == [
@@ -365,7 +366,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=gadget.id, branch=default_branch, at=deleted_at)
 
         after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
-        assert_relationship_retired_at(after=after, before=before, at=deleted_at)
+        assert_relationship_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     async def test_a_retirement_failure_propagates_and_leaves_the_graph_untouched(
         self,
@@ -425,7 +426,7 @@ class TestAgnosticRetirementOnDelete:
         await delete_node(db=db, node_id=holder.id, branch=default_branch, at=deleted_at)
 
         after = await attribute_global_edges(db=db, node_id=holder.id, attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+        assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
         assert await pool_reservation_edges(db=db, pool_id=serial_pool.id, identifier=holder.id) == reserved_before, (
             "the reservation is never cleaned up on delete, and does not need to be"
         )

--- a/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
@@ -9,7 +9,6 @@ through the real rebase flow, because that transaction is where the point lives.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import pytest
 
@@ -40,6 +39,7 @@ from tests.component.core.agnostic_retirement.support import (
     delete_node,
 )
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     assert_attribute_retired_at,
     assert_relationship_retired_at,
     attribute_global_edges,
@@ -72,7 +72,7 @@ async def _rebase_branch(
     lock.initialize_lock(local_only=True)
     context = InfrahubContext.init(
         branch=default_branch,
-        account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+        account=AccountSession(account_id=TEST_ACTOR_ID, auth_type=AuthType.NONE),
     )
     with (
         dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
@@ -142,11 +142,13 @@ class TestAgnosticRetirementOnRebase:
             "the rebase carried the deletion into the branch's view"
         )
         attribute_after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name="serial")
-        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=rebase_at)
+        assert_attribute_retired_at(after=attribute_after, before=attribute_before, at=rebase_at, by=TEST_ACTOR_ID)
         relationship_after = await relationship_global_edges(
             db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER
         )
-        assert_relationship_retired_at(after=relationship_after, before=relationship_before, at=rebase_at)
+        assert_relationship_retired_at(
+            after=relationship_after, before=relationship_before, at=rebase_at, by=TEST_ACTOR_ID
+        )
 
     async def test_rebasing_releases_nothing_while_another_branch_retains_the_object(
         self,

--- a/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
+++ b/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
@@ -16,6 +16,7 @@ from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.migrations.graph.m078_retire_agnostic_property_edges import Migration078
 from infrahub.core.migrations.shared import MigrationInput, MigrationResult
+from tests.helpers.agnostic_edges import TEST_ACTOR_ID
 from tests.helpers.schema.agnostic_retirement import AGNOSTIC_RETIREMENT_SCHEMA
 
 if TYPE_CHECKING:
@@ -42,10 +43,10 @@ async def agnostic_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
     registry.schema.register_schema(schema=AGNOSTIC_RETIREMENT_SCHEMA, branch=default_branch.name)
 
 
-async def run_migration(db: InfrahubDatabase) -> MigrationRun:
+async def run_migration(db: InfrahubDatabase, user_id: str = TEST_ACTOR_ID) -> MigrationRun:
     console = Console(record=True, width=250)
     migration = Migration078()
-    migration_input = MigrationInput(db=db, console=console)
+    migration_input = MigrationInput(db=db, console=console, user_id=user_id)
     result = await migration.execute(migration_input=migration_input)
     validation = await migration.validate_migration(db=db)
     assert not validation.errors

--- a/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/test_retention.py
+++ b/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/test_retention.py
@@ -18,7 +18,9 @@ from tests.component.core.migrations.graph.m078_retire_agnostic_property_edges.c
     run_migration,
 )
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     attribute_global_edges,
+    closing_actors,
     create_gadget,
     create_widget,
     edge_summary,
@@ -82,3 +84,5 @@ async def test_a_branch_forked_before_the_deletion_keeps_the_value_reserved(
     assert open_edges(relationship_after) == []
     assert to_times(attribute_after) == {gone_at.to_string()}
     assert to_times(relationship_after) == {gone_at.to_string()}
+    assert closing_actors(attribute_after) == {TEST_ACTOR_ID}, "the release names the account the run was given"
+    assert closing_actors(relationship_after) == {TEST_ACTOR_ID}

--- a/backend/tests/component/core/migrations/graph/test_075_finish_deleting_branches.py
+++ b/backend/tests/component/core/migrations/graph/test_075_finish_deleting_branches.py
@@ -3,6 +3,7 @@ import pytest
 from infrahub.core.branch.data_deleter import BranchDataDeleter, BranchDataDeleterInterface, BranchDeleteResult
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.branch.models import Branch
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m075_finish_deleting_branches import Migration075
@@ -24,11 +25,11 @@ class FailingBranchDeleter:
         self.failing_branch_name = failing_branch_name
         self.attempted: list[str] = []
 
-    async def delete(self, branch: Branch) -> BranchDeleteResult:
+    async def delete(self, branch: Branch, user_id: str = SYSTEM_USER_ID) -> BranchDeleteResult:
         self.attempted.append(branch.name)
         if branch.name == self.failing_branch_name:
             raise ValueError("FAILED")
-        return await self.deleter.delete(branch=branch)
+        return await self.deleter.delete(branch=branch, user_id=user_id)
 
 
 class Migration075WithFailingDeleter(Migration075):

--- a/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
+++ b/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from infrahub.core import registry
-from infrahub.core.constants import GLOBAL_BRANCH_NAME, SYSTEM_USER_ID, HashableModelState, SchemaPathType
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, HashableModelState, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.schema.node_attribute_remove import NodeAttributeRemoveMigration
@@ -31,6 +31,7 @@ from infrahub.core.rollback import GraphRollbacker
 from infrahub.core.timestamp import Timestamp
 from infrahub.database.validation import verify_graph
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     VertexMetadata,
     assert_attribute_retired_at,
     assert_relationship_retired_at,
@@ -92,7 +93,7 @@ async def _create_gadget(db: InfrahubDatabase, branch: Branch, name: str) -> Nod
 
 async def _delete(db: InfrahubDatabase, node_id: str, branch: Branch, at: Timestamp) -> None:
     to_delete = await NodeManager.get_one(db=db, id=node_id, branch=branch, raise_on_error=True)
-    await to_delete.delete(db=db, at=at)
+    await to_delete.delete(db=db, at=at, user_id=TEST_ACTOR_ID)
 
 
 async def _remove_attribute_from_schema(
@@ -101,6 +102,7 @@ async def _remove_attribute_from_schema(
     at: Timestamp,
     kind: str = WIDGET_KIND,
     attribute_name: str = ATTRIBUTE_NAME,
+    user_id: str = TEST_ACTOR_ID,
 ) -> MigrationResult:
     """Run the attribute-removal migration for a branch-agnostic attribute on `branch`."""
     schema_branch = registry.schema.get_schema_branch(name=branch.name)
@@ -117,7 +119,7 @@ async def _remove_attribute_from_schema(
         new_node_schema=node_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=kind, field_name=attribute_name),
     )
-    return await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=branch)
+    return await migration.execute(migration_input=MigrationInput(db=db, at=at, user_id=user_id), branch=branch)
 
 
 async def _create_beacon(db: InfrahubDatabase, branch: Branch, name: str, serial: int) -> Node:
@@ -127,7 +129,9 @@ async def _create_beacon(db: InfrahubDatabase, branch: Branch, name: str, serial
     return beacon
 
 
-async def _remove_relationship_from_schema(db: InfrahubDatabase, branch: Branch, at: Timestamp) -> MigrationResult:
+async def _remove_relationship_from_schema(
+    db: InfrahubDatabase, branch: Branch, at: Timestamp, user_id: str = TEST_ACTOR_ID
+) -> MigrationResult:
     """Run the relationship-removal migration for the widget's branch-agnostic relationship on `branch`.
 
     Both sides of the identifier are dropped from the registered schema first, which is what the schema
@@ -152,7 +156,7 @@ async def _remove_relationship_from_schema(db: InfrahubDatabase, branch: Branch,
             path_type=SchemaPathType.RELATIONSHIP, schema_kind=WIDGET_KIND, field_name=RELATIONSHIP_NAME
         ),
     )
-    return await migration.execute(migration_input=MigrationInput(db=db, at=at), branch=branch)
+    return await migration.execute(migration_input=MigrationInput(db=db, at=at, user_id=user_id), branch=branch)
 
 
 async def test_an_attribute_removed_from_the_schema_is_closed_when_no_branch_declares_it(
@@ -170,7 +174,7 @@ async def test_an_attribute_removed_from_the_schema_is_closed_when_no_branch_dec
     assert result.nbr_migrations_executed == 1
 
     after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
-    assert_attribute_retired_at(after=after, before=before, at=removed_at)
+    assert_attribute_retired_at(after=after, before=before, at=removed_at, by=TEST_ACTOR_ID)
 
     owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == [
@@ -195,7 +199,7 @@ async def test_a_relationship_removed_from_the_schema_is_closed_when_no_branch_d
     assert result.nbr_migrations_executed == 1
 
     after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
-    assert_relationship_retired_at(after=after, before=before, at=removed_at)
+    assert_relationship_retired_at(after=after, before=before, at=removed_at, by=TEST_ACTOR_ID)
     assert await NodeManager.get_one(db=db, id=gadget.id, branch=default_branch) is not None, (
         "the peer object is untouched; only the relationship between the two was released"
     )
@@ -283,7 +287,7 @@ async def test_one_removal_closes_only_the_objects_the_fork_cannot_reach(
     assert to_times(retained_after) == {None}
 
     retired_after = await attribute_global_edges(db=db, node_id=retired.id, attribute_name=ATTRIBUTE_NAME)
-    assert_attribute_retired_at(after=retired_after, before=retired_before, at=removed_at)
+    assert_attribute_retired_at(after=retired_after, before=retired_before, at=removed_at, by=TEST_ACTOR_ID)
 
     on_branch = await NodeManager.get_one(db=db, id=retained.id, branch=branch)
     assert on_branch is not None
@@ -331,7 +335,7 @@ async def test_a_relationship_is_closed_when_the_only_fork_reads_one_of_its_peer
     assert result.nbr_migrations_executed == 1
 
     after = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
-    assert_relationship_retired_at(after=after, before=before, at=removed_at)
+    assert_relationship_retired_at(after=after, before=before, at=removed_at, by=TEST_ACTOR_ID)
 
 
 async def test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_deleted_elsewhere(
@@ -359,7 +363,7 @@ async def test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_delet
     await _delete(db=db, node_id=widget.id, branch=default_branch, at=deleted_at)
 
     after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
-    assert_attribute_retired_at(after=after, before=before, at=deleted_at)
+    assert_attribute_retired_at(after=after, before=before, at=deleted_at, by=TEST_ACTOR_ID)
 
     owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == sorted(
@@ -400,7 +404,7 @@ async def test_an_attribute_removed_from_the_schema_is_closed_when_the_only_fork
     assert result.nbr_migrations_executed == 1
 
     after = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
-    assert_attribute_retired_at(after=after, before=before, at=removed_at)
+    assert_attribute_retired_at(after=after, before=before, at=removed_at, by=TEST_ACTOR_ID)
 
     owning_edges = await attribute_owning_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert sorted((edge.branch, edge.status, edge.to_time or "") for edge in owning_edges) == sorted(
@@ -439,7 +443,7 @@ async def test_an_attribute_of_a_branch_agnostic_kind_is_closed_when_no_branch_d
     assert result.nbr_migrations_executed == 1
 
     after = await attribute_global_edges(db=db, node_id=beacon.id, attribute_name=ATTRIBUTE_NAME)
-    assert_attribute_retired_at(after=after, before=before, at=removed_at)
+    assert_attribute_retired_at(after=after, before=before, at=removed_at, by=TEST_ACTOR_ID)
 
 
 async def test_an_attribute_of_a_branch_agnostic_kind_stays_open_for_a_branch_that_forked_before(
@@ -488,7 +492,7 @@ async def test_removing_an_attribute_stamps_the_removal_time_on_its_vertex(
 
     after = await attribute_metadata(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert after.updated_at == removed_at.to_string(), "the attribute vertex carries the removal time"
-    assert after.updated_by == SYSTEM_USER_ID
+    assert after.updated_by == TEST_ACTOR_ID, "the vertex stamp names the account the removal ran as"
     assert after.previous_updated_at == before.updated_at, "the pre-removal stamp is kept for a rollback"
     assert after.previous_updated_by == before.updated_by
 
@@ -519,7 +523,7 @@ async def test_removing_a_relationship_stamps_the_removal_time_on_its_vertex(
 
     after = await relationship_metadata(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
     assert after.updated_at == removed_at.to_string(), "the relationship vertex carries the removal time"
-    assert after.updated_by == SYSTEM_USER_ID
+    assert after.updated_by == TEST_ACTOR_ID, "the vertex stamp names the account the removal ran as"
     assert after.previous_updated_at == before.updated_at, "the pre-removal stamp is kept for a rollback"
     assert after.previous_updated_by == before.updated_by
 

--- a/backend/tests/component/query/test_node_agnostic_retirement_query.py
+++ b/backend/tests/component/query/test_node_agnostic_retirement_query.py
@@ -29,6 +29,7 @@ from infrahub.core.query.node_agnostic_retirement import (
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from tests.helpers.agnostic_edges import (
+    TEST_ACTOR_ID,
     assert_attribute_retired_at,
     attribute_global_edges,
     attribute_vertex_count,
@@ -70,8 +71,10 @@ async def _rename_widget_kind(db: InfrahubDatabase, branch: Branch) -> None:
     await query.execute(db=db)
 
 
-async def _retire(db: InfrahubDatabase, node_id: str, at: Timestamp) -> NodeAgnosticRetirementResult:
-    query = await RetireNodeAgnosticFieldsQuery.init(db=db, node_uuids=[node_id], at=at)
+async def _retire(
+    db: InfrahubDatabase, node_id: str, at: Timestamp, user_id: str = TEST_ACTOR_ID
+) -> NodeAgnosticRetirementResult:
+    query = await RetireNodeAgnosticFieldsQuery.init(db=db, node_uuids=[node_id], at=at, user_id=user_id)
     await query.execute(db=db)
     return query.get_data()
 
@@ -204,7 +207,7 @@ class TestRetireNodeAgnosticFields:
         )
 
         after = await attribute_global_edges(db=db, node_id=widget.get_id(), attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=retired_at)
+        assert_attribute_retired_at(after=after, before=before, at=retired_at, by=TEST_ACTOR_ID)
 
     async def test_a_relationship_stays_open_while_both_peers_are_live_on_one_branch(
         self,
@@ -261,7 +264,7 @@ class TestRetireNodeAgnosticFields:
         )
 
         after = await attribute_global_edges(db=db, node_id=widget.get_id(), attribute_name="serial")
-        assert_attribute_retired_at(after=after, before=before, at=at)
+        assert_attribute_retired_at(after=after, before=before, at=at, by=TEST_ACTOR_ID)
 
     async def test_a_partially_closed_relationship_is_retired(
         self,

--- a/backend/tests/helpers/agnostic_edges.py
+++ b/backend/tests/helpers/agnostic_edges.py
@@ -48,6 +48,8 @@ class EdgeState:
     status: str
     from_time: str
     to_time: str | None
+    to_user_id: str | None = None
+    """Who closed the edge. `None` on an open edge, and on one closed before the actor was recorded."""
 
     @property
     def is_open(self) -> bool:
@@ -101,6 +103,15 @@ def to_times(edges: list[EdgeState]) -> set[str | None]:
     return {edge.to_time for edge in edges}
 
 
+def closing_actors(edges: list[EdgeState]) -> set[str | None]:
+    """The distinct actors recorded on the closed edges, for asserting who a release is attributed to.
+
+    Open edges are left out: they carry no actor, and including them would let a run that closed
+    nothing satisfy an assertion about who closed what.
+    """
+    return {edge.to_user_id for edge in edges if not edge.is_open}
+
+
 def expected_closed_at(edges: list[EdgeState], at: Timestamp) -> list[tuple[str, str, str]]:
     """What `edge_summary` should return once every open edge has been closed at `at`.
 
@@ -135,7 +146,7 @@ async def attribute_global_edges(db: InfrahubDatabase, node_id: str, attribute_n
         MATCH (a)-[e]-()
         WHERE e.branch = $global_branch
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"node_id": node_id, "attribute_name": attribute_name, "global_branch": GLOBAL_BRANCH_NAME},
     )
@@ -156,7 +167,7 @@ async def relationship_global_edges(db: InfrahubDatabase, node_id: str, identifi
         MATCH (r)-[e]-()
         WHERE e.branch = $global_branch
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"node_id": node_id, "identifier": identifier, "global_branch": GLOBAL_BRANCH_NAME},
     )
@@ -187,7 +198,7 @@ async def global_edges_by_vertex_uuid(db: InfrahubDatabase, vertex_uuid: str) ->
         MATCH (v)-[e]-()
         WHERE e.branch = $global_branch
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"vertex_uuid": vertex_uuid, "global_branch": GLOBAL_BRANCH_NAME},
     )
@@ -202,7 +213,7 @@ async def attribute_owning_edges(db: InfrahubDatabase, node_id: str, attribute_n
         WITH DISTINCT a
         MATCH (:Node)-[e:HAS_ATTRIBUTE]->(a)
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"node_id": node_id, "attribute_name": attribute_name},
     )
@@ -215,7 +226,7 @@ async def existence_edges(db: InfrahubDatabase, node_id: str) -> list[EdgeState]
         query="""
         MATCH (n:Node {uuid: $node_id})-[e:IS_PART_OF]->(:Root)
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"node_id": node_id},
     )
@@ -360,7 +371,7 @@ async def pool_reservation_edges(db: InfrahubDatabase, pool_id: str, identifier:
         query="""
         MATCH (:Node {uuid: $pool_id})-[e:IS_RESERVED {identifier: $identifier}]->(:AttributeValue)
         RETURN type(e) AS edge_type, e.branch AS branch, e.status AS status,
-               e.from AS from_time, e.to AS to_time
+               e.from AS from_time, e.to AS to_time, e.to_user_id AS to_user_id
         """,
         params={"pool_id": pool_id, "identifier": identifier},
     )

--- a/backend/tests/helpers/agnostic_edges.py
+++ b/backend/tests/helpers/agnostic_edges.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
+TEST_ACTOR_ID = "17ce4c8a-6bf1-4b5f-9ec0-5cf6a9d4d1a2"
+"""A named account to drive an operation as, so a release attributed to nobody is distinguishable."""
+
 
 async def create_widget(
     db: InfrahubDatabase, branch: Branch, name: str, serial: int, at: Timestamp | None = None, **kwargs: Any
@@ -112,6 +115,15 @@ def closing_actors(edges: list[EdgeState]) -> set[str | None]:
     return {edge.to_user_id for edge in edges if not edge.is_open}
 
 
+def actors_closing_at(edges: list[EdgeState], at: Timestamp) -> set[str | None]:
+    """The actors recorded on the edges closed at `at`, isolating one operation's own closes.
+
+    A vertex can hold edges an earlier operation already closed, and those carry that operation's
+    actor; scoping by the stamp keeps them out of an assertion about this one.
+    """
+    return {edge.to_user_id for edge in edges if edge.to_time == at.to_string()}
+
+
 def expected_closed_at(edges: list[EdgeState], at: Timestamp) -> list[tuple[str, str, str]]:
     """What `edge_summary` should return once every open edge has been closed at `at`.
 
@@ -121,13 +133,14 @@ def expected_closed_at(edges: list[EdgeState], at: Timestamp) -> list[tuple[str,
     return sorted((edge.edge_type, edge.status, edge.to_time or at.to_string()) for edge in edges)
 
 
-def assert_attribute_retired_at(after: list[EdgeState], before: list[EdgeState], at: Timestamp) -> None:
-    """The attribute's global edges were time-closed at `at`, never tombstoned."""
+def assert_attribute_retired_at(after: list[EdgeState], before: list[EdgeState], at: Timestamp, by: str) -> None:
+    """The attribute's global edges were time-closed at `at` by `by`, never tombstoned."""
     assert edge_summary(after) == expected_closed_at(before, at)
     assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+    assert actors_closing_at(after, at) == {by}, "a release records the account it is attributed to"
 
 
-def assert_relationship_retired_at(after: list[EdgeState], before: list[EdgeState], at: Timestamp) -> None:
+def assert_relationship_retired_at(after: list[EdgeState], before: list[EdgeState], at: Timestamp, by: str) -> None:
     """No branch reads both peers live once the operation lands, so every open peer edge closes at `at`.
 
     Compared edge by edge against `before`: a peer update leaves a superseded relationship vertex
@@ -135,6 +148,7 @@ def assert_relationship_retired_at(after: list[EdgeState], before: list[EdgeStat
     """
     assert edge_summary(after) == expected_closed_at(before, at)
     assert {edge.status for edge in after} == {"active"}, "retirement is a time-close, never a status tombstone"
+    assert actors_closing_at(after, at) == {by}, "a release records the account it is attributed to"
 
 
 async def attribute_global_edges(db: InfrahubDatabase, node_id: str, attribute_name: str) -> list[EdgeState]:

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -72,8 +72,8 @@ class BrokenGraphMerger:
     async def merge(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         await self.real_merger.merge(at=at)
 
-    async def merge_graph(self, at: Timestamp) -> Never:
-        await self.real_merge_graph(at=at)
+    async def merge_graph(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
+        await self.real_merge_graph(at=at, user_id=user_id)
         raise ValueError("This is broken on purpose")
 
 

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -7,6 +7,7 @@ import pytest
 from infrahub_sdk.exceptions import GraphQLError
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.merge.graph_merger import GraphMerger
@@ -68,7 +69,7 @@ class BrokenGraphMerger:
         self.real_merge_graph = self.real_merger.diff_merger.merge_graph
         self.real_merger.diff_merger.merge_graph = self.merge_graph  # type: ignore
 
-    async def merge(self, at: Timestamp) -> None:
+    async def merge(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         await self.real_merger.merge(at=at)
 
     async def merge_graph(self, at: Timestamp) -> Never:
@@ -83,7 +84,7 @@ class MidMergeFailureGraphMerger:
         self.real_merger = GraphMerger(*args, **kwargs)
         self.real_merger.diff_merger._bulk_merge_relationship_property_edges = self._fail_bulk_merge  # type: ignore
 
-    async def merge(self, at: Timestamp) -> None:
+    async def merge(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         await self.real_merger.merge(at=at)
 
     async def _fail_bulk_merge(self, at: Timestamp, plan: MergeExclusionPlan) -> Never:

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -13,7 +13,7 @@ from infrahub_sdk.context import ContextAccount, RequestContext
 from infrahub_sdk.exceptions import GraphQLError
 from infrahub_sdk.protocols import CoreDataCheck, CoreProposedChange
 
-from infrahub.core.constants import InfrahubKind, ValidatorConclusion
+from infrahub.core.constants import SYSTEM_USER_ID, InfrahubKind, ValidatorConclusion
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_account, create_branch
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 
 class ErroringGraphMerger(GraphMerger):
-    async def merge(self, at: Timestamp) -> None:
+    async def merge(self, at: Timestamp, user_id: str = SYSTEM_USER_ID) -> None:
         raise ValueError("This will always fail")
 
 

--- a/backend/tests/unit/core/branch/test_delete_coordinator.py
+++ b/backend/tests/unit/core/branch/test_delete_coordinator.py
@@ -8,7 +8,7 @@ from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.branch.data_deleter import BranchDeleteResult
 from infrahub.core.branch.delete_coordinator import BranchDeleteOrchestrator
-from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, SYSTEM_USER_ID
 from infrahub.events.branch_action import BranchDeletedEvent
 from infrahub.workflows.catalogue import BRANCH_CANCEL_PROPOSED_CHANGES, GIT_REPOSITORIES_DELETE_BRANCH
 from tests.adapters.event import MemoryInfrahubEvent
@@ -17,14 +17,16 @@ from tests.adapters.workflow import WorkflowRecorder
 
 
 class RecordingDataDeleter:
-    """Reports a fixed outcome and remembers which branches it was asked to delete."""
+    """Reports a fixed outcome and remembers which branches it was asked to delete, and on whose behalf."""
 
     def __init__(self, result: BranchDeleteResult) -> None:
         self.result = result
         self.deleted: list[str] = []
+        self.actors: list[str] = []
 
-    async def delete(self, branch: Branch) -> BranchDeleteResult:
+    async def delete(self, branch: Branch, user_id: str = SYSTEM_USER_ID) -> BranchDeleteResult:
         self.deleted.append(branch.name)
+        self.actors.append(user_id)
         return self.result
 
 
@@ -97,6 +99,16 @@ async def test_delete_runs_post_delete_work(context: InfrahubContext) -> None:
     assert [call["parameters"] for call in workflow.get_submit_calls_for(GIT_REPOSITORIES_DELETE_BRANCH)] == [
         {"branch": branch.name}
     ]
+
+
+async def test_delete_names_the_requesting_account_to_the_data_deleter(context: InfrahubContext) -> None:
+    """The delete's actor comes from the request context, so the edges it closes name a real account."""
+    orchestrator, data_deleter, _, _, _, _ = _build(branch_deleted=True)
+
+    await orchestrator.delete(branch=_branch(), context=context)
+
+    assert data_deleter.actors == [context.account.account_id]
+    assert data_deleter.actors != [SYSTEM_USER_ID]
 
 
 async def test_delete_skips_post_delete_work_when_another_attempt_won(context: InfrahubContext) -> None:


### PR DESCRIPTION
the queries to close global edges when deleting an aware object that includes agnostic fields did not account for setting the `to_user_id` on the closed edges.

this PR adds that

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

