### PR TITLE
chore: release 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.11.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.11.2) - 2026-09-03
+
+### Fixed
+
+- In Account settings → Preferences, the date format and timezone fields now preview the value that saving would produce, including the organisation default that takes over when a personal override is cleared. The information icon describes the value you are about to save rather than the one already stored. ([#10200](https://github.com/opsmill/infrahub/issues/10200))
+- An SSO user's account can be deleted without leaving broken data behind. Deleting an account now also removes its external identities, its API tokens and its refresh tokens, which were left behind before. The ones left by an earlier release are removed on upgrade. ([#10304](https://github.com/opsmill/infrahub/issues/10304))
+- Deleting a branch now purges its settled tasks, so a new branch created with the same name no longer inherits the deleted branch's completed tasks. ([#10474](https://github.com/opsmill/infrahub/issues/10474))
+- A branch that cannot be refreshed into a worker's in-memory registry no longer aborts the periodic branch refresh. The failure is logged and the remaining branches are still refreshed.
+- Artifacts and Generators whose query reads an object's display label or human-friendly ID are now regenerated when a change to a backing field moves that value, instead of being skipped and left stale after a merge.
+- Update the in-memory cache for branches after a branch change is saved to prevent the cache diverging from the database. The BranchUpdate mutation and the Prefect task to run database migrations against a branch are both fixed.
+
 ## [Infrahub - v1.11.1](https://github.com/opsmill/infrahub/tree/infrahub-v1.11.1) - 2026-08-31
 
 ### Added

--- a/changelog/+branch-update-registry-cache.fixed.md
+++ b/changelog/+branch-update-registry-cache.fixed.md
@@ -1,1 +1,0 @@
-Update the in-memory cache for branches after a branch change is saved to prevent the cache diverging from the database. The BranchUpdate mutation and the Prefect task to run database migrations against a branch are both fixed.

--- a/changelog/+refresh-branches-per-branch-failure.fixed.md
+++ b/changelog/+refresh-branches-per-branch-failure.fixed.md
@@ -1,1 +1,0 @@
-A branch that cannot be refreshed into a worker's in-memory registry no longer aborts the periodic branch refresh. The failure is logged and the remaining branches are still refreshed.

--- a/changelog/+selective-regen-display-label-hfid.fixed.md
+++ b/changelog/+selective-regen-display-label-hfid.fixed.md
@@ -1,1 +1,0 @@
-Artifacts and Generators whose query reads an object's display label or human-friendly ID are now regenerated when a change to a backing field moves that value, instead of being skipped and left stale after a merge.

--- a/changelog/10200.fixed.md
+++ b/changelog/10200.fixed.md
@@ -1,1 +1,0 @@
-In Account settings → Preferences, the date format and timezone fields now preview the value that saving would produce, including the organisation default that takes over when a personal override is cleared. The information icon describes the value you are about to save rather than the one already stored.

--- a/changelog/10304.fixed.md
+++ b/changelog/10304.fixed.md
@@ -1,1 +1,0 @@
-An SSO user's account can be deleted without leaving broken data behind. Deleting an account now also removes its external identities, its API tokens and its refresh tokens, which were left behind before. The ones left by an earlier release are removed on upgrade.

--- a/changelog/10474.fixed.md
+++ b/changelog/10474.fixed.md
@@ -1,1 +1,0 @@
-Deleting a branch now purges its settled tasks, so a new branch created with the same name no longer inherits the deleted branch's completed tasks.

--- a/docs/docs/release-notes/infrahub/release-1_11_2.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_11_2.mdx
@@ -1,0 +1,31 @@
+---
+title: Release 1.11.2
+release_date: 2026-09-03
+release_type: patch
+description: "Fixes account preferences to preview the date and timezone values that saving will produce, cleans up an SSO account's identities and tokens when it is deleted, purges a deleted branch's settled tasks, and keeps the branch registry cache in sync with the database. Artifacts and Generators are now regenerated when a display label or human-friendly ID changes."
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.11.2</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 3rd, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.11.2](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.11.2)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- In Account settings → Preferences, the date format and timezone fields now preview the value that saving would produce, including the organisation default that takes over when a personal override is cleared. The information icon describes the value you are about to save rather than the one already stored. ([#10200](https://github.com/opsmill/infrahub/issues/10200))
+- An SSO user's account can be deleted without leaving broken data behind. Deleting an account now also removes its external identities, its API tokens and its refresh tokens, which were left behind before. The ones left by an earlier release are removed on upgrade. ([#10304](https://github.com/opsmill/infrahub/issues/10304))
+- Deleting a branch now purges its settled tasks, so a new branch created with the same name no longer inherits the deleted branch's completed tasks. ([#10474](https://github.com/opsmill/infrahub/issues/10474))
+- A branch that cannot be refreshed into a worker's in-memory registry no longer aborts the periodic branch refresh. The failure is logged and the remaining branches are still refreshed.
+- Artifacts and Generators whose query reads an object's display label or human-friendly ID are now regenerated when a change to a backing field moves that value, instead of being skipped and left stale after a merge.
+- Update the in-memory cache for branches after a branch change is saved to prevent the cache diverging from the database. The BranchUpdate mutation and the Prefect task to run database migrations against a branch are both fixed.


### PR DESCRIPTION
Release **1.11.2** (patch) cut from `stable`.

## Note on the docker-compose commit

I made a mistake and launched "Update Docker Compose & helm chart" propagation workflow which was dispatched with `--ref stable`, so its bot commit (`b97ad398a chore: update docker-compose for release 1.11.2`, pinning docker-compose.yml and the Helm `appVersion` to `1.11.2`) landed directly on `stable` before this PR was opened, rather than on the `prep-release-1.11.2` branch. That commit is the parent of this PR's release commit, so the docker-compose pin does not appear in this PR's diff. No action is needed — the pin is already correct on `stable` (`release.validate-docker-compose --version 1.11.2` passes) .

## Contents

- `CHANGELOG.md` — new `1.11.2` section (6 Fixed entries), fragments removed
- `docs/docs/release-notes/infrahub/release-1_11_2.mdx` — release note (`release_type: patch`), frontmatter validated
- `docker-compose.yml` — pinned to `1.11.2` via the propagation workflow bot commit (already on `stable`)

## Fixed

- Preferences preview the value saving would produce, incl. the org default ([#10200](https://github.com/opsmill/infrahub/issues/10200))
- Deleting an SSO account removes its external identities, API tokens and refresh tokens ([#10304](https://github.com/opsmill/infrahub/issues/10304))
- Deleting a branch purges its settled tasks ([#10474](https://github.com/opsmill/infrahub/issues/10474))
- A branch that cannot be refreshed no longer aborts the periodic branch refresh
- Artifacts and Generators are regenerated when a display label or HFID changes
- Branch in-memory cache is updated after a branch change is saved

## Local checks

- `release.validate-docker-compose --version 1.11.2` ✓
- `docs.validate` (no generated-doc drift) ✓
- `docs.lint` (0 errors) ✓
- No `pyproject.toml` changes ✓

Merge, then tag `infrahub-v1.11.2` from `stable` and create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
