### PR TITLE
docs/test: fix review wording flagged on the stable→develop merge

### DIFF
--- a/backend/tests/component/branch/test_purge_deleted_branch_tasks.py
+++ b/backend/tests/component/branch/test_purge_deleted_branch_tasks.py
@@ -18,10 +18,10 @@ def _noop_flow() -> None:
 async def test_purge_removes_settled_tasks_of_a_deleted_branch_but_leaves_running_ones(
     prefect_client: PrefectClient,
 ) -> None:
-    """A deleted branch's settled tasks are removed so a same-named branch starts with none.
+    """A deleted branch's settled tasks are removed so completed tasks no longer surface.
 
     In-flight work keeps the same branch tag while it runs, so only settled runs are purged; a
-    running run is left untouched.
+    running run is left untouched. Cleanup is best-effort and follows the committed deletion.
     """
     branch_name = f"task-leak-branch-{uuid4()}"
     branch_tag = WorkflowTag.BRANCH.render(identifier=branch_name)

--- a/backend/tests/helpers/prefect_diagnostics.py
+++ b/backend/tests/helpers/prefect_diagnostics.py
@@ -96,17 +96,9 @@ def timeout_diagnostics_section(nodeid: str, when: str, exception: BaseException
     """A report section on every registered server, for a test pytest-timeout killed. Else ``None``.
 
     Attach it to the test report rather than printing it: under xdist a worker's own stdout goes
-    nowhere, and only what the report carries reaches the CI log.
-
-    Any other failure is left alone. The report costs the server a signal, the run a two second
-    wait and the log three hundred lines, which only a suspected wedge earns.
-
-    The message is the only mark pytest-timeout leaves on the failure, so a test failing itself
-    with one that opens the same way would be reported on too. That is the right way round to be
-    wrong: a false positive costs an already-failing test two seconds and a log tail, and the
-    server survives being asked what it is doing, while matching on the plugin's own frames
-    instead would stop reporting the day its internals change — silently, and back to a wedge
-    that CI cannot describe.
+    nowhere, and only what the report carries reaches the CI log. Any other failure is left alone;
+    the report costs the server a signal, the run a two second wait and the log three hundred
+    lines, which only a suspected wedge earns.
     """
     if not isinstance(exception, pytest.fail.Exception) or not str(exception).startswith(TIMEOUT_MESSAGE_PREFIX):
         return None

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -12,7 +12,7 @@ Git workflow and commit conventions for the project.
   that should ship the change — `stable` when the affected code is released and the change can ship
   in a patch release, `develop` when the code only exists there or the change can wait for the next
   minor. A fix that changes observable behavior (which branch an event fires on, a value that is no
-  longer accepted) defaults to `develop` with a release-notes flag — shipping it in a patch release
+  longer accepted) defaults to `develop` with a changelog fragment — shipping it in a patch release
   is a deliberate call for an urgent fix, not the default
 - **Repo-tooling/lint/CI-config changes:** target `develop` if the diff also edits runtime source —
   converting call sites, changing behavior a new lint rule now gates — since what the code emits at

--- a/dev/knowledge/backend/authentication.md
+++ b/dev/knowledge/backend/authentication.md
@@ -82,7 +82,7 @@ An account owns three kinds of bookkeeping node in the `Internal` namespace, eac
 | `InternalAccountToken` | `account__token` |
 | `InternalRefreshToken` | `account__refreshtoken` |
 
-All three are declared on the account side with `on_delete=CASCADE`, so a delete takes them with it. All three must be, not just the ones that cause visible trouble: a mandatory relationship that is not cascaded becomes a blocking dependent, and a refresh token exists for every account that has ever logged in, which would make those accounts impossible to delete.
+All three are declared on the account side with `on_delete=CASCADE`, so a delete takes them with it. All three must be cascaded, not just the ones that cause visible trouble: a mandatory relationship that is not cascaded becomes a blocking dependent, and a refresh token exists for every account that has ever logged in, which would make those accounts impossible to delete.
 
 These three are the only mandatory relationships declared on any `Internal` kind, which is why `NodeDeleteValidator` can resolve peers without excluding the namespace at all. The `Internal` exclusion remains on the public GraphQL relationship query, where it keeps bookkeeping nodes out of the API.
 

--- a/dev/knowledge/backend/database-schema.md
+++ b/dev/knowledge/backend/database-schema.md
@@ -374,7 +374,7 @@ These filters apply to *any* query whose contract mentions "active" or "current"
 
 Neo4j rejects some writes with errors that are safe to replay on a fresh transaction (a lock contention deadlock, or an entity that a concurrent transaction removed mid-statement). Infrahub retries these at the transaction layer with the `retry_db_transaction` decorator.
 
-`retry_db_transaction(name=...)` wraps an `async` method that owns its transaction. On a retriable error — `is_retriable_db_error` accepts `TransientError` (deadlock, lock timeout) and `EntityNotFound`, nothing else — it re-runs the whole method after an exponential backoff with jitter, configured by the `INFRAHUB_DB_RETRY_*` settings; a non-retriable error propagates immediately.
+`retry_db_transaction(name=...)` wraps an `async` method that owns its transaction. On a retriable error — `is_retriable_db_error` accepts `TransientError` (deadlock, lock timeout) and `ClientError` with code `Neo.ClientError.Statement.EntityNotFound`, nothing else — it re-runs the whole method after an exponential backoff with jitter, configured by the `INFRAHUB_DB_RETRY_*` settings; a non-retriable error propagates immediately.
 
 **A new session escapes the caller's transaction.** `start_transaction()` carries the current session forward, but `start_session()` builds a fresh session straight from the driver — writes made through it commit on their own, whatever transaction the caller holds, so a caller rollback keeps them. Code handed a `db` runs its queries on that `db`; a helper that opens per-task sessions for concurrency must fall back to running sequentially on the caller's `db` when `db.is_transaction`.
 


### PR DESCRIPTION
Addresses the cubic review comments on #10515 (the `stable` → `develop` merge) that were marked "to fix on stable", landing the fixes directly on `stable` where the affected code lives.

## Fixes

- **`dev/knowledge/backend/authentication.md`** — complete the garbled sentence: `All three must be` → `All three must be cascaded`.
- **`dev/knowledge/backend/database-schema.md`** — the retriable set is `TransientError` and a `ClientError` with code `Neo.ClientError.Statement.EntityNotFound`; the previous wording implied a non-existent `EntityNotFound` exception class.
- **`dev/guidelines/git-workflow.md`** — use the established **changelog fragment** term instead of the undefined "release-notes flag".
- **`backend/tests/component/branch/test_purge_deleted_branch_tasks.py`** — the docstring stated a same-named branch "starts with none"; the purge is best-effort and only removes settled runs, so state the durable guarantee (completed tasks no longer surface) instead.
- **`backend/tests/helpers/prefect_diagnostics.py`** — condense the `timeout_diagnostics_section` docstring to its contract and bounded-cost caveat, dropping the rejected-approach narration per `.agents/rules/code-doc-style.md`.

## Validation

- `ruff check` / `ruff format --check` and `ty` pass on the two changed Python files.
- `invoke docs.lint` clean on the changed docs (no new warnings).

Docs/test wording only — no runtime behavior change, so no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

