### PR TITLE
fix(backend): include branch failure reason in repository sync error

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -24,12 +24,12 @@ from infrahub.exceptions import (
     RepositoryError,
 )
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
-from infrahub.log import get_logger
+from infrahub.log import get_run_logger
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
 
-log = get_logger()
+log = get_run_logger()
 
 
 @dataclass
@@ -81,7 +81,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         await self.create_locally(
             infrahub_branch_name=self.infrahub_branch_name, update_commit_value=update_commit_value
         )
-        log.info("Created new repository locally.", repository=self.name)
+        log.info("Created new repository locally: %s", self.name)
         return self
 
     async def resolve_checkout_ref(self) -> str:
@@ -126,18 +126,28 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             return
 
         for failed in failed_imports:
+            # extra= preserves step and reason as discrete LogRecord fields so log shippers
+            # and alert rules can filter on them, even though the message already contains them.
             log.warning(
-                "Failed to synchronize branch, skipping it.",
-                repository=self.name,
-                branch=failed.branch_name,
-                step=failed.step.value,
-                reason=failed.reason,
+                "Failed to synchronize branch %s of repository %s at step %s: %s",
+                failed.branch_name,
+                self.name,
+                failed.step.value,
+                failed.reason,
+                extra={
+                    "repository": self.name,
+                    "branch": failed.branch_name,
+                    "step": failed.step.value,
+                    "reason": failed.reason,
+                },
             )
 
-        branches = ", ".join(failed.branch_name for failed in failed_imports)
+        branch_summaries = "; ".join(
+            f"{failed.branch_name} (step={failed.step.value}): {failed.reason}" for failed in failed_imports
+        )
         raise RepositoryError(
             identifier=self.name,
-            message=f"Unable to synchronize the following branches of repository {self.name}: {branches}",
+            message=f"Unable to synchronize the following branches of repository {self.name}: {branch_summaries}",
         )
 
     async def collect_pending_imports(self, staging_branch: str | None = None) -> CollectedImports:
