### PR TITLE
test: set up the Prefect task manager once in the git repository tests

### DIFF
--- a/.agents/rules/testing-python.md
+++ b/.agents/rules/testing-python.md
@@ -80,6 +80,10 @@ Never add a marker, attribute, or `type: ignore` to production code so a test ca
 
 Every test in an xdist worker shares one interpreter. Change `logging` levels/handlers/filters, `structlog` config, module-level registries/singletons, class attributes (your own or a third-party library's), `sys.path`/`sys.modules` or env vars only through a save/restore fixture (change it, `yield`, restore it), or `monkeypatch` where it applies. Never call an application startup routine such as `infrahub.log.configure_logging` from a test — it owns the whole process and undoes nothing, so it reconfigures every later test in the worker. Install only the piece under test and remove it after the `yield`. See `dev/guidelines/backend/testing.md` §"Leave process-global state as you found it".
 
+## Prefect task manager setup
+
+Never call `setup_task_manager()` from a test or fixture; call `tests.helpers.task_manager.setup_task_manager_once()`. The raw setup re-registers every block, pool, deployment and trigger against the worker's Prefect server with no timeout, and under CI load that hangs until pytest-timeout kills the whole class. The helper runs it once per server URL, bounded, and fails fast for that server afterwards. The only test allowed to call the raw function is the one that tests the setup itself. Mechanism in `dev/knowledge/backend/testing.md` §"Prefect Testing Patterns".
+
 ## A regression guard must be shown to bite
 
 Before trusting a test that pins a fix or an optimization, run it against the code without the change (revert it, or reintroduce the old call) and watch it fail — a guard that passes on both sides asserts nothing, and several have. State the check in the PR ("fails with X when the fix is reverted"). A `strict=True` xfail swallows every assertion in its body, so it holds only the expected failure; invariants that must hold today go in a passing test.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -63,7 +63,9 @@ Also see `dev/knowledge/backend/query-pattern.md` for the Query class pattern us
 
 ## Testing
 
-See `dev/knowledge/backend/testing.md` for detailed testing infrastructure documentation.
+See `dev/knowledge/backend/testing.md` for the test infrastructure; read it before writing a
+class-scoped fixture, anything that touches Prefect (task manager setup, the two test servers), or
+a test that swaps in an adapter.
 
 ## Boundaries
 

--- a/backend/infrahub/cli/tasks.py
+++ b/backend/infrahub/cli/tasks.py
@@ -11,7 +11,7 @@ from infrahub.task_manager.flow_run.prefect_client import PrefectClientAdapter
 from infrahub.task_manager.flow_run.retention import FlowRunRetention
 from infrahub.tasks.dummy import DUMMY_FLOW, DummyInput
 from infrahub.workers.dependencies import build_tls_registry
-from infrahub.workflows.initialization import setup_task_manager
+from infrahub.workflows.initialization import setup_task_manager  # noqa: TID251 - the CLI runs the one-off setup itself
 from infrahub.workflows.models import WorkerPoolDefinition
 
 app = AsyncTyper()

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -8,7 +8,10 @@ from prefect.deployments import run_deployment
 
 from infrahub import config, lock
 from infrahub.workers.utils import inject_context_parameter
-from infrahub.workflows.initialization import setup_task_manager, setup_task_manager_identifiers
+from infrahub.workflows.initialization import (
+    setup_task_manager,  # noqa: TID251 - worker startup owns the setup
+    setup_task_manager_identifiers,
+)
 from infrahub.workflows.models import WorkflowInfo
 
 from . import InfrahubWorkflow, Return

--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -41,7 +41,7 @@ from collections.abc import Awaitable, Callable
 
 from prefect.settings import get_current_settings
 
-from infrahub.workflows.initialization import setup_task_manager
+from infrahub.workflows.initialization import setup_task_manager  # noqa: TID251 - the helper wraps the raw setup
 from tests.helpers.prefect_diagnostics import dump_prefect_test_server_diagnostics
 
 # Ceiling for one setup attempt. It has to stay under the 300s pytest timeout, so that a wedged

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -21,8 +21,8 @@ from infrahub.server import app, lifespan
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.utils import get_models_dir
 from infrahub.workers.dependencies import build_database, clear_singletons
-from infrahub.workflows.initialization import setup_task_manager
 from tests.helpers.file_repo import FileRepo
+from tests.helpers.task_manager import setup_task_manager_once
 from tests.helpers.test_app import TestInfrahubApp
 from tests.helpers.test_client import InfrahubTestClient
 from tests.integration.conftest import IntegrationHelper
@@ -52,7 +52,7 @@ class TestInfrahubClient:
     async def workflow_local(self, prefect_test_fixture: None) -> AsyncGenerator[WorkflowLocalExecution, None]:
         original = config.OVERRIDE.workflow
         workflow = WorkflowLocalExecution()
-        await setup_task_manager()
+        await setup_task_manager_once()
         config.OVERRIDE.workflow = workflow
         yield workflow
         config.OVERRIDE.workflow = original

--- a/backend/tests/integration/services/adapters/workflow/test_setup.py
+++ b/backend/tests/integration/services/adapters/workflow/test_setup.py
@@ -1,7 +1,7 @@
 from prefect.client.orchestration import PrefectClient
 
 from infrahub.workflows.catalogue import INFRAHUB_WORKER_POOL
-from infrahub.workflows.initialization import setup_task_manager
+from infrahub.workflows.initialization import setup_task_manager  # noqa: TID251 - this module tests the setup itself
 from tests.helpers.test_worker import TestWorkerInfrahubAsync
 
 # @pytest.fixture

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -305,7 +305,9 @@ Container (session)
 
 ### Schema Fixtures
 
-**Always prefer existing schema fixtures** over creating new ones. The codebase provides several reusable schema fixtures in `backend/tests/conftest.py`:
+Registered schemas come from fixtures in `backend/tests/conftest.py`. The rules for deriving a
+variant (`deepcopy` an unregistered one, never edit a shared one, promote only what several modules
+need) are in `dev/guidelines/backend/testing.md` §"Test Schemas".
 
 | Fixture | Description |
 |---------|-------------|
@@ -317,66 +319,11 @@ Container (session)
 
 When several tests share an expensive schema/data load, group them in a class and use the
 `_scope_class` variant with `@pytest.fixture(scope="class")` fixtures for the data; methods run in
-definition order and may build on accumulated state. See `TestNumberPoolAllocation` in
-`backend/tests/component/core/resource_manager/test_number_pool.py`.
+definition order and may build on accumulated state.
 
-**When to use existing fixtures:**
-
-```python
-# GOOD: Use existing fixture directly
-async def test_my_feature(db: InfrahubDatabase, car_person_schema: SchemaBranch):
-    # car_person_schema provides TestCar, TestPerson with relationships
-    ...
-```
-
-**When you need additional schema elements:**
-
-1. **Live update within the test** - Use `deepcopy` to modify an unregistered schema fixture:
+JSON schemas under `backend/tests/fixtures/schemas/` load through the test helper:
 
 ```python
-from copy import deepcopy
-
-async def test_with_custom_constraint(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    car_person_schema_unregistered: SchemaRoot,
-):
-    # Copy and modify the schema
-    custom_schema = deepcopy(car_person_schema_unregistered)
-    custom_schema.nodes[0].uniqueness_constraints = [["name__value", "color__value"]]
-
-    # Register the modified schema
-    registry.schema.register_schema(schema=custom_schema, branch=default_branch.name)
-    ...
-```
-
-2. **Update the base fixture** - If the modification is broadly useful, add it to `backend/tests/conftest.py`:
-
-```python
-# In conftest.py - add a new reusable fixture
-@pytest.fixture
-async def car_person_schema_with_extra_attr(
-    db: InfrahubDatabase, default_branch: Branch, car_person_schema_unregistered: SchemaRoot
-) -> SchemaBranch:
-    schema = deepcopy(car_person_schema_unregistered)
-    schema.nodes[0].attributes.append(
-        AttributeSchema(name="year", kind="Number", optional=True)
-    )
-    return registry.schema.register_schema(schema=schema, branch=default_branch.name)
-```
-
-**Avoid:**
-
-- Creating inline schema dictionaries when existing fixtures suffice
-- Duplicating schema definitions across test files
-- Defining schemas in test files that could be shared fixtures
-
-**Schema files in `backend/tests/fixtures/schemas/`:**
-
-For JSON-based schemas, use the helper methods:
-
-```python
-# Load schema from fixtures directory
 schema_dict = helper.schema_file("infra_simple_01.json")
 await client.schema.load(schemas=[schema_dict])
 ```

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -305,9 +305,10 @@ Container (session)
 
 ### Schema Fixtures
 
-Registered schemas come from fixtures in `backend/tests/conftest.py`. The rules for deriving a
-variant (`deepcopy` an unregistered one, never edit a shared one, promote only what several modules
-need) are in `dev/guidelines/backend/testing.md` §"Test Schemas".
+Registered schemas come from fixtures in `backend/tests/conftest.py`. Derive a variant the way
+`dev/guidelines/backend/testing.md` §"Test Schemas" prescribes for the `tests/helpers/schema/`
+constants: `deepcopy` the unregistered fixture, never edit a shared one, and promote to
+`conftest.py` only what several modules need.
 
 | Fixture | Description |
 |---------|-------------|

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -422,8 +422,6 @@ async def test_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     assert "expected message" in caplog.text
 ```
 
-This matches the pattern used in `test_webhook_header.py` and `test_models.py`.
-
 ### Prefect Server State Outlives the Test Class
 
 The Prefect test server is session-scoped — one per xdist worker — while the database and the
@@ -453,13 +451,16 @@ depend on `prefect` therefore falls back to the harness server, even in a proces
 container is running — `component/api/conftest.py::workflow_local` and
 `TestInfrahubApp.workflow_local` sit on opposite sides of this line.
 
-**Never memoize server-side registration per process.** `setup_task_manager` registers blocks,
-worker pools, deployments and builtin triggers against whichever server is current, so a
-process-wide "already done" flag lets the first server's setup satisfy fixtures pointing at the
-second. The second server then has no deployments, and `setup_triggers` raises `KeyError` on the
-empty deployment mapping rather than failing anywhere near the cause.
-`tests/helpers/task_manager.py` keys its memo on `get_current_settings().api.url` for this reason;
-anything else cached against a Prefect server needs the same treatment.
+**Tests register the task manager through `setup_task_manager_once()`, never the raw
+`setup_task_manager()`.** The raw call redoes every block, worker pool, deployment and builtin
+trigger against the current server with no timeout of its own; under CI load it hangs until
+pytest-timeout kills the whole class. The helper runs the registration once per server, bounded,
+and fails fast for that server afterwards.
+
+**Never memoize server-side registration per process.** The registration goes to whichever server is
+current, so a process-wide "already done" flag lets the first server's setup satisfy fixtures pointing
+at the second, which then has no deployments and fails far from the cause. The helper keys its memo
+on `get_current_settings().api.url`; anything else cached against a Prefect server needs the same key.
 
 ### Swapping the Workflow Adapter for a Test Double
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -569,6 +569,9 @@ ignorelist = [
     "type",
 ]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"infrahub.workflows.initialization.setup_task_manager".msg = "Only the application's own startup calls the raw setup. Tests use tests.helpers.task_manager.setup_task_manager_once(), which runs it once per Prefect server and bounds it with a timeout."
+
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -570,7 +570,7 @@ ignorelist = [
 ]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-"infrahub.workflows.initialization.setup_task_manager".msg = "Only the application's own startup calls the raw setup. Tests use tests.helpers.task_manager.setup_task_manager_once(), which runs it once per Prefect server and bounds it with a timeout."
+"infrahub.workflows.initialization.setup_task_manager".msg = "The raw setup belongs to the application's own startup. Tests use tests.helpers.task_manager.setup_task_manager_once(), which runs it once per Prefect server and bounds it with a timeout."
 
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub"]


### PR DESCRIPTION
# Why

`backend-tests-integration (a)` fails intermittently with every test of `test_git_repository.py::TestInfrahubClient` erroring at setup with `Failed: Timeout >300.0s` (seen on #10381 and #10504, green on rerun). The class was the last one in the suite still calling the raw `setup_task_manager()`, which recreates every block, work pool, work queue, deployment and trigger against the per-worker Prefect test server. Run mid-session under four-worker load, against a SQLite database that already holds a session's worth of events, that call has no timeout of its own and can hang until pytest-timeout kills the fixture.

Goal: the class sets up the task manager the way every other class has since 3a799eef4.

Non-goals: no change to what the tests assert, no change to the Prefect test server configuration.

## What changed

- `TestInfrahubClient.workflow_local` calls `setup_task_manager_once()`: one setup per Prefect server (keyed on the server URL), bounded by its own timeout, with a server diagnostics dump when it fails.
- The rule is now written down where a test author meets it: `.agents/rules/testing-python.md` (always loaded for `backend/tests/**`) says never to call the raw `setup_task_manager()` from a test, with the one carve-out; `dev/knowledge/backend/testing.md` opens its Prefect section with the same rule; `backend/AGENTS.md` names the situations that should trigger reading that page. The caplog section loses a sentence citing two test files as provenance.
- A ruff banned-api entry makes the rule a CI failure: importing `infrahub.workflows.initialization.setup_task_manager` anywhere fails with a message pointing at the helper. The four legitimate sites (the CLI, worker startup, the helper itself, and the setup test) carry an inline `noqa` each, so a new caller has to justify itself rather than inherit a blanket ignore.
- `dev/knowledge/backend/testing.md` also loses the schema-fixtures material that restated `dev/guidelines/backend/testing.md` §"Test Schemas"; it keeps the fixture table, the class-scoped grouping advice and the JSON loader, and links to the guideline for the deriving rules. That brings the page back under its size ceiling.
- The setup test in `services/adapters/workflow/test_setup.py` keeps the raw call on purpose, since it tests the setup itself.

## How to review

The class passes locally in 2.5 minutes with this change (`uv run pytest backend/tests/integration/git/test_git_repository.py --neo4j`). Nothing in the integration suite deletes deployments or pools, so a memoized setup is safe for the tests that follow on the same worker.

Analysis of the flake, with the CI evidence, is in the discussion on #10504.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



