### PR TITLE
fix(agents): stop mis-tagging Prefect fixture cascades as green-exit-1

### DIFF
--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -90,7 +90,8 @@ For failed jobs with an empty `tests` list and no bucket tag, read the log yours
 | `runner-oom` | `Process completed with exit code 137` | Runner OOM/SIGKILL; the mass test failures in the same job are casualties, not flakes. |
 | `docker-network-pool-exhausted` | `all predefined address pools have been fully subnetted` | Leaked compose networks exhausted the docker address pools on a self-hosted runner. |
 | `actions-download-429` | `Failed to download action … 429` | GitHub rate-limited its own action download; pure platform flake. |
-| `pytest-green-exit-1` | green pytest summary directly followed by exit 1 | Session-teardown/plugin abort after all tests passed (e.g. testcontainers result reporting). |
+| `prefect-task-manager-wedged` | `Prefect task manager setup (already )failed for http…` | The memoized task-manager setup (`backend/tests/helpers/task_manager.py`) timed out once against a Prefect test server; every later class fail-fasts on the remembered failure. One incident, hundreds of cascaded ERRORs. |
+| `pytest-green-exit-1` | green pytest summary (no failed, no errors) directly followed by exit 1 | Session-teardown/plugin abort after all tests passed (e.g. testcontainers result reporting). |
 
 ## Step 4 — Judge: flake vs regression
 

--- a/.agents/skills/analyzing-ci-flakiness/SKILL.md
+++ b/.agents/skills/analyzing-ci-flakiness/SKILL.md
@@ -90,7 +90,7 @@ For failed jobs with an empty `tests` list and no bucket tag, read the log yours
 | `runner-oom` | `Process completed with exit code 137` | Runner OOM/SIGKILL; the mass test failures in the same job are casualties, not flakes. |
 | `docker-network-pool-exhausted` | `all predefined address pools have been fully subnetted` | Leaked compose networks exhausted the docker address pools on a self-hosted runner. |
 | `actions-download-429` | `Failed to download action … 429` | GitHub rate-limited its own action download; pure platform flake. |
