### PR TITLE
feat(backend): add infrahub db reset to wipe the configured databases

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -55,6 +55,7 @@ from infrahub.core.schema.definitions.deprecated import deprecated_models
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.update_coordinator import MigrationExecutor, SchemaUpdateCoordinator
 from infrahub.core.timestamp import Timestamp
+from infrahub.core.utils import count_nodes, delete_all_nodes
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import DatabaseType
@@ -66,6 +67,14 @@ from infrahub.exceptions import ValidationError
 from .constants import APPLIED_BADGE, ERROR_BADGE, FAILED_BADGE, SUCCESS_BADGE
 from .db_commands.check_inheritance import check_inheritance
 from .db_commands.clean_duplicate_schema_fields import clean_duplicate_schema_fields
+from .db_commands.reset import (
+    get_configured_task_manager_database_url,
+    get_task_manager_database_dialect,
+    is_graph_database_configured,
+    mask_connection_url_password,
+    reset_task_manager_database,
+    task_manager_database,
+)
 from .patch import patch_app
 
 
@@ -75,6 +84,8 @@ def get_timestamp_string() -> str:
 
 
 if TYPE_CHECKING:
+    from prefect.server.database.interface import PrefectDBInterface
+
     from infrahub.cli.context import CliContext
     from infrahub.core.root import Root
     from infrahub.database import InfrahubDatabase
@@ -398,6 +409,143 @@ async def reset_deployment_id_cmd(
         )
     finally:
         await dbdriver.close()
