### PR TITLE
fix(agents): fetch CI job logs with escape sequences intact

### DIFF
--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -114,7 +114,7 @@ def fetch_job_log(repo: str, job_id: int, log_path: Path) -> None:
     collection retries.
     """
     res = subprocess.run(  # noqa: S603
-        ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs"],  # noqa: S607
+        ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs", "--allow-escape-sequences"],  # noqa: S607
         capture_output=True,
         text=True,
         errors="replace",


### PR DESCRIPTION
## What

One fix to the `analyzing-ci-flakiness` collector (`.agents/skills/analyzing-ci-flakiness/scripts/collect.py`).

`fetch_job_log` calls `gh api .../logs` without `--allow-escape-sequences`. Under `gh` 2.99 that call errors on any log containing ANSI colour codes — i.e. every pytest job — so `log_ok` is false for every job, the ranked-test table and bucket tags come back empty, and the longitudinal ledger records nothing (a silent false "clean" report). The call now passes `--allow-escape-sequences`; the parser already strips ANSI on read (`ANSI.sub("", …)`), so downloaded logs classify correctly.

Found while analysing run 34029649238 — all 127 cached job logs were 0 bytes and no tests were extracted until the flag was added.

## Scope

Dev tooling under `.agents/skills/` only — no product code, no changelog fragment (matches prior `fix(agents)` collector commits). Verified with `uv run ruff check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)