### PR TITLE
docs: harvest review lessons from PRs reviewed 2026-08-28 to 2026-09-04

### DIFF
--- a/.agents/rules/code-doc-style.md
+++ b/.agents/rules/code-doc-style.md
@@ -2,6 +2,10 @@
 paths:
   - "backend/**/*.py"
   - "python_testcontainers/**/*.py"
+  - "tasks/**/*.py"
+  - "utilities/**/*.py"
+  - "tests/**/*.py"
+  - ".agents/**/*.py"
   - "frontend/**/*.ts"
   - "frontend/**/*.tsx"
 ---
@@ -53,4 +57,4 @@ Where IDs *do* belong:
 - Documents the contract of a public function (inputs, outputs, errors raised) when it crosses a module boundary.
 - Stays silent by default. If code needs a comment to explain *what* it does, rename or extract until it doesn't. A comment that restates the code is worse than none — noise that rots the moment the code changes.
 - When a why-comment is warranted, one sentence. If the why needs a paragraph, it belongs in the function's docstring or a `dev/knowledge/` page, not inline. Reviewers repeatedly ask for multi-line inline comments to be condensed.
-- Don't narrate the approach *not* taken. A paragraph on the alternative rejected, or the call deliberately avoided, belongs in the PR description; keep the line stating what the code does. Reviewers repeatedly ask for these paragraphs to be deleted. A negative statement that is part of the contract stays — "this never raises", "does not commit the transaction", "not thread-safe".
+- Don't narrate the approach *not* taken, and don't narrate the code's history. A paragraph on the alternative rejected, or the call deliberately avoided, belongs in the PR description; keep the line stating what the code does. A comment describes what the code does from now on, never what it used to do or why the old shape was wrong — sweep your additions for "used to", "no longer", "previously", "was rejected", "would have". A negative statement that is part of the contract stays — "this never raises", "does not commit the transaction", "not thread-safe".

