### PR TITLE
chore(frontend): upgrade zod to 4.5.4

### DIFF
--- a/changelog/+zod-4-5.changed.md
+++ b/changelog/+zod-4-5.changed.md
@@ -1,0 +1,1 @@
+Upgraded the frontend's zod validation library from 4.4 to 4.5.

--- a/changelog/+zod-4-5.changed.md
+++ b/changelog/+zod-4-5.changed.md
@@ -1,1 +1,1 @@
-Upgraded the frontend's zod validation library from 4.4 to 4.5.
+Upgraded the frontend `zod` validation library from 4.4 to 4.5.

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -97,7 +97,7 @@
     "tailwind-merge": "catalog:",
     "tailwindcss-animate": "^1.0.7",
     "unidiff": "^1.0.4",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@betterer/cli": "6.0.0-alpha.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -276,8 +276,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@betterer/cli':
         specifier: 6.0.0-alpha.1
@@ -7662,8 +7662,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -12033,8 +12033,8 @@ snapshots:
       '@babel/parser': 7.29.8
       eslint: 10.4.1(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
+      zod: 4.5.4
+      zod-validation-error: 4.0.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -12689,7 +12689,7 @@ snapshots:
       tinyglobby: 0.2.17
       unbash: 4.0.10
       yaml: 2.9.0
-      zod: 4.4.3
+      zod: 4.5.4
 
   layout-base@1.0.2: {}
 
@@ -14537,7 +14537,7 @@ snapshots:
       jsonc-parser: 3.3.1
       nypm: 0.6.7
       yaml: 2.9.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       oxfmt: 0.63.0
       oxlint: 1.79.0
@@ -14835,11 +14835,11 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
-  zod-validation-error@4.0.2(zod@4.4.3):
+  zod-validation-error@4.0.2(zod@4.5.4):
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
-  zod@4.4.3: {}
+  zod@4.5.4: {}
 
   zustand@4.5.7(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
# Why

Zod 4.5 shrinks the per-schema memory footprint ~9x, stops capturing a stack trace on every `safeParse` failure, and always strips `__proto__` keys from parsed objects. The last point hardens the two URL query-string schemas (pagination and filters), which parse JSON straight from the address bar.

Non-goals: no adoption of the new 4.5 APIs (`z.compile`, `z.validate`, `z.deepPartial`, ...) and no changes to form validation. Both were assessed alongside this bump and deliberately left out so the PR stays a pure dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
