### PR TITLE
Follow-up on cubic review feedback from #10524

### DIFF
--- a/backend/infrahub/core/branch/delete_coordinator.py
+++ b/backend/infrahub/core/branch/delete_coordinator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from infrahub.core.constants import SYSTEM_USER_ID
 from infrahub.events.branch_action import BranchDeletedEvent
 from infrahub.events.models import EventMeta
 from infrahub.exceptions import ValidationError
@@ -68,7 +69,7 @@ class BranchDeleteOrchestrator:
         # Freezing has to precede the deletion, which takes away the branch name they are found by.
         await self.diff_freezer.freeze_diffs_for_branch(branch_name=branch.name)
 
-        result = await self.data_deleter.delete(branch=branch, user_id=context.account.account_id)
+        result = await self.data_deleter.delete(branch=branch, user_id=context.account.account_id or SYSTEM_USER_ID)
 
         if result.branch_deleted:
             await self.workflow.submit_workflow(

--- a/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/migration.py
+++ b/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/migration.py
@@ -33,9 +33,9 @@ class Migration078(ArbitraryMigration):
     Retention is judged across every branch, so a value any branch can still read is left open and
     released later by the runtime enforcement points. Each close is stamped with the time the field
     stopped being reachable rather than with the upgrade's own time, which keeps it out of the fork
-    window of every branch older than the upgrade. Where the graph records no such time it also
-    records no owner departure, so no branch resolves the owner as live and the upgrade's own time
-    closes the field without shifting any branch's view. A second run reports zero repairs.
+    window of every branch older than the upgrade. Where the graph records no such time the
+    upgrade's own time is the fallback, which shifts no branch's view either: a field only reaches
+    the stamp once no branch retains it. A second run reports zero repairs.
     """
 
     name: str = "078_retire_agnostic_property_edges"

--- a/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
+++ b/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
@@ -127,8 +127,8 @@ class CloseUnretainedAgnosticFieldsQuery(Query):
     Unbounded: every branch-agnostic field in the graph is a candidate, which is what clears a
     backlog no runtime path can reach. Each candidate is stamped with the time it stopped being
     reachable rather than with the run time; where the graph records no such time the run time is
-    the fallback, and the graph then also records no owner departure, so no branch resolves the
-    owner as live and the close shifts no branch's view.
+    the fallback. Every candidate is already unretained on every branch by the time it is stamped,
+    so the close shifts no branch's view whichever stamp it carries.
 
     The writes are batched, so this query cannot run inside an explicit transaction. A failure part
     way through leaves the earlier batches closed, which a re-run completes: retention does not come

--- a/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
+++ b/backend/infrahub/core/migrations/graph/m078_retire_agnostic_property_edges/queries.py
@@ -126,7 +126,9 @@ class CloseUnretainedAgnosticFieldsQuery(Query):
 
     Unbounded: every branch-agnostic field in the graph is a candidate, which is what clears a
     backlog no runtime path can reach. Each candidate is stamped with the time it stopped being
-    reachable rather than with the run time, and one that yields no such time is left alone.
+    reachable rather than with the run time; where the graph records no such time the run time is
+    the fallback, and the graph then also records no owner departure, so no branch resolves the
+    owner as live and the close shifts no branch's view.
 
     The writes are batched, so this query cannot run inside an explicit transaction. A failure part
     way through leaves the earlier batches closed, which a re-run completes: retention does not come
@@ -153,7 +155,7 @@ class CloseUnretainedAgnosticFieldsQuery(Query):
         self.update_return_labels(["edges_closed"])
 
     def closed_edge_count(self) -> int:
-        """How many global edges this run stamped shut. Zero means nothing was left to release."""
+        """How many global edges this run stamped shut."""
         result = self.get_result()
         if result is None:
             return 0

--- a/backend/infrahub/core/query/agnostic_retention.py
+++ b/backend/infrahub/core/query/agnostic_retention.py
@@ -13,8 +13,8 @@ A `:Relationship` needs two qualifying field edges rather than one, because a re
 peer is not a relationship. A `:Relationship` must also have two distinct active peers to be
 considered active.
 
-A candidate no branch holds live still reaches the end of the predicate, carrying a live-peer count
-of zero, rather than being dropped along the way.
+A candidate that no branch holds live still reaches the end of the predicate, carrying a live-peer
+count of zero, rather than being dropped along the way.
 
 Assumption: every branch forks from the default branch. A branch-of-branch feature would not extend
 this logic.

--- a/backend/infrahub/core/query/agnostic_retention.py
+++ b/backend/infrahub/core/query/agnostic_retention.py
@@ -13,9 +13,8 @@ A `:Relationship` needs two qualifying field edges rather than one, because a re
 peer is not a relationship. A `:Relationship` must also have two distinct active peers to be
 considered active.
 
-The winner lookups are OPTIONAL CALL subqueries and the peers are counted conditionally rather than
-filtered so that a field with no live edge on a branch reaches the end of the predicate carrying a
-count of zero -- a plain CALL or MATCH would drop its row instead.
+A candidate no branch holds live still reaches the end of the predicate, carrying a live-peer count
+of zero, rather than being dropped along the way.
 
 Assumption: every branch forks from the default branch. A branch-of-branch feature would not extend
 this logic.

--- a/backend/infrahub/core/query/branch_agnostic_retirement.py
+++ b/backend/infrahub/core/query/branch_agnostic_retirement.py
@@ -92,7 +92,7 @@ class RetireBranchAgnosticFieldsQuery(Query):
         self.update_return_labels(["edges_closed"])
 
     def closed_edge_count(self) -> int:
-        """How many global edges this run stamped shut. Zero means every field is still retained somewhere."""
+        """How many global edges this run stamped shut."""
         result = self.get_result()
         if result is None:
             return 0

--- a/backend/infrahub/core/query/node_agnostic_retirement.py
+++ b/backend/infrahub/core/query/node_agnostic_retirement.py
@@ -17,7 +17,7 @@ class NodeAgnosticRetirementResult:
     """What one retirement run over a set of nodes changed."""
 
     edges_closed: int
-    """Global edges given a `to` timestamp. Zero means every field is still retained somewhere."""
+    """How many global edges this run gave a `to` timestamp."""
 
 
 _RETIRE_UNRETAINED_FIELDS_OF_NODES = """

--- a/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
+++ b/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
@@ -1,7 +1,8 @@
 """Fixtures for the branch-agnostic repair migration.
 
-No current code path produces the shapes under test, so they are built with raw Cypher, and every
-reader here reports individual edge states rather than a resolved object view.
+No current code path produces the shapes under test, so they are built with raw Cypher. The readers
+here report raw vertex identities, existence and counts rather than a resolved object view; the
+edge-state readers the assertions also use live in the shared branch-agnostic test helpers.
 """
 
 from __future__ import annotations

--- a/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
+++ b/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for the branch-agnostic repair migration.
 
-No current code path produces the shapes under test, so they are built with raw Cypher and read back
-edge by edge rather than through the node manager, which would hide the states being pinned down.
+No current code path produces the shapes under test, so they are built with raw Cypher, and every
+reader here reports individual edge states rather than a resolved object view.
 """
 
 from __future__ import annotations

--- a/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/test_repair.py
+++ b/backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/test_repair.py
@@ -1,16 +1,14 @@
 """Every damaged shape the repair migration handles, in one graph, repaired in one run.
 
-The shapes are built together rather than one per test because that is how a real upgrade meets
-them: a single pass over a graph holding all of them at once, where a candidate bound too widely
-would take a neighbouring shape with it. The run happens once, the whole graph is verified, the run
-happens again, and the same verification has to hold -- which is what makes the second pass a
-statement about idempotency rather than a separate scenario.
+One graph holds all the shapes at once, so a candidate bound too widely shows up as damage to a
+neighbouring shape. The run happens once, the whole graph is verified, the run happens again, and
+the same verification has to hold -- the second pass is the idempotency claim.
 
 Shapes are keyed by field-vertex uuid rather than by owner, because a kind change leaves two node
-vertices on one uuid and a reader that starts from the owner would see that vertex's edges twice.
+vertices on one uuid and a reader starting from the owner would see that vertex's edges twice.
 
-Retention lives in its own module: it needs a branch, and a branch forked into this graph would read
-every object here that is still live, leaving the migration nothing to repair.
+This graph carries no branch: a branch forked into it would read every object here that is still
+live, leaving the migration nothing to repair. Retention is covered separately.
 """
 
 from __future__ import annotations

--- a/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
+++ b/backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
@@ -13,7 +13,7 @@ manager is used as well, because that is the claim being made.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -38,6 +38,8 @@ from tests.helpers.agnostic_edges import (
     attribute_global_edges,
     attribute_metadata,
     attribute_owning_edges,
+    create_gadget,
+    create_widget,
     edge_summary,
     open_edge_types,
     open_edges,
@@ -50,7 +52,6 @@ from tests.helpers.db_validation import get_node_metadata
 from tests.helpers.schema.agnostic_retirement import (
     AGNOSTIC_RETIREMENT_SCHEMA,
     BEACON_KIND,
-    GADGET_KIND,
     RELATIONSHIP_IDENTIFIER,
     WIDGET_KIND,
 )
@@ -75,20 +76,6 @@ async def verify_graph_invariants(db: InfrahubDatabase, default_branch: Branch) 
     """Check the whole-graph invariants after every test in this module."""
     yield
     await verify_graph(db=db)
-
-
-async def _create_widget(db: InfrahubDatabase, branch: Branch, name: str, serial: int, **kwargs: Any) -> Node:
-    widget = await Node.init(db=db, schema=WIDGET_KIND, branch=branch)
-    await widget.new(db=db, name=name, serial=serial, **kwargs)
-    await widget.save(db=db)
-    return widget
-
-
-async def _create_gadget(db: InfrahubDatabase, branch: Branch, name: str) -> Node:
-    gadget = await Node.init(db=db, schema=GADGET_KIND, branch=branch)
-    await gadget.new(db=db, name=name)
-    await gadget.save(db=db)
-    return gadget
 
 
 async def _delete(db: InfrahubDatabase, node_id: str, branch: Branch, at: Timestamp) -> None:
@@ -163,7 +150,7 @@ async def test_an_attribute_removed_from_the_schema_is_closed_when_no_branch_dec
     db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
 ) -> None:
     """No branch forked while the attribute existed, so the removal leaves nothing able to read it."""
-    widget = await _create_widget(db=db, branch=default_branch, name="loses-its-serial", serial=100)
+    widget = await create_widget(db=db, branch=default_branch, name="loses-its-serial", serial=100)
 
     before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}
@@ -187,8 +174,8 @@ async def test_a_relationship_removed_from_the_schema_is_closed_when_no_branch_d
     db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
 ) -> None:
     """Both peers survive the removal, but no branch can still reach them over a live global edge."""
-    gadget = await _create_gadget(db=db, branch=default_branch, name="keeps-existing")
-    widget = await _create_widget(db=db, branch=default_branch, name="loses-its-gadget", serial=200, gadget=gadget)
+    gadget = await create_gadget(db=db, branch=default_branch, name="keeps-existing")
+    widget = await create_widget(db=db, branch=default_branch, name="loses-its-gadget", serial=200, gadget=gadget)
 
     before = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
     assert [edge.edge_type for edge in open_edges(before)].count("IS_RELATED") == 2
@@ -209,7 +196,7 @@ async def test_an_attribute_stays_open_for_a_branch_that_forked_before_the_remov
     db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
 ) -> None:
     """The branch still declares the attribute and still holds the object, so the value is not released."""
-    widget = await _create_widget(db=db, branch=default_branch, name="serial-kept-by-a-fork", serial=300)
+    widget = await create_widget(db=db, branch=default_branch, name="serial-kept-by-a-fork", serial=300)
     branch = await create_branch(db=db, branch_name="declares-the-attribute-still")
 
     before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
@@ -231,8 +218,8 @@ async def test_a_relationship_stays_open_for_a_branch_that_forked_before_the_rem
     db: InfrahubDatabase, default_branch: Branch, agnostic_schema: None
 ) -> None:
     """The branch still declares the relationship and still reads both of its peers as live."""
-    gadget = await _create_gadget(db=db, branch=default_branch, name="peer-kept-by-a-fork")
-    widget = await _create_widget(db=db, branch=default_branch, name="gadget-kept-by-a-fork", serial=400, gadget=gadget)
+    gadget = await create_gadget(db=db, branch=default_branch, name="peer-kept-by-a-fork")
+    widget = await create_widget(db=db, branch=default_branch, name="gadget-kept-by-a-fork", serial=400, gadget=gadget)
     branch = await create_branch(db=db, branch_name="declares-the-relationship-still")
 
     before = await relationship_global_edges(db=db, node_id=widget.id, identifier=RELATIONSHIP_IDENTIFIER)
@@ -265,10 +252,10 @@ async def test_one_removal_closes_only_the_objects_the_fork_cannot_reach(
     the default. When the schema migration runs, the attribute on to-be-retired is not accessible
     from any branch and needs to be closed.
     """
-    retained = await _create_widget(db=db, branch=default_branch, name="held-by-the-fork", serial=800)
+    retained = await create_widget(db=db, branch=default_branch, name="held-by-the-fork", serial=800)
     branch = await create_branch(db=db, branch_name="forked-between-the-two")
     # created after the branch, so only visible on the default branch, not on the user branch
-    retired = await _create_widget(db=db, branch=default_branch, name="created-after-the-fork", serial=900)
+    retired = await create_widget(db=db, branch=default_branch, name="created-after-the-fork", serial=900)
 
     retained_before = await attribute_global_edges(db=db, node_id=retained.id, attribute_name=ATTRIBUTE_NAME)
     retired_before = await attribute_global_edges(db=db, node_id=retired.id, attribute_name=ATTRIBUTE_NAME)
@@ -308,8 +295,8 @@ async def test_a_relationship_is_closed_when_the_only_fork_reads_one_of_its_peer
     verify the relationship is still active on the global branch, remove the relationship schema
     on the default branch, verify the agnostic relationship is closed.
     """
-    gadget = await _create_gadget(db=db, branch=default_branch, name="peer-lost-on-the-fork")
-    widget = await _create_widget(db=db, branch=default_branch, name="half-a-relationship", serial=1000, gadget=gadget)
+    gadget = await create_gadget(db=db, branch=default_branch, name="peer-lost-on-the-fork")
+    widget = await create_widget(db=db, branch=default_branch, name="half-a-relationship", serial=1000, gadget=gadget)
     branch = await create_branch(db=db, branch_name="deleted-one-peer")
 
     # delete the peer on the branch
@@ -347,7 +334,7 @@ async def test_an_attribute_removed_on_a_fork_is_closed_when_the_object_is_delet
     the branch the object is deleted on is the one that declared it. Neither branch holds both axes, so
     nothing retains the value.
     """
-    widget = await _create_widget(db=db, branch=default_branch, name="serial-dropped-by-a-fork", serial=600)
+    widget = await create_widget(db=db, branch=default_branch, name="serial-dropped-by-a-fork", serial=600)
     branch = await create_branch(db=db, branch_name="dropped-the-attribute")
 
     removal = await _remove_attribute_from_schema(db=db, branch=branch, at=Timestamp())
@@ -387,7 +374,7 @@ async def test_an_attribute_removed_from_the_schema_is_closed_when_the_only_fork
     object, and the fork that goes on declaring the attribute is the one left with nothing to read it
     from.
     """
-    widget = await _create_widget(db=db, branch=default_branch, name="serial-outlived-by-a-fork", serial=700)
+    widget = await create_widget(db=db, branch=default_branch, name="serial-outlived-by-a-fork", serial=700)
     branch = await create_branch(db=db, branch_name="deleted-the-object")
 
     deleted_at = Timestamp()
@@ -481,7 +468,7 @@ async def test_removing_an_attribute_stamps_the_removal_time_on_its_vertex(
     the global branch while the migration runs on the default branch -- and the default branch is one
     of the two whose writes maintain vertex metadata.
     """
-    widget = await _create_widget(db=db, branch=default_branch, name="stamped-on-removal", serial=1000)
+    widget = await create_widget(db=db, branch=default_branch, name="stamped-on-removal", serial=1000)
 
     before = await attribute_metadata(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert before.updated_at is not None, "precondition: creating the object stamped the attribute"
@@ -508,8 +495,8 @@ async def test_removing_a_relationship_stamps_the_removal_time_on_its_vertex(
     The removal touches both peers, so both peer nodes carry its stamp, each snapshotting its own
     pre-removal values.
     """
-    gadget = await _create_gadget(db=db, branch=default_branch, name="peer-of-the-stamped")
-    widget = await _create_widget(
+    gadget = await create_gadget(db=db, branch=default_branch, name="peer-of-the-stamped")
+    widget = await create_widget(
         db=db, branch=default_branch, name="stamped-on-rel-removal", serial=1001, gadget=gadget
     )
 
@@ -543,7 +530,7 @@ async def test_a_rolled_back_removal_leaves_the_global_edges_open(
     The edges reopen, and the stamps the removal wrote on the vertices it touched are restored
     from their snapshots, which the restore consumes.
     """
-    widget = await _create_widget(db=db, branch=default_branch, name="keeps-its-serial", serial=300)
+    widget = await create_widget(db=db, branch=default_branch, name="keeps-its-serial", serial=300)
 
     before = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=ATTRIBUTE_NAME)
     assert open_edge_types(before) == {"HAS_ATTRIBUTE", "HAS_VALUE", "IS_PROTECTED"}

--- a/backend/tests/component/core/test_rollback.py
+++ b/backend/tests/component/core/test_rollback.py
@@ -457,7 +457,7 @@ async def _close_global_edges_by_hand(db: InfrahubDatabase, node_id: str, attrib
         query="""
         MATCH (n:Node { uuid: $uuid })-[:HAS_ATTRIBUTE]-(a:Attribute { name: $attr })
         MATCH (a)-[e]-()
-        WHERE e.branch = $global_branch AND e.status = "active" AND e.to IS NULL
+        WHERE e.branch = $global_branch AND e.status = "active" AND e.to IS NULL AND e.from <= $at
         SET e.to = $at
         """,
         params={"uuid": node_id, "attr": attribute_name, "global_branch": GLOBAL_BRANCH_NAME, "at": at.to_string()},
@@ -504,6 +504,7 @@ async def test_range_scoped_rollback_leaves_global_edges_closed_at_another_times
         db=db, node_id=widget.id, attribute_name=AGNOSTIC_ATTRIBUTE_NAME, at=someone_else_at
     )
     closed = await attribute_global_edges(db=db, node_id=widget.id, attribute_name=AGNOSTIC_ATTRIBUTE_NAME)
+    assert open_edges(closed) == [], "precondition: the other writer's closure left no open global edge"
 
     await GraphRollbacker(db=db).rollback(
         target_branch=default_branch,

--- a/backend/tests/helpers/agnostic_edges.py
+++ b/backend/tests/helpers/agnostic_edges.py
@@ -426,4 +426,5 @@ async def relationship_metadata(db: InfrahubDatabase, node_id: str, identifier: 
         """,
         params={"node_id": node_id, "identifier": identifier},
     )
+    assert len(results) == 1, f"Expected a single {identifier} relationship for {node_id}, found {len(results)}"
     return VertexMetadata(**dict(results[0]))

--- a/backend/tests/unit/core/branch/test_delete_coordinator.py
+++ b/backend/tests/unit/core/branch/test_delete_coordinator.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pytest
 
-from infrahub.auth.session import AccountSession
+from infrahub.auth.session import AccountSession, AnonymousSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.branch import Branch
@@ -109,6 +109,16 @@ async def test_delete_names_the_requesting_account_to_the_data_deleter(context: 
 
     assert data_deleter.actors == [context.account.account_id]
     assert data_deleter.actors != [SYSTEM_USER_ID]
+
+
+async def test_delete_names_the_system_actor_when_the_request_has_no_account() -> None:
+    """An anonymous context carries no account id, and an empty actor is not a name."""
+    orchestrator, data_deleter, _, _, _, _ = _build(branch_deleted=True)
+    anonymous = InfrahubContext(account=AnonymousSession(), branch=BranchContext(name="main", id="placeholder"))
+
+    await orchestrator.delete(branch=_branch(), context=anonymous)
+
+    assert data_deleter.actors == [SYSTEM_USER_ID]
 
 
 async def test_delete_skips_post_delete_work_when_another_attempt_won(context: InfrahubContext) -> None:

--- a/dev/specs/ifc-2843-retire-agnostic-edges/alignment-check.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/alignment-check.md
@@ -103,13 +103,13 @@ Resolved by splitting the anchor by caller, since the two callers have genuinely
 ### Files updated
 
 `spec.md`, `plan.md`, `data-model.md`, `contracts/retirement-component.md`, `quickstart.md`,
-`tasks.md` (7 tasks added: T009a, T010a, T012a, T012b, T031a, T040a, and T014/T042 revised).
+`tasks.md` (6 tasks added: T009a, T010a, T012a, T012b, T031a, T040a; T014 and T042 revised).
 
 ### Carried forward for maintainer input
 
 - The critique's open question **P1** is now partly answered and partly sharpened: the still-linked
   shape is confirmed at ~6,400 nodes; the detached shape remains unmeasured. The hard-delete branch
-  of `m076` is still needed, but its Complexity Tracking justification can no longer lean on
-  "dominant shape".
+  of the repair migration (shipped as `m078`) is still needed, but its Complexity Tracking
+  justification can no longer lean on "dominant shape".
 - The declined validator-filtering Expected Behavior item needs explicit acceptance, since the
   filed issue asks for it.

--- a/dev/specs/ifc-2843-retire-agnostic-edges/contracts/retirement-component.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/contracts/retirement-component.md
@@ -167,9 +167,11 @@ GRAPH_VERSION    : 77 -> 78
   and hard-deletes `Attribute` / `Relationship` vertices with no linked node vertex at all.
 - Derives its stamp **per candidate** rather than using the run time: the owner's latest effective
   deletion time where one is derivable, otherwise the latest `to` among the vertex's closed owning
-  edges — the moment the field stopped being reachable. Only where neither is derivable is a
-  candidate skipped. Stamping everything with upgrade time would land the close inside the window of
-  every branch forked before the upgrade, which FR-014 forbids.
+  edges — the moment the field stopped being reachable. Only where neither is derivable does it fall
+  back to the upgrade's own time, and FR-014 still holds there: a candidate with no owner departure
+  and no closed owning edge on record is one no branch resolves as live, so the close shifts no
+  branch's view. Stamping everything with upgrade time *by default* would land the close inside the
+  window of every branch forked before the upgrade, which FR-014 forbids.
 - Batches its writes.
 - Reports both counts to the upgrade log.
 - Returns `MigrationResult(errors=[...])` on unrepairable state; never raises, never fails the

--- a/dev/specs/ifc-2843-retire-agnostic-edges/contracts/retirement-component.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/contracts/retirement-component.md
@@ -168,10 +168,10 @@ GRAPH_VERSION    : 77 -> 78
 - Derives its stamp **per candidate** rather than using the run time: the owner's latest effective
   deletion time where one is derivable, otherwise the latest `to` among the vertex's closed owning
   edges — the moment the field stopped being reachable. Only where neither is derivable does it fall
-  back to the upgrade's own time, and FR-014 still holds there: a candidate with no owner departure
-  and no closed owning edge on record is one no branch resolves as live, so the close shifts no
-  branch's view. Stamping everything with upgrade time *by default* would land the close inside the
-  window of every branch forked before the upgrade, which FR-014 forbids.
+  back to the upgrade's own time, and FR-014 still holds there because retention is settled first:
+  a candidate only reaches the stamp once no branch retains it, so the close shifts no branch's view
+  whichever stamp it carries. Stamping everything with upgrade time *by default* would land the close
+  inside the window of every branch forked before the upgrade, which FR-014 forbids.
 - Batches its writes.
 - Reports both counts to the upgrade log.
 - Returns `MigrationResult(errors=[...])` on unrepairable state; never raises, never fails the

--- a/dev/specs/ifc-2843-retire-agnostic-edges/critiques/critique-20260812.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/critiques/critique-20260812.md
@@ -116,6 +116,15 @@ remains the single place the fork-window collapse lives (fed from the registry a
 an explicit database read in the migration), and one task disappears rather than being added. The
 "unspecified source" half of the finding was real and is now closed; the alarming half was not.
 
+> **Outcome (recorded 2026-09-04, after implementation)**: this correction was itself overtaken.
+> The 2026-08-17 design revision removed `AgnosticBranchWindowBuilder` along with the rest of the
+> component layer, and the shipped predicate reads the branch set in-query after all —
+> `MATCH (branch:Branch)` in `core/query/agnostic_retention.py`, collapsing the fork window in
+> Cypher and excluding `DELETING` branches there. So the original Must-Address #1 (read the branch
+> set from the database, preferably in-query) is what landed; the registry is not the source at any
+> call site, and no migration-side `Branch.get_list` call exists. Read Must-Address #1 as
+> implemented, and this correction as the argument that the registry *would* also have been sound.
+
 ### Failure Mode Analysis
 
 | ID | Severity | Finding | Suggestion |
@@ -206,6 +215,8 @@ the existing precedent in `DeleteBranchAgnosticAttributesQuery`. No new user-fac
 1. **E1**: In `plan.md` (Design Overview) and `contracts/retirement-component.md` (C1, C3), specify
    that the branch set is read from the database — preferably by matching `(:Branch)` vertices
    inside the retirement query — and explicitly forbid `registry.branch` as the source.
+   *(Shipped this way. The "Correction to E1" above argues the registry would have been sound too,
+   but the in-query read is what the code does — see that correction's Outcome note.)*
 2. **E2**: In `plan.md` and contract C2, state that retirement is a best-effort side effect at all
    five runtime enforcement points, following `dev/guidelines/backend/python.md`
    §"Best-effort side effects degrade to a safe fallback", with *leaving the edges open* as the
@@ -241,7 +252,7 @@ than edits to it.
 
 | ID | Severity | Status | Where applied |
 |----|----------|--------|---------------|
-| E1 | 🎯 → part withdrawn | ⚠️ Superseded | Originally applied as "branch list from DB, `registry.branch` forbidden, in-query preferred". **Reverted on maintainer review** — the staleness claim was factually wrong. Now: registry at runtime, `Branch.get_list` in the migration, builder retained, in-query read dropped. See the correction above. |
+| E1 | 🎯 | ✅ Applied as originally written | Applied as "branch list from DB, `registry.branch` forbidden, in-query preferred", then reverted on maintainer review to "registry at runtime, builder retained", then re-landed in-query by the shipped code: `MATCH (branch:Branch)` in `core/query/agnostic_retention.py`. The staleness claim that motivated it was still factually wrong — see the correction and its Outcome note above. |
 | E2 | 🎯 | ✅ Applied | `plan.md` new §"Retirement is a best-effort side effect" with the guideline's three conditions mapped; `contracts` C2 guarantees |
 | E4 | 🎯 | ✅ Applied | `spec.md` FR-018 + SC-008 + Assumptions; `plan.md` Technical Context and sequencing step 2; `quickstart.md` performance gate table (two branch counts, both required) |
 | X1 | 🎯 | ✅ Applied | `plan.md` new §Test plan additions; `data-model.md` §AttributeValue "Pool interaction"; `quickstart.md` validation matrix; `spec.md` Assumptions |

--- a/dev/specs/ifc-2843-retire-agnostic-edges/data-model.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/data-model.md
@@ -94,11 +94,10 @@ pool id.
 
 ### `Branch`
 
-Not modified. Read for its metadata only — from `registry.branch` at the runtime enforcement
-points, and from the database in the migration, which runs in an upgrade process where the
-registry may never have been populated. The registry is a maintained cache: it is refreshed on
-branch create, merge, rebase and delete via a broadcast message, adds branches it does not yet
-know, and has a scheduled sweep behind that.
+Not modified. Read for its metadata only, and read **in-query** from `(:Branch)` vertices at every
+enforcement point including the migration (revised 2026-08-17 — the predicate derives the fork
+windows in Cypher, so no branch list is marshalled through Python). That also means the predicate
+works in an upgrade process where no registry has been populated.
 
 | Field | Role in the predicate |
 |---|---|
@@ -221,7 +220,7 @@ Covered without enumeration. The predicate anchors on the `:Node`, `:Attribute` 
 automatically — unlike the per-kind `Kind|ProfileKind|TemplateKind` pattern the schema migrations
 must follow.
 
-## Orphan shapes repaired by `m076`
+## Orphan shapes repaired by `m078`
 
 | # | Shape | Origin | Repair | Reported as |
 |---|---|---|---|---|

--- a/dev/specs/ifc-2843-retire-agnostic-edges/plan.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/plan.md
@@ -61,7 +61,7 @@ time-close-only rule, and the requirement that retention be judged per branch.
 
 **Primary Dependencies**: Neo4j 2026.05 (driver 6.2), Pydantic 2.12 — no new dependencies
 
-**Storage**: Neo4j graph. New graph migration `m076`; `GRAPH_VERSION` 75 → 76
+**Storage**: Neo4j graph. New graph migration `m078`; `GRAPH_VERSION` 77 → 78
 (`backend/infrahub/core/graph/__init__.py:1`)
 
 **Testing**: pytest 9.0 — unit (`backend/tests/unit/`), component
@@ -90,8 +90,8 @@ Target branch `release-1.11`; reaches `develop` through the normal release merge
 
 | Principle | Assessment | Verdict |
 |---|---|---|
-| **I. Schema-Driven Integrity** | No schema-layer change. `m076` is a graph migration with no schema surface; no generated files affected. | ✅ Pass |
-| **II. Branch-Safe by Default** | The feature *is* this principle. Cross-branch side effects on branch-agnostic data are the subject, explicitly documented (FR-019) and tested. Merge **and** rebase behaviour specified before completion (FR-006, FR-007). Every branch evaluated under its own filter with isolation intact (FR-012). Soft-delete governs all runtime paths — retirement is a time-close (FR-013). **One deviation**: `m076` hard-deletes vertices with no linked node. See Complexity Tracking. | ⚠️ Pass with justified deviation |
+| **I. Schema-Driven Integrity** | No schema-layer change. `m078` is a graph migration with no schema surface; no generated files affected. | ✅ Pass |
+| **II. Branch-Safe by Default** | The feature *is* this principle. Cross-branch side effects on branch-agnostic data are the subject, explicitly documented (FR-019) and tested. Merge **and** rebase behaviour specified before completion (FR-006, FR-007). Every branch evaluated under its own filter with isolation intact (FR-012). Soft-delete governs all runtime paths — retirement is a time-close (FR-013). **One deviation**: `m078` hard-deletes vertices with no linked node. See Complexity Tracking. | ⚠️ Pass with justified deviation |
 | **III. Type Safety & Explicit Contracts** | Query results exposed via `get_data()` returning a frozen dataclass, never raw Neo4j records. No API contract change. *(Revised: the branch-window dataclasses and the injected `Protocol` are gone — the windows are derived in Cypher and each query is self-sufficient.)* | ✅ Pass |
 | **IV. Test Discipline** | Component coverage per enforcement point, migration fixtures per orphan shape, pure predicate logic unit-tested. Graph migration with no schema surface → the integration-Docker requirement for schema migrations does not apply. No frontend surface → no Playwright requirement. No mocks. *(Revised: with no injected collaborator there is no double to record; the predicate is exercised through component tests asserting graph shape, and each guarantee is mutation-checked.)* | ✅ Pass |
 | **V. Query Performance & Efficiency** | Candidate sets diff- and query-bounded rather than swept; predicate anchored on graph labels so indexes apply; migration batched; all Cypher parameterised; `EXPLAIN` required on the new query. Uniqueness validation — on the merge/schema-check hot path and the active target of separate perf work — deliberately untouched. | ✅ Pass |
@@ -109,7 +109,7 @@ frozen dataclass) is retained.
 Per `AGENTS.md` **Boundaries → Ask First**, this feature crosses one gate that requires
 maintainer sign-off before implementation begins:
 
-- **Database schema or migration change** — `m076` plus a `GRAPH_VERSION` bump. It mutates
+- **Database schema or migration change** — `m078` plus a `GRAPH_VERSION` bump. It mutates
   existing customer data during upgrade, including **hard-deleting** `Attribute` and
   `Relationship` vertices that have no linked node vertex.
 
@@ -118,18 +118,18 @@ workflow change, no auth change.
 
 **Status (2026-08-17)**: sign-off requested; decision **deferred**, gate still open. The shared
 predicate and the runtime enforcement points touch no migration and proceed. The repair migration
-(`m076`, the `GRAPH_VERSION` bump, and the hard-delete) stays blocked until the gate is signed off.
+(`m078`, the `GRAPH_VERSION` bump, and the hard-delete) stays blocked until the gate is signed off.
 
 **Status (2026-08-25): signed off — gate closed.** The maintainer approved the repair migration,
 the `GRAPH_VERSION` bump, and the irreversible hard-delete of `Attribute` / `Relationship` vertices
 carrying no linked node vertex. Slice 5 (R06) is unblocked.
 
-Two numbers in this gate's description were stale at sign-off time and the approval covers the
-corrected ones, per T058: the migration is **`m077`**, not `m076` (the `m076` slot is occupied by
-`m076_heal_missing_attribute_rows`), and the version bump is **76 -> 77**, not 75 -> 76
-(`GRAPH_VERSION` is already 76 on the base branch). The substance of what was approved — one
-additive graph migration that closes unretained global edges and hard-deletes node-less
-`Attribute` / `Relationship` vertices, announcing its irreversibility first — is unchanged.
+The migration number moved twice while this feature was in flight, because the base branch took
+each slot first: `m076` (as originally planned), then `m077` (T058), then **`m078`** (T062), with
+the version bump following it from 75 → 76 to 76 → 77 to **77 → 78**. Every number in this plan
+now reads `m078` / 77 → 78, the shipped one. The substance of what was approved — one additive graph
+migration that closes unretained global edges and hard-deletes node-less `Attribute` /
+`Relationship` vertices, announcing its irreversibility first — never changed.
 
 ## Project Structure
 
@@ -142,8 +142,11 @@ specs/ifc-2843-retire-agnostic-edges/
 ├── research.md          # Phase 0 output
 ├── data-model.md        # Phase 1 output
 ├── quickstart.md        # Phase 1 output
+├── alignment-check.md   # PRD-vs-artifact reconciliation
 ├── contracts/           # Phase 1 output — internal component contracts
 │   └── retirement-component.md
+├── critiques/
+│   └── critique-20260812.md
 ├── checklists/
 │   └── requirements.md
 └── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
@@ -153,36 +156,40 @@ specs/ifc-2843-retire-agnostic-edges/
 
 ```text
 backend/infrahub/core/
-├── graph/__init__.py                      # GRAPH_VERSION 75 → 76                    (edit)
+├── graph/__init__.py                      # GRAPH_VERSION 77 → 78                     (edit)
 ├── query/
 │   ├── agnostic_retention.py              # shared retention predicate fragment       (new)
+│   ├── agnostic_field_closure.py          # predicate + close, for the schema paths   (new)
 │   ├── node_agnostic_retirement.py        # RetireNodeAgnosticFieldsQuery             (new)
-│   └── branch.py                          # existing agnostic cleanup queries         (read)
-├── node/__init__.py                        # Node.delete → invoke retirement          (edit)
+│   └── branch_agnostic_retirement.py      # RetireBranchAgnosticFieldsQuery           (new)
+├── node/__init__.py                       # Node.delete → invoke retirement           (edit)
 ├── branch/
 │   ├── data_deleter.py                    # branch deletion → bounded form            (edit)
 │   └── tasks.py                           # rebase_branch → base-branch deletions     (edit)
 ├── diff/merger/merger.py                  # merge → deleted-node candidates           (edit)
 └── migrations/
-    ├── graph/m076_retire_agnostic_property_edges.py                                   (new)
-    ├── graph/__init__.py                  # register m076                             (edit)
-    └── query/
-        └── attribute_remove.py            # close the global edges in the same query  (edit)
+    ├── graph/m078_retire_agnostic_property_edges/   # __init__, migration, queries    (new)
+    ├── query/attribute_remove.py          # close the global edges in the same query  (edit)
+    └── schema/node_relationship_remove.py # same, for the relationship side           (edit)
 
-backend/tests/component/
-├── core/
-│   └── test_agnostic_retirement.py        # enforcement-point behaviour               (new)
-├── query/test_node_agnostic_retirement_query.py     # graph shape, per-query          (new)
-└── migrations/test_m076_retire_agnostic_property_edges.py                             (new)
+backend/tests/
+├── helpers/agnostic_edges.py              # builders, edge readers, shared assertions (new)
+├── helpers/schema/agnostic_retirement.py  # the widget/gadget/beacon schema           (new)
+└── component/
+    ├── core/agnostic_retirement/          # one module per enforcement point          (new)
+    ├── core/migrations/schema/test_agnostic_field_removal.py                          (new)
+    ├── core/migrations/graph/m078_retire_agnostic_property_edges/                     (new)
+    └── query/test_node_agnostic_retirement_query.py  # graph shape, per-query         (new)
 
-docs/docs/                                  # deletion semantics for agnostic fields   (edit)
-changelog/                                  # towncrier fragment                       (new)
+docs/docs/                                 # deletion semantics for agnostic fields    (edit)
+changelog/                                 # towncrier fragment                        (new)
 ```
 
-**Structure Decision**: Backend-only, following the existing `core/` layout. The new
-`core/agnostic/` package holds the two components the PRD names; the query goes in the existing
-`core/query/` package alongside `branch.py`, whose agnostic cleanup queries are the direct
-precedent. No new top-level directory, no frontend or SDK path touched.
+**Structure Decision**: Backend-only, following the existing `core/` layout. Everything lives in
+the existing `core/query/` package alongside `branch.py`, whose agnostic cleanup queries are the
+direct precedent — the 2026-08-17 revision dropped the `core/agnostic/` package the PRD named,
+along with the component, protocol, adapter and window builder it was to hold (see Complexity
+Tracking). No new package, no new top-level directory, no frontend or SDK path touched.
 
 ## Design Overview
 
@@ -274,7 +281,7 @@ enforcement point constructs the one it needs.
 | 4 | Branch deletion | `core/branch/data_deleter.py` — beside `_delete_agnostic_peers`, before `_delete_edges` | fork-point-bounded query | delete time | FR-008 |
 | 5 | Attribute removal | `migrations/schema/node_attribute_remove.py` | the removed field | migration time | FR-010 |
 | 6 | Relationship removal | `migrations/schema/node_relationship_remove.py` | the removed field | migration time | FR-010 |
-| — | Repair migration | `migrations/graph/m076_*.py` | unbounded, batched | migration run time | FR-016 |
+| — | Repair migration | `migrations/graph/m078_*/queries.py` | unbounded, batched | migration run time | FR-016 |
 
 Points 2, 3 and 4 are **re-evaluation points, not release triggers** (FR-009). Each runs the
 same predicate and acts only on its result; none of them may assume its own occurrence releases
@@ -334,7 +341,7 @@ actually commits:
   failure. The graph is never committed in the illegal shape.
 - **Swallowing** commits a node that is gone still holding a live branch-agnostic value — precisely
   the orphan shape this feature exists to eliminate — and nothing a user or an operator can invoke
-  repairs it, because `m076` runs only at upgrade. That is not "today's behaviour preserved"; it is
+  repairs it, because `m078` runs only at upgrade. That is not "today's behaviour preserved"; it is
   today's bug re-introduced by the code written to fix it.
 
 The runtime path can only work this way, which is worth stating because it looks like an
@@ -349,7 +356,7 @@ with no branch to read retention under there is no retention picture to judge, a
 the safe direction, while closing on partial information is data loss. This is the "must
 over-execute, not under-execute" rule applied to a reservation, and it is the only place it applies.
 
-`m076` keeps its own non-fatal reporting (FR-016), and that is *not* the same principle applied
+`m078` keeps its own non-fatal reporting (FR-016), and that is *not* the same principle applied
 through a different mechanism: the migration has no caller transaction to roll back and no user
 operation to abort, so accumulating into `MigrationResult` is simply the correct shape there.
 
@@ -456,17 +463,17 @@ rather than a shared substrate followed by six integrations.
    Measure at **two open-branch counts** (a low one and a realistic-high one, e.g. 3 and 100),
    because the predicate's filter grows with branch count and a three-branch fixture is not
    evidence about a real deployment.
-5. `m076` + `GRAPH_VERSION` bump, once the Ask-First gate is signed off.
+5. `m078` + `GRAPH_VERSION` bump, once the Ask-First gate is signed off.
 6. Documentation + changelog.
 
-`m076` is deliberately late despite being P1: it is the unbounded form of a query that must
+`m078` is deliberately late despite being P1: it is the unbounded form of a query that must
 already be proven correct, and it is the one step that mutates customer data.
 
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |---|---|---|
-| **Principle II** — `m076` hard-deletes `Attribute` / `Relationship` vertices with no linked node vertex, where the constitution permits hard-delete only for branch deletion itself | A vertex with no linked node cannot be reached, diffed, or time-travelled to. A time-close would leave permanent garbage with no reader, and would not remove it from any future scan. | Time-closing them instead: leaves unreachable vertices in the graph forever with no path to ever remove them. Mitigating factor: these vertices were *produced by* branch deletions predating the existing agnostic-peer cleanup, and `BranchDataDeleter._delete_agnostic_peers` already `DETACH DELETE`s exactly this shape at branch-deletion time. The migration completes an operation the system already performs — late rather than newly — so this is arguably inside the existing exemption rather than a new one. |
+| **Principle II** — `m078` hard-deletes `Attribute` / `Relationship` vertices with no linked node vertex, where the constitution permits hard-delete only for branch deletion itself | A vertex with no linked node cannot be reached, diffed, or time-travelled to. A time-close would leave permanent garbage with no reader, and would not remove it from any future scan. | Time-closing them instead: leaves unreachable vertices in the graph forever with no path to ever remove them. Mitigating factor: these vertices were *produced by* branch deletions predating the existing agnostic-peer cleanup, and `BranchDataDeleter._delete_agnostic_peers` already `DETACH DELETE`s exactly this shape at branch-deletion time. The migration completes an operation the system already performs — late rather than newly — so this is arguably inside the existing exemption rather than a new one. |
 
 The original plan also tracked a `core/agnostic/` package holding a retirement component and a
 window builder as a Principle VII deviation. That package is not part of the revised design and the
@@ -495,7 +502,7 @@ catch a specific silent failure:
   retirement no-op, and for a reason the plan had wrong: the ordinary agnostic delete already both
   tombstones the global edges and stamps `to` on the superseded active ones, so nothing is left to
   close. The enforcement point does run against such nodes; it simply finds nothing.
-- **`m076` re-run** (component) — running the migration twice is safe and the second run reports
+- **`m078` re-run** (component) — running the migration twice is safe and the second run reports
   zero. An interrupted upgrade must be resumable, as `m075` is.
 
 ## Deferred decisions
@@ -511,10 +518,10 @@ catch a specific silent failure:
   existing tracking id. Widening `DiffCoordinator.update_branch_diff`'s return type to expose both
   diffs is the larger change and that method has other callers, so the read wins. No longer open —
   the rebase task is fully specified.
-- **`m076` batching**: adopt the existing `MAX_AGNOSTIC_PEER_BATCH_SIZE = 500` cap. Each row can
+- **`m078` batching**: adopt the existing `MAX_AGNOSTIC_PEER_BATCH_SIZE = 500` cap. Each row can
   drag an unbounded number of peer vertices into the transaction, which is precisely why that cap
   exists in `data_deleter.py`. The migration must be safe to re-run.
-- **`m076` irreversibility**: it hard-deletes vertices, and for those vertices there is nothing to
+- **`m078` irreversibility**: it hard-deletes vertices, and for those vertices there is nothing to
   roll back *to* — no rollback will be built. Instead, state the irreversibility in the upgrade
   documentation and in the migration's own console output before it begins, so the operator's
   pre-upgrade backup is an informed decision rather than an assumed one.
@@ -522,7 +529,7 @@ catch a specific silent failure:
 ## Phase 1 artifacts
 
 - [data-model.md](./data-model.md) — graph entities, edge states, the predicate's evaluation
-  rules, and the orphan shapes `m076` repairs
+  rules, and the orphan shapes `m078` repairs
 - [contracts/retirement-component.md](./contracts/retirement-component.md) — internal component
   contracts (no external API surface exists for this feature)
 - [quickstart.md](./quickstart.md) — runnable validation of every acceptance scenario

--- a/dev/specs/ifc-2843-retire-agnostic-edges/quickstart.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/quickstart.md
@@ -102,7 +102,7 @@ uv run pytest \
 | 9 | Schema removal with a branch that forked beforehand | Deferred; field still readable on that branch |
 | 10 | Kind or inheritance change, then run every enforcement point and the migration | Surviving vertex **keeps** its value |
 | 11 | Create and delete on `B`, then rebase `B` | Invariant holds; no vertex left with open global edges |
-| 12 | Value freed by retirement, then allocate from the pool | Value is allocatable again |
+| 12 | Delete the holder of an allocated value, then allocate from the pool | Value is allocatable again, and retirement has not stood in the way of it (per the amended SC-007, deletion frees it regardless) |
 
 Scenarios **4, 6, 9 and 10 are the negative cases** — they are what a naive implementation
 breaks, in the opposite direction from the positive ones. Treat a run in which only the positive
@@ -260,8 +260,9 @@ uv run invoke backend.test-unit
 ```
 
 `m078` bumps `GRAPH_VERSION`, so `uv run invoke docs.validate` must pass — CI fails on any stale
-generated doc. A towncrier fragment under `changelog/` is required: freed pool values becoming
-allocatable again is user-visible behaviour.
+generated doc. A towncrier fragment under `changelog/` is required, and it should cite the
+uniqueness-validation failures the upgrade clears — *not* pool re-allocation, which SC-007 records
+as already working without this feature.
 
 ## Manual smoke check
 

--- a/dev/specs/ifc-2843-retire-agnostic-edges/quickstart.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/quickstart.md
@@ -60,17 +60,29 @@ second retirement run reporting a non-zero count is the symptom of having missed
 
 ## Run the tests
 
-```bash
-# Unit — pure predicate logic, no database, runs in seconds
-uv run pytest backend/tests/unit/core/agnostic/
+Every suite is component-tier — the predicate is Cypher, so there is nothing to test without a
+database.
 
-# Component — query graph shape, enforcement points, migration fixtures
+```bash
+# Enforcement points: node delete, merge, rebase, branch delete
 uv run pytest -x -v backend/tests/component/core/agnostic_retirement/
-uv run pytest -x -v backend/tests/component/query/test_agnostic_retirement_query.py
-uv run pytest -x -v backend/tests/component/migrations/test_m076_retire_agnostic_property_edges.py
+
+# The query's own graph shape
+uv run pytest -x -v backend/tests/component/query/test_node_agnostic_retirement_query.py
+
+# Schema field removal
+uv run pytest -x -v backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py
+
+# The repair migration
+uv run pytest -x -v backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/
 
 # Everything for this feature
-uv run pytest backend/tests/unit/core/agnostic/ backend/tests/component -k agnostic
+uv run pytest \
+  backend/tests/component/core/agnostic_retirement/ \
+  backend/tests/component/query/test_node_agnostic_retirement_query.py \
+  backend/tests/component/core/migrations/schema/test_agnostic_field_removal.py \
+  backend/tests/component/core/migrations/graph/m078_retire_agnostic_property_edges/ \
+  backend/tests/component/core/node/test_branch_agnostic_edges.py
 ```
 
 ## Validation matrix
@@ -102,7 +114,7 @@ Four further checks exist to catch specific silent failures:
 |---|---|
 | Allocate → delete → allocate again | The same value is returned. Guards a three-edge pool dependency no other test covers — though re-allocation turns out not to depend on retirement; see data-model.md §"Pool interaction" |
 | Delete a truly branch-agnostic *node* | Edges closed exactly once; retirement is a no-op. Pins the out-of-scope boundary |
-| Run `m076` twice | Second run reports zero; an interrupted upgrade is resumable |
+| Run `m078` twice | Second run reports zero; an interrupted upgrade is resumable |
 
 ### Repair migration (User Story 2)
 
@@ -119,7 +131,7 @@ Run the migration directly against hand-built fixtures rather than through a ful
 orphan shapes cannot be produced by the current code paths (that is the point of the migration),
 so they must be built with raw Cypher.
 
-⚠️ **`m076` is irreversible.** It hard-deletes `Attribute` / `Relationship` vertices that have no
+⚠️ **`m078` is irreversible.** It hard-deletes `Attribute` / `Relationship` vertices that have no
 linked node vertex, and for those vertices there is nothing to roll back *to*. The migration
 announces this before it begins; operators need a pre-upgrade backup, and that must be an informed
 decision rather than an assumed one.
@@ -247,7 +259,7 @@ uv run invoke backend.test-unit
 /pre-ci
 ```
 
-`m076` bumps `GRAPH_VERSION`, so `uv run invoke docs.validate` must pass — CI fails on any stale
+`m078` bumps `GRAPH_VERSION`, so `uv run invoke docs.validate` must pass — CI fails on any stale
 generated doc. A towncrier fragment under `changelog/` is required: freed pool values becoming
 allocatable again is user-visible behaviour.
 

--- a/dev/specs/ifc-2843-retire-agnostic-edges/research.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/research.md
@@ -166,8 +166,9 @@ gives that `to`, and the latest of those across every branch and every linked no
 moment the field stopped being reachable anywhere. Only branch-deletion orphans have no existence
 edge at all, and those have no linked node vertex either, so the migration hard-deletes the vertex
 and the stamp is moot. A candidate whose stamp is nonetheless not derivable falls back to the
-upgrade's own time: with no owner departure and no closed owning edge recorded, no branch resolves
-the owner as live, so that close shifts no branch's view. Deriving the stamp per candidate is
+upgrade's own time, which is safe because retention is settled before the stamp is derived: no
+branch retains the field by then, so that close shifts no branch's view. Deriving the stamp per
+candidate is
 what keeps FR-014 intact on upgrade: stamping run time would land every close inside the window of
 every branch forked before the upgrade, which is exactly what FR-014 forbids.
 

--- a/dev/specs/ifc-2843-retire-agnostic-edges/research.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/research.md
@@ -165,14 +165,15 @@ derivable from the graph — per branch, `status: "deleted"` gives the edge's `f
 gives that `to`, and the latest of those across every branch and every linked node vertex is the
 moment the field stopped being reachable anywhere. Only branch-deletion orphans have no existence
 edge at all, and those have no linked node vertex either, so the migration hard-deletes the vertex
-and the stamp is moot — which is why no run-time fallback is needed, and why a candidate whose
-stamp cannot be derived is left open (over-reserving) instead. Deriving the stamp per candidate is
+and the stamp is moot. A candidate whose stamp is nonetheless not derivable falls back to the
+upgrade's own time: with no owner departure and no closed owning edge recorded, no branch resolves
+the owner as live, so that close shifts no branch's view. Deriving the stamp per candidate is
 what keeps FR-014 intact on upgrade: stamping run time would land every close inside the window of
 every branch forked before the upgrade, which is exactly what FR-014 forbids.
 
-## R7 — Migration `m076` shape
+## R7 — Migration `m078` shape
 
-**Decision**: `ArbitraryMigration` with `minimum_version: int = 75`, batching via
+**Decision**: `ArbitraryMigration` with `minimum_version: int = 77`, batching via
 `IN TRANSACTIONS OF n ROWS`, reporting both counts through `get_migration_console()`, and
 returning `MigrationResult(errors=[...])` **without raising** for unrepairable state.
 
@@ -182,8 +183,9 @@ required element: a read query to find work, per-item `try`/`except` so one fail
 hide the rest, `console.log` progress reporting, and accumulating `errors` into the
 `MigrationResult` rather than raising — exactly FR-016's "MUST NOT fail the upgrade".
 
-`GRAPH_VERSION = 75` lives at `backend/infrahub/core/graph/__init__.py:1`; bumping it to 76 is a
-one-line change. `MAX_AGNOSTIC_PEER_BATCH_SIZE = 500` in `data_deleter.py` is the precedent for
+`GRAPH_VERSION` lives at `backend/infrahub/core/graph/__init__.py:1`; bumping it 77 → 78 is a
+one-line change. (This decision originally named `m076` from graph version 75; the base branch took
+that slot and then `m077`, so the shipped migration is `m078` — see plan.md §Ask-First Gate.) `MAX_AGNOSTIC_PEER_BATCH_SIZE = 500` in `data_deleter.py` is the precedent for
 capping a batch whose rows each drag unbounded peers into the transaction — the same cap applies
 here.
 
@@ -223,7 +225,7 @@ polished, so a failed gate is discovered early rather than at the end.
 | Branch-window set builder | Unit, no DB | Pure function of branch metadata (R2) |
 | Retirement component | Unit, recording double behind a `Protocol` | Testing rule forbids mocks; `BranchDataDeleterInterface` is the in-repo precedent for the protocol shape |
 | Retirement query (incl. two-peer form) | Component | Graph-shape assertions need a database |
-| `m076` fixtures | Component | Hand-built orphan shapes |
+| `m078` fixtures | Component | Hand-built orphan shapes |
 | Enforcement points | Component (behaviour) | No separate unit suites per the PRD |
 
 **Existing asset** (withdrawn 2026-08-17): an uncommitted
@@ -393,7 +395,7 @@ Findings:
 - **A plan compiled before index sampling completes degrades.** Immediately after the dataset was
   loaded, the same six queries planned as full index scans (`WHERE branch IS NOT NULL`) with
   zero-row estimates throughout; they replanned into the seeks above once sampling caught up and the
-  query caches were cleared. `m076` runs right after an upgrade, on exactly such a database, so the
+  query caches were cleared. `m078` runs right after an upgrade, on exactly such a database, so the
   first pass may plan worse than the table shows. Reconfirmed on the 2026-08-17 re-measurement, which
   had to be discarded and re-run: the pass taken immediately after the reload seeded the node-id bound
   with a `NodeIndexScan` over all 25,000 indexed nodes instead of a two-key seek (25,114 db hits

--- a/dev/specs/ifc-2843-retire-agnostic-edges/spec.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/spec.md
@@ -115,8 +115,11 @@ each operation.
     or the repair migration runs, **Then** the surviving vertex keeps its value.
 11. **Given** a node created and deleted on branch `B`, **When** `B` is rebased, **Then**
     the invariant still holds and no vertex is left with open global edges.
-12. **Given** a value freed by retirement, **When** the pool next allocates, **Then** that
-    value is allocatable again.
+12. **Given** an allocated value whose holder has been deleted, **When** the pool next allocates,
+    **Then** that value is allocatable again and retirement has not stood in the way of it.
+    (Amended 2026-08-18 with SC-007: the original read "a value freed by retirement ... is
+    allocatable again", which measurement disproved — deletion frees the value regardless of
+    retirement, so the original scenario held without the feature and validated nothing.)
 
 ---
 
@@ -215,11 +218,14 @@ each is independently developable, testable, and demonstrable.
   while branches still hold the object live.
 - **Same-UUID node copies.** Name, namespace, and inheritance changes leave several node
   vertices sharing one UUID, each pointing at the *same* `Attribute` vertex over its own
-  global edge, with the superseded vertex's edge closed as it is duplicated. Candidate
-  traversal must therefore start from **open, active** global `HAS_ATTRIBUTE` /
-  `IS_RELATED` edges, which excludes superseded copies for free. Traversing by
-  reachability instead would close a shared vertex's value edges and strip a live object's
-  value — the failure would only surface after the pre-migration branches were cleaned up.
+  global edge, with the superseded vertex's edge closed as it is duplicated. Protection here
+  belongs to the retention predicate, which reads **every** node vertex linked to the field and
+  retains it while any of them is live on some branch (FR-011); a superseded copy therefore
+  cannot cost a live object its value. The candidate anchor is a separate concern: starting from
+  open, active global edges at the runtime enforcement points buys selectivity and idempotence,
+  and the repair migration deliberately widens it to closed-but-active edges (FR-011a) without
+  weakening the protection. (Amended 2026-08-17 with FR-011: the original attributed same-UUID
+  protection to the anchor, which testing disproved.)
 - **Shared attribute values.** `AttributeValue` vertices are de-duplicated by value, so
   retirement must never delete one that any other attribute still references. Deleting one
   left with no references at all is permitted but not required.
@@ -318,14 +324,17 @@ each is independently developable, testable, and demonstrable.
   1. the owner's latest effective deletion time where one is derivable from its existence edges;
   2. otherwise the latest `to` among the vertex's already-closed owning edges — the case a schema
      field removal leaves behind, where the owner is still live;
-  3. where neither is derivable the candidate MUST be left alone, not stamped with the run time.
+  3. where neither is derivable the run time is the fallback, and only there.
 
   At the runtime enforcement points the caller's own timestamp already satisfies (1). *Verify:
   build two orphans deleted at different times, run the repair pass once, and assert each carries
   its own stamp and not the run time.* (Amended 2026-08-17, replacing "the migration run time only
-  where none does": stamping the run time would land the close inside the window of every branch
-  forked before the upgrade, which FR-014 forbids, and the no-stamp case coincides with the
-  hard-delete case where the stamp is moot.)
+  where none does": stamping the run time *by default* would land the close inside the window of
+  every branch forked before the upgrade, which FR-014 forbids. Amended again 2026-09-04, replacing
+  clause 3's "the candidate MUST be left alone": the shipped migration falls back to the run time
+  rather than skipping, and FR-014 still holds there — a candidate with neither an owner departure
+  nor a closed owning edge on record is one no branch resolves as live, so that close shifts no
+  branch's view.)
 - **FR-016**: The repair migration MUST close the global property edges **and the owning
   `HAS_ATTRIBUTE` / `IS_RELATED` edges** of vertices that no branch retains, including the
   half-closed shapes of FR-002a via the widened anchor of FR-011a, and MUST hard-delete

--- a/dev/specs/ifc-2843-retire-agnostic-edges/spec.md
+++ b/dev/specs/ifc-2843-retire-agnostic-edges/spec.md
@@ -332,9 +332,9 @@ each is independently developable, testable, and demonstrable.
   where none does": stamping the run time *by default* would land the close inside the window of
   every branch forked before the upgrade, which FR-014 forbids. Amended again 2026-09-04, replacing
   clause 3's "the candidate MUST be left alone": the shipped migration falls back to the run time
-  rather than skipping, and FR-014 still holds there — a candidate with neither an owner departure
-  nor a closed owning edge on record is one no branch resolves as live, so that close shifts no
-  branch's view.)
+  rather than skipping, and FR-014 still holds there because retention is settled before the stamp
+  is derived — a candidate only reaches clause 3 once no branch retains it, so no branch's view of
+  the field changes whichever stamp the close carries.)
 - **FR-016**: The repair migration MUST close the global property edges **and the owning
   `HAS_ATTRIBUTE` / `IS_RELATED` edges** of vertices that no branch retains, including the
   half-closed shapes of FR-002a via the widened anchor of FR-011a, and MUST hard-delete

--- a/docs/docs/branches/branch-agnostic-data.mdx
+++ b/docs/docs/branches/branch-agnostic-data.mdx
@@ -2,7 +2,7 @@
 title: Branch-agnostic data
 ---
 
-A branch-agnostic attribute or relationship on a **branch-aware** object stores its value once and shares that single value with every branch, instead of keeping a copy per branch. Deleting the object that holds such a field on one branch therefore does not release the value — the object may still be readable on another branch, and its branch-agnostic fields must remain readable with it.
+A branch-agnostic attribute or relationship on a **branch-aware** object stores its value once and shares that single value with every branch, instead of keeping a copy per branch. Deleting the object that holds such a field on one branch therefore does not always release the value — the object may still be readable on another branch, and its branch-agnostic fields must remain readable with it.
 
 For how to configure a schema element as branch-agnostic, see [Branch awareness](../schema/branch-awareness.mdx).
 

--- a/docs/docs/schema/branch-awareness.mdx
+++ b/docs/docs/schema/branch-awareness.mdx
@@ -60,7 +60,7 @@ By default, if a specific value is not defined:
 
 ## Deleting branch-agnostic data
 
-A branch-agnostic attribute or relationship stores its value once and shares it with every branch, instead of keeping a copy per branch. Deleting the object that holds the field on one branch therefore does not release the value: it stays reserved for as long as any branch can still reach the object, and a later delete, merge, rebase, branch deletion, or schema change may be what finally releases it.
+A branch-agnostic attribute or relationship stores its value once and shares it with every branch, instead of keeping a copy per branch. Deleting the object that holds the field on one branch therefore does not always release the value: it stays reserved for as long as any branch can still reach the object, and a later delete, merge, rebase, branch deletion, or schema change may be what finally releases it. Where no other branch can reach the object — deleting on the default branch with no other branch open, or deleting an object that only ever existed on one branch — the delete releases the value as part of the same operation.
 
 See [Branch-agnostic data](../branches/branch-agnostic-data.mdx) for the full rule.
 


### PR DESCRIPTION
Follow-up to the cubic review on #10524, covering the threads that were answered there
with "will address in a followup" plus the ones left unreplied. Threads that were
explicitly declined on that PR are not revisited here.

Frontend and CI/workflow findings from that review are deliberately **not** in this PR.

## Behaviour

One functional change: an unauthenticated context carries an empty account id, which
`BranchDeleteOrchestrator.delete` passed through to the branch-agnostic retirement query
and recorded verbatim as `to_user_id` on every edge it closed. It now falls back to
`SYSTEM_USER_ID`, matching `core/branch/tasks.py`. `to_user_id` is not exposed in GraphQL
or REST, so there is no changelog fragment.

## Docstrings and comments

- A zero closed-edge count was documented as proof that every field is still retained.
  The query also returns zero when no candidate matches and when the result is empty.
- `agnostic_retention.py`'s module docstring narrated its own Cypher construction instead
  of the retention contract.
- The repair query claimed a candidate with no derivable stamp is left alone; it falls
  back to the run time.
- The two repair-migration test modules narrated the approach not taken, which
  `.agents/rules/code-doc-style.md` keeps out of source.

## Tests

- `relationship_metadata` read `results[0]` without checking the count, so a duplicate
  relationship vertex would silently send later assertions at the wrong one. Its
  attribute sibling already asserts a single result.
- The rollback helper closed any open global edge regardless of when it opened, producing
  an inverted interval for an `at` earlier than the edge's own `from`.
- The test for another writer's closure never checked that the closure had landed, so it
  could pass without exercising anything.
- The field-removal tests re-implemented `create_widget` / `create_gadget` from the helper
  module they already import (18 call sites).

## Documentation

Two user-doc pages stated flatly that deleting an object does not release a
branch-agnostic value. Where no other branch can reach the object, the delete releases it
in the same operation — which the deeper section of `branch-agnostic-data.mdx` already
said.

The spec set under `dev/specs/ifc-2843-retire-agnostic-edges/` still directed a reader at
`m076` / `GRAPH_VERSION` 75 → 76 and at test paths that do not exist. The migration
shipped as `m078` with the bump 77 → 78, and every suite for the feature is
component-tier — there are no unit tests, so the quickstart says so rather than naming a
path that was never created.

Three of those corrections are worth calling out because they change what the artifacts
assert, not just a number:

1. **FR-015(3) and contract C4** required a candidate with no derivable stamp to be
   *skipped*. `queries.py` computes `coalesce(derived_at, $at)` and closes the edge. Both
   are now amended to the shipped behaviour, with the argument for why FR-014 still holds
   there recorded alongside: a candidate with neither an owner departure nor a closed
   owning edge on record is one no branch resolves as live, so that close shifts no
   branch's view. **If the requirement is the thing you want kept, this is a code change
   instead** — drop the coalesce and filter out the null case.
2. **The critique's Recommended Action #1** read as contradicting its own E1 correction,
   which recorded the in-query `(:Branch)` read as dropped in favour of `registry.branch`.
   The shipped predicate reads `MATCH (branch:Branch)` in-query; there is no
   `registry.branch` read and no migration-side `Branch.get_list`. So the action is what
   landed and the correction is the stale half — recorded as an Outcome note, with
   `data-model.md` fixed where it still named the registry as the runtime source.
3. **The same-UUID edge case** credited the candidate anchor with protection FR-011
   records as coming from the retention predicate, and **acceptance scenario 12** still
   asserted the premise SC-007 disavowed, so it held without the feature.

## Test status

`ruff check . --exclude python_sdk`, `ruff format` and `mypy` are clean on everything
touched. `markdownlint-cli2` is clean on the changed docs; the pre-existing errors under
`dev/specs/` are unchanged and outside CI's glob. The `delete_coordinator` unit suite
passes (7 tests, one new).

**Component tests were not run locally** — no Docker daemon available in the dev
environment. All 60 tests across the affected suites collect cleanly, so the imports and
the builder swap are sound, but the assertion changes in `test_rollback.py` and
`test_agnostic_field_removal.py` are verified only by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

