### PR TITLE
fix: report per-member outcomes when a generator definition run fails (closes #10199)

### DIFF
--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -256,6 +256,11 @@ async def request_generator_definition_run(
 
     # Let every member run and report each outcome, rather than aborting on the first failure.
     results = await asyncio.gather(*tasks, return_exceptions=True)
+    # A cancelled member is a BaseException, not an Exception, so propagate the cancellation
+    # instead of letting it slip past the failure filter below and count as a success.
+    for result in results:
+        if isinstance(result, asyncio.CancelledError):
+            raise result
     failures = [
         (target_id, target_name, result)
         for (target_id, target_name), result in zip(members, results, strict=True)

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
-from infrahub_sdk.exceptions import ModuleImportError
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import CoreGeneratorInstance
 from infrahub_sdk.schema.repository import InfrahubGeneratorDefinitionConfig
@@ -91,7 +90,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         )
         await generator.run(identifier=generator_definition.name)
         generator_instance.status.value = GeneratorInstanceStatus.READY.value
-    except (ModuleImportError, Exception):
+    except Exception:
         generator_instance.status.value = GeneratorInstanceStatus.ERROR.value
         await generator_instance.update(do_full_update=True)
         raise
@@ -227,6 +226,7 @@ async def request_generator_definition_run(
         )
 
     tasks: list[Coroutine[Any, Any, Any]] = []
+    members: list[tuple[str, str]] = []
     for relationship in group.members.peers:
         member = relationship.peer
 
@@ -247,14 +247,26 @@ async def request_generator_definition_run(
             target_id=member.id,
             target_name=member.display_label,
         )
+        members.append((request_generator_run_model.target_id, request_generator_run_model.target_name))
         tasks.append(
             get_workflow().execute_workflow(
                 workflow=REQUEST_GENERATOR_RUN, context=context, parameters={"model": request_generator_run_model}
             )
         )
 
-    try:
-        await asyncio.gather(*tasks)
+    # Let every member run and report each outcome, rather than aborting on the first failure.
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    failures = [
+        (target_id, target_name, result)
+        for (target_id, target_name), result in zip(members, results, strict=True)
+        if isinstance(result, Exception)
+    ]
+    if not failures:
         return Completed(message=f"Successfully run {len(tasks)} generators")
-    except Exception as exc:
-        return Failed(message="One or more generators failed", error=exc)
+
+    succeeded = len(results) - len(failures)
+    details = "; ".join(f"{target_name} ({target_id}): {error}" for target_id, target_name, error in failures)
+    return Failed(
+        message=f"{len(failures)} of {len(results)} generators failed, {succeeded} succeeded: {details}",
+        error=ExceptionGroup("generator run failures", [error for *_, error in failures]),
+    )

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -273,5 +273,5 @@ async def request_generator_definition_run(
     details = "; ".join(f"{target_name} ({target_id}): {error}" for target_id, target_name, error in failures)
     return Failed(
         message=f"{len(failures)} of {len(results)} generators failed, {succeeded} succeeded: {details}",
-        error=ExceptionGroup("generator run failures", [error for *_, error in failures]),
+        data=ExceptionGroup("generator run failures", [error for *_, error in failures]),
     )

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -254,5 +254,7 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
         # The result names the one failed member and its error, reporting the healthy member as
         # succeeded, rather than collapsing into an opaque failure.
         assert state.is_failed()
-        failure_detail = f"{_FAILING_MEMBER} ({dataset[_FAILING_ID]}): {_member_failure_message(_FAILING_MEMBER)}"
-        assert state.message == f"1 of 2 generators failed, 1 succeeded: {failure_detail}"
+        assert state.message == (
+            "1 of 2 generators failed, 1 succeeded: "
+            f"member-beta ({dataset[_FAILING_ID]}): generator run failed for member-beta"
+        )

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub import config
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import BranchContext, InfrahubContext
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.generators.models import (
+    ProposedChangeGeneratorDefinition,
+    RequestGeneratorDefinitionRun,
+    RequestGeneratorRun,
+)
+from infrahub.generators.tasks import request_generator_definition_run
+from infrahub.server import app
+from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workflows.catalogue import REQUEST_GENERATOR_RUN
+from tests.adapters.workflow import WorkflowRecorder
+from tests.constants.kind import TAG as TAG_KIND
+from tests.helpers.schema import load_schema
+from tests.helpers.schema.tag import TAG
+from tests.helpers.test_app import TestInfrahubAppBase
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from fast_depends import Provider
+
+    from infrahub.context import EventContext
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+    from infrahub.workflows.constants import WorkflowPriority
+    from infrahub.workflows.models import WorkflowDefinition
+    from tests.helpers.test_client import InfrahubTestClient
+
+TAG_QUERY = f"""
+query GetGenTag($ids: [ID!]!) {{
+    {TAG_KIND}(ids: $ids) {{
+        edges {{ node {{ name {{ value }} }} }}
+    }}
+}}
+"""
+
+TAG_SCHEMA = SchemaRoot(nodes=[TAG])
+
+_HEALTHY_MEMBER = "member-alpha"
+_FAILING_MEMBER = "member-beta"
+
+_DEFINITION_ID = "definition_id"
+_REPOSITORY_ID = "repository_id"
+_GROUP_ID = "group_id"
+_QUERY_ID = "query_id"
+_HEALTHY_ID = "healthy_id"
+_FAILING_ID = "failing_id"
+
+
+def _member_failure_message(target_name: str) -> str:
+    return f"generator run failed for {target_name}"
+
+
+class WorkflowRecorderFailingMember(WorkflowRecorder):
+    """Records every workflow call and raises for the generator runs whose target is selected to fail.
+
+    Simulates a single target-group member's generator run raising while the others succeed, without
+    running the real generator body.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failing_target_ids: set[str] = set()
+
+    async def execute_workflow(
+        self,
+        workflow: WorkflowDefinition,
+        expected_return: type | None = None,
+        context: InfrahubContext | EventContext | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+        priority: WorkflowPriority | None = None,
+    ) -> Any:
+        result = await super().execute_workflow(
+            workflow=workflow,
+            expected_return=expected_return,
+            context=context,
+            parameters=parameters,
+            tags=tags,
+            priority=priority,
+        )
+        if workflow == REQUEST_GENERATOR_RUN:
+            model = (parameters or {})["model"]
+            if isinstance(model, RequestGeneratorRun) and model.target_id in self.failing_target_ids:
+                raise RuntimeError(_member_failure_message(model.target_name))
+        return result
+
+
+class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
+    """One member failing must be reported per-member, not collapsed into an opaque failure.
+
+    When a target-group member's generator run raises, the definition run's result must identify which
+    member failed, so a single misbehaving target is distinguishable from every target failing.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_recorder(
+        self,
+        prefect: Generator[str, None, None],
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[WorkflowRecorderFailingMember, None]:
+        original = config.OVERRIDE.workflow
+        recorder = WorkflowRecorderFailingMember()
+        config.OVERRIDE.workflow = recorder
+        with dependency_provider.scope(build_workflow, lambda: recorder):
+            yield recorder
+        config.OVERRIDE.workflow = original
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+    @pytest.fixture(scope="class")
+    async def client(
+        self,
+        test_client: InfrahubTestClient,
+        api_admin_token: str,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[InfrahubClient, None]:
+        sdk_client = InfrahubClient(
+            config=Config(
+                api_token=api_admin_token,
+                requester=test_client.async_request,
+                sync_requester=test_client.sync_request,
+                schema_converge_timeout=5,
+            )
+        )
+        original_client = service._client
+        service._client = sdk_client
+        with dependency_provider.scope(build_client, lambda: sdk_client):
+            yield sdk_client
+        service._client = original_client
+
+    @pytest.fixture(autouse=True)
+    def clear_recorder(self, workflow_recorder: WorkflowRecorderFailingMember) -> None:
+        workflow_recorder.reset()
+
+    def _context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext(
+            branch=BranchContext(name=default_branch.name),
+            account=AccountSession(account_id=account.id, auth_type=AuthType.API),
+        )
+
+    @pytest.fixture(scope="class")
+    async def dataset(self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient) -> dict[str, Any]:
+        await load_schema(db=db, schema=TAG_SCHEMA, update_db=True)
+
+        healthy = await Node.init(db=db, schema=TAG_KIND)
+        await healthy.new(db=db, name=_HEALTHY_MEMBER)
+        await healthy.save(db=db)
+        failing = await Node.init(db=db, schema=TAG_KIND)
+        await failing.new(db=db, name=_FAILING_MEMBER)
+        await failing.save(db=db)
+
+        repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await repo.new(
+            db=db,
+            name="gen-member-repo",
+            location="https://github.com/test/gen-member.git",
+            commit="1234567890abcdef1234567890abcdef12345678",
+        )
+        await repo.save(db=db)
+
+        query = await Node.init(db=db, schema=InfrahubKind.GRAPHQLQUERY)
+        await query.new(db=db, name="GetGenTag", query=TAG_QUERY, models=[TAG_KIND])
+        await query.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await group.new(db=db, name="member-targets", members=[healthy, failing])
+        await group.save(db=db)
+
+        gendef = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION)
+        await gendef.new(
+            db=db,
+            name="tag-generator",
+            query=query,
+            repository=repo,
+            targets=group,
+            file_path="generators/tag.py",
+            class_name="TagGenerator",
+            parameters={"value": {"name": "name__value"}},
+        )
+        await gendef.save(db=db)
+
+        return {
+            _DEFINITION_ID: gendef.id,
+            _REPOSITORY_ID: repo.id,
+            _GROUP_ID: group.id,
+            _QUERY_ID: query.id,
+            _HEALTHY_ID: healthy.id,
+            _FAILING_ID: failing.id,
+        }
+
+    def _model(self, dataset: dict[str, Any], branch: str) -> RequestGeneratorDefinitionRun:
+        return RequestGeneratorDefinitionRun(
+            branch=branch,
+            generator_definition=ProposedChangeGeneratorDefinition(
+                definition_id=dataset[_DEFINITION_ID],
+                definition_name="tag-generator",
+                class_name="TagGenerator",
+                file_path="generators/tag.py",
+                query_name="GetGenTag",
+                query_id=dataset[_QUERY_ID],
+                query_models=[TAG_KIND],
+                query_payload=TAG_QUERY,
+                repository_id=dataset[_REPOSITORY_ID],
+                parameters={"name": "name__value"},
+                group_id=dataset[_GROUP_ID],
+                convert_query_response=False,
+                execute_in_proposed_change=False,
+                execute_after_merge=True,
+            ),
+        )
+
+    async def test_failing_member_is_named_in_the_run_result(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.failing_target_ids = {dataset[_FAILING_ID]}
+
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Both members are dispatched, so the failure is one target's, not the definition's.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+        # The result names the one failed member and its error, reporting the healthy member as
+        # succeeded, rather than collapsing into an opaque failure.
+        assert state.is_failed()
+        failure_detail = f"{_FAILING_MEMBER} ({dataset[_FAILING_ID]}): {_member_failure_message(_FAILING_MEMBER)}"
+        assert state.message == f"1 of 2 generators failed, 1 succeeded: {failure_detail}"

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -67,15 +68,21 @@ def _member_failure_message(target_name: str) -> str:
 
 
 class WorkflowRecorderFailingMember(WorkflowRecorder):
-    """Records every workflow call and raises for the generator runs whose target is selected to fail.
+    """Records every workflow call and raises for the generator runs whose target is selected to fail or cancel.
 
-    Simulates a single target-group member's generator run raising while the others succeed, without
-    running the real generator body.
+    Simulates individual target-group members' generator runs raising while the others succeed, without
+    running the real generator body. A selected member either raises an ordinary error or is cancelled.
     """
 
     def __init__(self) -> None:
         super().__init__()
         self.failing_target_ids: set[str] = set()
+        self.cancelled_target_ids: set[str] = set()
+
+    def reset(self) -> None:
+        super().reset()
+        self.failing_target_ids = set()
+        self.cancelled_target_ids = set()
 
     async def execute_workflow(
         self,
@@ -96,8 +103,12 @@ class WorkflowRecorderFailingMember(WorkflowRecorder):
         )
         if workflow == REQUEST_GENERATOR_RUN:
             model = (parameters or {})["model"]
-            if isinstance(model, RequestGeneratorRun) and model.target_id in self.failing_target_ids:
-                raise RuntimeError(_member_failure_message(model.target_name))
+            if isinstance(model, RequestGeneratorRun):
+                if model.target_id in self.cancelled_target_ids:
+                    # asyncio.gather discards this instance's message, so none is set here.
+                    raise asyncio.CancelledError
+                if model.target_id in self.failing_target_ids:
+                    raise RuntimeError(_member_failure_message(model.target_name))
         return result
 
 
@@ -258,3 +269,29 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
             "1 of 2 generators failed, 1 succeeded: "
             f"member-beta ({dataset[_FAILING_ID]}): generator run failed for member-beta"
         )
+
+    async def test_a_cancelled_member_propagates_the_cancellation(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.cancelled_target_ids = {dataset[_FAILING_ID]}
+
+        # The cancellation propagates out of the definition run rather than being dropped by the
+        # failure filter and letting the run report success.
+        with pytest.raises(asyncio.CancelledError):
+            await request_generator_definition_run(
+                model=self._model(dataset, default_branch.name),
+                context=self._context(admin_account, default_branch),
+                return_state=True,
+            )
+
+        # Both members are dispatched, so the cancellation is one target's.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -218,9 +218,12 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
             _FAILING_ID: failing.id,
         }
 
-    def _model(self, dataset: dict[str, Any], branch: str) -> RequestGeneratorDefinitionRun:
+    def _model(
+        self, dataset: dict[str, Any], branch: str, target_members: list[str] | None = None
+    ) -> RequestGeneratorDefinitionRun:
         return RequestGeneratorDefinitionRun(
             branch=branch,
+            target_members=target_members or [],
             generator_definition=ProposedChangeGeneratorDefinition(
                 definition_id=dataset[_DEFINITION_ID],
                 definition_name="tag-generator",
@@ -295,3 +298,73 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
             for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
         }
         assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+    async def test_only_the_selected_members_are_run(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name, target_members=[dataset[_HEALTHY_ID]]),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Only the selected member runs; the other group member is skipped entirely.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID]}
+        assert state.is_completed()
+        assert state.message == "Successfully run 1 generators"
+
+    async def test_every_failing_member_is_reported(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.failing_target_ids = {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Every failed member is named; member order in the group is not guaranteed, so compare the set.
+        assert state.is_failed()
+        prefix = "2 of 2 generators failed, 0 succeeded: "
+        assert state.message.startswith(prefix)
+        assert set(state.message.removeprefix(prefix).split("; ")) == {
+            f"{_HEALTHY_MEMBER} ({dataset[_HEALTHY_ID]}): {_member_failure_message(_HEALTHY_MEMBER)}",
+            f"{_FAILING_MEMBER} ({dataset[_FAILING_ID]}): {_member_failure_message(_FAILING_MEMBER)}",
+        }
+
+    async def test_all_members_succeeding_reports_completed(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+        assert state.is_completed()
+        assert state.message == "Successfully run 2 generators"

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -273,6 +273,11 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
             f"member-beta ({dataset[_FAILING_ID]}): generator run failed for member-beta"
         )
 
+        # The failure stays recoverable: the state re-raises the member's error inside an ExceptionGroup.
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await state.result(raise_on_failure=True)
+        assert [str(error) for error in exc_info.value.exceptions] == [_member_failure_message(_FAILING_MEMBER)]
+
     async def test_a_cancelled_member_propagates_the_cancellation(
         self,
         dataset: dict[str, Any],
@@ -345,6 +350,14 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
         assert set(state.message.removeprefix(prefix).split("; ")) == {
             f"{_HEALTHY_MEMBER} ({dataset[_HEALTHY_ID]}): {_member_failure_message(_HEALTHY_MEMBER)}",
             f"{_FAILING_MEMBER} ({dataset[_FAILING_ID]}): {_member_failure_message(_FAILING_MEMBER)}",
+        }
+
+        # Every member's error is recoverable from the state as an ExceptionGroup.
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await state.result(raise_on_failure=True)
+        assert {str(error) for error in exc_info.value.exceptions} == {
+            _member_failure_message(_HEALTHY_MEMBER),
+            _member_failure_message(_FAILING_MEMBER),
         }
 
     async def test_all_members_succeeding_reports_completed(

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from infrahub_sdk import Config, InfrahubClient
 
-from infrahub import config
 from infrahub.auth.session import AccountSession
 from infrahub.auth.types import AuthType
 from infrahub.context import BranchContext, InfrahubContext
@@ -20,13 +19,15 @@ from infrahub.generators.models import (
 )
 from infrahub.generators.tasks import request_generator_definition_run
 from infrahub.server import app
-from infrahub.workers.dependencies import build_client, build_workflow
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_GENERATOR_RUN
 from tests.adapters.workflow import WorkflowRecorder
 from tests.constants.kind import TAG as TAG_KIND
+from tests.helpers.dependency_override import override_dependency
 from tests.helpers.schema import load_schema
 from tests.helpers.schema.tag import TAG
 from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -125,12 +126,9 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
         prefect: Generator[str, None, None],
         dependency_provider: Provider,
     ) -> AsyncGenerator[WorkflowRecorderFailingMember, None]:
-        original = config.OVERRIDE.workflow
         recorder = WorkflowRecorderFailingMember()
-        config.OVERRIDE.workflow = recorder
-        with dependency_provider.scope(build_workflow, lambda: recorder):
+        with override_workflow(recorder, dependency_provider=dependency_provider):
             yield recorder
-        config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
@@ -154,9 +152,11 @@ class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
         )
         original_client = service._client
         service._client = sdk_client
-        with dependency_provider.scope(build_client, lambda: sdk_client):
-            yield sdk_client
-        service._client = original_client
+        try:
+            with override_dependency(build_client, lambda: sdk_client, dependency_provider=dependency_provider):
+                yield sdk_client
+        finally:
+            service._client = original_client
 
     @pytest.fixture(autouse=True)
     def clear_recorder(self, workflow_recorder: WorkflowRecorderFailingMember) -> None:

--- a/changelog/10199.fixed.md
+++ b/changelog/10199.fixed.md
@@ -1,0 +1,1 @@
+Running a Generator definition whose targets include a failing member now reports which targets failed and how many succeeded, instead of collapsing into a single opaque failure.


### PR DESCRIPTION
## Why

When a Generator definition runs against a group of targets, a failure in a single target used to
collapse the whole run into one opaque failure. An operator could not tell whether one target
misbehaved or the whole definition was broken, nor how the remaining targets fared.

Closes #10199

## What changed

The run now reports the outcome of every target. When any target fails, the run result identifies
which targets failed and why, alongside how many succeeded; when all targets succeed, it completes
as before.

Operator-facing only — no API or schema changes.

## How to test

Run a Generator definition against a group with more than one target and make a single target fail.
The run result now names the failing target instead of a generic "one or more generators failed".

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated (if user-facing or ops-facing change) — N/A
- [ ] Internal .md docs updated — N/A
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
