### PR TITLE
fix(frontend): keep the active branch when navigating the app chrome

### DIFF
--- a/changelog/+branch-lost-on-sidebar-navigation.fixed.md
+++ b/changelog/+branch-lost-on-sidebar-navigation.fixed.md
@@ -1,0 +1,1 @@
+Navigating with the sidebar logo, the account menu or the Users & Permissions tabs no longer resets the active branch to the default branch.

--- a/dev/guidelines/frontend/url-construction.md
+++ b/dev/guidelines/frontend/url-construction.md
@@ -4,6 +4,45 @@
 
 Guidelines for constructing URLs and paths in the React TypeScript frontend.
 
+## Build paths with `useConstructPath` during render
+
+`constructPath` resolves the active branch and the time-machine date by reading `window.location` at
+call time. That is accurate in an event handler and wrong during render: React Compiler caches a
+render-time call whose inputs are all non-reactive once per mount, so a link in a component that
+outlives a branch switch — the sidebar, the header, breadcrumbs, a tab bar — keeps pointing at the
+branch that was active when it first rendered. Clicking it silently returns the user to the default
+branch.
+
+Use the hook in render, the plain function in handlers:
+
+```tsx
+// ✅ Render: the hook reads the branch from context, so the path recomputes on a branch switch
+function AppSidebarHeader() {
+  const constructPath = useConstructPath();
+  return <Link to={constructPath("/")}>…</Link>;
+}
+
+// ✅ Event handler: reading the URL at call time is accurate
+const onSuccess = () => navigate(constructPath("/tasks"));
+
+// ❌ Render: frozen at mount, so the link loses the branch
+function AppSidebarHeader() {
+  return <Link to={constructPath("/")}>…</Link>;
+}
+```
+
+**Location:** `frontend/app/src/entities/navigation/ui/hooks/use-construct-path.ts`
+
+Caller overrides are applied after the ambient branch and date, so a link that deliberately targets
+another branch still wins:
+
+```tsx
+constructPath("/tasks", [{ name: QSP.BRANCH, value: task.branch }]);
+```
+
+The detail-page helpers below still call `constructPath` directly and carry the same staleness when
+called during render.
+
 ## Use `getObjectDetailsUrl` for Object URLs
 
 **Always use `getObjectDetailsUrl` for constructing URLs to object detail pages:**

