### PR TITLE
fix(frontend): keep the object menu reachable on a short sidebar

### DIFF
--- a/changelog/10158.fixed.md
+++ b/changelog/10158.fixed.md
@@ -1,0 +1,1 @@
+Fixed the sidebar menu hiding your object items on a short window. The lower (built-in) menu no longer takes all the vertical space: both menu sections now shrink and scroll, and the object section keeps a minimum height so its items stay reachable at any window size or zoom level.

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.test.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SidebarContent, SidebarProvider } from "@/shared/components/layout/sidebar";
+
+import { useMenu } from "@/entities/navigation/ui/queries/get-menu.query";
+import { SidebarMenu } from "@/entities/navigation/ui/sidebar/sidebar-menu";
+
+import { render } from "../../../../../tests/components/render";
+import { generateMenuItems } from "../../../../../tests/fake/menu";
+
+vi.mock("@/entities/navigation/ui/queries/get-menu.query");
+
+/**
+ * Shorter than the two menu sections need, so the flex column has to take height away from
+ * one of them. Reproduces #10158: a laptop-height window, or a large screen zoomed in.
+ */
+const SHORT_SIDEBAR_HEIGHT = 320;
+
+/** Below this the object section is too small to read or scroll — the sidebar is unusable. */
+const MIN_USABLE_SECTION_HEIGHT = 60;
+
+const renderShortSidebar = () =>
+  render(
+    <SidebarProvider>
+      <div
+        className="flex flex-col"
+        style={{ height: `${SHORT_SIDEBAR_HEIGHT}px`, width: "16rem" }}
+      >
+        <SidebarContent>
+          <SidebarMenu />
+        </SidebarContent>
+      </div>
+    </SidebarProvider>
+  );
+
+const queryOne = (container: Element, selector: string) => {
+  const element = container.querySelector(selector);
+  if (!element) throw new Error(`expected the sidebar to render ${selector}`);
+  return element;
+};
+
+/** The Radix viewport that actually clips a section's items. */
+const viewportAround = (section: Element) => {
+  const viewport = section.closest("[data-radix-scroll-area-viewport]");
+  if (!viewport) throw new Error("the section is not rendered inside a ScrollArea");
+  return viewport;
+};
+
+const objectViewportOf = (container: Element) =>
+  viewportAround(queryOne(container, "a[href$='/objects/Objects1']"));
+
+const internalViewportOf = (container: Element) =>
+  viewportAround(queryOne(container, "a[href$='/objects/Internal1']"));
+
+const heightOf = (element: Element) => element.getBoundingClientRect().height;
+
+describe("SidebarMenu", () => {
+  beforeEach(() => {
+    vi.mocked(useMenu).mockReturnValue({
+      data: {
+        sections: {
+          object: generateMenuItems(8, "Objects", { section: "object" }),
+          internal: generateMenuItems(8, "Internal", { section: "internal" }),
+        },
+      },
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useMenu>);
+  });
+
+  test("keeps the object section usable when the sidebar is too short for both sections", async () => {
+    // GIVEN
+    const sidebar = await renderShortSidebar();
+
+    // WHEN
+    await expect.element(sidebar.getByText("Objects 1")).toBeVisible();
+
+    // THEN
+    expect(heightOf(objectViewportOf(sidebar.container))).toBeGreaterThanOrEqual(
+      MIN_USABLE_SECTION_HEIGHT
+    );
+  });
+
+  test("lets the internal section give up height instead of pinning it to its full size", async () => {
+    // GIVEN
+    const sidebar = await renderShortSidebar();
+
+    // WHEN
+    await expect.element(sidebar.getByText("Internal 1")).toBeVisible();
+
+    // THEN
+    const internalViewport = internalViewportOf(sidebar.container);
+    expect(heightOf(internalViewport)).toBeLessThan(
+      SHORT_SIDEBAR_HEIGHT - MIN_USABLE_SECTION_HEIGHT
+    );
+    expect(internalViewport.scrollHeight).toBeGreaterThan(heightOf(internalViewport));
+  });
+
+  test("scrolls the last object item into view on a short sidebar", async () => {
+    // GIVEN
+    const sidebar = await renderShortSidebar();
+    await expect.element(sidebar.getByText("Objects 8")).toBeVisible();
+    const viewport = objectViewportOf(sidebar.container);
+
+    // WHEN
+    viewport.scrollTop = viewport.scrollHeight;
+
+    // THEN
+    const itemBox = queryOne(
+      sidebar.container,
+      "a[href$='/objects/Objects8']"
+    ).getBoundingClientRect();
+    const viewportBox = viewport.getBoundingClientRect();
+    expect(itemBox.top).toBeGreaterThanOrEqual(Math.floor(viewportBox.top));
+    expect(itemBox.bottom).toBeLessThanOrEqual(Math.ceil(viewportBox.bottom));
+  });
+});

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.test.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/entities/navigation/ui/queries/get-menu.query");
 
 /**
  * Shorter than the two menu sections need, so the flex column has to take height away from
- * one of them. Reproduces #10158: a laptop-height window, or a large screen zoomed in.
+ * one of them: a laptop-height window, or a large screen zoomed in.
  */
 const SHORT_SIDEBAR_HEIGHT = 320;
 

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
@@ -16,15 +16,21 @@ export function SidebarMenu() {
 
   if (!menu?.sections) return <div className="grow" />;
 
+  // Both sections have to be able to give up height, or the one that cannot starves the other:
+  // a flex child's automatic minimum size is its content height unless it is a scroll container,
+  // so wrapping the internal section in a ScrollArea is what lets it shrink at all. The object
+  // section then keeps an explicit floor so it never collapses to an unusable sliver (#10158).
   return (
     <>
-      <ScrollArea>
+      <ScrollArea className="min-h-25 flex-1">
         <div className="p-2">
           <SidebarMenuSectionObject items={menu.sections.object} />
         </div>
       </ScrollArea>
       <Separator />
-      <SidebarMenuSectionInternal items={menu.sections.internal} />
+      <ScrollArea>
+        <SidebarMenuSectionInternal items={menu.sections.internal} />
+      </ScrollArea>
     </>
   );
 }

--- a/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx
@@ -19,7 +19,7 @@ export function SidebarMenu() {
   // Both sections have to be able to give up height, or the one that cannot starves the other:
   // a flex child's automatic minimum size is its content height unless it is a scroll container,
   // so wrapping the internal section in a ScrollArea is what lets it shrink at all. The object
-  // section then keeps an explicit floor so it never collapses to an unusable sliver (#10158).
+  // section then keeps an explicit floor so it never collapses to an unusable sliver.
   return (
     <>
       <ScrollArea className="min-h-25 flex-1">

--- a/frontend/app/tests/fake/menu.ts
+++ b/frontend/app/tests/fake/menu.ts
@@ -1,0 +1,31 @@
+import type { MenuItem } from "../../src/entities/navigation/domain/model/menu";
+
+export const generateMenuItem = (override: Partial<MenuItem> = {}): MenuItem => {
+  const label = override.label ?? "Menu item";
+
+  return {
+    id: `menu-${label}`,
+    namespace: "Builtin",
+    name: label.replace(/\s/g, ""),
+    description: "",
+    protected: false,
+    label,
+    path: `/objects/${label.replace(/\s/g, "")}`,
+    icon: "mdi:cube-outline",
+    kind: "",
+    order_weight: 5000,
+    section: "object",
+    identifier: `menu-${label}`,
+    ...override,
+  };
+};
+
+/** `count` sibling menu items, labelled `<prefix> 1`..`<prefix> N`. */
+export const generateMenuItems = (
+  count: number,
+  prefix: string,
+  override: Partial<MenuItem> = {}
+): MenuItem[] =>
+  Array.from({ length: count }, (_, index) =>
+    generateMenuItem({ label: `${prefix} ${index + 1}`, ...override })
+  );


### PR DESCRIPTION
# Why

On a short window — a laptop screen, or a large screen that's been zoomed in — the sidebar's built-in menu took all the vertical space and squeezed the object menu down to nothing, so custom object entries like `BuiltinTag` became unreachable. Scrolling didn't help, because the object section had no viewport left to scroll.

Goal: both menu sections stay usable at any window height or zoom level.

Non-goals: this is not a general responsive/mobile pass on the sidebar, and it does not add a persistent "there's more above" affordance (the Radix scrollbar still appears on hover only).

Closes #10158

<img width="1469" height="909" alt="image" src="https://github.com/user-attachments/assets/6e131dc2-6b3e-4729-a736-57e01cbdd4e9" />


## What changed

**Behavioral changes**

- The object menu keeps a minimum height (100px) instead of collapsing to zero on a short sidebar.
- The built-in menu now shrinks and scrolls its own overflow instead of holding its full natural height.

**Implementation notes**

`SidebarContent` is a bounded flex column with `overflow-hidden` and no scrolling of its own. Its two children both defaulted to `flex: 0 1 auto` with no declared floor, so space distribution fell through to CSS's **automatic minimum size** — and that resolved differently for each:

| Section | Overflow | `min-height: auto` | Could shrink? |
|---|---|---|---|
| Object menu (in `ScrollArea`) | `hidden` | **0** | yes — all the way to nothing |
| Built-in menu (bare `Col`) | visible | **min-content height** | no |

So the built-in section hit its floor immediately and contributed no shrinkage, and every pixel of deficit came out of the object section. Measured on `stable`: the object viewport was **15px** in a 320px sidebar and **0px** at a 440px browser viewport, while its `scrollHeight` stayed 412 — the items were mounted the whole time, there was just no viewport left.

The fix makes the intent explicit rather than accidental:

- Wrap the built-in section in a `ScrollArea` so it becomes a scroll container — that alone is what lets it shrink at all — and so it scrolls its own overflow.
- Give the object section `flex-1` plus a `min-h-25` floor, so it claims spare space when there is any and never drops below a usable viewport.

**What stayed the same**

- No changes to the shared `SidebarContent` / `Sidebar` layout primitives, or to the `ScrollArea` primitive — the fix is local to `sidebar-menu.tsx`.
- No changes to the menu model, the API layer, or how either section renders its items.
- No arbitrary Tailwind values; `min-h-25` is a scale token.
- Collapsed (`w-14`) sidebar behaviour unchanged apart from the same fix applying.

## How to review

Start with `frontend/app/src/entities/navigation/ui/sidebar/sidebar-menu.tsx` — it's +8/−2 and the whole behavioural change. Everything else is the test, its factory, and the changelog fragment.

The part worth scrutiny is the `min-h-25` floor. 100px shows ~2–3 object items plus a scrollbar; it's a judgement call, not a derived number. Below a ~360px viewport the sidebar is cramped regardless, and `SidebarContent`'s `overflow-hidden` will start clipping again — that's out of scope here (the issue is `priority/4`, and the reported dimensions are below the unofficially-supported tablet minimum).

## How to test

```bash
cd frontend/app && pnpm exec vitest run src/entities/navigation/ui/sidebar/sidebar-menu.test.tsx
```

The three new tests assert **real geometry**, not DOM presence — the menu items were always mounted, so a `toBeVisible()` assertion would have passed on the bug. Reverting just the `sidebar-menu.tsx` change makes all three fail:

```
1. keeps the object section usable …       AssertionError: expected 15 to be >= 60
2. lets the internal section give up …     Error: the section is not rendered inside a ScrollArea
3. scrolls the last object item into view  AssertionError: expected -44 to be >= 0
```

Manually: run the frontend, log in, and drag the window short (or zoom in). Measured in the running app, object-section height by browser viewport height:

| viewport h | before | after | built-in after |
|---|---|---|---|
| 700 | 251 | 251 | 296 |
| 560 | 111 | 111 | 296 |
| 480 | 31 | **100** | 227 (scrolls) |
| 440 | **0** | **100** | 187 (scrolls) |
| 360 | 0 | **100** | 107 (scrolls) |

Verified in both the expanded and collapsed sidebar states.

Local gate: `biome ci` ✅ (1448 files) · `knip` ✅ · `betterer ci` ✅ (188 issues, unchanged) · `pnpm test` ✅ (182 files, 1249 tests).

## Impact & rollout

- **Backward compatibility:** no breaking changes; CSS-only behavioural fix.
- **Performance:** none — no new JS, no resize observers, no extra renders. One additional `ScrollArea` wrapper in the sidebar.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/10158.fixed.md`)
- [ ] External docs updated (if user-facing or ops-facing change) — n/a, no documented behaviour changes
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