+
+
+@app.command(name="reset")
+async def reset_cmd(
+    ctx: typer.Context,
+    yes_graph: bool = typer.Option(
+        False, "--yes-graph", help="Reset the graph database without asking for confirmation."
+    ),
+    yes_task_manager: bool = typer.Option(
+        False, "--yes-task-manager", help="Reset the task manager database without asking for confirmation."
+    ),
+    config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
+) -> None:
+    """Erase all Infrahub data from the databases configured in this environment.
+
+    This resets Infrahub completely: objects, schemas, branches, accounts, permissions, task history
+    and logs are permanently erased and cannot be recovered, so make sure a backup exists before
+    running it. The graph database is reset when its connection is configured, through INFRAHUB_DB_* settings
+    or the `database` section of the configuration file: every vertex and edge is removed, indexes
+    and constraints are kept. The task manager (Prefect) database is reset when
+    PREFECT_API_DATABASE_CONNECTION_URL is set: every table is dropped and recreated empty. A
+    database that is not configured is skipped, and each configured one is confirmed separately
+    unless its --yes flag is given. Each Infrahub container only knows its own database, so run the
+    command in the infrahub-server container to reset the graph and in the task-manager container
+    to reset the task manager. Stop the Infrahub server and task workers first and start them
+    again afterwards: on startup the server initializes the empty databases exactly as on a first
+    installation.
+
+    Raises:
+        Exit: When no database is configured, the task manager database URL is unsupported or its
+            database unreachable, or every configured database is declined at its confirmation
+            prompt (raises typer.Exit to terminate the CLI command).
+
+    """
+    logging.getLogger("infrahub").setLevel(logging.WARNING)
+    logging.getLogger("neo4j").setLevel(logging.ERROR)
+    logging.getLogger("prefect").setLevel(logging.ERROR)
+    logging.getLogger("alembic").setLevel(logging.WARNING)
+
+    console = Console()
+
+    config.load_and_exit(config_file_name=config_file)
+
+    graph_configured = is_graph_database_configured(database_settings=config.SETTINGS.database)
+    task_manager_db_url = get_configured_task_manager_database_url()
+
+    if not graph_configured and task_manager_db_url is None:
+        console.print(
+            "[red]No database is configured in this environment: neither an INFRAHUB_DB_* setting "
+            "nor PREFECT_API_DATABASE_CONNECTION_URL is set.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if task_manager_db_url is not None:
+        try:
+            get_task_manager_database_dialect(connection_url=task_manager_db_url)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from exc
+
+    dbdriver: InfrahubDatabase | None = None
+    if graph_configured:
+        context: CliContext = ctx.obj
+        dbdriver = await context.init_db(retry=1)
+
+    try:
+        with contextlib.ExitStack() as stack:
+            vertex_count = 0
+            if dbdriver is not None:
+                database_settings = config.SETTINGS.database
+                graph_target = (
+                    f"{database_settings.db_type.value} at {database_settings.address}:{database_settings.port}"
+                )
+                if database_settings.database:
+                    graph_target += f", database {database_settings.database}"
+                vertex_count = await count_nodes(db=dbdriver)
+                console.print(f"Graph database:        [bold]{graph_target}[/bold] ({vertex_count} vertices)")
+            else:
+                console.print(
+                    "Graph database:        [yellow]not configured here (no INFRAHUB_DB_* setting), skipped[/yellow]"
+                )
+
+            task_db: PrefectDBInterface | None = None
+            if task_manager_db_url is not None:
+                task_db = stack.enter_context(task_manager_database(connection_url=task_manager_db_url))
+                masked_url = mask_connection_url_password(connection_url=task_manager_db_url)
+                if not await task_db.is_db_connectable():
+                    console.print(f"[red]Cannot connect to the task manager database at {masked_url}.[/red]")
+                    raise typer.Exit(code=1)
+                console.print(f"Task manager database: [bold]{masked_url}[/bold]")
+            else:
+                console.print(
+                    "Task manager database: [yellow]not configured here "
+                    "(PREFECT_API_DATABASE_CONNECTION_URL is unset), skipped[/yellow]"
+                )
+
+            console.print(
+                "[bold red]WARNING: this resets Infrahub completely. All data in the databases listed above "
+                "is permanently erased and cannot be recovered. Make sure you have a backup before "
+                "continuing.[/bold red]"
+            )
+
+            # Collect every decision before the first wipe, so a declined prompt never follows a
+            # deletion that already happened.
+            reset_graph = False
+            if dbdriver is not None:
+                reset_graph = yes_graph or typer.confirm(
+                    "Erase ALL Infrahub data from the graph database (objects, schemas, branches, accounts, "
+                    "permissions)? This cannot be undone."
+                )
+                if not reset_graph:
+                    console.print("[yellow]Graph database: skipped.[/yellow]")
+            reset_task_manager = False
+            if task_db is not None:
+                reset_task_manager = yes_task_manager or typer.confirm(
+                    "Erase ALL task manager data (task history, logs, schedules)? This cannot be undone."
+                )
+                if not reset_task_manager:
+                    console.print("[yellow]Task manager database: skipped.[/yellow]")
+
+            if dbdriver is not None and reset_graph:
+                await delete_all_nodes(db=dbdriver)
+                console.print(f"[green]Graph database reset: {vertex_count} vertices deleted.[/green]")
+
+            if task_db is not None and reset_task_manager:
+                await reset_task_manager_database(task_db=task_db)
+                console.print("[green]Task manager database reset: all tables dropped and recreated.[/green]")
+
+        if not reset_graph and not reset_task_manager:
+            console.print("[yellow]Nothing was reset.[/yellow]")
+            raise typer.Exit(code=1)
+        console.print(
+            "[yellow]Start the Infrahub server and task workers again to initialize the empty databases.[/yellow]"
+        )
+    finally:
+        if dbdriver is not None:
+            await dbdriver.close()
 
 
 @app.command(name="check-duplicate-schema-fields")

--- a/backend/infrahub/cli/db_commands/reset.py
+++ b/backend/infrahub/cli/db_commands/reset.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+
+from prefect.server.database import provide_database_interface
+from prefect.server.database.configurations import AioSqliteConfiguration, AsyncPostgresConfiguration
+from prefect.server.database.dependencies import (
+    temporary_database_config,
+    temporary_orm_config,
+    temporary_query_components,
+)
+from prefect.server.database.orm_models import AioSqliteORMConfiguration, AsyncPostgresORMConfiguration
+from prefect.server.database.query_components import AioSqliteQueryComponents, AsyncPostgresQueryComponents
+from prefect.server.utilities.database import get_dialect
+from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL, get_current_settings, temporary_settings
+from sqlalchemy.exc import ArgumentError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from prefect.server.database.configurations import BaseDatabaseConfiguration
+    from prefect.server.database.interface import PrefectDBInterface
+    from prefect.server.database.orm_models import BaseORMConfiguration
+    from prefect.server.database.query_components import BaseQueryComponents
+
+    from infrahub.config import DatabaseSettings
+
+GRAPH_DATABASE_CONNECTION_FIELDS = frozenset(
+    {
+        "db_type",
+        "protocol",
+        "username",
+        "password",
+        "address",
+        "port",
+        "database",
+        "policy",
+        "tls_enabled",
+        "tls_insecure",
+        "tls_ca_file",
+    }
+)
+"""Graph database settings that identify which database a process talks to, as opposed to tuning knobs."""
+
+
+class TaskManagerDatabaseDialect(StrEnum):
+    """Database engines Prefect can back the task manager with."""
+
+    POSTGRESQL = "postgresql"
+    SQLITE = "sqlite"
+
+
+def is_graph_database_configured(database_settings: DatabaseSettings) -> bool:
+    """Tell whether the graph database connection was configured explicitly.
+
+    Every connection field has a default, so a process started without any ``INFRAHUB_DB_*``
+    setting or ``[database]`` section would happily aim at ``localhost``. Only a connection field
+    that was actually provided counts as configuration; tuning fields such as the query size limit
+    do not.
+
+    Args:
+        database_settings: The loaded graph database settings.
+
+    Returns:
+        True when at least one connection field was provided.
+
+    """
+    return bool(database_settings.model_fields_set & GRAPH_DATABASE_CONNECTION_FIELDS)
+
+
+def get_configured_task_manager_database_url() -> str | None:
+    """Return the task manager database URL when Prefect was configured with one.
+
+    Prefect falls back to a SQLite file under ``PREFECT_HOME`` when no URL is configured and
+    materializes that fallback into its settings, so the settings value alone cannot tell a
+    configured database from the fallback; only an explicitly provided ``connection_url`` counts.
+
+    Returns:
+        The configured URL, or None when the environment carries no task manager database.
+
+    """
+    database_settings = get_current_settings().server.database
+    if "connection_url" not in database_settings.model_fields_set or database_settings.connection_url is None:
+        return None
+    return database_settings.connection_url.get_secret_value()
+
+
+def get_task_manager_database_dialect(connection_url: str) -> TaskManagerDatabaseDialect:
+    """Identify the database engine behind a task manager connection URL.
+
+    Args:
+        connection_url: SQLAlchemy URL of the task manager database.
+
+    Returns:
+        The dialect the URL points at.
+
+    Raises:
+        ValueError: When the URL cannot be parsed or names an engine Prefect does not support.
+
+    """
+    try:
+        dialect_name = get_dialect(connection_url).name
+    except ArgumentError as exc:
+        raise ValueError(f"Invalid task manager database URL: {exc}") from exc
+    try:
+        return TaskManagerDatabaseDialect(dialect_name)
+    except ValueError:
+        raise ValueError(
+            f"Unsupported task manager database {dialect_name!r}: only PostgreSQL and SQLite are supported."
+        ) from None
+
+
+@contextmanager
+def task_manager_database(connection_url: str) -> Iterator[PrefectDBInterface]:
+    """Provide the task manager database interface bound to ``connection_url``.
+
+    Prefect (3.x) keeps reusing the first database configuration built in a process, whatever its
+    settings say afterwards, so the dialect-specific configuration for ``connection_url`` is
+    installed explicitly for the duration of the block. Keep the block open while the interface is
+    used: the schema upgrade runs in a worker thread that resolves the database on its own.
+
+    Args:
+        connection_url: SQLAlchemy URL of the task manager database.
+
+    Yields:
+        The database interface for that URL.
+
+    Raises:
+        ValueError: When the URL cannot be parsed or names an engine Prefect does not support.
+
+    """
+    dialect = get_task_manager_database_dialect(connection_url=connection_url)
+    database_config: BaseDatabaseConfiguration
+    query_components: BaseQueryComponents
+    orm: BaseORMConfiguration
+    if dialect is TaskManagerDatabaseDialect.POSTGRESQL:
+        database_config = AsyncPostgresConfiguration(connection_url=connection_url)
+        query_components = AsyncPostgresQueryComponents()
+        orm = AsyncPostgresORMConfiguration()
+    else:
+        database_config = AioSqliteConfiguration(connection_url=connection_url)
+        query_components = AioSqliteQueryComponents()
+        orm = AioSqliteORMConfiguration()
+
+    with (
+        temporary_settings(updates={PREFECT_API_DATABASE_CONNECTION_URL: connection_url}),
+        temporary_database_config(tmp_database_config=database_config),
+        temporary_query_components(tmp_queries=query_components),
+        temporary_orm_config(tmp_orm_config=orm),
+    ):
+        yield provide_database_interface()
+
+
+async def reset_task_manager_database(task_db: PrefectDBInterface) -> None:
+    """Drop every table of the task manager database and recreate the schema empty.
+
+    Args:
+        task_db: Database interface bound to the task manager database.
+
+    """
+    await task_db.drop_db()
+    await task_db.create_db()
+    engine = await task_db.engine()
+    await engine.dispose()
+
+
+def mask_connection_url_password(connection_url: str) -> str:
+    """Return ``connection_url`` with the password of its userinfo replaced by ``***``.
+
+    Args:
+        connection_url: SQLAlchemy URL, possibly carrying ``user:password@`` credentials.
+
+    Returns:
+        The URL unchanged when it carries no password, masked otherwise.
+
+    """
+    parts = urlsplit(connection_url)
+    userinfo, separator, hostport = parts.netloc.rpartition("@")
+    if not separator or ":" not in userinfo:
+        return connection_url
+    username = userinfo.partition(":")[0]
+    return urlunsplit(parts._replace(netloc=f"{username}:***@{hostport}"))

--- a/backend/infrahub/core/utils.py
+++ b/backend/infrahub/core/utils.py
@@ -5,6 +5,7 @@ import re
 from inspect import isclass
 from typing import TYPE_CHECKING, Any
 
+from infrahub.constants.database import DatabaseType
 from infrahub.core.constants import RelationshipStatus
 from infrahub.core.models import NodeKind
 from infrahub.core.query import QueryType
@@ -132,13 +133,45 @@ async def count_nodes(db: InfrahubDatabase, label: str | None = None) -> int:
     return result[0][0]
 
 
-async def delete_all_nodes(db: InfrahubDatabase) -> list[Record]:
-    query = """
-    MATCH (n)
-    DETACH DELETE n
-    """
+DELETE_ALL_NODES_BATCH_SIZE = 10_000
+"""Vertices detached and deleted per transaction by ``delete_all_nodes``.
 
-    params: dict = {}
+Each batch commits on its own, so a graph of any size can be wiped without a single transaction
+having to hold every deleted vertex and edge in the heap.
+"""
+
+
+async def delete_all_nodes(db: InfrahubDatabase, batch_size: int = DELETE_ALL_NODES_BATCH_SIZE) -> list[Record]:
+    """Delete every vertex and edge of the graph database.
+
+    On Neo4j the vertices are deleted in batches of ``batch_size``, each committed on its own, as
+    long as the connection is in auto-commit mode: Neo4j only accepts ``CALL ... IN TRANSACTIONS``
+    in an implicit transaction, so a caller that is already inside an explicit transaction gets a
+    single-statement delete instead. Memgraph has no batched transactions and always gets the
+    single statement.
+
+    Args:
+        db: Database connection.
+        batch_size: Number of vertices deleted per transaction in the batched case.
+
+    Returns:
+        The records returned by the delete query, always empty.
+
+    """
+    params: dict[str, Any] = {}
+    if db.db_type is DatabaseType.MEMGRAPH or db.is_transaction:
+        query = """
+        MATCH (n)
+        DETACH DELETE n
+        """
+    else:
+        query = """
+        MATCH (n)
+        CALL (n) {
+            DETACH DELETE n
+        } IN TRANSACTIONS OF $batch_size ROWS
+        """
+        params["batch_size"] = batch_size
 
     return await db.execute_query(query=query, params=params, name="delete_all_nodes")
 

--- a/backend/tests/unit/cli/test_cli.py
+++ b/backend/tests/unit/cli/test_cli.py
@@ -1,8 +1,19 @@
+import re
+from unittest.mock import patch
+
+from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL, temporary_settings
 from typer.testing import CliRunner
 
 from infrahub.cli import app
 
 runner = CliRunner()
+
+ANSI_STYLE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    """Strip the ANSI styling Rich adds when the terminal, or the CI runner, advertises colors."""
+    return ANSI_STYLE.sub("", output)
 
 
 def test_main_app() -> None:
@@ -21,3 +32,30 @@ def test_server_app() -> None:
     result = runner.invoke(app, ["server", "--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
+
+
+def test_db_reset_help() -> None:
+    result = runner.invoke(app, ["db", "reset", "--help"])
+    assert result.exit_code == 0
+    assert "--yes-graph" in _plain(result.stdout)
+    assert "--yes-task-manager" in _plain(result.stdout)
+
+
+def test_db_reset_without_any_configured_database() -> None:
+    with (
+        patch("infrahub.cli.db.is_graph_database_configured", return_value=False),
+        temporary_settings(updates={PREFECT_API_DATABASE_CONNECTION_URL: None}),
+    ):
+        result = runner.invoke(app, ["db", "reset"])
+    assert result.exit_code == 1
+    assert "No database is configured" in result.output
+
+
+def test_db_reset_rejects_an_unsupported_task_manager_database() -> None:
+    with (
+        patch("infrahub.cli.db.is_graph_database_configured", return_value=False),
+        temporary_settings(updates={PREFECT_API_DATABASE_CONNECTION_URL: "mysql+pymysql://user:pw@db/prefect"}),
+    ):
+        result = runner.invoke(app, ["db", "reset"])
+    assert result.exit_code == 1
+    assert "Unsupported task manager database" in result.output

--- a/backend/tests/unit/cli/test_db_reset.py
+++ b/backend/tests/unit/cli/test_db_reset.py
@@ -1,0 +1,115 @@
+import pytest
+from prefect.server.database.configurations import AioSqliteConfiguration, AsyncPostgresConfiguration
+from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL, temporary_settings
+
+from infrahub.cli.db_commands.reset import (
+    GRAPH_DATABASE_CONNECTION_FIELDS,
+    TaskManagerDatabaseDialect,
+    get_configured_task_manager_database_url,
+    get_task_manager_database_dialect,
+    is_graph_database_configured,
+    mask_connection_url_password,
+    task_manager_database,
+)
+from infrahub.config import DatabaseSettings
+
+
+@pytest.mark.parametrize(
+    ("connection_url", "expected"),
+    [
+        pytest.param(
+            "postgresql+asyncpg://postgres:s3cret@task-manager-db:5432/prefect",
+            "postgresql+asyncpg://postgres:***@task-manager-db:5432/prefect",
+            id="password",
+        ),
+        pytest.param(
+            "postgresql+asyncpg://user:p%40ss%3Aword@[::1]:5432/prefect?ssl=require",
+            "postgresql+asyncpg://user:***@[::1]:5432/prefect?ssl=require",
+            id="encoded-password-ipv6-host-query",
+        ),
+        pytest.param(
+            "postgresql+asyncpg://postgres@task-manager-db:5432/prefect",
+            "postgresql+asyncpg://postgres@task-manager-db:5432/prefect",
+            id="username-only",
+        ),
+        pytest.param(
+            "postgresql+asyncpg://task-manager-db:5432/prefect",
+            "postgresql+asyncpg://task-manager-db:5432/prefect",
+            id="no-credentials",
+        ),
+        pytest.param(
+            "sqlite+aiosqlite:////tmp/prefect.db",
+            "sqlite+aiosqlite:////tmp/prefect.db",
+            id="sqlite-file",
+        ),
+    ],
+)
+def test_mask_connection_url_password(connection_url: str, expected: str) -> None:
+    assert mask_connection_url_password(connection_url=connection_url) == expected
+
+
+@pytest.mark.parametrize(
+    ("connection_url", "expected"),
+    [
+        pytest.param(
+            "postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect",
+            TaskManagerDatabaseDialect.POSTGRESQL,
+            id="postgresql",
+        ),
+        pytest.param("sqlite+aiosqlite:////tmp/prefect.db", TaskManagerDatabaseDialect.SQLITE, id="sqlite"),
+    ],
+)
+def test_get_task_manager_database_dialect(connection_url: str, expected: TaskManagerDatabaseDialect) -> None:
+    assert get_task_manager_database_dialect(connection_url=connection_url) is expected
+
+
+@pytest.mark.parametrize(
+    ("connection_url", "message"),
+    [
+        pytest.param("task-manager-db:5432/prefect", "Invalid task manager database URL", id="not-a-url"),
+        pytest.param("mysql+pymysql://user:password@db/prefect", "Unsupported task manager database", id="mysql"),
+    ],
+)
+def test_get_task_manager_database_dialect_rejects(connection_url: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        get_task_manager_database_dialect(connection_url=connection_url)
+
+
+class TestIsGraphDatabaseConfigured:
+    def test_nothing_provided(self) -> None:
+        assert not is_graph_database_configured(database_settings=DatabaseSettings.model_construct(_fields_set=set()))
+
+    @pytest.mark.parametrize("field", sorted(GRAPH_DATABASE_CONNECTION_FIELDS))
+    def test_connection_field_provided(self, field: str) -> None:
+        settings = DatabaseSettings.model_construct(_fields_set={field})
+        assert is_graph_database_configured(database_settings=settings)
+
+    def test_tuning_field_only(self) -> None:
+        settings = DatabaseSettings.model_construct(_fields_set={"query_size_limit", "retry_limit"})
+        assert not is_graph_database_configured(database_settings=settings)
+
+
+class TestGetConfiguredTaskManagerDatabaseUrl:
+    def test_unset_ignores_the_sqlite_fallback(self) -> None:
+        with temporary_settings(updates={PREFECT_API_DATABASE_CONNECTION_URL: None}):
+            assert get_configured_task_manager_database_url() is None
+
+    def test_configured(self) -> None:
+        connection_url = "postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect"
+        with temporary_settings(updates={PREFECT_API_DATABASE_CONNECTION_URL: connection_url}):
+            assert get_configured_task_manager_database_url() == connection_url
+
+
+class TestTaskManagerDatabase:
+    def test_binds_each_interface_to_its_own_url(self) -> None:
+        """Prefect pins the first database configuration per process; every later URL must still win."""
+        sqlite_url = "sqlite+aiosqlite:////tmp/first.db"
+        postgres_url = "postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect"
+
+        with task_manager_database(connection_url=sqlite_url) as sqlite_db:
+            assert isinstance(sqlite_db.database_config, AioSqliteConfiguration)
+            assert sqlite_db.database_config.connection_url == sqlite_url
+
+        with task_manager_database(connection_url=postgres_url) as postgres_db:
+            assert isinstance(postgres_db.database_config, AsyncPostgresConfiguration)
+            assert postgres_db.database_config.connection_url == postgres_url

--- a/changelog/+db-reset-command.added.md
+++ b/changelog/+db-reset-command.added.md
@@ -1,0 +1,1 @@
+Added the `infrahub db reset` command to delete all data from the graph database and the task manager database, resetting whichever of the two the current environment is configured for, for example to start over on a development or test deployment without recreating the containers.

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -21,6 +21,7 @@ $ infrahub db [OPTIONS] COMMAND [ARGS]...
 * `showmigration`: Show detailed information about a specific...
 * `check-inheritance`: Check the database for any vertices with...
 * `reset-deployment-id`: Reset the internal deployment_id on the...
+* `reset`: Erase all Infrahub data from the databases...
 * `check-duplicate-schema-fields`: Check for any duplicate schema attributes...
 * `update-core-schema`: Reload the internal core schema definition...
 * `constraint`: Manage Database Constraints.
@@ -129,6 +130,39 @@ $ infrahub db reset-deployment-id [OPTIONS] [CONFIG_FILE]
 
 * `--deployment-id TEXT`: Set an explicit UUID instead of generating a random one.
 * `-y, --yes`: Skip the confirmation prompt.
+* `--help`: Show this message and exit.
+
+## `infrahub db reset`
+
+Erase all Infrahub data from the databases configured in this environment.
+
+This resets Infrahub completely: objects, schemas, branches, accounts, permissions, task history
+and logs are permanently erased and cannot be recovered, so make sure a backup exists before
+running it. The graph database is reset when its connection is configured, through INFRAHUB_DB_* settings
+or the `database` section of the configuration file: every vertex and edge is removed, indexes
+and constraints are kept. The task manager (Prefect) database is reset when
+PREFECT_API_DATABASE_CONNECTION_URL is set: every table is dropped and recreated empty. A
+database that is not configured is skipped, and each configured one is confirmed separately
+unless its --yes flag is given. Each Infrahub container only knows its own database, so run the
+command in the infrahub-server container to reset the graph and in the task-manager container
+to reset the task manager. Stop the Infrahub server and task workers first and start them
+again afterwards: on startup the server initializes the empty databases exactly as on a first
+installation.
+
+**Usage**:
+
+```console
+$ infrahub db reset [OPTIONS] [CONFIG_FILE]
+```
+
+**Arguments**:
+
+* `[CONFIG_FILE]`: [env var: INFRAHUB_CONFIG; default: infrahub.toml]
+
+**Options**:
+
+* `--yes-graph`: Reset the graph database without asking for confirmation.
+* `--yes-task-manager`: Reset the task manager database without asking for confirmation.
 * `--help`: Show this message and exit.
 
 ## `infrahub db check-duplicate-schema-fields`


### PR DESCRIPTION
## Summary

Resetting an Infrahub deployment today means destroying the containers and their volumes and starting them again. `infrahub db reset` wipes the graph database and the task manager (Prefect) database in place, so a development or test deployment can start over in seconds and keep its containers.

## Key changes

- New `infrahub db reset` command. It detects which database the current environment is configured for and resets only that one: the graph when `INFRAHUB_DB_*` settings (or a `database` section in the config file) are present, the task manager when `PREFECT_API_DATABASE_CONNECTION_URL` is set. Run it in the `infrahub-server` container to reset the graph and in the `task-manager` container to reset Prefect; nothing has to be passed on the command line.
- Each configured database is confirmed separately. `--yes-graph` and `--yes-task-manager` skip the prompt for their own database only, so a scripted reset can never silently wipe a database it did not name. Both questions are asked before the first deletion.
- The graph wipe removes every vertex and edge and keeps indexes and constraints. `delete_all_nodes` now deletes in committed batches of 10,000 vertices on Neo4j, so a large graph no longer needs one transaction holding everything. It falls back to the single statement on Memgraph and inside an explicit transaction, because Neo4j only accepts `CALL ... IN TRANSACTIONS` in auto-commit mode and `infrahub dev init` wipes inside one.
- The task manager reset drops and recreates every Prefect table, the same procedure as `prefect server database reset`. Prefect's SQLite fallback is never treated as a target: an unset URL means "not configured here" and the database is skipped.
- The PostgreSQL connection is checked before either database is touched, so a bad URL aborts with nothing deleted.
- The CLI reference is regenerated and a changelog fragment is included.

## Notable implementation details

- Prefect pins the first database configuration it builds for the whole process and ignores later settings changes. The reset installs the dialect-specific configuration explicitly, through Prefect's `temporary_database_config` and friends, for the duration of the operation. A unit test guards this: without it the command could reset a different database than the one it printed.
- Running server and worker processes must be restarted after a reset; the command says so. On startup the server runs first-time initialization on the empty databases.

## Risk

Destructive database CLI touching `backend/infrahub/cli/` and `backend/infrahub/core/utils.py`. Both wipes are irreversible by design and gated by per-database confirmation prompts. The batched `delete_all_nodes` is shared with the test fixtures and `infrahub dev init`.

## Testing performed

- `uv run pytest backend/tests/unit/cli`: 27 passed. Covers the two configuration detectors, URL masking and dialect validation, the Prefect interface binding, and the command's help and error exits.
- The batched `delete_all_nodes` runs in every component fixture that empties the graph. As a spot check, `backend/tests/component/core/test_core_utils.py`, `core/test_initialization.py` and `cli/test_migrate.py` passed against Neo4j (19 tests).
- Manual end-to-end runs against throwaway Neo4j 2026.05 and PostgreSQL 18 containers: nothing configured (exit 1), graph only, task manager only, both, declined prompts, each `--yes-*` flag alone and together, unreachable PostgreSQL with the graph left untouched, and a rerun on already-empty databases.
- `ruff`, `mypy`, `ty` and `uv run invoke docs.validate` pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

