### PR TITLE
fix(tests): restore workflow override when a fixture body raises

### DIFF
--- a/backend/tests/component/conftest.py
+++ b/backend/tests/component/conftest.py
@@ -3035,9 +3035,11 @@ def workflow_local(dependency_provider: Provider) -> Generator[WorkflowLocalExec
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     config.OVERRIDE.workflow = workflow
-    with dependency_provider.scope(build_workflow, lambda: workflow):
-        yield workflow
-    config.OVERRIDE.workflow = original
+    try:
+        with dependency_provider.scope(build_workflow, lambda: workflow):
+            yield workflow
+    finally:
+        config.OVERRIDE.workflow = original
 
 
 @pytest.fixture
@@ -3046,9 +3048,11 @@ def workflow_recorder(dependency_provider: Provider) -> Generator[WorkflowRecord
     original = config.OVERRIDE.workflow
     recorder = WorkflowRecorder()
     config.OVERRIDE.workflow = recorder
-    with dependency_provider.scope(build_workflow, lambda: recorder):
-        yield recorder
-    config.OVERRIDE.workflow = original
+    try:
+        with dependency_provider.scope(build_workflow, lambda: recorder):
+            yield recorder
+    finally:
+        config.OVERRIDE.workflow = original
 
 
 @pytest.fixture

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -317,9 +317,11 @@ class TestInfrahubApp(TestInfrahubAppBase):
         workflow = WorkflowLocalExecution()
         await setup_task_manager_once()
         config.OVERRIDE.workflow = workflow
-        with dependency_provider.scope(build_workflow, lambda: workflow):
-            yield workflow
-        config.OVERRIDE.workflow = original
+        try:
+            with dependency_provider.scope(build_workflow, lambda: workflow):
+                yield workflow
+        finally:
+            config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
@@ -335,9 +337,11 @@ class TestInfrahubAppWithoutLocalWorkflow(TestInfrahubAppBase):
         workflow = WorkflowLocalExecution()
         await setup_task_manager_once()
         config.OVERRIDE.workflow = workflow
-        with dependency_provider.scope(build_workflow, lambda: workflow):
-            yield workflow
-        config.OVERRIDE.workflow = original
+        try:
+            with dependency_provider.scope(build_workflow, lambda: workflow):
+                yield workflow
+        finally:
+            config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class")
     async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:


### PR DESCRIPTION
## What

Wrap the `config.OVERRIDE.workflow` swap in `try/finally` in the four
component-suite fixtures (`workflow_local` / `workflow_recorder` in
`tests/component/conftest.py`, and the two `workflow_local` fixtures in
`tests/helpers/test_app.py`), matching the existing `message_bus` and cache
fixtures.

## Why

Restoration ran only on the statement after `yield`, so a wrapped test that
raised or timed out left the override in place. Under xdist the leak was picked
up by every later class on the same worker, whose service was built against the
wrong workflow adapter and errored at setup with `AssertionError: These tests
are currently meant to run with a local worker` — the top
`backend-tests-component (other)` failure of the week (~30 job logs across ~18
PRs, several recovering on retry). The victim class shifted with scheduling
while the assertion stayed constant.

Verified locally with a throwaway test driving each fixture generator: the
override survives a raising body before the change and is restored after.

Scope is the leak fix only; the upstream timeout in
`merge_recompute_coalescing/test_bulk_recompute_writer.py` that can trigger a
skipped teardown is a separate issue.