### PR TITLE
fix: list a generator instance's runs in its Tasks tab (closes #10107)

### DIFF
--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -42,9 +42,7 @@ if TYPE_CHECKING:
 async def run_generator(model: RequestGeneratorRun) -> None:
     client = get_client()
 
-    # The instance id is only known once the repository is initialized, so accumulate the related
-    # node ids and tag once in `finally`. add_tags can delete existing tags if these tags are not synced
-    # with what's actually in Prefect
+    # Each tag update replaces the whole set, so collect the related node ids and send them in one update.
     node_ids = [model.target_id]
     try:
         repository = await get_initialized_repo(
@@ -77,7 +75,11 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         generator_instance = await _define_instance(model=model, client=client)
         node_ids.append(generator_instance.id)
     finally:
-        await add_tags(branches=[model.branch_name], nodes=node_ids)
+        # Tagging is best-effort observability: it must not fail the run or mask a setup error.
+        try:
+            await add_tags(branches=[model.branch_name], nodes=node_ids)
+        except Exception:
+            get_run_logger().warning("Failed to tag the generator run", exc_info=True)
 
     try:
         generator_class = generator_definition.load_class(

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -79,7 +79,11 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         try:
             await add_tags(branches=[model.branch_name], nodes=node_ids)
         except Exception:
-            get_run_logger().warning("Failed to tag the generator run", exc_info=True)
+            get_run_logger().warning(
+                f"Failed to tag the run of generator '{model.generator_definition.definition_name}' "
+                f"for target '{model.target_name}'",
+                exc_info=True,
+            )
 
     try:
         generator_class = generator_definition.load_class(

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -40,38 +40,44 @@ if TYPE_CHECKING:
     flow_run_name="Run generator {model.generator_definition.definition_name}",
 )
 async def run_generator(model: RequestGeneratorRun) -> None:
-    await add_tags(branches=[model.branch_name], nodes=[model.target_id])
-
     client = get_client()
 
-    repository = await get_initialized_repo(
-        client=client,
-        repository_id=model.repository_id,
-        name=model.repository_name,
-        repository_kind=model.repository_kind,
-        commit=model.commit,
-    )
+    # The instance id is only known once the repository is initialized, so accumulate the related
+    # node ids and tag once in `finally`. add_tags can delete existing tags if these tags are not synced
+    # with what's actually in Prefect
+    node_ids = [model.target_id]
+    try:
+        repository = await get_initialized_repo(
+            client=client,
+            repository_id=model.repository_id,
+            name=model.repository_name,
+            repository_kind=model.repository_kind,
+            commit=model.commit,
+        )
 
-    generator_definition = InfrahubGeneratorDefinitionConfig(
-        name=model.generator_definition.definition_name,
-        class_name=model.generator_definition.class_name,
-        file_path=model.generator_definition.file_path,
-        parameters=model.generator_definition.parameters,
-        query=model.generator_definition.query_name,
-        targets=model.generator_definition.group_id,
-        convert_query_response=model.generator_definition.convert_query_response,
-        execute_in_proposed_change=model.generator_definition.execute_in_proposed_change,
-        execute_after_merge=model.generator_definition.execute_after_merge,
-    )
+        generator_definition = InfrahubGeneratorDefinitionConfig(
+            name=model.generator_definition.definition_name,
+            class_name=model.generator_definition.class_name,
+            file_path=model.generator_definition.file_path,
+            parameters=model.generator_definition.parameters,
+            query=model.generator_definition.query_name,
+            targets=model.generator_definition.group_id,
+            convert_query_response=model.generator_definition.convert_query_response,
+            execute_in_proposed_change=model.generator_definition.execute_in_proposed_change,
+            execute_after_merge=model.generator_definition.execute_after_merge,
+        )
 
-    commit_worktree = repository.get_commit_worktree(commit=model.commit)
+        commit_worktree = repository.get_commit_worktree(commit=model.commit)
 
-    file_info = extract_repo_file_information(
-        full_filename=commit_worktree.directory / generator_definition.file_path,
-        repo_directory=repository.directory_root,
-        worktree_directory=commit_worktree.directory,
-    )
-    generator_instance = await _define_instance(model=model, client=client)
+        file_info = extract_repo_file_information(
+            full_filename=commit_worktree.directory / generator_definition.file_path,
+            repo_directory=repository.directory_root,
+            worktree_directory=commit_worktree.directory,
+        )
+        generator_instance = await _define_instance(model=model, client=client)
+        node_ids.append(generator_instance.id)
+    finally:
+        await add_tags(branches=[model.branch_name], nodes=node_ids)
 
     try:
         generator_class = generator_definition.load_class(

--- a/backend/tests/functional/generator/test_mutation_generator.py
+++ b/backend/tests/functional/generator/test_mutation_generator.py
@@ -6,6 +6,8 @@ import pytest
 from fast_depends import dependency_provider
 from infrahub_sdk.graphql import Mutation
 from infrahub_sdk.protocols import CoreGeneratorDefinition
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.filters import FlowFilter, FlowFilterName, FlowRunFilter, FlowRunFilterTags
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
@@ -15,6 +17,7 @@ from infrahub.actions.tasks import _run_generators
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.workers.dependencies import build_client
+from infrahub.workflows.constants import WorkflowTag
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -117,6 +120,53 @@ class TestMutationGenerator(TestInfrahubApp):
         response = await client.execute_graphql(query=mutation.render(), branch_name="branch1")
         assert response["CoreGeneratorDefinitionRun"]["ok"]
         assert response["CoreGeneratorDefinitionRun"]["task"]["id"]
+
+    async def test_generator_run_is_tagged_with_its_instance(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient
+    ) -> None:
+        """A generator run tags its flow run with the generator instance it creates or reuses."""
+        manufacturer = await client.get(kind=TestKind.MANUFACTURER, branch="branch1", name__value="Koenigsegg")
+        target = await client.create(kind=TestKind.PERSON, branch="branch1", data={"name": "Marcus", "height": 170})
+        await target.save()
+        car = await client.create(
+            kind=TestKind.CAR,
+            branch="branch1",
+            data={"name": "Regera", "color": "Blue", "owner": target.id, "manufacturer": manufacturer.id},
+        )
+        await car.save()
+        people = await client.get(kind=InfrahubKind.STANDARDGROUP, branch="branch1", name__value="people")
+        await people.members.fetch()
+        people.members.add(target.id)
+        await people.save()
+
+        generator = await client.get(kind=CoreGeneratorDefinition, branch="branch1", name__value="cartags")
+        mutation = Mutation(
+            mutation="CoreGeneratorDefinitionRun", input_data={"data": {"id": generator.id}}, query={"ok": None}
+        )
+        response = await client.execute_graphql(query=mutation.render(), branch_name="branch1")
+        assert response["CoreGeneratorDefinitionRun"]["ok"]
+
+        instances = await client.filters(kind=InfrahubKind.GENERATORINSTANCE, object__ids=[target.id], branch="branch1")
+        assert len(instances) == 1
+
+        instance_tag = WorkflowTag.RELATED_NODE.render(identifier=instances[0].id)
+        target_tag = WorkflowTag.RELATED_NODE.render(identifier=target.id)
+        branch_tag = WorkflowTag.BRANCH.render(identifier="branch1")
+
+        async with get_client(sync_client=False) as prefect:
+            runs = await prefect.read_flow_runs(
+                flow_filter=FlowFilter(name=FlowFilterName(any_=["generator-run"])),
+                flow_run_filter=FlowRunFilter(tags=FlowRunFilterTags(all_=[instance_tag])),
+            )
+
+        # run_generator tags the branch, the target node and the instance in a single call, so the
+        # run carries exactly the target and instance related-node tags plus the branch tag: the
+        # instance tag is added alongside the target, not swapped in for it.
+        assert len(runs) == 1
+        related_node_prefix = WorkflowTag.RELATED_NODE.render(identifier="")
+        tags = set(runs[0].tags)
+        assert {tag for tag in tags if tag.startswith(related_node_prefix)} == {target_tag, instance_tag}
+        assert branch_tag in tags
 
     async def test_execute_generator_action(
         self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient

--- a/changelog/10107.fixed.md
+++ b/changelog/10107.fixed.md
@@ -1,0 +1,1 @@
+The Tasks tab of a generator instance now lists the flow runs that executed the generator for that target, so an instance's execution history is visible from the instance itself.

--- a/changelog/10107.fixed.md
+++ b/changelog/10107.fixed.md
@@ -1,1 +1,1 @@
-The Tasks tab of a generator instance now lists the flow runs that executed the generator for that target, so an instance's execution history is visible from the instance itself.
+The Tasks tab of a Generator instance now lists the flow runs that executed the Generator for that target, so an instance's execution history is visible from the instance itself.


### PR DESCRIPTION
## Why

Opening a `CoreGeneratorInstance` and switching to the **Tasks** tab showed an empty list, even after the generator had run. The runs had to be hunted down in the global Tasks view.

The object Tasks tab filters flow runs on the viewed node's id (`related_node__ids`). The `generator-run` flow tagged the branch and the target node, but never the `CoreGeneratorInstance` it creates or reuses, so no flow run was ever associated with the instance.

Closes #10107

## What changed

- **Behavioral:** a generator run now tags its flow run with the generator instance id.
- **Implementation:** the related node ids are accumulated and applied in a single `add_tags` call from a `finally` block. This matters because `add_tags` reads the flow run's tags from the start-of-run context snapshot and *replaces* the whole set on the server.

## How to test

Automated (functional): runs a generator against a fresh target and asserts the resulting `generator-run` flow carries exactly the target and instance related-node tags plus the branch tag.

```bash
uv run pytest backend/tests/functional/generator/test_mutation_generator.py::TestMutationGenerator::test_generator_run_is_tagged_with_its_instance
```

Manual (verified on a live stack with demo data + the `infrahub-demo-edge` repo): run the `update_upstream_interfaces_description` generator, open one of the resulting `CoreGeneratorInstance` objects → **Tasks** tab now lists its completed `generator-run`. The instance's Tasks-tab query returns the run with `related_nodes` containing both the `CoreGeneratorInstance` and the target interface (confirming the target association is not dropped).

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