@@ -154,7 +164,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             GraphQLError: When a branch or commit update against the database fails.
 
         """
-        log.info("Starting the synchronization.", repository=self.name)
+        log.info("Starting the synchronization of %s.", self.name)
 
         await self.fetch()
 
@@ -163,7 +173,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         if not new_branches and not updated_branches:
             return CollectedImports()
 
-        log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
+        log.debug("New Branches %s, Updated Branches %s for %s", new_branches, updated_branches, self.name)
 
         imports: list[PendingObjectImport] = []
         failed_imports: list[FailedImport] = []
@@ -231,9 +241,10 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
                 elif commit_after is True:
                     log.warning(
-                        f"An update was detected but the commit remained the same after pull() ({commit_after}).",
-                        repository=self.name,
-                        branch=branch_name,
+                        "An update was detected but the commit remained the same after pull() (%s) for branch %s of repository %s.",
+                        commit_after,
+                        branch_name,
+                        self.name,
                     )
 
         imports.extend(
@@ -277,9 +288,10 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         if commit_after is True:
             log.warning(
-                f"An update was detected but the commit remained the same after pull() ({commit_after}).",
-                repository=self.name,
-                branch=self.default_branch,
+                "An update was detected but the commit remained the same after pull() (%s) for branch %s of repository %s.",
+                commit_after,
+                self.default_branch,
+                self.name,
             )
         return []
 
@@ -294,7 +306,9 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
             return False
 
         log.debug(
-            f"Pushing the latest update to the remote origin for the branch '{branch_name}'", repository=self.name
+            "Pushing the latest update to the remote origin for the branch '%s' of repository %s.",
+            branch_name,
+            self.name,
         )
 
         repo = self.get_git_repo_worktree(identifier=branch_name)
@@ -378,7 +392,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 
         self = cls(**kwargs)
         await self.create_locally(checkout_ref=self.ref, infrahub_branch_name=self.infrahub_branch_name)
-        log.info("Created new repository locally.", repository=self.name)
+        log.info("Created new repository locally: %s", self.name)
         return self
 
     async def resolve_checkout_ref(self) -> str:
@@ -414,7 +428,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
             except BadName:
                 ...
         if not commit:
-            log.error(f"No object found for refs {refs} on repository {self.name}")
+            log.error("No object found for refs %s on repository %s", refs, self.name)
             raise ValueError(f"Ref {self.ref} not found.")
 
         return str(commit)
@@ -450,7 +464,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
             try:
                 latest_commit = git_repo.git.rev_parse(self.ref)
             except GitCommandError as err:
-                log.error(f"No object found for ref {self.ref} on repository {self.name}")
+                log.error("No object found for ref %s on repository %s", self.ref, self.name)
                 raise ValueError(f"Ref {self.ref} not found.") from err
         latest_commit = str(git_repo.commit(latest_commit))
         synced_from_remote = await self.sync_from_remote(commit=latest_commit)

--- a/backend/tests/component/git/test_git_repository.py
+++ b/backend/tests/component/git/test_git_repository.py
@@ -669,8 +669,10 @@ async def test_sync_continues_after_branch_pull_failure(
     assert repo.get_commit_value(branch_name="branch02", remote=False) != str(remote_commit_branch02)
 
     # A branch failure surfaces as an error once all branches have been processed.
-    expected_message = f"Unable to synchronize the following branches of repository {repo.name}: branch01"
-    with pytest.raises(RepositoryError, match=re.escape(expected_message)):
+    expected_prefix = re.escape(
+        f"Unable to synchronize the following branches of repository {repo.name}: branch01 (step=collection):"
+    )
+    with pytest.raises(RepositoryError, match=expected_prefix):
         await _sync(repo)
 
     assert repo.get_commit_value(branch_name="branch02", remote=False) == str(remote_commit_branch02)

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -283,9 +283,7 @@ class RaiseBranchesCase:
         RaiseBranchesCase(
             name="single_failure",
             failed_imports=[
-                FailedImport(
-                    branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed"
-                ),
+                FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed"),
             ],
             expected_message=(
                 "Unable to synchronize the following branches of repository test-repo:"

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -315,9 +315,8 @@ def test_raise_if_branches_failed_error_message(case: RaiseBranchesCase) -> None
 def test_raise_if_branches_failed_logs_structured_fields(caplog: pytest.LogCaptureFixture) -> None:
     repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
     failed = FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed")
-    with caplog.at_level(logging.WARNING, logger="infrahub.tasks"):
-        with pytest.raises(RepositoryError):
-            repo.raise_if_branches_failed([failed])
+    with caplog.at_level(logging.WARNING, logger="infrahub.tasks"), pytest.raises(RepositoryError):
+        repo.raise_if_branches_failed([failed])
     assert len(caplog.records) == 1
     attrs = vars(caplog.records[0])
     assert attrs["branch"] == "branch01"

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -265,9 +265,25 @@ def test_check_connectivity_ignores_cwd_git_pointer(tmp_path: Path, monkeypatch:
     InfrahubRepository.check_connectivity(name="test", url=f"file://{source_dir}")
 
 
-def test_raise_if_branches_failed_empty_list_does_not_raise() -> None:
-    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
-    repo.raise_if_branches_failed([])
+@pytest.fixture
+def stub_repo() -> InfrahubRepository:
+    # Spell out all fields that carry positional defaults in Field() so mypy sees them.
+    return InfrahubRepository(
+        id=UUIDT.new(),
+        name="test-repo",
+        default_branch_name=None,
+        location=None,
+        has_origin=False,
+        cache_repo=None,
+        is_read_only=False,
+        internal_status="active",
+        reinitialized=False,
+        infrahub_branch_name=None,
+    )
+
+
+def test_raise_if_branches_failed_empty_list_does_not_raise(stub_repo: InfrahubRepository) -> None:
+    stub_repo.raise_if_branches_failed([])
 
 
 @dataclass
@@ -304,17 +320,17 @@ class RaiseBranchesCase:
     ],
     ids=lambda c: c.name,
 )
-def test_raise_if_branches_failed_error_message(case: RaiseBranchesCase) -> None:
-    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
+def test_raise_if_branches_failed_error_message(stub_repo: InfrahubRepository, case: RaiseBranchesCase) -> None:
     with pytest.raises(RepositoryError, match=rf"^{re.escape(case.expected_message)}$"):
-        repo.raise_if_branches_failed(case.failed_imports)
+        stub_repo.raise_if_branches_failed(case.failed_imports)
 
 
-def test_raise_if_branches_failed_logs_structured_fields(caplog: pytest.LogCaptureFixture) -> None:
-    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
+def test_raise_if_branches_failed_logs_structured_fields(
+    stub_repo: InfrahubRepository, caplog: pytest.LogCaptureFixture
+) -> None:
     failed = FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed")
     with caplog.at_level(logging.WARNING, logger="infrahub.tasks"), pytest.raises(RepositoryError):
-        repo.raise_if_branches_failed([failed])
+        stub_repo.raise_if_branches_failed([failed])
     assert len(caplog.records) == 1
     attrs = vars(caplog.records[0])
     assert attrs["branch"] == "branch01"

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,7 +12,9 @@ from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
 from infrahub.core.registry import registry
+from infrahub.exceptions import RepositoryError
 from infrahub.git import InfrahubRepository
+from infrahub.git.repository import FailedImport, ImportStep
 from tests.helpers.file_repo import MultipleStagesFileRepo
 from tests.helpers.test_client import dummy_async_request
 
@@ -259,3 +263,64 @@ def test_check_connectivity_ignores_cwd_git_pointer(tmp_path: Path, monkeypatch:
     monkeypatch.chdir(cwd)
 
     InfrahubRepository.check_connectivity(name="test", url=f"file://{source_dir}")
+
+
+def test_raise_if_branches_failed_empty_list_does_not_raise() -> None:
+    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
+    repo.raise_if_branches_failed([])
+
+
+@dataclass
+class RaiseBranchesCase:
+    name: str
+    failed_imports: list[FailedImport]
+    expected_message: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        RaiseBranchesCase(
+            name="single_failure",
+            failed_imports=[
+                FailedImport(
+                    branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed"
+                ),
+            ],
+            expected_message=(
+                "Unable to synchronize the following branches of repository test-repo:"
+                " branch01 (step=collection): schema validation failed"
+            ),
+        ),
+        RaiseBranchesCase(
+            name="multiple_failures",
+            failed_imports=[
+                FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="error 1"),
+                FailedImport(branch_name="branch02", step=ImportStep.IMPORT, reason="error 2"),
+            ],
+            expected_message=(
+                "Unable to synchronize the following branches of repository test-repo:"
+                " branch01 (step=collection): error 1; branch02 (step=import): error 2"
+            ),
+        ),
+    ],
+    ids=lambda c: c.name,
+)
+def test_raise_if_branches_failed_error_message(case: RaiseBranchesCase) -> None:
+    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
+    with pytest.raises(RepositoryError, match=rf"^{re.escape(case.expected_message)}$"):
+        repo.raise_if_branches_failed(case.failed_imports)
+
+
+def test_raise_if_branches_failed_logs_structured_fields(caplog: pytest.LogCaptureFixture) -> None:
+    repo = InfrahubRepository(id=UUIDT.new(), name="test-repo")
+    failed = FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed")
+    with caplog.at_level(logging.WARNING, logger="infrahub.tasks"):
+        with pytest.raises(RepositoryError):
+            repo.raise_if_branches_failed([failed])
+    assert len(caplog.records) == 1
+    attrs = vars(caplog.records[0])
+    assert attrs["branch"] == "branch01"
+    assert attrs["step"] == "collection"
+    assert attrs["reason"] == "schema validation failed"
+    assert attrs["repository"] == "test-repo"

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,8 +1,10 @@
 import logging
 import re
 from collections.abc import Iterator
+from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -282,28 +284,34 @@ def stub_repo() -> InfrahubRepository:
     )
 
 
-def test_raise_if_branches_failed_empty_list_does_not_raise(stub_repo: InfrahubRepository) -> None:
-    stub_repo.raise_if_branches_failed([])
-
-
 @dataclass
 class RaiseBranchesCase:
     name: str
     failed_imports: list[FailedImport]
-    expected_message: str
+    expectation: Any
 
 
 @pytest.mark.parametrize(
     "case",
     [
         RaiseBranchesCase(
+            name="empty_list_does_not_raise",
+            failed_imports=[],
+            expectation=does_not_raise(),
+        ),
+        RaiseBranchesCase(
             name="single_failure",
             failed_imports=[
                 FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="schema validation failed"),
             ],
-            expected_message=(
-                "Unable to synchronize the following branches of repository test-repo:"
-                " branch01 (step=collection): schema validation failed"
+            expectation=pytest.raises(
+                RepositoryError,
+                match=rf"^{
+                    re.escape(
+                        'Unable to synchronize the following branches of repository test-repo:'
+                        ' branch01 (step=collection): schema validation failed'
+                    )
+                }$",
             ),
         ),
         RaiseBranchesCase(
@@ -312,16 +320,21 @@ class RaiseBranchesCase:
                 FailedImport(branch_name="branch01", step=ImportStep.COLLECTION, reason="error 1"),
                 FailedImport(branch_name="branch02", step=ImportStep.IMPORT, reason="error 2"),
             ],
-            expected_message=(
-                "Unable to synchronize the following branches of repository test-repo:"
-                " branch01 (step=collection): error 1; branch02 (step=import): error 2"
+            expectation=pytest.raises(
+                RepositoryError,
+                match=rf"^{
+                    re.escape(
+                        'Unable to synchronize the following branches of repository test-repo:'
+                        ' branch01 (step=collection): error 1; branch02 (step=import): error 2'
+                    )
+                }$",
             ),
         ),
     ],
     ids=lambda c: c.name,
 )
-def test_raise_if_branches_failed_error_message(stub_repo: InfrahubRepository, case: RaiseBranchesCase) -> None:
-    with pytest.raises(RepositoryError, match=rf"^{re.escape(case.expected_message)}$"):
+def test_raise_if_branches_failed(stub_repo: InfrahubRepository, case: RaiseBranchesCase) -> None:
+    with case.expectation:
         stub_repo.raise_if_branches_failed(case.failed_imports)
 
 

--- a/changelog/10526.fixed.md
+++ b/changelog/10526.fixed.md
@@ -1,0 +1,1 @@
+Fixed repository sync failures reporting only the branch name; the failing step and reason are now included in the error and surfaced in the Tasks tab.


### PR DESCRIPTION
## Summary

Repository sync failures only named the failing branch in the error message — the
step and reason were discarded, and the log warning carrying them used a logger
Prefect does not collect. Operators without shell access to the task worker had no
way to determine why a branch sync failed from the Tasks tab alone.

## Key Changes

- `raise_if_branches_failed` now includes the failing step (`collection` or `import`)
  and reason per branch in the `RepositoryError` message, making them visible in the
  Tasks tab traceback.
- `repository.py` switches from `get_logger()` (structlog, `infrahub` namespace) to
  `get_run_logger()` (`infrahub.tasks`), routing all log records through the logger
  Prefect collects — fixing visibility for all ten call sites in the file.
- The warning in `raise_if_branches_failed` also passes `extra=` so `step` and
  `reason` survive as discrete `LogRecord` fields for log-pipeline filters and alert
  rules.

## Related Context

Closes #10526. Regression introduced in #9466 (`01ca0f5f4`, 2026-06-19), first
released in `infrahub-v1.9.9`. Still present on `stable` at `infrahub-v1.11.0`.

## Test Plan

- `uv run pytest backend/tests/unit/git/test_git_repository.py` — all unit tests pass.
- Component test `test_sync_continues_after_branch_pull_failure` updated to match the
  new message format (repo name + branch + `step=collection` pinned; variable reason
  left unmatched per test guidelines).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

