### PR TITLE
refactor(regeneration): field-level impact resolution as a DI component (IFC-3067)

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -577,7 +577,9 @@ async def _build_post_merge_regeneration_dispatcher(
     generator_output = GeneratorCascadeOutput(capturer=output_capturer)
     return PostMergeRegenerationDispatcher(
         workflow=get_workflow(),
-        planner=build_merge_selective_regeneration(client=get_client(), log=log, generator_output=generator_output),
+        planner=build_merge_selective_regeneration(
+            db=db, client=get_client(), log=log, generator_output=generator_output
+        ),
         summary_cache=DiffSummaryCache(
             cache=await get_cache(), serializer=DiffSummarySerializer(), key_namespace="branch_merge"
         ),

--- a/backend/infrahub/core/merge/selective_regen/definition_selector/base.py
+++ b/backend/infrahub/core/merge/selective_regen/definition_selector/base.py
@@ -108,10 +108,11 @@ class DefinitionSelectorBase[DefinitionT: DefinitionModel, RequestT](ABC):
             member_ids = await self._fetch_member_ids(definition=definition, target_branch=target_branch)
             impacted: list[str] = []
             if not regenerate_all_members:
+                # The merge target branch is the branch the definition's query is analysed against.
                 selection = await self.impacted_resolver.resolve(
                     query_payload=definition.query_payload,
                     diff_summary=diff_summary,
-                    target_branch=target_branch,
+                    query_branch=target_branch,
                     subscriber_kind=self.subscriber_kind,
                     every_target=list(subscriber_by_member.values()),
                 )

--- a/backend/infrahub/core/merge/selective_regen/impacted.py
+++ b/backend/infrahub/core/merge/selective_regen/impacted.py
@@ -1,38 +1,26 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from infrahub_sdk.diff import NodeDiff
 
-    from infrahub.core.regeneration.impact import FieldLevelImpactResolver
     from infrahub.core.regeneration.models import TargetSelection
 
 
-class ImpactedSubscriberResolver:
+class ImpactedSubscriberResolver(Protocol):
     """Resolve the subscribers whose queried fields a diff changed.
 
-    A seam rather than a translation: it forwards to the shared resolver under the merge's branch
-    vocabulary, so a selector can be driven with a canned selection instead of a live query analysis
-    and database.
+    A selector depends on this so it can be driven with a canned selection instead of a live query
+    analysis and database.
     """
-
-    def __init__(self, resolver: FieldLevelImpactResolver) -> None:
-        self.resolver = resolver
 
     async def resolve(
         self,
         *,
         query_payload: str,
         diff_summary: list[NodeDiff],
-        target_branch: str,
+        query_branch: str,
         subscriber_kind: str,
         every_target: list[str],
-    ) -> TargetSelection:
-        return await self.resolver.resolve(
-            query_payload=query_payload,
-            diff_summary=diff_summary,
-            query_branch=target_branch,
-            subscriber_kind=subscriber_kind,
-            every_target=every_target,
-        )
+    ) -> TargetSelection: ...

--- a/backend/infrahub/core/merge/selective_regen/impacted.py
+++ b/backend/infrahub/core/merge/selective_regen/impacted.py
@@ -2,24 +2,23 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub.core.regeneration.impact import get_field_level_impacted_subscribers
-
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
+    from infrahub.core.regeneration.impact import FieldLevelImpactResolver
     from infrahub.core.regeneration.models import TargetSelection
 
 
 class ImpactedSubscriberResolver:
     """Resolve the subscribers whose queried fields a diff changed.
 
-    A seam rather than a translation: it holds the client and forwards, so a selector can be driven
-    with a canned selection instead of a live query analysis and database.
+    A seam rather than a translation: it forwards to the shared resolver under the merge's branch
+    vocabulary, so a selector can be driven with a canned selection instead of a live query analysis
+    and database.
     """
 
-    def __init__(self, client: InfrahubClient) -> None:
-        self.client = client
+    def __init__(self, resolver: FieldLevelImpactResolver) -> None:
+        self.resolver = resolver
 
     async def resolve(
         self,
@@ -30,11 +29,10 @@ class ImpactedSubscriberResolver:
         subscriber_kind: str,
         every_target: list[str],
     ) -> TargetSelection:
-        return await get_field_level_impacted_subscribers(
+        return await self.resolver.resolve(
             query_payload=query_payload,
             diff_summary=diff_summary,
             query_branch=target_branch,
             subscriber_kind=subscriber_kind,
             every_target=every_target,
-            client=self.client,
         )

--- a/backend/infrahub/core/merge/selective_regen/orchestrator.py
+++ b/backend/infrahub/core/merge/selective_regen/orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 from infrahub.core import registry
+from infrahub.core.regeneration.impact import FieldLevelImpactResolver
 from infrahub.core.regeneration.profiles import SchemaProfileExpander
 from infrahub.proposed_change.branch_diff import get_modified_kinds
 
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.diff import NodeDiff
 
     from infrahub.core.regeneration.profiles import ModifiedKindsExpander
+    from infrahub.database import InfrahubDatabase
 
     from .models import CascadeSourceOutput, DefinitionModel, FullRegeneration, RegenerationRequest
     from .participant import CascadeParticipant
@@ -135,6 +137,7 @@ class MergeSelectiveRegeneration(RegenerationPlanner):
 
 def build_merge_selective_regeneration(
     *,
+    db: InfrahubDatabase,
     client: InfrahubClient,
     log: logging.Logger | logging.LoggerAdapter[logging.Logger],
     generator_output: CascadeSourceOutput[Any],
@@ -146,7 +149,7 @@ def build_merge_selective_regeneration(
     its output capture is built once at the composition root and injected here.
     """
     gate = DefinitionGate(log=log)
-    impacted_resolver = ImpactedSubscriberResolver(client=client)
+    impacted_resolver = ImpactedSubscriberResolver(resolver=FieldLevelImpactResolver(db=db, client=client))
     return MergeSelectiveRegeneration(
         participants=[
             CascadeSource(

--- a/backend/infrahub/core/merge/selective_regen/orchestrator.py
+++ b/backend/infrahub/core/merge/selective_regen/orchestrator.py
@@ -11,7 +11,6 @@ from .definition_selector.artifact_selector import ArtifactSelector
 from .definition_selector.generator_selector import GeneratorSelector
 from .fallbacks import repositories_forcing_full_regeneration
 from .gate import DefinitionGate
-from .impacted import ImpactedSubscriberResolver
 from .models import CascadeRole, PlannedRegeneration, SelectiveRegenerationPlan
 from .participant import CascadeSource, CascadeTerminal
 
@@ -149,7 +148,7 @@ def build_merge_selective_regeneration(
     its output capture is built once at the composition root and injected here.
     """
     gate = DefinitionGate(log=log)
-    impacted_resolver = ImpactedSubscriberResolver(resolver=FieldLevelImpactResolver(db=db, client=client))
+    impacted_resolver = FieldLevelImpactResolver(db=db, client=client)
     return MergeSelectiveRegeneration(
         participants=[
             CascadeSource(

--- a/backend/infrahub/core/regeneration/classifier_builder.py
+++ b/backend/infrahub/core/regeneration/classifier_builder.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
-from .derived_dependencies import DerivedFieldDependencyResolver
 from .impact_classifier import QueryImpactClassifier
 from .models import ReachedPath
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.graphql.analyzer import ObjectAccess
 
-    from .derived_dependencies import DerivedFieldDependencies
+    from .derived_dependencies import DerivedFieldDependencies, DerivedFieldDependencyResolver
 
 
 class AnalyzedQuery(Protocol):
@@ -40,9 +38,9 @@ class AnalyzedQuery(Protocol):
 class QueryClassifierBuilder:
     """Build a query's impact classifier from its analyzed read surface, on one branch."""
 
-    def __init__(self, *, query_branch: str, schema_branch: SchemaBranch) -> None:
+    def __init__(self, *, query_branch: str, dependency_resolver: DerivedFieldDependencyResolver) -> None:
         self._query_branch = query_branch
-        self._dependency_resolver = DerivedFieldDependencyResolver(schema_branch=schema_branch)
+        self._dependency_resolver = dependency_resolver
 
     def build(self, query_report: AnalyzedQuery) -> QueryImpactClassifier:
         readable_fields_by_kind = {kind: access.fields for kind, access in query_report.requested_read.items()}

--- a/backend/infrahub/core/regeneration/derived_dependencies.py
+++ b/backend/infrahub/core/regeneration/derived_dependencies.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, assert_never
+from typing import TYPE_CHECKING, Protocol, assert_never
 
 from infrahub.core.schema.derived_path import (
     DerivedPathResolver,
@@ -50,16 +50,20 @@ class DerivedFieldDependencies:
     widen: bool
 
 
-class DerivedFieldDependencyResolver:
+class DerivedFieldDependencyResolver(Protocol):
     """Resolve the peer kinds a query's display_label / human_friendly_id reads depend on.
 
     A derived value can be composed from a related node's field, so a change to that peer moves the
-    value while the peer's kind is never named in the query's read surface. This walks each derived
-    field's declared paths, following relationships to the kind that owns the backing attribute, and
-    reports the relationship chain that maps a changed peer back to the reading member. A read built
-    only from the reading kind's own attributes yields no peer -- the imprecise-read rule already
-    covers a same-kind change -- and anything that cannot be resolved sets ``widen``.
+    value while the peer's kind is never named in the query's read surface. A read built only from the
+    reading kind's own attributes yields no peer -- the imprecise-read rule already covers a same-kind
+    change -- and anything that cannot be resolved sets ``widen``.
     """
+
+    def resolve(self, readable_fields_by_kind: Mapping[str, set[str]]) -> DerivedFieldDependencies: ...
+
+
+class SchemaDerivedFieldDependencyResolver(DerivedFieldDependencyResolver):
+    """Resolve derived-field peers by walking each field's declared paths through the schema branch."""
 
     def __init__(self, schema_branch: SchemaBranch) -> None:
         self.schema_branch = schema_branch

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -10,6 +10,7 @@ from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
 
 from .classifier_builder import QueryClassifierBuilder
+from .derived_dependencies import DerivedFieldDependencyResolver
 from .impact_classifier import ChangedNodes, EveryTarget, RelationshipReachedChanges
 from .models import TargetSelection
 
@@ -61,7 +62,8 @@ class FieldLevelImpactResolver:
             document=cached_parse(query_payload),
         ).query_report
 
-        classifier = QueryClassifierBuilder(query_branch=query_branch, schema_branch=query_schema_branch).build(
+        dependency_resolver = DerivedFieldDependencyResolver(schema_branch=query_schema_branch)
+        classifier = QueryClassifierBuilder(query_branch=query_branch, dependency_resolver=dependency_resolver).build(
             query_report
         )
         assessment = classifier.assess(diff_summary=diff_summary)

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, assert_never
 
 from infrahub.core import registry
 from infrahub.core.query_group.subscribers import fetch_subscriber_refs
-from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
+from infrahub.core.relationship.dependent_resolver import QueryDependentNodeResolver
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
-    from infrahub.core.relationship.dependent_resolver import DependentNodeResolverInterface
+    from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
     from infrahub.database import InfrahubDatabase
 
 
@@ -72,7 +72,7 @@ class FieldLevelImpactResolver:
             case ChangedNodes(node_ids=node_ids):
                 member_ids = node_ids
             case RelationshipReachedChanges():
-                dependent_resolver = DependentNodeResolver(db=self.db, branch=query_branch_obj)
+                dependent_resolver = QueryDependentNodeResolver(db=self.db, branch=query_branch_obj)
                 member_ids = sorted(await ReachedMemberResolver(resolver=dependent_resolver).resolve(assessment))
             case _ as unreachable:
                 assert_never(unreachable)
@@ -90,7 +90,7 @@ class ReachedMemberResolver:
     resolved member set is a superset too.
     """
 
-    def __init__(self, *, resolver: DependentNodeResolverInterface) -> None:
+    def __init__(self, *, resolver: DependentNodeResolver) -> None:
         self.resolver = resolver
 
     async def resolve(self, changes: RelationshipReachedChanges) -> set[str]:

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -8,7 +8,6 @@ from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.workers.dependencies import get_database
 
 from .classifier_builder import QueryClassifierBuilder
 from .impact_classifier import ChangedNodes, EveryTarget, RelationshipReachedChanges
@@ -19,59 +18,68 @@ if TYPE_CHECKING:
     from infrahub_sdk.diff import NodeDiff
 
     from infrahub.core.relationship.dependent_resolver import DependentNodeResolverInterface
+    from infrahub.database import InfrahubDatabase
 
 
-async def get_field_level_impacted_subscribers(
-    query_payload: str,
-    diff_summary: list[NodeDiff],
-    query_branch: str,
-    subscriber_kind: str,
-    every_target: list[str],
-    client: InfrahubClient,
-) -> TargetSelection:
-    """Map data changes on `query_branch` to the subscribers a GraphQL query depends on.
+class FieldLevelImpactResolver:
+    """Map data changes on a branch to the subscribers a GraphQL query depends on.
 
     A change matters only when a modified field is one the query reads. The query analysis,
-    the diff-summary tag and the subscriber lookup all run on `query_branch`, so the caller
-    passes the branch the changed data lives on (a proposed change's source branch, a merge's
+    the diff-summary tag and the subscriber lookup all run on the branch passed to `resolve`, so the
+    caller passes the branch the changed data lives on (a proposed change's source branch, a merge's
     target branch).
-
-    `every_target` is the fallback when a change cannot be traced to specific subscribers;
-    taking it as an argument keeps "process everything" out of the return type, so the caller
-    always gets one authoritative list.
     """
-    db = await get_database()
-    query_schema_branch = registry.schema.get_schema_branch(name=query_branch)
-    query_branch_obj = registry.get_branch_from_registry(branch=query_branch)
 
-    graphql_params = await prepare_graphql_params(db=db, branch=query_branch)
-    query_report = InfrahubGraphQLQueryAnalyzer(
-        query=query_payload,
-        branch=query_branch_obj,
-        schema_branch=query_schema_branch,
-        schema=graphql_params.schema,
-        document=cached_parse(query_payload),
-    ).query_report
+    def __init__(self, db: InfrahubDatabase, client: InfrahubClient) -> None:
+        self.db = db
+        self.client = client
 
-    classifier = QueryClassifierBuilder(query_branch=query_branch, schema_branch=query_schema_branch).build(
-        query_report
-    )
-    assessment = classifier.assess(diff_summary=diff_summary)
+    async def resolve(
+        self,
+        *,
+        query_payload: str,
+        diff_summary: list[NodeDiff],
+        query_branch: str,
+        subscriber_kind: str,
+        every_target: list[str],
+    ) -> TargetSelection:
+        """Return the subscribers a change implicates, widening to `every_target` when it cannot narrow.
 
-    match assessment:
-        case EveryTarget():
-            return TargetSelection(ids=every_target, widened=True)
-        case ChangedNodes(node_ids=node_ids):
-            member_ids = node_ids
-        case RelationshipReachedChanges():
-            dependent_resolver = DependentNodeResolver(db=db, branch=query_branch_obj)
-            member_ids = sorted(await ReachedMemberResolver(resolver=dependent_resolver).resolve(assessment))
-        case _ as unreachable:
-            assert_never(unreachable)
+        `every_target` is the fallback when a change cannot be traced to specific subscribers;
+        taking it as an argument keeps "process everything" out of the return type, so the caller
+        always gets one authoritative list.
+        """
+        query_schema_branch = registry.schema.get_schema_branch(name=query_branch)
+        query_branch_obj = registry.get_branch_from_registry(branch=query_branch)
 
-    subscribers = await fetch_subscriber_refs(client=client, node_ids=member_ids, branch=query_branch)
-    ids = [subscriber.id for subscriber in subscribers if subscriber.kind == subscriber_kind]
-    return TargetSelection(ids=ids, widened=False)
+        graphql_params = await prepare_graphql_params(db=self.db, branch=query_branch)
+        query_report = InfrahubGraphQLQueryAnalyzer(
+            query=query_payload,
+            branch=query_branch_obj,
+            schema_branch=query_schema_branch,
+            schema=graphql_params.schema,
+            document=cached_parse(query_payload),
+        ).query_report
+
+        classifier = QueryClassifierBuilder(query_branch=query_branch, schema_branch=query_schema_branch).build(
+            query_report
+        )
+        assessment = classifier.assess(diff_summary=diff_summary)
+
+        match assessment:
+            case EveryTarget():
+                return TargetSelection(ids=every_target, widened=True)
+            case ChangedNodes(node_ids=node_ids):
+                member_ids = node_ids
+            case RelationshipReachedChanges():
+                dependent_resolver = DependentNodeResolver(db=self.db, branch=query_branch_obj)
+                member_ids = sorted(await ReachedMemberResolver(resolver=dependent_resolver).resolve(assessment))
+            case _ as unreachable:
+                assert_never(unreachable)
+
+        subscribers = await fetch_subscriber_refs(client=self.client, node_ids=member_ids, branch=query_branch)
+        ids = [subscriber.id for subscriber in subscribers if subscriber.kind == subscriber_kind]
+        return TargetSelection(ids=ids, widened=False)
 
 
 class ReachedMemberResolver:

--- a/backend/infrahub/core/regeneration/impact.py
+++ b/backend/infrahub/core/regeneration/impact.py
@@ -10,7 +10,7 @@ from infrahub.graphql.execution import cached_parse
 from infrahub.graphql.initialization import prepare_graphql_params
 
 from .classifier_builder import QueryClassifierBuilder
-from .derived_dependencies import DerivedFieldDependencyResolver
+from .derived_dependencies import SchemaDerivedFieldDependencyResolver
 from .impact_classifier import ChangedNodes, EveryTarget, RelationshipReachedChanges
 from .models import TargetSelection
 
@@ -62,7 +62,7 @@ class FieldLevelImpactResolver:
             document=cached_parse(query_payload),
         ).query_report
 
-        dependency_resolver = DerivedFieldDependencyResolver(schema_branch=query_schema_branch)
+        dependency_resolver = SchemaDerivedFieldDependencyResolver(schema_branch=query_schema_branch)
         classifier = QueryClassifierBuilder(query_branch=query_branch, dependency_resolver=dependency_resolver).build(
             query_report
         )

--- a/backend/infrahub/core/relationship/dependent_resolver.py
+++ b/backend/infrahub/core/relationship/dependent_resolver.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-class DependentNodeResolverInterface(Protocol):
+class DependentNodeResolver(Protocol):
     """Resolve which nodes of a kind reference a set of peer nodes through a relationship.
 
     When a peer is changed it is present in a diff, but the nodes that reach it through a relationship
@@ -28,8 +28,8 @@ class DependentNodeResolverInterface(Protocol):
     ) -> set[str]: ...
 
 
-class DependentNodeResolver:
-    """Resolve which nodes of a kind reference peer nodes through a named relationship."""
+class QueryDependentNodeResolver(DependentNodeResolver):
+    """Resolve dependent nodes by traversing the relationship with a graph query."""
 
     def __init__(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> None:
         self.db = db

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -6,7 +6,7 @@ from infrahub.core.constants import RelationshipKind, SchemaPathType
 from infrahub.core.constants.schema import UpdateSupport
 from infrahub.core.models import SchemaUpdateConstraintInfo
 from infrahub.core.path import SchemaPath
-from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
+from infrahub.core.relationship.dependent_resolver import QueryDependentNodeResolver
 from infrahub.core.schema.attribute_parameters import AttributeParameters
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
@@ -283,7 +283,7 @@ def build_constraint_validator_determiner(
     """Wire a determiner with its node-diff index and uniqueness scoper for a single operation."""
     node_diff_index = NodeDiffIndex()
     uniqueness_scoper = UniquenessConstraintScoper(
-        dependent_resolver=DependentNodeResolver(db=db, branch=branch, at=at),
+        dependent_resolver=QueryDependentNodeResolver(db=db, branch=branch, at=at),
         node_diff_index=node_diff_index,
     )
     return ConstraintValidatorDeterminer(node_diff_index=node_diff_index, uniqueness_scoper=uniqueness_scoper)

--- a/backend/infrahub/core/validators/uniqueness/scope.py
+++ b/backend/infrahub/core/validators/uniqueness/scope.py
@@ -10,7 +10,7 @@ LOG = get_logger(__name__)
 
 if TYPE_CHECKING:
     from infrahub.core.constants import RelationshipDirection
-    from infrahub.core.relationship.dependent_resolver import DependentNodeResolverInterface
+    from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
     from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
@@ -71,7 +71,7 @@ class UniquenessConstraintScoper:
 
     def __init__(
         self,
-        dependent_resolver: DependentNodeResolverInterface,
+        dependent_resolver: DependentNodeResolver,
         node_diff_index: NodeDiffIndex,
     ) -> None:
         self.dependent_resolver = dependent_resolver

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -755,7 +755,6 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     log = get_run_logger()
     client = get_client()
     client.request_context = context.to_request_context()
-    impact_resolver = FieldLevelImpactResolver(db=await get_database(), client=client)
 
     artifact_definition = await client.get(
         kind=CoreArtifactDefinition,
@@ -811,13 +810,16 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    selection = await impact_resolver.resolve(
-        query_payload=model.artifact_definition.query_payload,
-        diff_summary=diff_summary,
-        query_branch=model.source_branch,
-        subscriber_kind=InfrahubKind.ARTIFACT,
-        every_target=list(artifacts_by_member.values()),
-    )
+    database = await get_database()
+    async with database.start_session() as db:
+        impact_resolver = FieldLevelImpactResolver(db=db, client=client)
+        selection = await impact_resolver.resolve(
+            query_payload=model.artifact_definition.query_payload,
+            diff_summary=diff_summary,
+            query_branch=model.source_branch,
+            subscriber_kind=InfrahubKind.ARTIFACT,
+            every_target=list(artifacts_by_member.values()),
+        )
     impacted_artifacts = selection.ids
     if selection.widened:
         log.warning(
@@ -1052,7 +1054,6 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     log = get_run_logger()
     client = get_client()
     client.request_context = context.to_request_context()
-    impact_resolver = FieldLevelImpactResolver(db=await get_database(), client=client)
 
     proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
@@ -1101,13 +1102,16 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     requested_instances = 0
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    selection = await impact_resolver.resolve(
-        query_payload=model.generator_definition.query_payload,
-        diff_summary=diff_summary,
-        query_branch=model.source_branch,
-        subscriber_kind=InfrahubKind.GENERATORINSTANCE,
-        every_target=list(instance_by_member.values()),
-    )
+    database = await get_database()
+    async with database.start_session() as db:
+        impact_resolver = FieldLevelImpactResolver(db=db, client=client)
+        selection = await impact_resolver.resolve(
+            query_payload=model.generator_definition.query_payload,
+            diff_summary=diff_summary,
+            query_branch=model.source_branch,
+            subscriber_kind=InfrahubKind.GENERATORINSTANCE,
+            every_target=list(instance_by_member.values()),
+        )
     definition_name = model.generator_definition.definition_name
     impacted_instances = selection.ids
     if selection.widened:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -49,7 +49,7 @@ from infrahub.core.merge.constraints import build_merge_constraint_result, gathe
 from infrahub.core.protocols import CoreDataCheck, CoreGenericAccount, CoreValidator
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.regeneration.definitions import GATHER_ARTIFACT_DEFINITIONS, parse_artifact_definitions
-from infrahub.core.regeneration.impact import get_field_level_impacted_subscribers
+from infrahub.core.regeneration.impact import FieldLevelImpactResolver
 from infrahub.core.regeneration.members import (
     map_subscriber_ids_by_member,
     run_generator,
@@ -755,6 +755,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     log = get_run_logger()
     client = get_client()
     client.request_context = context.to_request_context()
+    impact_resolver = FieldLevelImpactResolver(db=await get_database(), client=client)
 
     artifact_definition = await client.get(
         kind=CoreArtifactDefinition,
@@ -810,13 +811,12 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     repository = model.branch_diff.get_repository(repository_id=model.artifact_definition.repository_id)
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    selection = await get_field_level_impacted_subscribers(
+    selection = await impact_resolver.resolve(
         query_payload=model.artifact_definition.query_payload,
         diff_summary=diff_summary,
         query_branch=model.source_branch,
         subscriber_kind=InfrahubKind.ARTIFACT,
         every_target=list(artifacts_by_member.values()),
-        client=client,
     )
     impacted_artifacts = selection.ids
     if selection.widened:
@@ -1052,6 +1052,7 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     log = get_run_logger()
     client = get_client()
     client.request_context = context.to_request_context()
+    impact_resolver = FieldLevelImpactResolver(db=await get_database(), client=client)
 
     proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
@@ -1100,13 +1101,12 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     requested_instances = 0
 
     diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
-    selection = await get_field_level_impacted_subscribers(
+    selection = await impact_resolver.resolve(
         query_payload=model.generator_definition.query_payload,
         diff_summary=diff_summary,
         query_branch=model.source_branch,
         subscriber_kind=InfrahubKind.GENERATORINSTANCE,
         every_target=list(instance_by_member.values()),
-        client=client,
     )
     definition_name = model.generator_definition.definition_name
     impacted_instances = selection.ids

--- a/backend/tests/component/core/regeneration/test_impact.py
+++ b/backend/tests/component/core/regeneration/test_impact.py
@@ -6,7 +6,7 @@ import pytest
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
-from infrahub.core.regeneration.impact import get_field_level_impacted_subscribers
+from infrahub.core.regeneration.impact import FieldLevelImpactResolver
 from infrahub.core.regeneration.models import TargetSelection
 from tests.constants import TestKind
 from tests.helpers.diff_summary import node_diff
@@ -126,22 +126,23 @@ class TestFieldLevelImpact(TestInfrahubApp):
     async def _resolve(
         self,
         *,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
         diff_summary: list[NodeDiff],
     ) -> TargetSelection:
-        return await get_field_level_impacted_subscribers(
+        return await FieldLevelImpactResolver(db=db, client=client).resolve(
             query_payload=QUERY_CAR_WITH_OWNER,
             diff_summary=diff_summary,
             query_branch=default_branch.name,
             subscriber_kind=SUBSCRIBER_KIND,
             every_target=[dataset["subscriber_id"]],
-            client=client,
         )
 
     async def test_root_node_change_selects_subscriber(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
@@ -152,6 +153,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
         routing regenerates the definitions it was asked about and nothing else.
         """
         resolved = await self._resolve(
+            db=db,
             dataset=dataset,
             default_branch=default_branch,
             client=client,
@@ -168,6 +170,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
 
     async def test_display_label_backing_change_selects_subscriber(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
@@ -178,7 +181,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
         exact-name match would drop it and leave the artifact stale. The label is built from the
         car's own attributes, so the routing narrows to the car's subscriber rather than widening.
         """
-        resolved = await get_field_level_impacted_subscribers(
+        resolved = await FieldLevelImpactResolver(db=db, client=client).resolve(
             query_payload=QUERY_CAR_DISPLAY_LABEL,
             diff_summary=[
                 node_diff(
@@ -191,12 +194,12 @@ class TestFieldLevelImpact(TestInfrahubApp):
             query_branch=default_branch.name,
             subscriber_kind=SUBSCRIBER_KIND,
             every_target=[dataset["subscriber_id"]],
-            client=client,
         )
         assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)
 
     async def test_related_node_change_narrows_to_the_owning_member(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
@@ -208,6 +211,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
         selected -- not every member of the definition.
         """
         resolved = await self._resolve(
+            db=db,
             dataset=dataset,
             default_branch=default_branch,
             client=client,
@@ -224,6 +228,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
 
     async def test_unread_related_field_change_selects_nothing(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
@@ -234,6 +239,7 @@ class TestFieldLevelImpact(TestInfrahubApp):
         actually reads off the owner can implicate the cars that read it.
         """
         resolved = await self._resolve(
+            db=db,
             dataset=dataset,
             default_branch=default_branch,
             client=client,
@@ -352,6 +358,7 @@ class TestGenericOwnerFieldLevelImpact(TestInfrahubApp):
 
     async def test_generic_owner_reached_change_narrows_to_the_owning_member(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         client: InfrahubClient,
@@ -362,7 +369,7 @@ class TestGenericOwnerFieldLevelImpact(TestInfrahubApp):
         traversal keyed on the generic slot label reaches only the slot holding the changed card, and
         through it only the owning rack, so a single subscriber comes back.
         """
-        resolved = await get_field_level_impacted_subscribers(
+        resolved = await FieldLevelImpactResolver(db=db, client=client).resolve(
             query_payload=QUERY_RACK_WITH_CARD,
             diff_summary=[
                 node_diff(
@@ -375,6 +382,5 @@ class TestGenericOwnerFieldLevelImpact(TestInfrahubApp):
             query_branch=default_branch.name,
             subscriber_kind=TestKind.TAG,
             every_target=[dataset["subscriber_id"], dataset["other_subscriber_id"]],
-            client=client,
         )
         assert resolved == TargetSelection(ids=[dataset["subscriber_id"]], widened=False)

--- a/backend/tests/component/core/relationship/test_dependent_resolver.py
+++ b/backend/tests/component/core/relationship/test_dependent_resolver.py
@@ -6,7 +6,7 @@ from infrahub.core.constants import RelationshipCardinality, RelationshipDirecti
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.core.relationship.dependent_resolver import DependentNodeResolver
+from infrahub.core.relationship.dependent_resolver import QueryDependentNodeResolver
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.database import InfrahubDatabase
@@ -58,7 +58,7 @@ class TestDependentNodeResolver:
         person_john_main: Node,
         default_branch: Branch,
     ) -> None:
-        resolver = DependentNodeResolver(db=db, branch=default_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -74,7 +74,7 @@ class TestDependentNodeResolver:
     async def test_empty_peer_uuids_returns_empty(
         self, db: InfrahubDatabase, car_accord_main: Node, default_branch: Branch
     ) -> None:
-        resolver = DependentNodeResolver(db=db, branch=default_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -99,7 +99,7 @@ class TestDependentNodeResolver:
         await latecomer_car.new(db=db, name="latecomer", nbr_seats=2, is_electric=False, owner=person_john_main.id)
         await latecomer_car.save(db=db)
 
-        resolver = DependentNodeResolver(db=db, branch=feature_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=feature_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -127,7 +127,7 @@ class TestDependentNodeResolver:
         accord_on_main = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
         await accord_on_main.delete(db=db)
 
-        resolver = DependentNodeResolver(db=db, branch=input_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=input_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -152,7 +152,7 @@ class TestDependentNodeResolver:
         accord_on_branch = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=input_branch)
         await accord_on_branch.delete(db=db)
 
-        resolver = DependentNodeResolver(db=db, branch=input_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=input_branch)
 
         dependents = await resolver.resolve(
             node_kind="TestCar",
@@ -188,7 +188,7 @@ class TestDependentNodeResolverSelfReferential:
         self, db: InfrahubDatabase, default_branch: Branch, tree: dict[str, Node]
     ) -> None:
         """A change to `middle` implicates the node whose `parent` is `middle`, not `middle`'s parent."""
-        resolver = DependentNodeResolver(db=db, branch=default_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind=TREE_NODE_KIND,
@@ -203,7 +203,7 @@ class TestDependentNodeResolverSelfReferential:
         self, db: InfrahubDatabase, default_branch: Branch, tree: dict[str, Node]
     ) -> None:
         """The same edges seen from `children` implicate the node holding `middle` as a child."""
-        resolver = DependentNodeResolver(db=db, branch=default_branch)
+        resolver = QueryDependentNodeResolver(db=db, branch=default_branch)
 
         dependents = await resolver.resolve(
             node_kind=TREE_NODE_KIND,

--- a/backend/tests/component/proposed_change/test_merge_selective_regen.py
+++ b/backend/tests/component/proposed_change/test_merge_selective_regen.py
@@ -241,6 +241,7 @@ class TestMergeSelectiveRegenSelection(TestInfrahubAppWithoutLocalWorkflow):
 
     async def test_relevant_kind_change_selects_matching_definitions(
         self,
+        db: InfrahubDatabase,
         dataset: dict[str, Any],
         default_branch: Branch,
         admin_account: CoreAccount,
@@ -267,6 +268,7 @@ class TestMergeSelectiveRegenSelection(TestInfrahubAppWithoutLocalWorkflow):
         dispatcher = PostMergeRegenerationDispatcher(
             workflow=workflow_recorder,
             planner=build_merge_selective_regeneration(
+                db=db,
                 client=client,
                 log=logging.getLogger("test"),
                 generator_output=GeneratorCascadeOutput(capturer=capturer),

--- a/backend/tests/helpers/selective_regen.py
+++ b/backend/tests/helpers/selective_regen.py
@@ -64,15 +64,12 @@ class RejectingGate(DefinitionGate):
 class NoImpactResolver(ImpactedSubscriberResolver):
     """A resolver that reports no impacted subscribers."""
 
-    def __init__(self) -> None:
-        pass
-
     async def resolve(
         self,
         *,
         query_payload: str,
         diff_summary: list[NodeDiff],
-        target_branch: str,
+        query_branch: str,
         subscriber_kind: str,
         every_target: list[str],
     ) -> TargetSelection:

--- a/backend/tests/unit/core/merge/selective_regen/definition_selector/conftest.py
+++ b/backend/tests/unit/core/merge/selective_regen/definition_selector/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from infrahub_sdk import Config, InfrahubClient
@@ -8,7 +9,10 @@ from infrahub_sdk import Config, InfrahubClient
 from infrahub.core.merge.selective_regen.definition_selector.artifact_selector import ArtifactSelector
 from infrahub.core.merge.selective_regen.definition_selector.generator_selector import GeneratorSelector
 from infrahub.core.merge.selective_regen.gate import DefinitionGate
-from infrahub.core.merge.selective_regen.impacted import ImpactedSubscriberResolver
+from tests.helpers.selective_regen import NoImpactResolver
+
+if TYPE_CHECKING:
+    from infrahub.core.merge.selective_regen.impacted import ImpactedSubscriberResolver
 
 
 @pytest.fixture
@@ -27,8 +31,8 @@ def gate(log: logging.Logger) -> DefinitionGate:
 
 
 @pytest.fixture
-def impacted_resolver(client: InfrahubClient) -> ImpactedSubscriberResolver:
-    return ImpactedSubscriberResolver(client=client)
+def impacted_resolver() -> ImpactedSubscriberResolver:
+    return NoImpactResolver()
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
+++ b/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
@@ -11,6 +11,7 @@ from infrahub.core.merge.selective_regen.fallbacks import repositories_forcing_f
 from infrahub.core.merge.selective_regen.gate import DefinitionGate
 from infrahub.core.merge.selective_regen.impacted import ImpactedSubscriberResolver
 from infrahub.core.merge.selective_regen.models import GateResult, LoadedDefinition
+from infrahub.core.regeneration.members import run_generator
 from infrahub.core.regeneration.models import TargetSelection
 from infrahub.generators.models import ProposedChangeGeneratorDefinition, RequestGeneratorDefinitionRun
 
@@ -151,7 +152,9 @@ class _StubSelector(DefinitionSelectorBase[ProposedChangeGeneratorDefinition, Re
         return self._member_ids
 
     def _should_render(self, *, subscriber_id: str | None, regenerate_all_members: bool, impacted: list[str]) -> bool:
-        return not subscriber_id or regenerate_all_members or subscriber_id in impacted
+        return run_generator(
+            instance_id=subscriber_id, regenerate_all_members=regenerate_all_members, impacted_instances=impacted
+        )
 
     def _build_request(
         self, *, definition: ProposedChangeGeneratorDefinition, target_branch: str, members: list[str]

--- a/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
+++ b/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
@@ -152,6 +152,7 @@ class _StubSelector(DefinitionSelectorBase[ProposedChangeGeneratorDefinition, Re
         return self._member_ids
 
     def _should_render(self, *, subscriber_id: str | None, regenerate_all_members: bool, impacted: list[str]) -> bool:
+        # Production code behavior
         return run_generator(
             instance_id=subscriber_id, regenerate_all_members=regenerate_all_members, impacted_instances=impacted
         )

--- a/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
+++ b/backend/tests/unit/core/merge/selective_regen/definition_selector/test_base.py
@@ -102,7 +102,7 @@ class _StubImpactedResolver(ImpactedSubscriberResolver):
         *,
         query_payload: str,
         diff_summary: list[NodeDiff],
-        target_branch: str,
+        query_branch: str,
         subscriber_kind: str,
         every_target: list[str],
     ) -> TargetSelection:

--- a/backend/tests/unit/core/regeneration/test_classifier_builder.py
+++ b/backend/tests/unit/core/regeneration/test_classifier_builder.py
@@ -8,8 +8,8 @@ from infrahub.core.constants import RelationshipCardinality, RelationshipDirecti
 from infrahub.core.regeneration.classifier_builder import QueryClassifierBuilder
 from infrahub.core.regeneration.derived_dependencies import (
     DerivedFieldDependencies,
-    DerivedFieldDependencyResolver,
     PeerDependency,
+    SchemaDerivedFieldDependencyResolver,
 )
 from infrahub.core.regeneration.impact_classifier import QueryImpactClassifier
 from infrahub.core.regeneration.models import ReachedPath, RelationshipHop
@@ -72,7 +72,7 @@ def _builder() -> QueryClassifierBuilder:
     branch = SchemaBranch(cache={}, name="test")
     for kind, schema in schemas.items():
         branch.set(name=kind, schema=schema)
-    resolver = DerivedFieldDependencyResolver(schema_branch=branch)
+    resolver = SchemaDerivedFieldDependencyResolver(schema_branch=branch)
     return QueryClassifierBuilder(query_branch=QUERY_BRANCH, dependency_resolver=resolver)
 
 

--- a/backend/tests/unit/core/regeneration/test_classifier_builder.py
+++ b/backend/tests/unit/core/regeneration/test_classifier_builder.py
@@ -6,7 +6,11 @@ import pytest
 
 from infrahub.core.constants import RelationshipCardinality, RelationshipDirection, RelationshipKind
 from infrahub.core.regeneration.classifier_builder import QueryClassifierBuilder
-from infrahub.core.regeneration.derived_dependencies import DerivedFieldDependencies, PeerDependency
+from infrahub.core.regeneration.derived_dependencies import (
+    DerivedFieldDependencies,
+    DerivedFieldDependencyResolver,
+    PeerDependency,
+)
 from infrahub.core.regeneration.impact_classifier import QueryImpactClassifier
 from infrahub.core.regeneration.models import ReachedPath, RelationshipHop
 from infrahub.core.schema import AttributeSchema, MainSchemaTypes, NodeSchema, RelationshipSchema
@@ -68,7 +72,8 @@ def _builder() -> QueryClassifierBuilder:
     branch = SchemaBranch(cache={}, name="test")
     for kind, schema in schemas.items():
         branch.set(name=kind, schema=schema)
-    return QueryClassifierBuilder(query_branch=QUERY_BRANCH, schema_branch=branch)
+    resolver = DerivedFieldDependencyResolver(schema_branch=branch)
+    return QueryClassifierBuilder(query_branch=QUERY_BRANCH, dependency_resolver=resolver)
 
 
 def test_build_folds_a_derived_peer_into_the_classifier() -> None:

--- a/backend/tests/unit/core/regeneration/test_derived_dependencies.py
+++ b/backend/tests/unit/core/regeneration/test_derived_dependencies.py
@@ -7,8 +7,8 @@ import pytest
 
 from infrahub.core.constants import RelationshipCardinality, RelationshipDirection, RelationshipKind
 from infrahub.core.regeneration.derived_dependencies import (
-    DerivedFieldDependencyResolver,
     PeerDependency,
+    SchemaDerivedFieldDependencyResolver,
 )
 from infrahub.core.regeneration.models import ReachedPath, RelationshipHop
 from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema
@@ -281,7 +281,7 @@ RESOLVE_CASES = [
 @pytest.mark.parametrize("case", RESOLVE_CASES, ids=lambda case: case.name)
 def test_resolve(case: ResolveCase) -> None:
     schemas: dict[str, MainSchemaTypes] = {**BASE_SCHEMAS, "TestReader": case.reader, **case.extra_schemas}
-    resolver = DerivedFieldDependencyResolver(schema_branch=_schema_branch(schemas))
+    resolver = SchemaDerivedFieldDependencyResolver(schema_branch=_schema_branch(schemas))
 
     dependencies = resolver.resolve(case.readable_fields_by_kind)
 


### PR DESCRIPTION
## Summary

Makes field-level impact resolution a dependency-injected component and tidies the surrounding regeneration/merge seams. Structural refactor — behavior unchanged.

## Changes

- **`FieldLevelImpactResolver`** (`core/regeneration/impact.py`): `db` + `client` injected at construction, `resolve()` takes the per-call payload — replacing the `get_field_level_impacted_subscribers` free function that reached the database through a global. Built at each entry point (the merge factory and the artifact/generator validation flows) and delegated to.
- **Impacted-subscriber seam** (`selective_regen/impacted.py`): selectors depend on an `ImpactedSubscriberResolver` `Protocol` that `FieldLevelImpactResolver` satisfies directly; test doubles implement it structurally instead of subclassing the concrete resolver.
- **Dependent-node resolver seam**: `DependentNodeResolver` `Protocol` + `QueryDependentNodeResolver` implementation, aligned across `core/relationship/` and `core/validators/`.

## Validation

`/pre-ci` green — ruff, ty, mypy, generated-file / schema / generated-doc validation (no drift), frontend lint, 2554 backend unit tests.

Ref: IFC-3067


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