-| `prefect-task-manager-wedged` | `Prefect task manager setup (already )failed for http…` | The memoized task-manager setup (`backend/tests/helpers/task_manager.py`) timed out once against a Prefect test server; every later class fail-fasts on the remembered failure. One incident, hundreds of cascaded ERRORs. |
+| `prefect-task-manager-wedged` | `RuntimeError: Prefect task manager setup already failed for http…` | The memoized task-manager setup (`backend/tests/helpers/task_manager.py`) timed out once against a Prefect test server; every later class fail-fasts on the remembered failure. One incident, hundreds of cascaded ERRORs. |
 | `pytest-green-exit-1` | green pytest summary (no failed, no errors) directly followed by exit 1 | Session-teardown/plugin abort after all tests passed (e.g. testcontainers result reporting). |
 
 ## Step 4 — Judge: flake vs regression

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -61,19 +61,16 @@ BUCKETS: list[tuple[str, str]] = [
     ("runner-oom", r"Process completed with exit code 137|exit code: 137"),
     ("docker-network-pool-exhausted", r"all predefined address pools have been fully subnetted"),
     ("actions-download-429", r"Failed to download action .*429"),
-    # The memoized Prefect task-manager setup (backend/tests/helpers/task_manager.py)
-    # hit its 180s timeout against a Prefect test server once, and every later test
-    # class fail-fasts on the remembered failure. One wedged server, hundreds of
-    # cascaded ERRORs -- count the incident, not the casualties.
+    # One Prefect test server stopped answering, and every later test class fail-fasts on the
+    # remembered failure. Matched through "RuntimeError: " so that a test asserting on this
+    # message cannot tag a job by having its own source line printed in a traceback.
     (
         "prefect-task-manager-wedged",
-        r"Prefect task manager setup (?:already )?failed for http",
+        r"RuntimeError: Prefect task manager setup already failed for http",
     ),
-    # pytest summary is green (no "N failed" and no "N error(s)") yet the process
-    # exits 1: a session-teardown/plugin abort, e.g. testcontainers result
-    # reporting. The negative lookahead must exclude errors too: "474 passed,
-    # 11 errors" summaries otherwise mis-tag whole fixture-cascade jobs (all 23
-    # tags in the 2026-08-24..09-03 window were such mis-tags).
+    # pytest summary is green (no "N failed" and no "N errors") yet the process exits 1: a
+    # session-teardown/plugin abort, e.g. the testcontainers result reporting. Errors have to be
+    # excluded too, or a fixture cascade ("474 passed, 11 errors") reads as a green session.
     (
         "pytest-green-exit-1",
         r"=+ \d+ passed(?:(?!\d+ (?:failed|error))[^\n])*=+[^\n]*\n(?:[^\n]*\n){0,3}[^\n]*Process completed with exit code 1\.",

--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -61,11 +61,22 @@ BUCKETS: list[tuple[str, str]] = [
     ("runner-oom", r"Process completed with exit code 137|exit code: 137"),
     ("docker-network-pool-exhausted", r"all predefined address pools have been fully subnetted"),
     ("actions-download-429", r"Failed to download action .*429"),
-    # pytest summary is green (no "N failed") yet the process exits 1: a
-    # session-teardown/plugin abort, e.g. the testcontainers result reporting.
+    # The memoized Prefect task-manager setup (backend/tests/helpers/task_manager.py)
+    # hit its 180s timeout against a Prefect test server once, and every later test
+    # class fail-fasts on the remembered failure. One wedged server, hundreds of
+    # cascaded ERRORs -- count the incident, not the casualties.
+    (
+        "prefect-task-manager-wedged",
+        r"Prefect task manager setup (?:already )?failed for http",
+    ),
+    # pytest summary is green (no "N failed" and no "N error(s)") yet the process
+    # exits 1: a session-teardown/plugin abort, e.g. testcontainers result
+    # reporting. The negative lookahead must exclude errors too: "474 passed,
+    # 11 errors" summaries otherwise mis-tag whole fixture-cascade jobs (all 23
+    # tags in the 2026-08-24..09-03 window were such mis-tags).
     (
         "pytest-green-exit-1",
-        r"=+ \d+ passed(?:(?!\d+ failed)[^\n])*=+[^\n]*\n(?:[^\n]*\n){0,3}[^\n]*Process completed with exit code 1\.",
+        r"=+ \d+ passed(?:(?!\d+ (?:failed|error))[^\n])*=+[^\n]*\n(?:[^\n]*\n){0,3}[^\n]*Process completed with exit code 1\.",
     ),
 ]
 


### PR DESCRIPTION
## Summary

The `analyzing-ci-flakiness` collector was reporting a bucket with zero real incidents as the top CI offender.

`pytest-green-exit-1` is meant to catch a *green* pytest session that still exits 1 (a teardown or plugin abort). Its regex excluded `N failed` from the summary line but not `N errors`, so a job ending `474 passed, 11 errors` was read as green. All 23 tags in the 2026-08-24..09-03 window were such mis-tags.

Two changes:

- Widen the negative lookahead to cover `N error` / `N errors`.
- Add a `prefect-task-manager-wedged` bucket for what those jobs actually were: the memoized Prefect task-manager setup (`backend/tests/helpers/task_manager.py`) times out once against a Prefect test server, and every later test class then fail-fasts on the remembered failure. One incident, hundreds of cascaded ERRORs — precisely what the bucket mechanism exists to collapse.

## Verification

Re-scanned the 301 cached job logs in the local ledger with the new regexes:

| bucket | before | after |
|---|---|---|
| `pytest-green-exit-1` | 23 jobs | **0** |
| `prefect-task-manager-wedged` | n/a | **16** jobs |

Regex unit-checked against synthetic summaries: a genuine `474 passed, 3 skipped` + exit 1 still matches; `474 passed, 11 errors` and `474 passed, 1 error` no longer do.

`ruff check` and `ruff format --check` clean. `.agents/**/*.md` is outside the markdownlint and vale globs, so no doc lint applies.

## Notes

- Agent tooling only, no runtime source, so no changelog fragment — consistent with the six prior `*(agents):` commits on this skill.
- Targets `stable` per `dev/guidelines/git-workflow.md`: repo tooling with no source-code changes. The only drift on `develop` for this file is an unrelated `TypedDict` annotation, so the merge back is clean.
- Corrected knock-on effect: the real #1 CI-flakiness family this window is Prefect test-server setup wedging (`prefect-setup-triggers-timeout` 10 PRs + `prefect-task-manager-wedged` 8 PRs), not a teardown abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

