### PR TITLE
Report each side of a hierarchy edge in the path query

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -462,7 +462,7 @@ def peer_relationships(peer_schema: MainSchemaTypes, rel_schema: RelationshipSch
     and logged: the answer is a guess, but dropping it would hide a change that did happen.
     """
     candidates = peer_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
-    mirrored = [candidate for candidate in candidates if candidate.direction == rel_schema.direction.neighbor_direction]
+    mirrored = [candidate for candidate in candidates if candidate.mirrors(rel_schema)]
     if mirrored:
         return mirrored
 

--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -60,6 +60,10 @@ class RelationshipSchema(GeneratedRelationshipSchema):
             raise ValueError("RelationshipSchema is not initialized")
         return self.identifier
 
+    def mirrors(self, other: RelationshipSchema) -> bool:
+        """True when the two declarations can be the two ends of one edge."""
+        return self.direction.neighbor_direction == other.direction
+
     def get_id(self) -> str:
         if not self.id:
             raise InitializationError("The relationship schema has not been saved yet and doesn't have an id")

--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -61,8 +61,8 @@ class RelationshipSchema(GeneratedRelationshipSchema):
         return self.identifier
 
     def mirrors(self, other: RelationshipSchema) -> bool:
-        """True when the two declarations can be the two ends of one edge."""
-        return self.direction.neighbor_direction == other.direction
+        """True when the two declarations can be the two ends of one edge: one identifier, mirrored directions."""
+        return self.get_identifier() == other.get_identifier() and self.direction.neighbor_direction == other.direction
 
     def get_id(self) -> str:
         if not self.id:

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -226,9 +226,11 @@ def select_hop_relationships(
 
     A hierarchy declares ``parent`` and ``children`` under one identifier, one per end of an
     edge, so the two ends must mirror each other's direction. Candidates on each end are
-    narrowed by peer kind first, then paired by mirrored direction. When several mirrored
-    pairs remain (a self-referential hierarchy), the first pair is a guess between
-    schema-equivalent sides; the schema alone cannot tell the ends apart.
+    narrowed by peer kind first, then paired by mirrored direction. The pick is exact only
+    when narrowing leaves a single mirrored pair. When several pairs remain — both ends
+    declare both sides with peers that cover each other, as with peers defaulting to the
+    hierarchy generic — the schema alone cannot tell the ends apart and the first pair is
+    kept, a deterministic guess.
     """
     from_candidates = (
         _candidate_relationships(schema=from_schema, identifier=identifier, other_kind=to_kind, other_schema=to_schema)
@@ -243,12 +245,7 @@ def select_hop_relationships(
         else []
     )
 
-    pairs = [
-        (from_rel, to_rel)
-        for from_rel in from_candidates
-        for to_rel in to_candidates
-        if from_rel.direction.neighbor_direction == to_rel.direction
-    ]
+    pairs = [(from_rel, to_rel) for from_rel in from_candidates for to_rel in to_candidates if from_rel.mirrors(to_rel)]
     if not pairs:
         return (
             from_candidates[0] if from_candidates else None,
@@ -296,8 +293,17 @@ def _resolve_relationship(
 
 
 def _path_data_to_result(
-    path_data: PathData, labels_map: dict[str, dict[str, Any]], graphql_context: GraphqlContext
+    path_data: PathData,
+    labels_map: dict[str, dict[str, Any]],
+    graphql_context: GraphqlContext,
+    relationship_cache: dict[tuple[str, str, str], dict[str, str]],
 ) -> dict[str, Any]:
+    """Project one path into the API shape.
+
+    ``relationship_cache`` is request-scoped: the same (identifier, from kind, to kind)
+    triple always resolves to the same payload, and caching it keeps the ambiguous-pair
+    warning to one line per triple per request.
+    """
     start_node_payload = _node_payload(
         node_id=path_data.start_node.uuid, kind=path_data.start_node.kind, labels_map=labels_map
     )
@@ -305,12 +311,16 @@ def _path_data_to_result(
     previous_kind = path_data.start_node.kind
     for hop in path_data.hops:
         node_payload = _node_payload(node_id=hop.node.uuid, kind=hop.node.kind, labels_map=labels_map)
-        relationship_payload = _resolve_relationship(
-            graphql_context=graphql_context,
-            identifier=hop.relationship_identifier,
-            from_kind=previous_kind,
-            to_kind=hop.node.kind,
-        )
+        cache_key = (hop.relationship_identifier, previous_kind, hop.node.kind)
+        relationship_payload = relationship_cache.get(cache_key)
+        if relationship_payload is None:
+            relationship_payload = _resolve_relationship(
+                graphql_context=graphql_context,
+                identifier=hop.relationship_identifier,
+                from_kind=previous_kind,
+                to_kind=hop.node.kind,
+            )
+            relationship_cache[cache_key] = relationship_payload
         hops.append({"node": node_payload, "relationship": relationship_payload})
         previous_kind = hop.node.kind
 
@@ -410,7 +420,8 @@ async def path_traversal_resolver(
         node_id=destination_node.id, kind=destination_node.get_kind(), labels_map=labels_map
     )
 
-    paths = [_path_data_to_result(p, labels_map, graphql_context) for p in path_data_list]
+    relationship_cache: dict[tuple[str, str, str], dict[str, str]] = {}
+    paths = [_path_data_to_result(p, labels_map, graphql_context, relationship_cache) for p in path_data_list]
 
     return {
         "paths": paths,

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -236,7 +236,9 @@ def select_hop_relationships(
         else []
     )
     to_candidates = (
-        _candidate_relationships(schema=to_schema, identifier=identifier, other_kind=from_kind, other_schema=from_schema)
+        _candidate_relationships(
+            schema=to_schema, identifier=identifier, other_kind=from_kind, other_schema=from_schema
+        )
         if to_schema
         else []
     )

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING, Any
 
 from graphene import Boolean, Field, InputObjectType, Int, List, NonNull, ObjectType, String
@@ -9,20 +8,24 @@ from graphql import GraphQLError
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.manager import NodeManager
+from infrahub.core.schema import NodeSchema
 from infrahub.exceptions import SchemaNotFoundError
 from infrahub.graph_traversal._cypher import GraphTraversalCypherRenderer
 from infrahub.graph_traversal.executor import PathTraversalExecutor
 from infrahub.graph_traversal.planning.models import TerminalById, UserFilters
 from infrahub.graph_traversal.planning.planner import SchemaPlanner
 from infrahub.graph_traversal.runner import DefaultQueryRunner
+from infrahub.log import get_logger
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
     from infrahub.core.node import Node
-    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema import MainSchemaTypes, RelationshipSchema
     from infrahub.graph_traversal.results import PathData
     from infrahub.graphql.initialization import GraphqlContext
+
+log = get_logger()
 
 
 MAX_PATHS = 100
@@ -192,47 +195,100 @@ def _node_payload(node_id: str, kind: str, labels_map: dict[str, dict[str, Any]]
     }
 
 
+def _get_schema_or_none(graphql_context: GraphqlContext, kind: str) -> MainSchemaTypes | None:
+    try:
+        return graphql_context.db.schema.get(name=kind, branch=graphql_context.branch, duplicate=False)
+    except SchemaNotFoundError:
+        return None
+
+
+def _candidate_relationships(
+    schema: MainSchemaTypes, identifier: str, other_kind: str, other_schema: MainSchemaTypes | None
+) -> list[RelationshipSchema]:
+    """Relationships declared under ``identifier``, narrowed to those whose peer covers the other endpoint."""
+    candidates = schema.get_relationships_by_identifier(id=identifier)
+    other_kinds = {other_kind}
+    if isinstance(other_schema, NodeSchema):
+        other_kinds.update(other_schema.inherit_from)
+    matching = [candidate for candidate in candidates if candidate.peer in other_kinds]
+    return matching or candidates
+
+
+def select_hop_relationships(
+    *,
+    from_schema: MainSchemaTypes | None,
+    to_schema: MainSchemaTypes | None,
+    from_kind: str,
+    to_kind: str,
+    identifier: str,
+) -> tuple[RelationshipSchema | None, RelationshipSchema | None]:
+    """Pick the relationship each end of a hop holds for ``identifier``.
+
+    A hierarchy declares ``parent`` and ``children`` under one identifier, one per end of an
+    edge, so the two ends must mirror each other's direction. Candidates on each end are
+    narrowed by peer kind first, then paired by mirrored direction. When several mirrored
+    pairs remain (a self-referential hierarchy), the first pair is a guess between
+    schema-equivalent sides; the schema alone cannot tell the ends apart.
+    """
+    from_candidates = (
+        _candidate_relationships(schema=from_schema, identifier=identifier, other_kind=to_kind, other_schema=to_schema)
+        if from_schema
+        else []
+    )
+    to_candidates = (
+        _candidate_relationships(schema=to_schema, identifier=identifier, other_kind=from_kind, other_schema=from_schema)
+        if to_schema
+        else []
+    )
+
+    pairs = [
+        (from_rel, to_rel)
+        for from_rel in from_candidates
+        for to_rel in to_candidates
+        if from_rel.direction.neighbor_direction == to_rel.direction
+    ]
+    if not pairs:
+        return (
+            from_candidates[0] if from_candidates else None,
+            to_candidates[0] if to_candidates else None,
+        )
+    if len(pairs) > 1:
+        log.warning(
+            "Several relationship pairs mirror each other for this hop, keeping the first one",
+            from_kind=from_kind,
+            to_kind=to_kind,
+            identifier=identifier,
+        )
+    return pairs[0]
+
+
 def _resolve_relationship(
     graphql_context: GraphqlContext, identifier: str, from_kind: str, to_kind: str
 ) -> dict[str, str]:
     """Project a hop's relationship identifier into bidirectional API fields.
 
-    Look up the schema for both endpoints and find the RelationshipSchema with
-    the given identifier on each side. Falls back to the identifier when schema
-    lookup fails (e.g. legacy data or unknown kinds).
+    Falls back to the identifier when schema lookup fails (e.g. legacy data or
+    unknown kinds).
     """
-    from_rel_name = identifier
-    from_label = identifier
-    to_rel_name = identifier
-    to_label = identifier
+    from_rel, to_rel = select_hop_relationships(
+        from_schema=_get_schema_or_none(graphql_context=graphql_context, kind=from_kind),
+        to_schema=_get_schema_or_none(graphql_context=graphql_context, kind=to_kind),
+        from_kind=from_kind,
+        to_kind=to_kind,
+        identifier=identifier,
+    )
+
     kind = ""
-
-    with contextlib.suppress(SchemaNotFoundError):
-        from_schema: MainSchemaTypes = graphql_context.db.schema.get(
-            name=from_kind, branch=graphql_context.branch, duplicate=False
-        )
-        from_rel = from_schema.get_relationship_by_identifier(id=identifier, raise_on_error=False)
-        if from_rel is not None:
-            from_rel_name = from_rel.name
-            from_label = from_rel.label or from_rel.name
-            kind = from_rel.kind.value if hasattr(from_rel.kind, "value") else str(from_rel.kind)
-
-    with contextlib.suppress(SchemaNotFoundError):
-        to_schema: MainSchemaTypes = graphql_context.db.schema.get(
-            name=to_kind, branch=graphql_context.branch, duplicate=False
-        )
-        to_rel = to_schema.get_relationship_by_identifier(id=identifier, raise_on_error=False)
-        if to_rel is not None:
-            to_rel_name = to_rel.name
-            to_label = to_rel.label or to_rel.name
-            if not kind:
-                kind = to_rel.kind.value if hasattr(to_rel.kind, "value") else str(to_rel.kind)
+    if from_rel is not None:
+        kind = from_rel.kind.value
+    elif to_rel is not None:
+        kind = to_rel.kind.value
 
     return {
-        "from_rel": from_rel_name,
-        "from_label": from_label,
-        "to_rel": to_rel_name,
-        "to_label": to_label,
+        "from_rel": from_rel.name if from_rel else identifier,
+        "from_label": (from_rel.label or from_rel.name) if from_rel else identifier,
+        "to_rel": to_rel.name if to_rel else identifier,
+        "to_label": (to_rel.label or to_rel.name) if to_rel else identifier,
         "kind": kind,
     }
 

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -224,13 +224,11 @@ def select_hop_relationships(
 ) -> tuple[RelationshipSchema | None, RelationshipSchema | None]:
     """Pick the relationship each end of a hop holds for ``identifier``.
 
-    A hierarchy declares ``parent`` and ``children`` under one identifier, one per end of an
-    edge, so the two ends must mirror each other's direction. Candidates on each end are
-    narrowed by peer kind first, then paired by mirrored direction. The pick is exact only
-    when narrowing leaves a single mirrored pair. When several pairs remain — both ends
-    declare both sides with peers that cover each other, as with peers defaulting to the
-    hierarchy generic — the schema alone cannot tell the ends apart and the first pair is
-    kept, a deterministic guess.
+    Both ends of an edge share one identifier, like a hierarchy's ``parent`` and
+    ``children``, so candidates are narrowed by peer kind and paired by mirrored
+    direction. The pick is exact when one mirrored pair remains. When peers cover
+    both ends, as when they default to the hierarchy generic, the schema cannot
+    tell the ends apart: the first pair is kept, a deterministic guess.
     """
     from_candidates = (
         _candidate_relationships(schema=from_schema, identifier=identifier, other_kind=to_kind, other_schema=to_schema)
@@ -300,9 +298,8 @@ def _path_data_to_result(
 ) -> dict[str, Any]:
     """Project one path into the API shape.
 
-    ``relationship_cache`` is request-scoped: the same (identifier, from kind, to kind)
-    triple always resolves to the same payload, and caching it keeps the ambiguous-pair
-    warning to one line per triple per request.
+    ``relationship_cache`` is request-scoped: a hop triple always resolves to the same
+    payload, and caching keeps the ambiguous-pair warning to one line per triple.
     """
     start_node_payload = _node_payload(
         node_id=path_data.start_node.uuid, kind=path_data.start_node.kind, labels_map=labels_map

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -205,13 +205,17 @@ def _get_schema_or_none(graphql_context: GraphqlContext, kind: str) -> MainSchem
 def _candidate_relationships(
     schema: MainSchemaTypes, identifier: str, other_kind: str, other_schema: MainSchemaTypes | None
 ) -> list[RelationshipSchema]:
-    """Relationships declared under ``identifier``, narrowed to those whose peer covers the other endpoint."""
+    """Relationships declared under ``identifier``, narrowed to those whose peer covers the other endpoint.
+
+    A peer naming the other endpoint's exact kind beats one covering it through a generic.
+    """
     candidates = schema.get_relationships_by_identifier(id=identifier)
     other_kinds = {other_kind}
     if isinstance(other_schema, NodeSchema):
         other_kinds.update(other_schema.inherit_from)
     matching = [candidate for candidate in candidates if candidate.peer in other_kinds]
-    return matching or candidates
+    exact = [candidate for candidate in matching if candidate.peer == other_kind]
+    return exact or matching or candidates
 
 
 def select_hop_relationships(
@@ -225,10 +229,10 @@ def select_hop_relationships(
     """Pick the relationship each end of a hop holds for ``identifier``.
 
     Both ends of an edge share one identifier, like a hierarchy's ``parent`` and
-    ``children``, so candidates are narrowed by peer kind and paired by mirrored
-    direction. The pick is exact when one mirrored pair remains. When peers cover
-    both ends, as when they default to the hierarchy generic, the schema cannot
-    tell the ends apart: the first pair is kept, a deterministic guess.
+    ``children``, so candidates are narrowed by peer kind, exact kind first, and
+    paired by mirrored direction. The pick is exact when one mirrored pair remains.
+    When every peer stays on the hierarchy generic, the schema cannot tell the
+    ends apart: the first pair is kept, a deterministic guess.
     """
     from_candidates = (
         _candidate_relationships(schema=from_schema, identifier=identifier, other_kind=to_kind, other_schema=to_schema)
@@ -245,6 +249,15 @@ def select_hop_relationships(
 
     pairs = [(from_rel, to_rel) for from_rel in from_candidates for to_rel in to_candidates if from_rel.mirrors(to_rel)]
     if not pairs:
+        if from_candidates and to_candidates:
+            log.warning(
+                "No relationship pair mirrors for this hop, reporting the first candidates",
+                from_kind=from_kind,
+                to_kind=to_kind,
+                identifier=identifier,
+                from_candidates=[candidate.name for candidate in from_candidates],
+                to_candidates=[candidate.name for candidate in to_candidates],
+            )
         return (
             from_candidates[0] if from_candidates else None,
             to_candidates[0] if to_candidates else None,
@@ -255,6 +268,8 @@ def select_hop_relationships(
             from_kind=from_kind,
             to_kind=to_kind,
             identifier=identifier,
+            kept=(pairs[0][0].name, pairs[0][1].name),
+            candidates=[(from_rel.name, to_rel.name) for from_rel, to_rel in pairs],
         )
     return pairs[0]
 
@@ -418,7 +433,15 @@ async def path_traversal_resolver(
     )
 
     relationship_cache: dict[tuple[str, str, str], dict[str, str]] = {}
-    paths = [_path_data_to_result(p, labels_map, graphql_context, relationship_cache) for p in path_data_list]
+    paths = [
+        _path_data_to_result(
+            path_data=p,
+            labels_map=labels_map,
+            graphql_context=graphql_context,
+            relationship_cache=relationship_cache,
+        )
+        for p in path_data_list
+    ]
 
     return {
         "paths": paths,

--- a/backend/infrahub/graphql/queries/path.py
+++ b/backend/infrahub/graphql/queries/path.py
@@ -205,17 +205,13 @@ def _get_schema_or_none(graphql_context: GraphqlContext, kind: str) -> MainSchem
 def _candidate_relationships(
     schema: MainSchemaTypes, identifier: str, other_kind: str, other_schema: MainSchemaTypes | None
 ) -> list[RelationshipSchema]:
-    """Relationships declared under ``identifier``, narrowed to those whose peer covers the other endpoint.
-
-    A peer naming the other endpoint's exact kind beats one covering it through a generic.
-    """
+    """Relationships declared under ``identifier``, narrowed to those whose peer covers the other endpoint."""
     candidates = schema.get_relationships_by_identifier(id=identifier)
     other_kinds = {other_kind}
     if isinstance(other_schema, NodeSchema):
         other_kinds.update(other_schema.inherit_from)
     matching = [candidate for candidate in candidates if candidate.peer in other_kinds]
-    exact = [candidate for candidate in matching if candidate.peer == other_kind]
-    return exact or matching or candidates
+    return matching or candidates
 
 
 def select_hop_relationships(
@@ -229,10 +225,12 @@ def select_hop_relationships(
     """Pick the relationship each end of a hop holds for ``identifier``.
 
     Both ends of an edge share one identifier, like a hierarchy's ``parent`` and
-    ``children``, so candidates are narrowed by peer kind, exact kind first, and
-    paired by mirrored direction. The pick is exact when one mirrored pair remains.
-    When every peer stays on the hierarchy generic, the schema cannot tell the
-    ends apart: the first pair is kept, a deterministic guess.
+    ``children``, so candidates are narrowed by peer kind, paired by mirrored
+    direction, and the pairs are ranked by how many of their peers name the other
+    end's exact kind. The pick is unambiguous when a single pair mirrors, or when
+    a single pair pins both peer kinds. Anything less is a deterministic guess
+    with a logged warning: a peer left on the hierarchy generic covers both ends,
+    so the schema cannot tell them apart.
     """
     from_candidates = (
         _candidate_relationships(schema=from_schema, identifier=identifier, other_kind=to_kind, other_schema=to_schema)
@@ -262,16 +260,23 @@ def select_hop_relationships(
             from_candidates[0] if from_candidates else None,
             to_candidates[0] if to_candidates else None,
         )
-    if len(pairs) > 1:
+
+    def exactness(pair: tuple[RelationshipSchema, RelationshipSchema]) -> int:
+        pair_from, pair_to = pair
+        return int(pair_from.peer == to_kind) + int(pair_to.peer == from_kind)
+
+    best_score = max(exactness(pair) for pair in pairs)
+    best_pairs = [pair for pair in pairs if exactness(pair) == best_score]
+    if len(pairs) > 1 and (len(best_pairs) > 1 or best_score < 2):
         log.warning(
-            "Several relationship pairs mirror each other for this hop, keeping the first one",
+            "Several relationship pairs mirror each other for this hop, keeping the best-ranked one",
             from_kind=from_kind,
             to_kind=to_kind,
             identifier=identifier,
-            kept=(pairs[0][0].name, pairs[0][1].name),
+            kept=(best_pairs[0][0].name, best_pairs[0][1].name),
             candidates=[(from_rel.name, to_rel.name) for from_rel, to_rel in pairs],
         )
-    return pairs[0]
+    return best_pairs[0]
 
 
 def _resolve_relationship(

--- a/backend/infrahub/graphql/queries/reachable.py
+++ b/backend/infrahub/graphql/queries/reachable.py
@@ -163,7 +163,12 @@ async def reachable_nodes_resolver(
         {
             "node": _node_payload(node_id=n.node.uuid, kind=n.node.kind, labels_map=labels_map),
             "depth": n.depth,
-            "path": _path_data_to_result(n.path, labels_map, graphql_context, relationship_cache),
+            "path": _path_data_to_result(
+                path_data=n.path,
+                labels_map=labels_map,
+                graphql_context=graphql_context,
+                relationship_cache=relationship_cache,
+            ),
         }
         for n in reachable_data
     ]

--- a/backend/infrahub/graphql/queries/reachable.py
+++ b/backend/infrahub/graphql/queries/reachable.py
@@ -158,11 +158,12 @@ async def reachable_nodes_resolver(
 
     source_info = _node_payload(node_id=source_node.id, kind=source_node.get_kind(), labels_map=labels_map)
 
+    relationship_cache: dict[tuple[str, str, str], dict[str, str]] = {}
     dependencies = [
         {
             "node": _node_payload(node_id=n.node.uuid, kind=n.node.kind, labels_map=labels_map),
             "depth": n.depth,
-            "path": _path_data_to_result(n.path, labels_map, graphql_context),
+            "path": _path_data_to_result(n.path, labels_map, graphql_context, relationship_cache),
         }
         for n in reachable_data
     ]

--- a/backend/tests/component/graphql/queries/test_path_traversal.py
+++ b/backend/tests/component/graphql/queries/test_path_traversal.py
@@ -479,8 +479,7 @@ async def test_resolver_names_each_end_of_a_hierarchy_hop(
     session_admin: AccountSession,
     hierarchical_location_data: dict[str, Node],
 ) -> None:
-    # Both ends of a hierarchy edge share one identifier, but each end holds
-    # its own side: the child holds `parent`, the parent holds `children`.
+    # One shared identifier, two sides: the child holds `parent`, the parent `children`.
     region = hierarchical_location_data["europe"]
     site = hierarchical_location_data["paris"]
     default_branch.update_schema_hash()

--- a/backend/tests/component/graphql/queries/test_path_traversal.py
+++ b/backend/tests/component/graphql/queries/test_path_traversal.py
@@ -45,6 +45,22 @@ query Traverse($data: PathTraversalInput!) {
 """
 
 
+PATH_TRAVERSAL_RELATIONSHIP_QUERY = """
+query Traverse($data: PathTraversalInput!) {
+  InfrahubPathTraversal(data: $data) {
+    count
+    paths {
+      depth
+      hops {
+        node { id kind }
+        relationship { from_rel from_label to_rel to_label kind }
+      }
+    }
+  }
+}
+"""
+
+
 async def _run_resolver(
     *,
     db: InfrahubDatabase,
@@ -454,6 +470,84 @@ class TestPathTraversalResolver:
         )
         assert errors is not None
         assert errors[0].message == "Source and destination nodes must be different"
+
+
+async def test_resolver_names_each_end_of_a_hierarchy_hop(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_permission_backend: None,
+    session_admin: AccountSession,
+    hierarchical_location_data: dict[str, Node],
+) -> None:
+    # Both ends of a hierarchy edge share one identifier, but each end holds
+    # its own side: the child holds `parent`, the parent holds `children`.
+    region = hierarchical_location_data["europe"]
+    site = hierarchical_location_data["paris"]
+    default_branch.update_schema_hash()
+
+    variables = {
+        "data": {
+            "source_id": site.id,
+            "destination_id": region.id,
+            "max_depth": 1,
+            "max_paths": 10,
+        }
+    }
+
+    data, errors = await _run_resolver(
+        db=db,
+        branch=default_branch,
+        session=session_admin,
+        variables=variables,
+        source=PATH_TRAVERSAL_RELATIONSHIP_QUERY,
+    )
+
+    assert errors is None
+    assert data is not None
+    result = data["InfrahubPathTraversal"]
+    assert result["count"] == 1
+    hops = result["paths"][0]["hops"]
+    assert [hop["node"]["id"] for hop in hops] == [site.id, region.id]
+    assert hops[0]["relationship"] is None
+    assert hops[1]["relationship"] == {
+        "from_rel": "parent",
+        "from_label": "Parent",
+        "to_rel": "children",
+        "to_label": "Children",
+        "kind": "Hierarchy",
+    }
+
+    reverse_variables = {
+        "data": {
+            "source_id": region.id,
+            "destination_id": site.id,
+            "max_depth": 1,
+            "max_paths": 10,
+        }
+    }
+
+    reverse_data, reverse_errors = await _run_resolver(
+        db=db,
+        branch=default_branch,
+        session=session_admin,
+        variables=reverse_variables,
+        source=PATH_TRAVERSAL_RELATIONSHIP_QUERY,
+    )
+
+    assert reverse_errors is None
+    assert reverse_data is not None
+    reverse_result = reverse_data["InfrahubPathTraversal"]
+    assert reverse_result["count"] == 1
+    reverse_hops = reverse_result["paths"][0]["hops"]
+    assert [hop["node"]["id"] for hop in reverse_hops] == [region.id, site.id]
+    assert reverse_hops[0]["relationship"] is None
+    assert reverse_hops[1]["relationship"] == {
+        "from_rel": "children",
+        "from_label": "Children",
+        "to_rel": "parent",
+        "to_label": "Parent",
+        "kind": "Hierarchy",
+    }
 
 
 async def test_resolver_respects_session_permissions(

--- a/backend/tests/component/graphql/queries/test_reachable_nodes.py
+++ b/backend/tests/component/graphql/queries/test_reachable_nodes.py
@@ -51,21 +51,86 @@ async def car_with_owner_and_driver(
     return car, owner, driver
 
 
+REACHABLE_NODES_RELATIONSHIP_QUERY = """
+query Reach($data: ReachableNodesInput!) {
+  InfrahubReachableNodes(data: $data) {
+    count
+    dependencies {
+      node { id kind }
+      path {
+        hops {
+          node { id kind }
+          relationship { from_rel from_label to_rel to_label kind }
+        }
+      }
+    }
+  }
+}
+"""
+
+
 async def _run_resolver(
     *,
     db: InfrahubDatabase,
     branch: Branch,
     session: AccountSession,
     variables: dict,
+    source: str = REACHABLE_NODES_QUERY,
 ) -> tuple[dict | None, list | None]:
     gql_params = await prepare_graphql_params(db=db, branch=branch, account_session=session)
     result = await graphql(
         schema=gql_params.schema,
-        source=REACHABLE_NODES_QUERY,
+        source=source,
         context_value=gql_params.context,
         variable_values=variables,
     )
     return result.data, list(result.errors) if result.errors else None
+
+
+async def test_resolver_names_each_end_of_a_hierarchy_hop(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_permission_backend: None,
+    session_admin: AccountSession,
+    hierarchical_location_data: dict[str, Node],
+) -> None:
+    # One shared identifier, two sides: the child holds `parent`, the parent `children`.
+    region = hierarchical_location_data["europe"]
+    site = hierarchical_location_data["paris"]
+    default_branch.update_schema_hash()
+
+    variables = {
+        "data": {
+            "source_id": site.id,
+            "target_kinds": ["LocationRegion"],
+            "max_depth": 1,
+        }
+    }
+
+    data, errors = await _run_resolver(
+        db=db,
+        branch=default_branch,
+        session=session_admin,
+        variables=variables,
+        source=REACHABLE_NODES_RELATIONSHIP_QUERY,
+    )
+
+    assert errors is None
+    assert data is not None
+    result = data["InfrahubReachableNodes"]
+    assert result["count"] == 1
+    dependency = result["dependencies"][0]
+    assert dependency["node"]["id"] == region.id
+    hops = dependency["path"]["hops"]
+    assert [hop["node"]["id"] for hop in hops] == [site.id, region.id]
+    assert hops[0]["relationship"] is None
+    assert hops[1]["relationship"] == {
+        "from_rel": "parent",
+        "from_label": "Parent",
+        "to_rel": "children",
+        "to_label": "Children",
+        "kind": "Hierarchy",
+    }
 
 
 async def test_resolver_short_circuits_when_no_route_to_target_kind(

--- a/backend/tests/unit/graphql/queries/test_path.py
+++ b/backend/tests/unit/graphql/queries/test_path.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.core.schema import RelationshipSchema, SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.graphql.queries.path import select_hop_relationships
+from tests.constants import TestKind
+from tests.helpers.schema import CONTINENT, COUNTRY, LOCATION, SITE
+
+PLAIN_IDENTIFIER = "country__managed_site"
+
+
+@pytest.fixture
+def location_schema_branch() -> SchemaBranch:
+    country = deepcopy(COUNTRY)
+    country.relationships.append(
+        RelationshipSchema(name="managed_sites", peer=TestKind.SITE, identifier=PLAIN_IDENTIFIER, optional=True)
+    )
+    site = deepcopy(SITE)
+    site.relationships.append(
+        RelationshipSchema(name="managed_by", peer=TestKind.COUNTRY, identifier=PLAIN_IDENTIFIER, optional=True)
+    )
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(
+        schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[deepcopy(CONTINENT), country, site])
+    )
+    schema_branch.process()
+    return schema_branch
+
+
+@dataclass
+class HopCase:
+    name: str
+    from_kind: str
+    to_kind: str
+    identifier: str
+    expected_from: str
+    expected_to: str
+
+
+HOP_CASES = [
+    HopCase(
+        name="child_end_holds_parent",
+        from_kind=TestKind.SITE,
+        to_kind=TestKind.COUNTRY,
+        identifier="parent__child",
+        expected_from="parent",
+        expected_to="children",
+    ),
+    HopCase(
+        name="parent_end_holds_children",
+        from_kind=TestKind.COUNTRY,
+        to_kind=TestKind.SITE,
+        identifier="parent__child",
+        expected_from="children",
+        expected_to="parent",
+    ),
+    HopCase(
+        name="generic_parent_peer_still_resolves",
+        from_kind=TestKind.CONTINENT,
+        to_kind=TestKind.COUNTRY,
+        identifier="parent__child",
+        expected_from="children",
+        expected_to="parent",
+    ),
+    HopCase(
+        name="single_declaration_identifier_keeps_both_sides",
+        from_kind=TestKind.COUNTRY,
+        to_kind=TestKind.SITE,
+        identifier=PLAIN_IDENTIFIER,
+        expected_from="managed_sites",
+        expected_to="managed_by",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", HOP_CASES, ids=[case.name for case in HOP_CASES])
+def test_select_hop_relationships(location_schema_branch: SchemaBranch, case: HopCase) -> None:
+    from_rel, to_rel = select_hop_relationships(
+        from_schema=location_schema_branch.get(name=case.from_kind, duplicate=False),
+        to_schema=location_schema_branch.get(name=case.to_kind, duplicate=False),
+        from_kind=case.from_kind,
+        to_kind=case.to_kind,
+        identifier=case.identifier,
+    )
+
+    assert from_rel is not None
+    assert to_rel is not None
+    assert (from_rel.name, to_rel.name) == (case.expected_from, case.expected_to)
+
+
+def test_self_referencing_hierarchy_reports_a_mirrored_pair() -> None:
+    # Both ends declare both sides with self peers: the schema cannot tell the
+    # ends apart, but the answer must stay one edge (a parent side and a
+    # children side), picked deterministically.
+    area = deepcopy(CONTINENT)
+    area.name = "Area"
+    area.parent = "TestingArea"
+    area.children = "TestingArea"
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[area]))
+    schema_branch.process()
+
+    from_rel, to_rel = select_hop_relationships(
+        from_schema=schema_branch.get(name="TestingArea", duplicate=False),
+        to_schema=schema_branch.get(name="TestingArea", duplicate=False),
+        from_kind="TestingArea",
+        to_kind="TestingArea",
+        identifier="parent__child",
+    )
+
+    assert from_rel is not None
+    assert to_rel is not None
+    assert (from_rel.name, to_rel.name) == ("parent", "children")

--- a/backend/tests/unit/graphql/queries/test_path.py
+++ b/backend/tests/unit/graphql/queries/test_path.py
@@ -5,13 +5,28 @@ from dataclasses import dataclass
 
 import pytest
 
-from infrahub.core.schema import RelationshipSchema, SchemaRoot
+from infrahub.core.schema import NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.graphql.queries.path import select_hop_relationships
 from tests.constants import TestKind
 from tests.helpers.schema import CONTINENT, COUNTRY, LOCATION, SITE
 
 PLAIN_IDENTIFIER = "country__managed_site"
+
+
+def _location_variant(name: str, parent: str | None, children: str | None) -> NodeSchema:
+    node = deepcopy(CONTINENT)
+    node.name = name
+    node.parent = parent
+    node.children = children
+    return node
+
+
+def _processed_branch(nodes: list[NodeSchema]) -> SchemaBranch:
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=nodes))
+    schema_branch.process()
+    return schema_branch
 
 
 @pytest.fixture
@@ -24,12 +39,7 @@ def location_schema_branch() -> SchemaBranch:
     site.relationships.append(
         RelationshipSchema(name="managed_by", peer=TestKind.COUNTRY, identifier=PLAIN_IDENTIFIER, optional=True)
     )
-    schema_branch = SchemaBranch(cache={}, name="test")
-    schema_branch.load_schema(
-        schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[deepcopy(CONTINENT), country, site])
-    )
-    schema_branch.process()
-    return schema_branch
+    return _processed_branch(nodes=[deepcopy(CONTINENT), country, site])
 
 
 @dataclass
@@ -93,25 +103,37 @@ def test_select_hop_relationships(location_schema_branch: SchemaBranch, case: Ho
     assert (from_rel.name, to_rel.name) == (case.expected_from, case.expected_to)
 
 
-def test_loose_hierarchy_keeps_a_deterministic_mirrored_pair() -> None:
-    # Both kinds leave parent/children unset, so both peers default to the
-    # hierarchy generic and both ends keep both candidates: the schema cannot
-    # tell the ends apart. The guess is the same pair in both hop directions,
-    # so one direction names the ends swapped — known limit until hops carry
-    # the edge orientation.
-    area = deepcopy(CONTINENT)
-    area.name = "Area"
-    area.parent = None
-    area.children = None
-    zone = deepcopy(CONTINENT)
-    zone.name = "Zone"
-    zone.parent = None
-    zone.children = None
-    schema_branch = SchemaBranch(cache={}, name="test")
-    schema_branch.load_schema(schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[area, zone]))
-    schema_branch.process()
+@dataclass
+class AmbiguousHopCase:
+    name: str
+    nodes: list[NodeSchema]
+    hops: list[tuple[str, str]]
 
-    for from_kind, to_kind in (("TestingArea", "TestingZone"), ("TestingZone", "TestingArea")):
+
+AMBIGUOUS_HOP_CASES = [
+    AmbiguousHopCase(
+        name="self_referencing_kind",
+        nodes=[_location_variant(name="Area", parent="TestingArea", children="TestingArea")],
+        hops=[("TestingArea", "TestingArea")],
+    ),
+    AmbiguousHopCase(
+        name="two_kinds_under_a_loose_generic",
+        nodes=[
+            _location_variant(name="Area", parent=None, children=None),
+            _location_variant(name="Zone", parent=None, children=None),
+        ],
+        hops=[("TestingArea", "TestingZone"), ("TestingZone", "TestingArea")],
+    ),
+]
+
+
+@pytest.mark.parametrize("case", AMBIGUOUS_HOP_CASES, ids=[case.name for case in AMBIGUOUS_HOP_CASES])
+def test_ambiguous_hierarchy_keeps_a_deterministic_mirrored_pair(case: AmbiguousHopCase) -> None:
+    # The schema cannot tell the ends apart, so the guess is the same pair in
+    # every hop direction: for two distinct kinds, one direction is swapped.
+    schema_branch = _processed_branch(nodes=case.nodes)
+
+    for from_kind, to_kind in case.hops:
         from_rel, to_rel = select_hop_relationships(
             from_schema=schema_branch.get(name=from_kind, duplicate=False),
             to_schema=schema_branch.get(name=to_kind, duplicate=False),
@@ -137,28 +159,3 @@ def test_unknown_end_falls_back_to_first_declaration(location_schema_branch: Sch
     assert from_rel is not None
     assert from_rel.name == "parent"
     assert to_rel is None
-
-
-def test_self_referencing_hierarchy_reports_a_mirrored_pair() -> None:
-    # Both ends declare both sides with self peers: the schema cannot tell the
-    # ends apart, but the answer must stay one edge (a parent side and a
-    # children side), picked deterministically.
-    area = deepcopy(CONTINENT)
-    area.name = "Area"
-    area.parent = "TestingArea"
-    area.children = "TestingArea"
-    schema_branch = SchemaBranch(cache={}, name="test")
-    schema_branch.load_schema(schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[area]))
-    schema_branch.process()
-
-    from_rel, to_rel = select_hop_relationships(
-        from_schema=schema_branch.get(name="TestingArea", duplicate=False),
-        to_schema=schema_branch.get(name="TestingArea", duplicate=False),
-        from_kind="TestingArea",
-        to_kind="TestingArea",
-        identifier="parent__child",
-    )
-
-    assert from_rel is not None
-    assert to_rel is not None
-    assert (from_rel.name, to_rel.name) == ("parent", "children")

--- a/backend/tests/unit/graphql/queries/test_path.py
+++ b/backend/tests/unit/graphql/queries/test_path.py
@@ -149,6 +149,19 @@ AMBIGUOUS_HOP_CASES = [
         ],
         hops=[("TestingArea", "TestingZone"), ("TestingZone", "TestingArea")],
     ),
+    AmbiguousHopCase(
+        name="self_referencing_kind_with_one_pinned_side",
+        nodes=[_location_variant(name="Area", parent="TestingArea", children="")],
+        hops=[("TestingArea", "TestingArea")],
+    ),
+    AmbiguousHopCase(
+        name="two_kinds_pinning_each_other_as_children",
+        nodes=[
+            _location_variant(name="Building", parent=None, children="TestingFloor"),
+            _location_variant(name="Floor", parent=None, children="TestingBuilding"),
+        ],
+        hops=[("TestingBuilding", "TestingFloor"), ("TestingFloor", "TestingBuilding")],
+    ),
 ]
 
 

--- a/backend/tests/unit/graphql/queries/test_path.py
+++ b/backend/tests/unit/graphql/queries/test_path.py
@@ -103,6 +103,31 @@ def test_select_hop_relationships(location_schema_branch: SchemaBranch, case: Ho
     assert (from_rel.name, to_rel.name) == (case.expected_from, case.expected_to)
 
 
+def test_two_level_hierarchy_names_both_ends() -> None:
+    # The top's parent peer and the leaf's children peer both fall back to the
+    # generic; only the exact peer preference keeps the pick out of the guess.
+    building = _location_variant(name="Building", parent="", children="TestingFloor")
+    floor = _location_variant(name="Floor", parent="TestingBuilding", children="")
+    schema_branch = _processed_branch(nodes=[building, floor])
+
+    expectations = {
+        ("TestingBuilding", "TestingFloor"): ("children", "parent"),
+        ("TestingFloor", "TestingBuilding"): ("parent", "children"),
+    }
+    for (from_kind, to_kind), expected in expectations.items():
+        from_rel, to_rel = select_hop_relationships(
+            from_schema=schema_branch.get(name=from_kind, duplicate=False),
+            to_schema=schema_branch.get(name=to_kind, duplicate=False),
+            from_kind=from_kind,
+            to_kind=to_kind,
+            identifier="parent__child",
+        )
+
+        assert from_rel is not None
+        assert to_rel is not None
+        assert (from_rel.name, to_rel.name) == expected
+
+
 @dataclass
 class AmbiguousHopCase:
     name: str

--- a/backend/tests/unit/graphql/queries/test_path.py
+++ b/backend/tests/unit/graphql/queries/test_path.py
@@ -93,6 +93,52 @@ def test_select_hop_relationships(location_schema_branch: SchemaBranch, case: Ho
     assert (from_rel.name, to_rel.name) == (case.expected_from, case.expected_to)
 
 
+def test_loose_hierarchy_keeps_a_deterministic_mirrored_pair() -> None:
+    # Both kinds leave parent/children unset, so both peers default to the
+    # hierarchy generic and both ends keep both candidates: the schema cannot
+    # tell the ends apart. The guess is the same pair in both hop directions,
+    # so one direction names the ends swapped — known limit until hops carry
+    # the edge orientation.
+    area = deepcopy(CONTINENT)
+    area.name = "Area"
+    area.parent = None
+    area.children = None
+    zone = deepcopy(CONTINENT)
+    zone.name = "Zone"
+    zone.parent = None
+    zone.children = None
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(generics=[deepcopy(LOCATION)], nodes=[area, zone]))
+    schema_branch.process()
+
+    for from_kind, to_kind in (("TestingArea", "TestingZone"), ("TestingZone", "TestingArea")):
+        from_rel, to_rel = select_hop_relationships(
+            from_schema=schema_branch.get(name=from_kind, duplicate=False),
+            to_schema=schema_branch.get(name=to_kind, duplicate=False),
+            from_kind=from_kind,
+            to_kind=to_kind,
+            identifier="parent__child",
+        )
+
+        assert from_rel is not None
+        assert to_rel is not None
+        assert (from_rel.name, to_rel.name) == ("parent", "children")
+
+
+def test_unknown_end_falls_back_to_first_declaration(location_schema_branch: SchemaBranch) -> None:
+    from_rel, to_rel = select_hop_relationships(
+        from_schema=location_schema_branch.get(name=TestKind.SITE, duplicate=False),
+        to_schema=None,
+        from_kind=TestKind.SITE,
+        to_kind="TestingUnknown",
+        identifier="parent__child",
+    )
+
+    assert from_rel is not None
+    assert from_rel.name == "parent"
+    assert to_rel is None
+
+
 def test_self_referencing_hierarchy_reports_a_mirrored_pair() -> None:
     # Both ends declare both sides with self peers: the schema cannot tell the
     # ends apart, but the answer must stay one edge (a parent side and a

--- a/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
+++ b/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
@@ -1,1 +1,1 @@
-In graph traversal results (path and dependency modes), both ends of a hierarchy edge were reported as `parent`; the parent end now reports its own `children` relationship.
+In graph traversal results (path and dependency modes), both ends of a hierarchy edge were reported as `parent`. Each end now reports its own side (`children` on the parent end); when the hierarchy does not pin its parent and children kinds, the sides are a consistent best guess.

--- a/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
+++ b/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
@@ -1,1 +1,1 @@
-Fixed the path query naming both ends of a hierarchy edge `parent`; the parent end now reports its own `children` relationship.
+In graph traversal results (path and dependency modes), both ends of a hierarchy edge were reported as `parent`; the parent end now reports its own `children` relationship.

--- a/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
+++ b/changelog/+ifc-3106-path-query-hierarchy-sides.fixed.md
@@ -1,0 +1,1 @@
+Fixed the path query naming both ends of a hierarchy edge `parent`; the parent end now reports its own `children` relationship.

--- a/docs/docs/reference/graph-traversal.mdx
+++ b/docs/docs/reference/graph-traversal.mdx
@@ -35,7 +35,9 @@ Reference for the `InfrahubPathTraversal` and `InfrahubReachableNodes` GraphQL q
 Each `PathResultType` has `depth` (number of edges) and `hops` — an ordered list where each hop
 has a `node` and (except the first) a `relationship`. Each `node` (`PathNodeType`) exposes `id`,
 `kind`, `label`, `display_label`, and `hfid`. Each `relationship` (`PathRelationshipType`) exposes
-`from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`.
+`from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`. `from_rel` and `from_label` name the
+relationship the hop's source node holds; `to_rel` and `to_label` name the destination node's own
+side of the same edge — for a hierarchy hop, `parent` on the child and `children` on the parent.
 
 ---
 

--- a/docs/docs/reference/graph-traversal.mdx
+++ b/docs/docs/reference/graph-traversal.mdx
@@ -38,6 +38,9 @@ has a `node` and (except the first) a `relationship`. Each `node` (`PathNodeType
 `from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`. `from_rel` and `from_label` name the
 relationship the hop's source object holds; `to_rel` and `to_label` name the destination object's
 own side of the same edge — for a hierarchy hop, `parent` on the child and `children` on the parent.
+The ends are named exactly when the hierarchy pins its `parent` and `children` kinds; when the peers
+stay on the hierarchy generic, the two ends cannot be told apart from the schema and the names are a
+consistent best guess.
 
 ---
 

--- a/docs/docs/reference/graph-traversal.mdx
+++ b/docs/docs/reference/graph-traversal.mdx
@@ -36,8 +36,8 @@ Each `PathResultType` has `depth` (number of edges) and `hops` — an ordered li
 has a `node` and (except the first) a `relationship`. Each `node` (`PathNodeType`) exposes `id`,
 `kind`, `label`, `display_label`, and `hfid`. Each `relationship` (`PathRelationshipType`) exposes
 `from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`. `from_rel` and `from_label` name the
-relationship the hop's source node holds; `to_rel` and `to_label` name the destination node's own
-side of the same edge — for a hierarchy hop, `parent` on the child and `children` on the parent.
+relationship the hop's source object holds; `to_rel` and `to_label` name the destination object's
+own side of the same edge — for a hierarchy hop, `parent` on the child and `children` on the parent.
 
 ---
 

--- a/docs/docs/reference/graph-traversal.mdx
+++ b/docs/docs/reference/graph-traversal.mdx
@@ -38,8 +38,8 @@ has a `node` and (except the first) a `relationship`. Each `node` (`PathNodeType
 `from_rel`, `from_label`, `to_rel`, `to_label`, and `kind`. `from_rel` and `from_label` name the
 relationship the hop's source object holds; `to_rel` and `to_label` name the destination object's
 own side of the same edge — for a hierarchy hop, `parent` on the child and `children` on the parent.
-The ends are named exactly when the hierarchy pins its `parent` and `children` kinds; when the peers
-stay on the hierarchy generic, the two ends cannot be told apart from the schema and the names are a
+The ends are named exactly when the hierarchy pins its `parent` and `children` kinds; when a peer
+stays on the hierarchy generic, the schema may not tell the ends apart and the names are a
 consistent best guess.
 
 ---


### PR DESCRIPTION
# Why

A hierarchical node declares `parent` and `children` under one identifier, `parent__child`. The traversal queries resolved each end of a hop with the first schema match, which is always `parent`. Both ends of a hierarchy edge then reported `parent`, and the labels carried the same error. The parent end holds `children`. Both `InfrahubPathTraversal` and `InfrahubReachableNodes` were affected: they share the hop projection.

This is the same inversion as #10485 (fixed by #10489), this time in the traversal queries. Fixes IFC-3106.

## What changed

- The two ends of a hop are resolved as a pair. Candidates on each end are narrowed by peer kind, paired by mirrored direction (a hard constraint), and the pairs are ranked by how many of their peers name the other end's exact kind. The mirror rule lives in `RelationshipSchema.mirrors()`, shared with the changelog fix from #10489.
- The pick is exact for every hierarchy that pins its `parent` and `children` kinds, including two-level ones whose outer peers fall back to the generic. Hierarchies with a peer left on the generic get a deterministic guess: the schema alone cannot tell their ends apart. IFC-3134 tracks the real fix, carrying the edge orientation in the traversal result.
- Each (identifier, from kind, to kind) triple resolves once per request. A pick is silent only when a single pair mirrors or a single pair pins both peer kinds; anything less logs a warning naming the kept pair and the alternatives, and another warning fires when no candidate pair mirrors at all.
- Identifiers with a single declaration on each side keep their behavior.

## How to test

```bash
uv run pytest backend/tests/unit/graphql/queries/test_path.py
INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest backend/tests/component/graphql/queries/test_path_traversal.py backend/tests/component/graphql/queries/test_reachable_nodes.py --neo4j
```

The new component tests fail on the parent commit: the parent end reports `parent`/`Parent` instead of `children`/`Children`. Dependency mode has its own hierarchy-hop assertion.

## Checklist

- [x] Tests added
- [x] Changelog entry added
- [x] Docs updated (`docs/docs/reference/graph-traversal.mdx`: which end each field names, and when the pick is exact)