--- a/dev/knowledge/frontend/react.md
+++ b/dev/knowledge/frontend/react.md
@@ -27,6 +27,25 @@ function Input({ ref, ...props }: InputProps) {
 }
 ```
 
+## A render-time read of mutable global state is frozen at mount
+
+The compiler memoizes a value whose inputs are all non-reactive by computing it on the first render
+and never again — its cache slot is guarded by `Symbol.for("react.memo_cache_sentinel")`, and nothing
+invalidates that guard. Reading `window.location` or a module-level mutable during render therefore
+does not merely risk a stale value, it guarantees one for the life of the mount:
+
+```tsx
+// ❌ Impure read, no reactive input — evaluated once, then frozen
+<Link to={constructPath("/")} />
+
+// ✅ The hook closes over reactive state, so the call re-evaluates
+const constructPath = useConstructPath();
+<Link to={constructPath("/")} />
+```
+
+Give the component a reactive dependency on whatever the value really derives from — a context
+value, a store value, a query result — instead of reaching for the global.
+
 ## Rules of React
 
 Required for compiler to work:

--- a/frontend/app/src/entities/navigation/ui/hooks/use-construct-path.test.tsx
+++ b/frontend/app/src/entities/navigation/ui/hooks/use-construct-path.test.tsx
@@ -1,0 +1,93 @@
+import { Provider } from "jotai";
+import type React from "react";
+import { afterEach, describe, expect, test } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { generateBranch } from "@/../tests/fake/branch";
+
+import { QSP } from "@/shared/config/qsp";
+import { store } from "@/shared/stores";
+import { datetimeAtom } from "@/shared/stores/time.atom";
+
+import type { BranchListItem } from "@/entities/branches/domain/model/branch";
+import { BranchContext } from "@/entities/branches/ui/branches-provider";
+import { useConstructPath } from "@/entities/navigation/ui/hooks/use-construct-path";
+
+// Deliberately not named "main": INFRAHUB_INITIAL_DEFAULT_BRANCH can rename the default branch.
+const defaultBranch = generateBranch({ id: "branch-default", name: "primary", is_default: true });
+const featureBranch = generateBranch({ id: "branch-feature", name: "feature-1" });
+
+const renderConstructPath = (currentBranch: BranchListItem) =>
+  renderHook(() => useConstructPath(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>
+        <BranchContext value={{ currentBranch, setCurrentBranch: () => {} }}>
+          {children}
+        </BranchContext>
+      </Provider>
+    ),
+  });
+
+describe("useConstructPath", () => {
+  afterEach(() => {
+    store.set(datetimeAtom, null);
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
+  test("omits the branch param on the default branch", async () => {
+    // GIVEN
+    const { result } = await renderConstructPath(defaultBranch);
+
+    // WHEN
+    const path = result.current("/");
+
+    // THEN
+    expect(path).toBe("/");
+  });
+
+  test("names the branch in the path when it is not the default branch", async () => {
+    // GIVEN
+    const { result } = await renderConstructPath(featureBranch);
+
+    // WHEN
+    const path = result.current("/");
+
+    // THEN
+    expect(path).toBe("/?branch=feature-1");
+  });
+
+  test("drops a branch inherited from the URL when the active branch is the default one", async () => {
+    // GIVEN
+    window.history.replaceState(null, "", `${window.location.pathname}?${QSP.BRANCH}=stale-branch`);
+    const { result } = await renderConstructPath(defaultBranch);
+
+    // WHEN
+    const path = result.current("/");
+
+    // THEN
+    expect(path).toBe("/");
+  });
+
+  test("lets the caller target another branch than the active one", async () => {
+    // GIVEN
+    const { result } = await renderConstructPath(featureBranch);
+
+    // WHEN
+    const path = result.current("/tasks", [{ name: QSP.BRANCH, value: "other-branch" }]);
+
+    // THEN
+    expect(path).toBe("/tasks?branch=other-branch");
+  });
+
+  test("carries the time-machine date", async () => {
+    // GIVEN
+    store.set(datetimeAtom, new Date("2026-08-31T13:08:29.000Z"));
+    const { result } = await renderConstructPath(featureBranch);
+
+    // WHEN
+    const path = result.current("/");
+
+    // THEN
+    expect(path).toBe("/?branch=feature-1&at=2026-08-31T13%3A08%3A29.000Z");
+  });
+});

--- a/frontend/app/src/entities/navigation/ui/hooks/use-construct-path.ts
+++ b/frontend/app/src/entities/navigation/ui/hooks/use-construct-path.ts
@@ -1,0 +1,33 @@
+import { useAtomValue } from "jotai";
+
+import { constructPath, type overrideQueryParams } from "@/shared/api/rest/fetch";
+import { QSP } from "@/shared/config/qsp";
+import { datetimeAtom } from "@/shared/stores/time.atom";
+
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+
+/**
+ * Builds in-app paths that carry the active branch and the time-machine date.
+ *
+ * Both are read from their in-app owners rather than from the URL. A render-time read of
+ * `window.location` is cached by React Compiler once per mount, so a link rendered by a component
+ * that outlives a branch switch — the sidebar, the header, breadcrumbs — would keep pointing at the
+ * branch that was active when it first rendered. nuqs also writes the branch with `shallow: true`,
+ * which leaves the URL a tick behind and invisible to the router's own location.
+ */
+export function useConstructPath() {
+  const { currentBranch } = useCurrentBranch();
+  const atDate = useAtomValue(datetimeAtom);
+
+  // Absence of the branch param *is* the default branch, so the default branch excludes it.
+  const ambientParams: overrideQueryParams[] = [
+    currentBranch.is_default
+      ? { name: QSP.BRANCH, exclude: true }
+      : { name: QSP.BRANCH, value: currentBranch.name },
+    ...(atDate ? [{ name: QSP.DATETIME, value: atDate.toISOString() }] : []),
+  ];
+
+  // Caller overrides come last so a link deliberately targeting another branch still wins.
+  return (path: string, overrideParams: overrideQueryParams[] = [], preserveQspLib?: string[]) =>
+    constructPath(path, [...ambientParams, ...overrideParams], preserveQspLib);
+}

--- a/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.test.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { render } from "@/../tests/components/render";
+import { generateBranch } from "@/../tests/fake/branch";
+
+import { SidebarProvider } from "@/shared/components/layout/sidebar";
+
+import type { BranchListItem } from "@/entities/branches/domain/model/branch";
+import { BranchContext } from "@/entities/branches/ui/branches-provider";
+import { AppSidebarHeader } from "@/entities/navigation/ui/sidebar/app-sidebar";
+
+// Deliberately not named "main": INFRAHUB_INITIAL_DEFAULT_BRANCH can rename the default branch.
+const defaultBranch = generateBranch({ id: "branch-default", name: "primary", is_default: true });
+const featureBranch = generateBranch({ id: "branch-feature", name: "feature-1" });
+
+// Switching branch only rewrites the query string, so the sidebar outlives it. The harness swaps
+// the branch in place rather than remounting to reproduce that.
+function SidebarHarness({ initialBranch }: { initialBranch: BranchListItem }) {
+  const [currentBranch, setCurrentBranch] = React.useState(initialBranch);
+
+  return (
+    <BranchContext value={{ currentBranch, setCurrentBranch }}>
+      <SidebarProvider>
+        <AppSidebarHeader />
+      </SidebarProvider>
+
+      <button type="button" onClick={() => setCurrentBranch(featureBranch)}>
+        Switch branch
+      </button>
+    </BranchContext>
+  );
+}
+
+const getHomeHref = (container: HTMLElement) =>
+  container.querySelector('a[aria-label="Infrahub home"]')?.getAttribute("href");
+
+describe("AppSidebarHeader", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
+  test("links home without a branch param on the default branch", async () => {
+    // GIVEN
+    const harness = <SidebarHarness initialBranch={defaultBranch} />;
+
+    // WHEN
+    const component = await render(harness);
+
+    // THEN
+    expect(getHomeHref(component.container)).toBe("/");
+  });
+
+  test("links home on the active branch", async () => {
+    // GIVEN
+    const harness = <SidebarHarness initialBranch={featureBranch} />;
+
+    // WHEN
+    const component = await render(harness);
+
+    // THEN
+    expect(getHomeHref(component.container)).toBe("/?branch=feature-1");
+  });
+
+  test("updates the home link when the branch changes after mount", async () => {
+    // GIVEN
+    const component = await render(<SidebarHarness initialBranch={defaultBranch} />);
+
+    // WHEN
+    await component.getByRole("button", { name: "Switch branch" }).click();
+
+    // THEN
+    await expect.poll(() => getHomeHref(component.container)).toBe("/?branch=feature-1");
+  });
+});

--- a/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.tsx
+++ b/frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router";
 
 import InfrahubWithTextLogo from "@/assets/Infrahub-SVG-hori.svg";
 
-import { constructPath } from "@/shared/api/rest/fetch";
 import {
   Sidebar,
   SidebarContent,
@@ -14,6 +13,7 @@ import {
 import { focusVisibleStyle } from "@/shared/components/ui/style";
 import { classNames } from "@/shared/utils/common";
 
+import { useConstructPath } from "@/entities/navigation/ui/hooks/use-construct-path";
 import { SearchAnywhere } from "@/entities/navigation/ui/search-anywhere/search-anywhere";
 import { SidebarMenu } from "@/entities/navigation/ui/sidebar/sidebar-menu";
 import { AccountMenu } from "@/entities/user-profile/ui/account-menu";
@@ -39,7 +39,9 @@ export function AppSidebar() {
   );
 }
 
-function AppSidebarHeader() {
+export function AppSidebarHeader() {
+  const constructPath = useConstructPath();
+
   return (
     <div className="relative h-8 transition-[height] duration-200 ease-linear group-data-[state=collapsed]:h-17.5">
       <Link

--- a/frontend/app/src/entities/role-manager/ui/role-management-tabs.tsx
+++ b/frontend/app/src/entities/role-manager/ui/role-management-tabs.tsx
@@ -1,11 +1,11 @@
 import { Icon } from "@iconify-icon/react";
 import { ScrollArea, Spinner } from "@infrahub/ui";
 
-import { constructPath } from "@/shared/api/rest/fetch";
 import { Row } from "@/shared/components/container";
 import { Badge } from "@/shared/components/ui/badge";
 import { LinkTab } from "@/shared/components/ui/link";
 
+import { useConstructPath } from "@/entities/navigation/ui/hooks/use-construct-path";
 import { useObjectsCount } from "@/entities/nodes/object/ui/queries/get-objects-count.query";
 import {
   GLOBAL_PERMISSION_OBJECT,
@@ -17,37 +17,32 @@ import {
   ACCOUNT_ROLE_OBJECT,
 } from "@/entities/role-manager/domain/model/account";
 
-const tabs = [
+const TABS = [
   {
-    to: constructPath("/role-management"),
     path: "/role-management",
     icon: "mdi:user-outline",
     label: "Accounts",
     kind: ACCOUNT_GENERIC_OBJECT,
   },
   {
-    to: constructPath("/role-management/groups"),
     path: "/role-management/groups",
     icon: "mdi:user-multiple-outline",
     label: "Groups",
     kind: ACCOUNT_GROUP_OBJECT,
   },
   {
-    to: constructPath("/role-management/roles"),
     path: "/role-management/roles",
     icon: "mdi:user-circle-outline",
     label: "Roles",
     kind: ACCOUNT_ROLE_OBJECT,
   },
   {
-    to: constructPath("/role-management/global-permissions"),
     path: "/role-management/global-permissions",
     icon: "mdi:ticket-confirmation-outline",
     label: "Global Permissions",
     kind: GLOBAL_PERMISSION_OBJECT,
   },
   {
-    to: constructPath("/role-management/object-permissions"),
     path: "/role-management/object-permissions",
     icon: "mdi:ticket-outline",
     label: "Object Permissions",
@@ -56,6 +51,8 @@ const tabs = [
 ] as const;
 
 export function RoleManagementTabs() {
+  const constructPath = useConstructPath();
+
   return (
     <ScrollArea
       scrollX
@@ -65,10 +62,10 @@ export function RoleManagementTabs() {
     >
       <nav aria-label="Tabs">
         <Row className="items-end gap-4 px-4">
-          {tabs.map((tab) => (
+          {TABS.map((tab) => (
             <RoleManagementTab
               key={tab.path}
-              to={tab.to}
+              to={constructPath(tab.path)}
               icon={tab.icon}
               label={tab.label}
               kind={tab.kind}

--- a/frontend/app/src/entities/tasks/ui/task-status.tsx
+++ b/frontend/app/src/entities/tasks/ui/task-status.tsx
@@ -4,15 +4,16 @@ import { useQuery } from "@tanstack/react-query";
 
 import TasksStatusIcon from "@/assets/icons/tasks-status.svg?react";
 
-import { constructPath, type overrideQueryParams } from "@/shared/api/rest/fetch";
 import { Pulse } from "@/shared/components/ui/pulse";
 import { QSP } from "@/shared/config/qsp";
 
 import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+import { useConstructPath } from "@/entities/navigation/ui/hooks/use-construct-path";
 import { isTaskRunningOnBranchQueryOptions } from "@/entities/tasks/ui/queries/is-task-running-on-branch.query";
 
 export function TaskStatus() {
   const { currentBranch } = useCurrentBranch();
+  const constructPath = useConstructPath();
 
   const {
     error,
@@ -28,20 +29,11 @@ export function TaskStatus() {
     value: currentBranch.name,
   };
 
-  // The branch must come from the context, not the URL: nuqs writes it one render later, so a
-  // param inherited from the URL would still point at the previous branch.
-  const branchParam: overrideQueryParams = currentBranch.is_default
-    ? { name: QSP.BRANCH, exclude: true }
-    : { name: QSP.BRANCH, value: currentBranch.name };
-
   const commonButtonProps: LinkButtonProps = {
     shape: "square",
     variant: "outline",
     size: "sm",
-    href: constructPath("/tasks", [
-      branchParam,
-      { name: QSP.FILTER, value: JSON.stringify([filter]) },
-    ]),
+    href: constructPath("/tasks", [{ name: QSP.FILTER, value: JSON.stringify([filter]) }]),
   };
 
   if (error) {

--- a/frontend/app/src/entities/user-profile/ui/account-menu.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-menu.tsx
@@ -22,7 +22,6 @@ import React from "react";
 import { useLocation } from "react-router";
 
 import { queryClient } from "@/shared/api/rest/client";
-import { constructPath } from "@/shared/api/rest/fetch";
 import { Avatar } from "@/shared/components/display/avatar";
 import { Skeleton } from "@/shared/components/loading/skeleton";
 import {
@@ -36,6 +35,7 @@ import { useAuth } from "@/entities/authentication/ui/auth-provider";
 import { useLogoutMutation } from "@/entities/authentication/ui/queries/logout.mutation";
 import { AboutModal } from "@/entities/config/ui/about-modal";
 import { AppInfo } from "@/entities/config/ui/app-info";
+import { useConstructPath } from "@/entities/navigation/ui/hooks/use-construct-path";
 import { MANAGE_GLOBAL_PREFERENCES } from "@/entities/permission/domain/model/permission";
 import { useHasGlobalPermission } from "@/entities/permission/ui/queries/has-global-permission.query";
 import { useGetAccountProfile } from "@/entities/user-profile/ui/queries/get-account-profile.query";
@@ -56,39 +56,43 @@ export const AccountMenu = () => {
   );
 };
 
-const CommonMenuItems = ({ onAboutClick }: { onAboutClick: () => void }) => (
-  <>
-    <MenuItem onAction={onAboutClick}>
-      <InfoIcon /> About Infrahub
-    </MenuItem>
+const CommonMenuItems = ({ onAboutClick }: { onAboutClick: () => void }) => {
+  const constructPath = useConstructPath();
 
-    <MenuItem href={INFRAHUB_DOC_LOCAL} target="_blank" rel="noreferrer">
-      <FileTextIcon /> Infrahub documentation
-    </MenuItem>
+  return (
+    <>
+      <MenuItem onAction={onAboutClick}>
+        <InfoIcon /> About Infrahub
+      </MenuItem>
 
-    <MenuItem href={constructPath("/graphql")}>
-      <Icon icon="mdi:graphql" className="text-base" />
-      GraphQL Sandbox
-    </MenuItem>
+      <MenuItem href={INFRAHUB_DOC_LOCAL} target="_blank" rel="noreferrer">
+        <FileTextIcon /> Infrahub documentation
+      </MenuItem>
 
-    <MenuItem href={INFRAHUB_SWAGGER_DOC_URL} target="_blank" rel="noreferrer">
-      <Icon icon="mdi:code-json" className="text-base" />
-      Swagger documentation
-    </MenuItem>
+      <MenuItem href={constructPath("/graphql")}>
+        <Icon icon="mdi:graphql" className="text-base" />
+        GraphQL Sandbox
+      </MenuItem>
 
-    <MenuSeparator />
+      <MenuItem href={INFRAHUB_SWAGGER_DOC_URL} target="_blank" rel="noreferrer">
+        <Icon icon="mdi:code-json" className="text-base" />
+        Swagger documentation
+      </MenuItem>
 
-    <MenuItem href={INFRAHUB_GITHUB_URL} target="_blank" rel="noreferrer">
-      <Icon icon="mdi:github" className="text-base" />
-      GitHub Repository
-    </MenuItem>
+      <MenuSeparator />
 
-    <MenuItem href={INFRAHUB_DISCORD_URL} target="_blank" rel="noreferrer">
-      <Icon icon="mdi:discord" className="text-base" />
-      Join our Discord server
-    </MenuItem>
-  </>
-);
+      <MenuItem href={INFRAHUB_GITHUB_URL} target="_blank" rel="noreferrer">
+        <Icon icon="mdi:github" className="text-base" />
+        GitHub Repository
+      </MenuItem>
+
+      <MenuItem href={INFRAHUB_DISCORD_URL} target="_blank" rel="noreferrer">
+        <Icon icon="mdi:discord" className="text-base" />
+        Join our Discord server
+      </MenuItem>
+    </>
+  );
+};
 
 const AppInfoFooter = () => (
   <div className="border-stone-300 border-t px-2.5 py-1">
@@ -152,6 +156,7 @@ const AuthenticatedAccountMenu = ({ onAboutClick }: { onAboutClick: () => void }
   const { data: canManageGlobalPreferences = false } =
     useHasGlobalPermission(MANAGE_GLOBAL_PREFERENCES);
   const { mutateAsync: logout, isPending: isLoggingOut } = useLogoutMutation();
+  const constructPath = useConstructPath();
 
   const handleSignOut = async () => {
     try {

--- a/frontend/app/src/shared/components/ui/link-tab.test.tsx
+++ b/frontend/app/src/shared/components/ui/link-tab.test.tsx
@@ -35,6 +35,17 @@ describe("LinkTab", () => {
     expect(link?.className).toMatch(/border-custom-blue-600/);
   });
 
+  test("stays active when the target URL carries query params", async () => {
+    // GIVEN
+    const tab = <LinkTab to="/parent/data?branch=feature-1">Data</LinkTab>;
+
+    // WHEN
+    const component = await renderAt("/parent/data", tab);
+
+    // THEN
+    expect(component.container.querySelector("a")?.className).toMatch(/border-custom-blue-600/);
+  });
+
   test("does not apply active border when URL does not match", async () => {
     const component = await renderAt("/parent/files", <LinkTab to="/parent/data">Data</LinkTab>);
     const link = component.container.querySelector("a");

--- a/tests/e2e/branches/test_branch_selector.py
+++ b/tests/e2e/branches/test_branch_selector.py
@@ -53,6 +53,21 @@ class TestBranchSelectorNotLoggedIn:
         await branch_list.get_by_role("option", name="atl1-delete-upstream").click()
         await expect(page.get_by_role("button", name="atl1-delete-upstream", exact=True)).to_be_visible()
 
+    async def test_sidebar_navigation_keeps_the_active_branch(
+        self, page: Page, data_scenario_branches: ScenarioBranchesHandle
+    ) -> None:
+        await page.goto("/branches")
+        await page.get_by_test_id("branch-selector-trigger").click()
+        branch_list = page.get_by_label("branch list")
+        await page.get_by_placeholder("Search...").fill("atl1")
+        await branch_list.get_by_role("option", name="atl1-delete-upstream").click()
+        await expect(page.get_by_role("button", name="atl1-delete-upstream", exact=True)).to_be_visible()
+
+        await page.get_by_label("Infrahub home").click()
+
+        await expect(page.get_by_role("button", name="atl1-delete-upstream", exact=True)).to_be_visible()
+        assert "branch=atl1-delete-upstream" in page.url
+
 
 class TestBranchSelectorLoggedInAsAdmin:
     async def test_create_a_branch_with_a_name_that_does_not_exist(self, admin_page: Page) -> None:


### PR DESCRIPTION
## Summary

Reported internally against 1.11: switch to a non-default branch, go to the landing page, and you
are silently back on the default branch.

The landing page was innocent — the sidebar logo link was stale. Several other links in the
persistent app chrome had the same defect, and the Users & Permissions tabs never carried a branch
at all.

## Root cause

`constructPath` resolves the `branch` and `at` query params by reading `window.location` **during
render**. React Compiler is enabled repo-wide, so a call whose inputs are all non-reactive is cached
behind `Symbol.for("react.memo_cache_sentinel")` and evaluated exactly once per mount:

```js
if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
  t0 = constructPath("/");   // computed once, for the life of the mount
  $[0] = t0;
}
```

Switching branch never changes the route — it only rewrites the query string — so the sidebar never
remounts and keeps serving the href it computed on first render. Clicking it navigates to a bare
`/`, and an absent `branch` param *is* the default branch.

The `Users & Permissions` tabs were worse: their hrefs were built in a module-scope array, so they
were baked in at bundle evaluation and never carried a branch on any page load.

## Key changes

- Navigating from the sidebar logo, the account menu, or the Users & Permissions tabs now keeps the
  branch you are working on. The time-machine date survives those navigations too.
- New `useConstructPath()` hook reads the branch from `BranchContext` and the date from
  `datetimeAtom` and returns a closure — that closure identity is what gives the calling component
  the reactive dependency the compiler needs. Caller overrides are still applied last, so a link
  that deliberately targets another branch keeps working.
- `task-status.tsx` had hand-rolled this workaround; it now uses the hook.

Reading the context rather than the URL is not only about reactivity. nuqs writes the branch with
`shallow: true`, so the URL trails the context by a tick and react-router's own location never
observes the change at all — the URL is not a viable source here.

## Scope

This fixes the reported symptom and the cases that were unconditionally broken. It deliberately does
**not** migrate the remaining ~170 render-time `constructPath` call sites (breadcrumbs, the other tab
bars, homepage widgets, and the four wrapper helpers). A follow-up issue covering that migration —
including the call sites that must *not* be converted — is being filed separately.

## Documentation updates

- `dev/guidelines/frontend/url-construction.md` — when to use the hook (render) versus the plain
  function (event handlers). Without this the guideline actively points at the trap.
- `dev/knowledge/frontend/react.md` — why a render-time read of mutable global state is frozen at
  mount under React Compiler.

## Test plan

- `frontend/app/src/entities/navigation/ui/sidebar/app-sidebar.test.tsx` asserts the home link
  updates when the branch changes after mount. Verified it fails on the unfixed code
  (`expected '/' to be '/?branch=feature-1'`), so it genuinely guards the regression.
- `use-construct-path.test.tsx` covers default-branch omission, caller-override precedence, and `at`
  serialization.
- `tests/e2e/branches/test_branch_selector.py::test_sidebar_navigation_keeps_the_active_branch`
  switches branch, clicks the logo, and asserts the branch survives. Ran green locally (4/4 in the
  class) against an image built from this branch.
- Full frontend suite 1255/1255, graph package 23/23, `biome ci`, `knip`, `betterer ci` (188 issues,
  unchanged), `docs.validate`.

## Note for reviewers

While checking that the Users & Permissions tabs still highlight correctly, I found a **separate
pre-existing bug**, not fixed here: `LinkTab` passes `to` straight into `useMatch({ path: to })`, and
React Router's `compilePath` does not escape `?`, so any `to` carrying a query string compiles to a
regex that can never match. The visible active styling is unaffected (`NavLink` resolves `to` through
`parsePath`, which splits the search off), but `scrollIntoViewOnActive` silently stops working
whenever a branch is active — affecting `object-tabs.tsx`, `object-details-tabs.tsx` and
`repository-objects-tab.tsx`. This PR only adds a test pinning the behaviour it relies on; the fix
belongs in the follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

