### PR TITLE
docs(agents): forbid new type suppressions, cast(), and getattr() in Python rules

### DIFF
--- a/.agents/rules/python-typing.md
+++ b/.agents/rules/python-typing.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python typing discipline
+
+Applies to all Python, production and tests. Full reference: `dev/guidelines/backend/python.md`.
+
+## Suppressions are tech debt, not a tool
+
+The mypy `disable_error_code` blocks and the `[[tool.ty.overrides]]` in `pyproject.toml` are existing tech debt, removed rule-by-rule. Treat each as a defect, never a pattern to copy.
+
+- Do **not** add a new module/directory ignore, and do **not** extend an existing ignore list to cover a violation your change introduces.
+- Do **not** add a new inline `# type: ignore` / `# ty: ignore` to silence a new violation.
+- If your change trips a checker, fix the code — do not silence it.
+
+Two narrow exceptions:
+
+- A linter/type-checker **version upgrade** introduces new rules the codebase has not yet met. Grandfather those as a scoped, commented step, then burn them down.
+- Re-enabling a previously-disabled rule for a module, where a scoped `# type: ignore[code]  # reason` grandfathers unrelated pre-existing violations (a net reduction, per `python.md`). This never applies to a new violation.
+
+## Fix the type, don't discard it
+
+When the checker warns, find the approach that is actually correct — a Pydantic-native shape, a proper model/field type, or `isinstance` narrowing — rather than defeating the check.
+
+- **No `cast()`.** It asserts a type without verifying it, turning type checking off exactly where a bug would hide. Avoid it at all costs; reshape the code so the real type flows through.
+- **Prefer `isinstance` over `getattr()`.** `getattr(obj, "x", default)` hides the read from the checker and from grep. Narrow with `isinstance` (cover the whole family carrying the attribute) or use the typed, named accessor.

--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -84,3 +84,7 @@ Do not reference issue numbers, GitHub URLs, or Jira tickets in test names, docs
 ## Schema fixtures
 
 Check `backend/tests/helpers/schema/` before defining test schemas inline. Use `deepcopy` to derive variants from existing helpers rather than writing new schemas from scratch.
+
+## Generate protocols for test schemas
+
+The typing rules in `python-typing.md` apply to tests too. When a test drives an SDK client with kind strings, node attribute access resolves to un-narrowable unions and tempts a new `type: ignore`, `cast()`, or `getattr()`. The way to avoid introducing one is to generate the protocol classes for the test schema and type the nodes against them, so the real types flow through. `tests/e2e` deliberately opts out via a ty override — do not copy that pattern into new tests.


### PR DESCRIPTION
## What

Adds a hard rule for agents writing Python, plus a tests-only note.

- **New `.agents/rules/python-typing.md`** (scoped to all Python, `**/*.py`):
  - The mypy `disable_error_code` blocks and `[[tool.ty.overrides]]` in `pyproject.toml` are existing tech debt, not a pattern to copy.
  - No new module/directory ignore, no extending an existing ignore list, and no new inline `# type: ignore` / `# ty: ignore` to cover a violation your change introduces. Fix the code instead.
  - Two narrow exceptions: new rules from a linter/type-checker **version upgrade** (grandfather + burn down), and grandfathering unrelated pre-existing violations while re-enabling a previously-disabled rule (never for a new violation).
  - **No `cast()`** - it asserts a type without verifying it, turning off checking where a bug hides.
  - Prefer `isinstance` narrowing over `getattr()`.
- **`.agents/rules/testing-python.md`**: tests-only note that references `python-typing.md` and points to generating protocol classes for test schemas as the way to avoid introducing a new ignore/`cast()`/`getattr()` when driving SDK clients with kind strings. Kept in the tests-scoped rule so this context never loads for production code.

## Why

Keeps new implementations honest about types instead of silencing checkers. Aligns the hard-rules layer with the depth already in `dev/guidelines/backend/python.md`.

## Notes

No changelog fragment: agent-doc change, not user-visible.