### PR TITLE
fix(backend): account for changes on default branch schema during merge

### DIFF
--- a/backend/infrahub/core/merge/graph_merger.py
+++ b/backend/infrahub/core/merge/graph_merger.py
@@ -115,11 +115,10 @@ class GraphMerger:
 
         """
         candidate_schema = self.schema_analyzer.get_candidate_schema()
-        # Gate on the freshly-recomputed diff (same check the migration calculation uses) rather than
-        # the branch's cached schema-hash flag, so a schema change is never missed at merge time.
+        # Run constraint validations if the schemas of the two branches differ
         schema_diff_constraints = (
             await self.schema_analyzer.calculate_validations(target_schema=candidate_schema)
-            if await self.schema_analyzer.has_schema_changes()
+            if self.schema_analyzer.schemas_differ()
             else []
         )
         result = await self.constraint_validator.validate(

--- a/backend/infrahub/core/merge/schema_analyzer.py
+++ b/backend/infrahub/core/merge/schema_analyzer.py
@@ -79,6 +79,15 @@ class MergeSchemaAnalyzer:
 
         return self._common_ancestor_schema
 
+    def schemas_differ(self) -> bool:
+        """Whether the two branches hold different schemas.
+
+        Symmetric, so a change made on the destination after the fork counts. A branch keeps the
+        schema it forked with until it is rebased, so its hash only matches the destination's when
+        neither side has moved or both have converged on the same state.
+        """
+        return self.source_schema.get_hash() != self.destination_schema.get_hash()
+
     async def has_schema_changes(self) -> bool:
         diff_summary = await self.diff_repository.summary(
             base_branch_name=self.destination_branch.name,

--- a/backend/tests/integration/schema_lifecycle/test_destination_schema_change.py
+++ b/backend/tests/integration/schema_lifecycle/test_destination_schema_change.py
@@ -1,0 +1,165 @@
+"""A schema property changed on main after a branch forked, with the branch changing related data.
+
+Test that schema changes on the destination branch are correctly evaluated against data changes on
+the source branch during merge and rebase.
+"""
+
+from typing import Any
+
+import pytest
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+
+from ..shared import load_schema
+from .shared import PERSON_KIND, TestSchemaLifecycleBase
+
+STRICT_NAME_REGEX = r"^[A-Z][a-z]+$"
+PERMISSIVE_NAME_REGEX = r".*"
+ILLEGAL_NAME = "not a valid name"
+
+BRANCH_MERGE_MUTATION = """
+mutation($branch: String!) {
+    BranchMerge(data: { name: $branch }) {
+        ok
+    }
+}
+"""
+
+
+def _person_with_regex(person: dict[str, Any], regex: str | None) -> dict[str, Any]:
+    updated = {**person, "attributes": [{**attr} for attr in person["attributes"]]}
+    assert updated["attributes"][0]["name"] == "name"
+    if regex is None:
+        updated["attributes"][0].pop("regex", None)
+    else:
+        updated["attributes"][0]["regex"] = regex
+    return updated
+
+
+def _schema_root(person: dict[str, Any], others: list[dict[str, Any]]) -> dict[str, Any]:
+    """Person relates to the car kind, so the whole base set has to load together."""
+    return {"version": "1.0", "nodes": [person, *others]}
+
+
+async def _person_names_on_main(db: InfrahubDatabase, default_branch: Branch) -> list[str]:
+    people = await NodeManager.query(db=db, schema=PERSON_KIND, branch=default_branch)
+    return sorted(str(node.get_attribute("name").value) for node in people)
+
+
+class DestinationSchemaChangeBase(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_base_others(
+        self,
+        schema_car_base: dict[str, Any],
+        schema_manufacturer_base: dict[str, Any],
+        schema_tag_base: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        return [schema_car_base, schema_manufacturer_base, schema_tag_base]
+
+
+class TestMergeWhenMainAddedTheProperty(DestinationSchemaChangeBase):
+    """Regex updated on the default branch is evaluated against new data on the merging branch."""
+
+    @pytest.fixture(scope="class")
+    async def branch_2(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="main_added_property")
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        schema_person_base: dict[str, Any],
+        schema_base_others: list[dict[str, Any]],
+    ) -> None:
+        await load_schema(
+            db=db,
+            schema=_schema_root(_person_with_regex(schema_person_base, regex=None), others=schema_base_others),
+        )
+        john = await Node.init(schema=PERSON_KIND, db=db)
+        await john.new(db=db, name="John", height=175)
+        await john.save(db=db)
+
+    async def test_merge_is_refused(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        client: InfrahubClient,
+        initial_dataset: None,
+        schema_person_base: dict[str, Any],
+        schema_base_others: list[dict[str, Any]],
+        branch_2: Branch,
+    ) -> None:
+        response = await client.schema.load(
+            schemas=[
+                _schema_root(_person_with_regex(schema_person_base, regex=STRICT_NAME_REGEX), others=schema_base_others)
+            ]
+        )
+        assert not response.errors
+
+        offender = await Node.init(schema=PERSON_KIND, db=db, branch=branch_2)
+        await offender.new(db=db, name=ILLEGAL_NAME, height=160)
+        await offender.save(db=db)
+
+        with pytest.raises(GraphQLError) as exc:
+            await client.execute_graphql(query=BRANCH_MERGE_MUTATION, variables={"branch": branch_2.name})
+
+        assert "regex" in exc.value.message
+        assert await _person_names_on_main(db=db, default_branch=default_branch) == ["John"]
+
+
+class TestRebaseWhenMainReplacedTheProperty(DestinationSchemaChangeBase):
+    """Regex updated on the default branch is evaluated against new data on a branch during rebase."""
+
+    @pytest.fixture(scope="class")
+    async def branch_2(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="main_replaced_property")
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        schema_person_base: dict[str, Any],
+        schema_base_others: list[dict[str, Any]],
+    ) -> None:
+        await load_schema(
+            db=db,
+            schema=_schema_root(
+                _person_with_regex(schema_person_base, regex=PERMISSIVE_NAME_REGEX), others=schema_base_others
+            ),
+        )
+        john = await Node.init(schema=PERSON_KIND, db=db)
+        await john.new(db=db, name="John", height=175)
+        await john.save(db=db)
+
+    async def test_rebase_is_refused(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset: None,
+        schema_person_base: dict[str, Any],
+        schema_base_others: list[dict[str, Any]],
+        branch_2: Branch,
+    ) -> None:
+        response = await client.schema.load(
+            schemas=[
+                _schema_root(_person_with_regex(schema_person_base, regex=STRICT_NAME_REGEX), others=schema_base_others)
+            ]
+        )
+        assert not response.errors
+
+        offender = await Node.init(schema=PERSON_KIND, db=db, branch=branch_2)
+        await offender.new(db=db, name=ILLEGAL_NAME, height=160)
+        await offender.save(db=db)
+
+        with pytest.raises(GraphQLError) as exc:
+            await client.branch.rebase(branch_name=branch_2.name)
+
+        assert "regex" in exc.value.message

--- a/changelog/+default-schema-update-on-merge.fixed.md
+++ b/changelog/+default-schema-update-on-merge.fixed.md
@@ -1,0 +1,1 @@
+Run schema constraint validations during a merge if the schema on the default branch has been updated.


### PR DESCRIPTION
we were not correctly checking for changes to the schema on the default branch during a merge, which could allow illegal data to merge into the default branch.

for example

1. make a branch
2. update a schema on the default branch with a new regex
3. on the branch, add/update an object to violate that new regex
4. merge the branch

this would succeed. the illegal value would be allowed and present on the default branch.

the fix is to update the schema constraint validations gate to check if there is any difference between the default branch schema and the merging branch schema instead of just checking the merging branch side

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

