### PR TITLE
test: build the test app under its workflow override and restore overrides on exit

### DIFF
--- a/backend/tests/component/api/conftest.py
+++ b/backend/tests/component/api/conftest.py
@@ -15,9 +15,10 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_database, build_message_bus, build_workflow
+from infrahub.workers.dependencies import build_database, build_message_bus
 from tests.conftest import TestHelper
 from tests.helpers.task_manager import setup_task_manager_once
+from tests.helpers.workflow_override import override_workflow
 
 
 @pytest.fixture
@@ -56,13 +57,9 @@ def rpc_bus(helper: TestHelper, dependency_provider: Provider) -> Generator[Any,
 
 @pytest.fixture
 async def workflow_local(dependency_provider: Provider) -> AsyncGenerator[WorkflowLocalExecution, None]:
-    original = config.OVERRIDE.workflow
-    workflow = WorkflowLocalExecution()
     await setup_task_manager_once()
-    config.OVERRIDE.workflow = workflow
-    with dependency_provider.scope(build_workflow, lambda: workflow):
+    with override_workflow(WorkflowLocalExecution(), dependency_provider=dependency_provider) as workflow:
         yield workflow
-    config.OVERRIDE.workflow = original
 
 
 @pytest.fixture

--- a/backend/tests/component/computed_attribute/_base.py
+++ b/backend/tests/component/computed_attribute/_base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, ClassVar, Generator
 
 import pytest
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import InfrahubContext
@@ -17,10 +16,10 @@ from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema
 from infrahub.core.schema.computed_attribute import ComputedAttribute, ComputedAttributeKind
 from infrahub.events.schema_action import ChangedElementsPayload  # noqa: TC001  used in dataclass field
 from infrahub.server import app
-from infrahub.workers.dependencies import build_workflow
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.task_manager import setup_task_manager_once
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from fast_depends import Provider
@@ -140,13 +139,9 @@ class ScopedRecomputeTestBase(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
         await setup_task_manager_once()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: Any) -> InfrahubServices:

--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -71,7 +71,6 @@ from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import InfrahubRepository
 from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_workflow
 from tests.adapters.workflow import WorkflowRecorder
 from tests.conftest import TestHelper
 from tests.helpers.constants import (
@@ -84,6 +83,7 @@ from tests.helpers.file_repo import FileRepo
 from tests.helpers.prefect_diagnostics import register_prefect_test_server, timeout_diagnostics_section
 from tests.helpers.test_client import dummy_async_request
 from tests.helpers.utils import find_available_prefect_port
+from tests.helpers.workflow_override import override_workflow
 from tests.test_data import dataset01 as ds01
 
 COMPONENT_TESTS_DIR = Path(__file__).parent
@@ -3032,23 +3032,15 @@ async def prefix_pool_01(
 
 @pytest.fixture
 def workflow_local(dependency_provider: Provider) -> Generator[WorkflowLocalExecution, None, None]:
-    original = config.OVERRIDE.workflow
-    workflow = WorkflowLocalExecution()
-    config.OVERRIDE.workflow = workflow
-    with dependency_provider.scope(build_workflow, lambda: workflow):
+    with override_workflow(WorkflowLocalExecution(), dependency_provider=dependency_provider) as workflow:
         yield workflow
-    config.OVERRIDE.workflow = original
 
 
 @pytest.fixture
 def workflow_recorder(dependency_provider: Provider) -> Generator[WorkflowRecorder, None, None]:
     """Record workflow submissions instead of running them."""
-    original = config.OVERRIDE.workflow
-    recorder = WorkflowRecorder()
-    config.OVERRIDE.workflow = recorder
-    with dependency_provider.scope(build_workflow, lambda: recorder):
+    with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
         yield recorder
-    config.OVERRIDE.workflow = original
 
 
 @pytest.fixture

--- a/backend/tests/component/proposed_change/conftest.py
+++ b/backend/tests/component/proposed_change/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.diff import NodeDiff, NodeDiffElement, NodeDiffSummary
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -19,10 +18,11 @@ from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestProposedChangeRefreshArtifacts
 from infrahub.proposed_change.tasks import refresh_artifacts
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_ARTIFACT_DEFINITION_CHECK
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -122,12 +122,8 @@ class ArtifactRegenTestBase(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_artifact_definition_generate_members.py
+++ b/backend/tests/component/proposed_change/test_artifact_definition_generate_members.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -15,11 +14,12 @@ from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.git.models import RequestArtifactDefinitionGenerate
 from infrahub.git.tasks import generate_request_artifact_definition
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_ARTIFACT_GENERATE
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -74,12 +74,8 @@ class TestArtifactDefinitionGenerateMembers(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_generator_definition_run_orphan.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_orphan.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -15,11 +14,12 @@ from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.generators.models import ProposedChangeGeneratorDefinition, RequestGeneratorDefinitionRun
 from infrahub.generators.tasks import request_generator_definition_run
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_GENERATOR_RUN
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -71,12 +71,8 @@ class TestGeneratorDefinitionRunToleratesOrphanInstance(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_generator_regen_selection.py
+++ b/backend/tests/component/proposed_change/test_generator_regen_selection.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -19,11 +18,12 @@ from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestProposedChangeRunGenerators
 from infrahub.proposed_change.tasks import run_generators
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_GENERATOR_DEFINITION_CHECK
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 from .conftest import make_node_diff
 
@@ -119,12 +119,8 @@ class GeneratorRegenTestBase(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_merge_selective_regen.py
+++ b/backend/tests/component/proposed_change/test_merge_selective_regen.py
@@ -19,7 +19,7 @@ from infrahub.core.merge.selective_regen.orchestrator import build_merge_selecti
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import (
     REQUEST_ARTIFACT_DEFINITION_GENERATE,
     REQUEST_GENERATOR_DEFINITION_RUN,
@@ -28,6 +28,7 @@ from infrahub.workflows.catalogue import (
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 from .conftest import make_node_diff
 
@@ -109,12 +110,8 @@ class TestMergeSelectiveRegenSelection(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_request_generator_definition_check.py
+++ b/backend/tests/component/proposed_change/test_request_generator_definition_check.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -21,11 +20,12 @@ from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestGeneratorDefinitionCheck
 from infrahub.proposed_change.tasks import request_generator_definition_check
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import RUN_GENERATOR_AS_CHECK
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 from .conftest import QUERY_NON_UNIQUE_TARGETS, QUERY_UNIQUE_TARGETS, make_node_diff
 
@@ -186,12 +186,8 @@ class TestRequestGeneratorDefinitionCheck(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
+++ b/backend/tests/component/proposed_change/test_validate_artifacts_generation.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -23,10 +22,11 @@ from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestArtifactDefinitionCheck
 from infrahub.proposed_change.tasks import validate_artifacts_generation
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -71,12 +71,8 @@ class TestValidateArtifactsGeneration(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorder, None]:
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -36,7 +36,6 @@ from infrahub.workers.dependencies import (
     build_client,
     build_database,
     build_message_bus,
-    build_workflow,
     clear_singletons,
 )
 from tests.adapters.cache import MemoryCache
@@ -46,6 +45,7 @@ from tests.helpers.diagnostics import dump_event_loop_closed_diagnostic
 from tests.helpers.events import query_events_by_name
 from tests.helpers.schema_cache import install_processed_core_schema_branch, install_processed_internal_schema_branch
 from tests.helpers.task_manager import setup_task_manager_once
+from tests.helpers.workflow_override import override_workflow
 
 from .test_client import InfrahubTestClient
 
@@ -313,16 +313,16 @@ class TestInfrahubApp(TestInfrahubAppBase):
     async def workflow_local(
         self, prefect: Generator[str, None, None], dependency_provider: Provider
     ) -> AsyncGenerator[WorkflowLocalExecution, None]:
-        original = config.OVERRIDE.workflow
         workflow = WorkflowLocalExecution()
         await setup_task_manager_once()
-        config.OVERRIDE.workflow = workflow
-        with dependency_provider.scope(build_workflow, lambda: workflow):
+        with override_workflow(workflow, dependency_provider=dependency_provider):
             yield workflow
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
-    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+    async def service(
+        self, workflow_local: WorkflowLocalExecution, test_client: InfrahubTestClient
+    ) -> InfrahubServices:
+        # pytest orders autouse fixtures by name, so the app has to be told to wait for its workflow
         return app.state.service
 
 
@@ -331,13 +331,10 @@ class TestInfrahubAppWithoutLocalWorkflow(TestInfrahubAppBase):
     async def workflow_local(
         self, prefect: Generator[str, None, None], dependency_provider: Provider
     ) -> AsyncGenerator[WorkflowLocalExecution, None]:
-        original = config.OVERRIDE.workflow
         workflow = WorkflowLocalExecution()
         await setup_task_manager_once()
-        config.OVERRIDE.workflow = workflow
-        with dependency_provider.scope(build_workflow, lambda: workflow):
+        with override_workflow(workflow, dependency_provider=dependency_provider):
             yield workflow
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class")
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -322,7 +322,6 @@ class TestInfrahubApp(TestInfrahubAppBase):
     async def service(
         self, workflow_local: WorkflowLocalExecution, test_client: InfrahubTestClient
     ) -> InfrahubServices:
-        # pytest orders autouse fixtures by name, so the app has to be told to wait for its workflow
         return app.state.service
 
 

--- a/backend/tests/helpers/workflow_override.py
+++ b/backend/tests/helpers/workflow_override.py
@@ -1,0 +1,48 @@
+"""Point the workflow adapter at a test double and put the previous one back afterwards."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from infrahub import config
+from infrahub.workers.dependencies import build_workflow
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from fast_depends import Provider
+
+    from infrahub.services.adapters.workflow import InfrahubWorkflow
+
+
+@contextmanager
+def override_workflow[WorkflowT: InfrahubWorkflow](
+    workflow: WorkflowT, dependency_provider: Provider
+) -> Iterator[WorkflowT]:
+    """Route both workflow lookups to ``workflow`` for the duration of the block.
+
+    The provider's own ``scope`` drops the override it replaced instead of restoring it, and
+    neither it nor ``config.OVERRIDE`` is put back when the block is left through an exception,
+    so a leftover double could reach whatever the tests build next.
+
+    Args:
+        workflow: The adapter every workflow lookup should return inside the block.
+        dependency_provider: The provider the dependency injection resolves ``build_workflow`` through.
+
+    Yields:
+        ``workflow`` itself.
+
+    """
+    previous_workflow = config.OVERRIDE.workflow
+    previous_dependant = dependency_provider.overrides.get(build_workflow)
+    config.OVERRIDE.workflow = workflow
+    dependency_provider.override(build_workflow, lambda: workflow)
+    try:
+        yield workflow
+    finally:
+        config.OVERRIDE.workflow = previous_workflow
+        if previous_dependant is None:
+            dependency_provider.overrides.pop(build_workflow, None)
+        else:
+            dependency_provider.overrides[build_workflow] = previous_dependant

--- a/backend/tests/helpers/workflow_override.py
+++ b/backend/tests/helpers/workflow_override.py
@@ -22,9 +22,8 @@ def override_workflow[WorkflowT: InfrahubWorkflow](
 ) -> Iterator[WorkflowT]:
     """Route both workflow lookups to ``workflow`` for the duration of the block.
 
-    The provider's own ``scope`` drops the override it replaced instead of restoring it, and
-    neither it nor ``config.OVERRIDE`` is put back when the block is left through an exception,
-    so a leftover double could reach whatever the tests build next.
+    Both lookups go back to their previous values when the block ends, normally or through an
+    exception, and an override that did not exist before is removed.
 
     Args:
         workflow: The adapter every workflow lookup should return inside the block.

--- a/backend/tests/integration/proposed_change/artifact_regen_harness.py
+++ b/backend/tests/integration/proposed_change/artifact_regen_harness.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -14,10 +13,10 @@ from infrahub.message_bus.types import ProposedChangeBranchDiff, ProposedChangeR
 from infrahub.proposed_change.branch_diff import set_diff_summary_cache
 from infrahub.proposed_change.models import RequestProposedChangeRefreshArtifacts
 from infrahub.proposed_change.tasks import refresh_artifacts
-from infrahub.workers.dependencies import build_workflow
 from infrahub.workflows.catalogue import REQUEST_ARTIFACT_DEFINITION_CHECK
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.test_app import TestInfrahubApp
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -47,12 +46,8 @@ class ArtifactRegenGateHarness(TestInfrahubApp):
     ) -> AsyncGenerator[WorkflowRecorder, None]:
         # workflow_local scopes build_workflow to the live local backend; depend on it so it runs
         # first, then re-scope to the recorder as the inner (active) provider for refresh_artifacts.
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(autouse=True)
     def clear_recorder(self, workflow_recorder: WorkflowRecorder) -> None:

--- a/backend/tests/integration/proposed_change/test_merge_selective_regen.py
+++ b/backend/tests/integration/proposed_change/test_merge_selective_regen.py
@@ -26,7 +26,6 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.git import InfrahubRepository
-from infrahub.workers.dependencies import build_workflow
 from infrahub.workflows.catalogue import (
     REQUEST_ARTIFACT_DEFINITION_GENERATE,
     REQUEST_GENERATOR_DEFINITION_RUN,
@@ -38,6 +37,7 @@ from tests.helpers.diff_summary import node_diff
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -111,12 +111,8 @@ class _MergeSelectiveRegenBase(TestInfrahubApp):
     ) -> AsyncGenerator[WorkflowRecorder, None]:
         # workflow_local scopes build_workflow to the live local backend; depend on it so it runs
         # first, then re-scope to the recorder as the inner (active) provider for the follow-up.
-        original = config.OVERRIDE.workflow
-        recorder = WorkflowRecorder()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider) as recorder:
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(autouse=True)
     def clear_recorder(self, workflow_recorder: WorkflowRecorder) -> None:

--- a/backend/tests/unit/helpers/test_workflow_override.py
+++ b/backend/tests/unit/helpers/test_workflow_override.py
@@ -1,0 +1,59 @@
+from collections.abc import Iterator
+
+import pytest
+from fast_depends import Provider
+
+from infrahub import config
+from infrahub.workers.dependencies import build_workflow
+from tests.adapters.workflow import WorkflowRecorder
+from tests.helpers.workflow_override import override_workflow
+
+
+@pytest.fixture
+def provider() -> Provider:
+    return Provider()
+
+
+@pytest.fixture(autouse=True)
+def no_global_override() -> Iterator[None]:
+    original = config.OVERRIDE.workflow
+    config.OVERRIDE.workflow = None
+    yield
+    config.OVERRIDE.workflow = original
+
+
+def resolved(provider: Provider) -> object:
+    return provider.overrides[build_workflow].call()
+
+
+def test_override_is_removed_when_there_was_none_before(provider: Provider) -> None:
+    recorder = WorkflowRecorder()
+
+    with override_workflow(recorder, dependency_provider=provider) as active:
+        assert active is recorder
+        assert config.OVERRIDE.workflow is recorder
+        assert resolved(provider) is recorder
+
+    assert config.OVERRIDE.workflow is None
+    assert build_workflow not in provider.overrides
+
+
+def test_nested_override_gives_the_outer_one_back(provider: Provider) -> None:
+    outer = WorkflowRecorder()
+    inner = WorkflowRecorder()
+
+    with override_workflow(outer, dependency_provider=provider):
+        with override_workflow(inner, dependency_provider=provider):
+            assert resolved(provider) is inner
+            assert config.OVERRIDE.workflow is inner
+
+        assert resolved(provider) is outer
+        assert config.OVERRIDE.workflow is outer
+
+
+def test_exception_inside_the_block_still_restores(provider: Provider) -> None:
+    with pytest.raises(RuntimeError), override_workflow(WorkflowRecorder(), dependency_provider=provider):
+        raise RuntimeError("boom")
+
+    assert config.OVERRIDE.workflow is None
+    assert build_workflow not in provider.overrides

--- a/backend/tests/unit/helpers/test_workflow_override.py
+++ b/backend/tests/unit/helpers/test_workflow_override.py
@@ -1,9 +1,10 @@
 from collections.abc import Iterator
 
 import pytest
-from fast_depends import Provider
+from fast_depends import Depends, Provider, inject
 
 from infrahub import config
+from infrahub.services.adapters.workflow import InfrahubWorkflow
 from infrahub.workers.dependencies import build_workflow
 from tests.adapters.workflow import WorkflowRecorder
 from tests.helpers.workflow_override import override_workflow
@@ -22,8 +23,11 @@ def no_global_override() -> Iterator[None]:
     config.OVERRIDE.workflow = original
 
 
-def resolved(provider: Provider) -> object:
-    return provider.overrides[build_workflow].call()
+def resolved(provider: Provider) -> InfrahubWorkflow:
+    def lookup(workflow: InfrahubWorkflow = Depends(build_workflow)) -> InfrahubWorkflow:  # noqa: B008
+        return workflow
+
+    return inject(lookup, dependency_provider=provider)()
 
 
 def test_override_is_removed_when_there_was_none_before(provider: Provider) -> None:

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -461,6 +461,21 @@ empty deployment mapping rather than failing anywhere near the cause.
 `tests/helpers/task_manager.py` keys its memo on `get_current_settings().api.url` for this reason;
 anything else cached against a Prefect server needs the same treatment.
 
+### Swapping the Workflow Adapter for a Test Double
+
+Every fixture that installs a `WorkflowLocalExecution` or a `WorkflowRecorder` goes through
+`tests/helpers/workflow_override.py::override_workflow`. It sets both places a lookup can come
+from — `config.OVERRIDE.workflow` and the `build_workflow` override in the dependency provider — and
+puts the *previous* values back in a `finally`. Do not hand-roll it with `dependency_provider.scope`:
+that context manager pops its override instead of restoring the one it replaced, and neither it nor
+`config.OVERRIDE` is restored when the fixture is finalised through an exception, so the double
+leaks into whatever the next class builds.
+
+The app built by `test_client` resolves its workflow once, during `lifespan`. pytest orders autouse
+fixtures by name, so `service` (and with it `test_client`) would otherwise run before
+`workflow_local`; `TestInfrahubApp.service` therefore depends on `workflow_local` explicitly, and a
+subclass that swaps in a different adapter must do the same for the app to see it.
+
 ### Functional Tests with `TestInfrahubApp`
 
 `TestInfrahubApp` provides a `memory_cache` fixture (class-scoped) that injects a `MemoryCache` via `dependency_provider.scope(build_cache, ...)`. Use it in functional tests to pre-fill and assert on cache state:

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -463,13 +463,17 @@ anything else cached against a Prefect server needs the same treatment.
 
 ### Swapping the Workflow Adapter for a Test Double
 
-Every fixture that installs a `WorkflowLocalExecution` or a `WorkflowRecorder` goes through
-`tests/helpers/workflow_override.py::override_workflow`. It sets both places a lookup can come
-from — `config.OVERRIDE.workflow` and the `build_workflow` override in the dependency provider — and
-puts the *previous* values back in a `finally`. Do not hand-roll it with `dependency_provider.scope`:
-that context manager pops its override instead of restoring the one it replaced, and neither it nor
-`config.OVERRIDE` is restored when the fixture is finalised through an exception, so the double
-leaks into whatever the next class builds.
+Every class-scoped fixture that installs a `WorkflowLocalExecution` or a `WorkflowRecorder` goes
+through `tests/helpers/workflow_override.py::override_workflow`. It sets both places a lookup can
+come from — `config.OVERRIDE.workflow` and the `build_workflow` override in the dependency
+provider — and puts the *previous* values back in a `finally`. Do not hand-roll a class-scoped swap
+with `dependency_provider.scope`: that context manager pops its override instead of restoring the
+one it replaced, and neither it nor `config.OVERRIDE` is restored when the fixture is finalised
+through an exception, so the double leaks into whatever the next class builds.
+
+A `dependency_provider.scope(build_workflow, …)` that opens and closes around a single test, next
+to the other scoped dependencies, is fine as it is: it leaves `config.OVERRIDE.workflow` alone, so
+once it pops, lookups fall back to the adapter the class installed.
 
 The app built by `test_client` resolves its workflow once, during `lifespan`. pytest orders autouse
 fixtures by name, so `service` (and with it `test_client`) would otherwise run before


### PR DESCRIPTION
# Why

`backend-tests-component (other)` fails intermittently with every test of one `TestInfrahubApp` class erroring at setup on `These tests are currently meant to run with a local worker`: the `client` fixture finds a `WorkflowRecorder` on the app service instead of the `WorkflowLocalExecution` the class installs. Ten incidents on nine unrelated PRs over three weeks (`test_impact.py` mostly; on #10504 attempt 2 it was `test_get_kinds_lock.py`), always exactly one class, always green on rerun.

Two things make that possible:

- pytest orders class autouse fixtures alphabetically, so `service` (and with it `test_client`, which runs `lifespan`) executes before `workflow_local`. The app resolves its workflow during `lifespan` from whatever override the previous class on that xdist worker left behind, and the local one is installed only afterwards.
- Every fixture that swaps the adapter in does so through `dependency_provider.scope`, which pops its override instead of restoring the one it replaced, and, like the `config.OVERRIDE.workflow` write after the `yield`, is skipped when the fixture is finalised through an exception. A recorder left behind that way reaches the next class to build an app, whose own `workflow_local` exit then pops it again, which is why exactly one class fails per incident and everything after it passes.

Goal: the app is always built under the override it is asserted against, and no fixture can leave a workflow double behind.

Non-goals: no change to which adapter any existing class runs with, no change to the Prefect test servers.

## What changed

- `tests/helpers/workflow_override.py::override_workflow` sets both lookups (`config.OVERRIDE.workflow` and the provider override for `build_workflow`) and restores the *previous* values in a `finally`. Unit tests cover the no-previous-override, nested, and exception paths.
- All fourteen fixtures that swapped the adapter in by hand now go through it (`test_app.py` ×2, `component/conftest.py` ×2, `component/api/conftest.py`, `proposed_change/conftest.py`, `computed_attribute/_base.py`, `component/proposed_change/test_merge_selective_regen.py`, the five `component/proposed_change/test_*.py` modules that carried their own copy of the recorder fixture, and the two integration copies). Net −54 lines. The `dependency_provider.scope(build_workflow, …)` blocks that open and close around a single call stay as they are: they never touch `config.OVERRIDE.workflow`, so nothing outlives the test.
- `TestInfrahubApp.service` depends on `workflow_local`, so `test_client` builds the app after the local workflow is installed. The recorder-based bases (`ArtifactRegenTestBase`, `ScopedRecomputeTestBase`) keep their current ordering on purpose: their app service was never the recorder, and changing that would change what those tests exercise.
- `dev/knowledge/backend/testing.md` gets a section on the helper and the ordering rule.

## How to review

The full analysis, with the per-incident worker histories, is in the discussion on #10504. Locally, the recorder bases, `test_impact` and an `api` client class pass in one process (`uv run pytest backend/tests/component/proposed_change/test_artifact_regen_edge_cases.py backend/tests/component/core/regeneration/test_impact.py backend/tests/component/computed_attribute/test_scoped_recompute_python.py backend/tests/component/api/test_11_artifact.py --neo4j`, 17 passed), and the five converted proposed-change modules pass on their own (32 passed). The exact leak trigger (which finalisation skips the restore) is not pinned; the fix removes both the window and the pop-not-restore behaviour, so it holds whatever the trigger is.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