--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -49,11 +49,20 @@ Make `match` cover the whole stable message (anchor with `^...$` where practical
 
 ## GraphQL error assertions
 
-Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. The full-message-over-fragment preference applies to any exception assertion, not just GraphQL; with `pytest.raises` express it through an anchored `match` (above) rather than `==`.
+Assert on the exact message with `==`, not substring checks with `in`. Vague checks hide regressions when error wording changes. This covers a query result's `errors` list too, not only raised exceptions:
+
+```python
+# ❌ passes for any error — or, when data is also empty, for none at all
+assert result.errors or result.data["edges"] == []
+# ✅ pins exactly what the API returned
+assert [error.message for error in result.errors] == ["You do not have the permission to update this preference"]
+```
+
+The full-message-over-fragment preference applies to any exception assertion, not just GraphQL; with `pytest.raises` express it through an anchored `match` (above) rather than `==`.
 
 ## Assert exact expectations
 
-Exact-match is not only for error messages. Assert the exact collection (full set/dict equality, not `in`/`issubset`), never mere non-emptiness (`!= frozenset()`, `len() > 0`), and a positive count where the number matters (so a run that silently measures zero fails). A denial test must also reload the target and assert nothing changed. Pin literal expected values — never compute the expectation with the same serializer/library the implementation calls. Full guidance in `dev/guidelines/backend/testing.md` §"Assert exact expectations".
+Exact-match is not only for error messages. Assert the exact collection (full set/dict equality, not `in`/`issubset`), never mere non-emptiness (`!= frozenset()`, `len() > 0`), and a positive count where the number matters (so a run that silently measures zero fails). Never `or` two acceptable outcomes in one assertion — if you cannot say which one the system produces, you do not yet know the behavior under test. A denial test must also reload the target and assert nothing changed. Pin literal expected values — never compute the expectation with the same serializer/library the implementation calls. Full guidance in `dev/guidelines/backend/testing.md` §"Assert exact expectations".
 
 ## Don't test the framework
 

--- a/.agents/skills/creating-changelog-entries/SKILL.md
+++ b/.agents/skills/creating-changelog-entries/SKILL.md
@@ -89,7 +89,10 @@ uv run towncrier create -c "Migrated the frontend build to pnpm workspaces" +pnp
   number or a `+`-prefixed slug, because `issue_format` turns a bare name straight into a GitHub
   issue URL: `IFC-2747.fixed.md` ships a link to an issue that does not exist. The `+` marks the
   entry as an orphan and suppresses the link, so `+ifc-2546-lorem-ipsum.changed.md` is valid — but
-  the ticket ID never appears in the output, so spend the slug on a description instead.
+  the ticket ID never appears in the output, so spend the slug on a description instead. Use a bare
+  issue number only when the release note should link that GitHub issue; a change merely related to
+  an issue — a follow-up, a separate fix found along the way — takes an orphan `+slug`, and the slug
+  carries no metadata, so there is nothing to "fix" in an orphan name that lacks an issue ID.
 - **Hand-writing the fragment file.** Use `towncrier create` so the name and location are correct.
 - **Placing it in a sub-package directory** (e.g. `backend/changelog/`) instead of the configured fragments directory.
 - **Describing the implementation.** "Refactored the auth-token cache layer" → instead say what the user sees: "Fixed users being unexpectedly logged out".

--- a/dev/guidelines/backend/python.md
+++ b/dev/guidelines/backend/python.md
@@ -188,32 +188,13 @@ branch_data = BranchCreateInput(name="feature-x")
 
 ### Use dict.get() for Default Values
 
-Prefer `dict.get(key, default)` over an existence check or `try/except` when reading a key that may be missing. It is more concise and avoids the cost of raising and catching `KeyError`:
+Read a possibly-missing key with `dict.get(key, default)`, not an `in` check or `try/except KeyError`:
 
 ```python
-config: dict[str, int] = {"timeout": 30}
-
-# ❌ Bad - verbose existence check
-if "retries" in config:
-    retries = config["retries"]
-else:
-    retries = 3
-
-# ❌ Bad - exception handling for an expected-missing key
-try:
-    retries = config["retries"]
-except KeyError:
-    retries = 3
-
-# ✅ Good - get() with an explicit default
 retries = config.get("retries", 3)
 ```
 
-Guidelines:
-
-- `get()` without a second argument returns `None` for missing keys.
-- Chain for nested access: `config.get("db", {}).get("host", "localhost")`.
-- Use `setdefault()` when the default is a mutable object you intend to build up: `cache.setdefault("results", []).append(42)`.
+Without a second argument `get()` returns `None`. Use `setdefault()` when the default is a mutable object you build up: `cache.setdefault("results", []).append(42)`.
 
 ## Configuration Settings
 
@@ -384,7 +365,7 @@ async def set(self, key: str, value: str, expires: KVTTL | int | None = None) ->
 
 To branch on or read from a typed object, use `isinstance` so the type checker can narrow it; reaching for `getattr(obj, "attr", default)` defeats type analysis. When guarding a schema object, cover the whole family that carries the attribute — `isinstance(schema, (NodeSchema, ProfileSchema, TemplateSchema))` — since profiles and templates inherit node behavior and a `NodeSchema`-only check silently drops them.
 
-The same goes for named accessors: read a relationship manager with `node.get_relationship(name)`, not `getattr(node, name)` — the accessor is typed and greppable, and `getattr` hides the read from both.
+The same goes for named accessors: read a relationship manager with `node.get_relationship(name)`, not `getattr(node, name)` — the accessor is typed and greppable, and `getattr` hides the read from both. When the field is optional, use the raising accessor instead of coercing: `str(rel_schema.identifier)` turns a missing identifier into the literal string `"None"`, which then matches nothing downstream — `rel_schema.get_identifier()` raises at the fault instead.
 
 ### Don't write "one or many" unions — take the plural form and let callers wrap
 

--- a/dev/guidelines/backend/testing.md
+++ b/dev/guidelines/backend/testing.md
@@ -378,25 +378,21 @@ In integration-tier tests the clock cannot be injected — a consumer or worker 
 wall-clock time to act. Never guess that duration with a fixed `asyncio.sleep(n)` before
 asserting: on a loaded CI runner the test flakes, and on a fast machine it wastes the time. Poll
 the expected state in a small loop with a deadline, so the test waits exactly as long as the
-outcome takes and fails with a timeout when it never arrives.
+outcome takes and fails with a timeout when it never arrives. Poll for the exact state the
+assertion will check — the specific log line, the exact count — not for mere arrival: a loop that
+exits as soon as anything shows up hands an unrelated first event to the assertion and the test
+fails (or passes) spuriously.
 
 ## Exception Testing
 
 When testing that code raises an exception, use the `match` parameter of `pytest.raises` to validate the error message:
 
 ```python
-# Good - use match parameter for message validation
 with pytest.raises(PoolExhaustedError, match=r"no more addresses available"):
     allocate_from_pool(pool_id=exhausted_pool.id)
-
-# Bad - manual assertion on exception message
-with pytest.raises(PoolExhaustedError) as exc_info:
-    allocate_from_pool(pool_id=exhausted_pool.id)
-
-assert "no more addresses available" in exc_info.value.message
 ```
 
-The `match` parameter accepts a regular expression pattern and is more concise. Use `r"..."` raw strings to avoid escaping issues.
+The `match` parameter accepts a regular expression pattern and is more concise than a manual assertion on `exc_info.value.message`. Use `r"..."` raw strings to avoid escaping issues.
 
 ## GraphQL Result Assertions
 

--- a/dev/guidelines/documentation.md
+++ b/dev/guidelines/documentation.md
@@ -97,7 +97,7 @@ agents with a job to finish.
 - Link to topic/explanation docs for background information (in guides)
 - Link to guides for task instructions (in topics)
 - Define technical terms on first use
-- Before citing a specific test as verifying a scenario (a spec table, a status doc), confirm that test function actually exists in the change or repo — label not-yet-written coverage as planned/unverified instead of naming a test that isn't there
+- Before citing a concrete name — a test function, a flow or automation's registered name, a config key, a file path — grep for it and copy it verbatim: a near-miss name sends the reader (and every grep) to nothing. Label not-yet-written coverage as planned/unverified instead of naming a test that isn't there
 
 ### Don't
 

--- a/dev/guides/backend/creating-migrations.md
+++ b/dev/guides/backend/creating-migrations.md
@@ -34,7 +34,7 @@ Choose the right base class in `backend/infrahub/core/migrations/shared.py`:
 
 ## Migrations run at the current timestamp
 
-Every entry point builds `MigrationInput` with `at` = now — the upgrade CLI, branch rebase, and the schema-migration batch. All stored edges were written earlier, so a migration query never encounters an edge whose `from` lies after `$at`: a `from <= $at` guard against future-dated edges is dead code here, and test data that can only exist at a historical `at` exercises nothing the migration can reach.
+Each caller supplies `MigrationInput.at` for its operation: the graph upgrade and branch-version runner use a fresh timestamp, while rebases derive it from the diff timestamp and schema-migration batches forward `message.at`. Keep `from <= $at` predicates and historical-`at` tests whenever the migration query is time-scoped.
 
 ## Steps
 

--- a/dev/guides/backend/creating-migrations.md
+++ b/dev/guides/backend/creating-migrations.md
@@ -32,6 +32,10 @@ Choose the right base class in `backend/infrahub/core/migrations/shared.py`:
 
 `SchemaMigration` is a separate family under `backend/infrahub/core/migrations/schema/`, registered in `MIGRATION_MAP` and selected by the schema diff rather than by `GRAPH_VERSION`. Steps 1-3 below do not apply to it, but the retry rule does.
 
+## Migrations run at the current timestamp
+
+Every entry point builds `MigrationInput` with `at` = now — the upgrade CLI, branch rebase, and the schema-migration batch. All stored edges were written earlier, so a migration query never encounters an edge whose `from` lies after `$at`: a `from <= $at` guard against future-dated edges is dead code here, and test data that can only exist at a historical `at` exercises nothing the migration can reach.
+
 ## Steps
 
 ### Step 1: Create the Migration File


### PR DESCRIPTION
# Why

Reviewers repeated themselves across this week's PRs — exact-assertion asks came up on three PRs (once with the reviewer explicitly saying the rule exists in `.claude/rules/testing-python.md` but the agent missed it), rejected-approach/history narration in comments and docstrings was flagged roughly a dozen times across seven PRs, and "migrations run at the current timestamp" was rebutted for the second week running. This is the weekly harvest run: it mines the week's review threads for rules that generalize, verifies each against the code, and routes the durable ones into the internal-doc layer.

**Non-goals**: no production code or test changes; no new rules for lessons owned by still-open PRs (the retry-ownership design on #10121/#10496).

## PRs I learned from

Lessons in this PR trace to review threads on:

- **#10424** — polmichel asked for strict assertions twice and diagnosed the miss directly: the exact-assertions rule exists in `testing-python.md` but lacked an example with a GraphQL `result.errors` structure; he also flagged an `or` nested in an assertion ("forces us to run the test to know what the concrete system behavior is"). The rule file now carries the ❌/✅ `result.errors` example and the no-`or` sentence. Same ask appeared on **#10435** (twice, both "Done") and **#10443** (assert exact trigger names).
- **#10503, #10476, #10484, #10488** — the code-doc-style rule's path globs didn't cover `tasks/`, `utilities/`, root `tests/` (e2e), or `.agents` scripts: saltas888 noted on #10503 that the rule "does not formally cover this file. The point stands on its own merits", and a ticket ID landed in a `tests/e2e` docstring on #10484. Globs extended. saltas888 on #10476 ("Context should describe whats happening from now on, not past") plus pa-lem's own sweep list ("used to", "would have", "was rejected", "no longer") turned the recurring rejected-approach-narration flags (~12 across #10443, #10461, #10466, #10477, #10484, #10495, #10509) into a concrete greppable addition to the same bullet.
- **#10509** (with the same exchange on **#10438** last week) — ajtmccarty rebutted future-dated-edge guards three times ("migrations only run at the latest time"); verified in code that every `MigrationInput` entry point passes `at=now`. Now stated in `creating-migrations.md`, which should stop both the repeat bot findings and agents adding dead `from <= $at` guards.
- **#10479, #10495** — internal docs cited a Prefect automation by a name that doesn't exist (twice) and a spec cited a helper path that doesn't exist; the documentation guideline's verify-the-test bullet now covers any concrete name (registered flow/automation names, config keys, file paths): grep it, copy it verbatim.
- **#10505** — saltas888's fix showed the existing poll-don't-sleep guidance under-specified the loop condition: two tests polled for "any line logged" while asserting one exact line. The section now says to poll for the exact state the assertion checks.
- **#10489** — `str(rel_schema.identifier)` queried the literal `"None"` and silently dropped a peer changelog; the fix landed as `get_identifier()`. One sentence added to the existing accessor paragraph in `python.md`.
- **#10461** (twice) and **#10490** — bots repeatedly demanded issue IDs inside orphan changelog-fragment slugs; ogenstad ("If the first part of the fragment filename is not a number its only purpose is to not conflict") and ajtmccarty ("that's not the format of our changelog file names") rebutted. The `creating-changelog-entries` skill now states when a bare issue number is right and that an orphan slug carries no metadata.

Also read, with nothing durable to harvest: #10367 (Vale file-scope suppression — unresolved, no landed fix; worth watching), #9807 (ogenstad's "drop the version pins from AGENTS.md Tech Stack?" is directional with no landed change — a genuine open question for the team), #10121/#10496 (retry-scope and re-entrancy design owned by those open PRs), #10443's architecture threads (open PR), #10456, #10466, #10470, #10477, #10481, #10483, #10487, #10491, #10492, #10504, #10506, #10508, #10510, #10231 (gh-aw timeout semantics — too tool-specific), #10451 (hover-only affordance — unresolved, no landed change), #10453, #10465, #10508, and the dependabot/bot-merge/release PRs in the window.

Notable non-edits, recorded deliberately:

- **`Sequence[str]` accepts a bare `str`** (bot on #10461) and **objects-vs-nodes wording** (bot on #10437, #10467, #10490, #10509) are already codified precisely (`python.md` §one-or-many unions; `docs/AGENTS.md`), and in every case the bot cited the rule and the author complied — that is the enforcement loop working, not a coverage gap.
- **`tasks/*.py` function-local imports** (fatih-acar's rationale on #10488) is not yet established practice — `tasks/docs.py` carries a module-level `pydantic_settings` import today — and the PR is open; not codified.
- **Spec-file drift** (stale migration numbers, checked-off tasks without coverage on #10483, #10495, #10509) is covered by the existing root-`AGENTS.md` Always-Do sweep rule; the bot catches the residue post-hoc. No stronger wording suggested itself.
- **Rot sweep** (§5 of the harvesting skill): clean. The only "known gap" note in the layer (`async-tasks.md`, branch-purge race) still matches `branch_cleanup.py` on this branch, so it stays.

## What changed

Documentation layer only, 7 files, **+33/−36** — the deletions paid for the additions:

- `.agents/rules/testing-python.md` (86→95): `result.errors` ❌/✅ example; no-`or`-in-assertions sentence
- `.agents/rules/code-doc-style.md` (56→60): four path globs added; history/past-tense narration folded into the rejected-approach bullet (its redundant motivation sentence cut)
- `dev/guidelines/documentation.md` (152, net 0): verify-the-name bullet broadened in place
- `dev/guides/backend/creating-migrations.md` (177→180, range 200–500): migrations-run-at-now section
- `dev/guidelines/backend/testing.md` (465→461, still over its 400 cap but net −4): poll-for-the-asserted-state sentences, paid for by trimming the redundant bad-example in Exception Testing
- `dev/guidelines/backend/python.md` (473→454, toward its 400 cap): optional-coercion sentence in the accessor paragraph, paid for by compressing the universal `dict.get()` section
- `.agents/skills/creating-changelog-entries/SKILL.md` (102→106): orphan-slug clause

What stayed the same: no production code, no tests, no user-facing docs pages, no schema changes. `.claude/rules` and `.claude/skills` are symlinks into `.agents/`, so both harnesses see the edits.

## How to review

Every edit cites its review threads in the commit message. The judgement calls worth a second pair of eyes: the migrations-at-now section states a guarantee ("a migration query never encounters an edge whose `from` lies after `$at`") — flag it if any migration path can run at a historical timestamp; and the changelog-skill clause encodes ogenstad's and ajtmccarty's rebuttals over the bots' repeated renaming asks.

## How to test

```bash
npx --yes markdownlint-cli2 <the 7 changed files>
```

Ran locally: 0 issues in 7 files. CI's `docs.lint` globs cover `docs/docs/**` only — this diff touches no files there, so it passes trivially.

## Impact & rollout

- **Backward compatibility:** documentation only; no behavior change.

## Checklist

- [ ] Tests added/updated — N/A, docs only
- [ ] Changelog entry added — N/A, internal agent docs only (the kind the boundary in `AGENTS.md` exempts)
- [ ] External docs updated — N/A, no user-facing change
- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UMZLsCXN6gmnT1JcWB4JV

---
_Generated by [Claude Code](https://claude.ai/code/session_013UMZLsCXN6gmnT1JcWB4JV)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

