### PR TITLE
test(backend): rebind Prefect queue services on a test server change

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,7 +5,7 @@ import os
 import sys
 import tempfile
 import time
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, AsyncGenerator, Generator, TypeVar
@@ -20,7 +20,6 @@ from infrahub_sdk.branch import BranchData
 from infrahub_sdk.uuidt import UUIDT
 from neo4j import GraphDatabase
 from neo4j.exceptions import ServiceUnavailable
-from prefect import settings as prefect_settings
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
@@ -83,6 +82,7 @@ from tests.helpers.constants import (
 )
 from tests.helpers.diagnostics import install_redis_loop_diagnostics, register_known_loop
 from tests.helpers.file_repo import FileRepo
+from tests.helpers.prefect_services import prefect_api_target
 from tests.helpers.schema_cache import install_processed_core_schema_branch, install_processed_internal_schema_branch
 from tests.helpers.test_client import dummy_async_request
 from tests.helpers.utils import get_exposed_port, start_neo4j_container, start_prefect_server_container
@@ -537,14 +537,7 @@ def prefect(
     else:
         server_api_url = f"http://localhost:{PORT_PREFECT}/api"
 
-    with ExitStack() as stack:
-        stack.enter_context(
-            prefect_settings.temporary_settings(
-                updates={
-                    prefect_settings.PREFECT_API_URL: server_api_url,
-                }
-            )
-        )
+    with prefect_api_target(server_api_url):
         yield server_api_url
 
 
@@ -558,14 +551,7 @@ def prefect_class(
     else:
         server_api_url = f"http://localhost:{PORT_PREFECT}/api"
 
-    with ExitStack() as stack:
-        stack.enter_context(
-            prefect_settings.temporary_settings(
-                updates={
-                    prefect_settings.PREFECT_API_URL: server_api_url,
-                }
-            )
-        )
+    with prefect_api_target(server_api_url):
         yield server_api_url
 
 

--- a/backend/tests/helpers/prefect_services.py
+++ b/backend/tests/helpers/prefect_services.py
@@ -1,0 +1,92 @@
+"""Rebind Prefect's background queue services when the test process changes Prefect server.
+
+Prefect emits events and API logs through process-wide background services, ``EventsWorker`` and
+``APILogWorker``. ``EventsWorker.instance()`` is memoized on ``(client_type, client_options)``,
+and for a self-hosted server the options are empty, so the key carries no API URL. The worker it
+hands back built its websocket client and its orchestration client once, from whatever
+``PREFECT_API_URL`` was set the first time an event was emitted.
+
+A test process talks to more than one Prefect server: an ephemeral one for the whole session, plus
+a container that modules and classes opt into. Every orchestration client a test builds follows
+the current setting; the queue services do not. So from the second server onwards the events go to
+the previous one — silently, while that server is still up, and then as a wall of ``Service
+'EventsWorker' failed to process item`` once it has been torn down. Either way the events the
+current server's automations and the tests that assert on them are waiting for never arrive.
+
+Draining is what unpins them: ``_stop`` unregisters an instance synchronously, so the next event
+builds a new worker against the URL current at that point. Drain on both sides of a change of
+server — on the way in, while the old URL still resolves, so queued items reach the server they
+were meant for, and on the way out, before the new server is torn down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from prefect.events.worker import EventsWorker
+from prefect.logging.handlers import APILogWorker
+from prefect.settings import PREFECT_API_URL, temporary_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# Upper bound on how long the queue services are given to flush what they still hold. A drain
+# against a live server is quick; the ceiling is there for one against a server that has gone
+# away, where closing the events websocket waits on a close handshake that will never come.
+DRAIN_TIMEOUT_SECONDS = 10.0
+
+# Prefect registers every queue service in one dict on their shared base class, so draining
+# through one subclass already drains the other. Both are named anyway: the registry being shared
+# is an implementation detail of the pinned version, and this stays correct if a later one gives
+# each subclass a registry of its own.
+_QUEUE_SERVICES = (EventsWorker, APILogWorker)
+
+
+def drain_prefect_queue_services(timeout: float = DRAIN_TIMEOUT_SECONDS) -> None:
+    """Stop Prefect's queue services and wait for the work they still hold.
+
+    A drain that hits the timeout still rebinds — ``_stop`` unregisters the instance before any
+    waiting — it just leaves items unflushed. It also announces itself: the service logs
+    ``Still processing items: N items remaining`` every few seconds while a drain is pending, so
+    a slow one is already visible in the test output without anything reported from here.
+
+    Args:
+        timeout: Seconds to wait for the services to flush before giving up on them.
+
+    Raises:
+        RuntimeError: When called from a coroutine, where ``drain_all`` returns an awaitable this
+            function cannot wait on.
+
+    """
+    if _running_loop() is not None:
+        raise RuntimeError(
+            "drain_prefect_queue_services() only works outside the event loop; from a coroutine, "
+            "await EventsWorker.drain_all() instead."
+        )
+
+    for service in _QUEUE_SERVICES:
+        service.drain_all(timeout=timeout)
+
+
+@contextmanager
+def prefect_api_target(server_api_url: str) -> Generator[str, None, None]:
+    """Point Prefect at ``server_api_url`` for the duration of the block.
+
+    Both the setting and the queue services follow, so events and logs emitted inside the block
+    reach the server the block names.
+    """
+    drain_prefect_queue_services()
+    with temporary_settings(updates={PREFECT_API_URL: server_api_url}):
+        try:
+            yield server_api_url
+        finally:
+            drain_prefect_queue_services()
+
+
+def _running_loop() -> asyncio.AbstractEventLoop | None:
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 from typing import Any, AsyncGenerator
 from uuid import UUID
 
@@ -9,8 +8,6 @@ from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.client.schemas.filters import WorkPoolFilter, WorkPoolFilterId
 from prefect.client.schemas.objects import FlowRun, StateType, WorkPool
-from prefect.events.worker import EventsWorker
-from prefect.logging.handlers import APILogWorker
 from prefect.results import _default_storages
 from prefect.workers.base import BaseWorkerResult
 
@@ -123,10 +120,8 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         stop.set()
         await lifecycle_task
 
-        # Clear local worker instances to avoid issues with multiple test classes running in the same pytest worker
-        for drained in (EventsWorker.drain_all(), APILogWorker.drain_all()):
-            if inspect.isawaitable(drained):
-                await drained
+        # The Prefect queue services are unpinned by `prefect_class`, which tears down after this
+        # fixture and while its server is still up; see tests/helpers/prefect_services.py.
 
         # Clear local worker result storage cache
         _default_storages.clear()

--- a/backend/tests/unit/helpers/test_prefect_services.py
+++ b/backend/tests/unit/helpers/test_prefect_services.py
@@ -1,0 +1,92 @@
+"""Tests for the Prefect queue service rebinding in tests.helpers.prefect_services."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from prefect._internal.concurrency.services import QueueService
+from prefect.settings import PREFECT_API_URL, get_current_settings, temporary_settings
+
+from tests.helpers.prefect_services import drain_prefect_queue_services, prefect_api_target
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+SERVER_A = "http://localhost:14200/api"
+SERVER_B = "http://localhost:14201/api"
+
+
+class StubQueueService(QueueService[int]):
+    """Stands in for EventsWorker and APILogWorker, which need a live server to start.
+
+    Prefect keeps every queue service in one registry, so this is drained by the same call.
+    """
+
+    async def _handle(self, item: int) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def no_leftover_services() -> Generator[None, None, None]:
+    drain_prefect_queue_services()
+    yield
+    drain_prefect_queue_services()
+
+
+def test_prefect_api_target_points_prefect_at_the_server_and_restores_it() -> None:
+    with temporary_settings(updates={PREFECT_API_URL: SERVER_A}):
+        with prefect_api_target(SERVER_B) as target:
+            assert target == SERVER_B
+            assert get_current_settings().api.url == SERVER_B
+
+        assert get_current_settings().api.url == SERVER_A
+
+
+def test_entering_a_target_unpins_a_service_bound_to_the_previous_server() -> None:
+    """A service started against one server must not be reused against the next one.
+
+    `EventsWorker.instance()` is memoized on a key that holds no API URL, and the clients it
+    builds read `PREFECT_API_URL` once, so without this every event after the first change of
+    server is emitted at the server the process has moved off.
+    """
+    with temporary_settings(updates={PREFECT_API_URL: SERVER_A}):
+        bound_to_a = StubQueueService.instance()
+
+        with prefect_api_target(SERVER_B):
+            assert StubQueueService.instance() is not bound_to_a
+
+
+def test_leaving_a_target_unpins_a_service_bound_to_it() -> None:
+    with temporary_settings(updates={PREFECT_API_URL: SERVER_A}):
+        with prefect_api_target(SERVER_B):
+            bound_to_b = StubQueueService.instance()
+
+        assert StubQueueService.instance() is not bound_to_b
+
+
+def test_a_service_is_reused_while_the_server_does_not_change() -> None:
+    with temporary_settings(updates={PREFECT_API_URL: SERVER_A}), prefect_api_target(SERVER_B):
+        assert StubQueueService.instance() is StubQueueService.instance()
+
+
+def test_draining_hands_over_the_items_a_service_still_holds() -> None:
+    """The drain has to flush, not just unregister: it runs while the old server is still up."""
+    handled: list[int] = []
+
+    class RecordingQueueService(QueueService[int]):
+        async def _handle(self, item: int) -> None:
+            handled.append(item)
+
+    service = RecordingQueueService.instance()
+    for item in range(10):
+        service.send(item)
+
+    drain_prefect_queue_services()
+
+    assert handled == list(range(10))
+
+
+async def test_draining_from_a_coroutine_is_refused() -> None:
+    with pytest.raises(RuntimeError, match="outside the event loop"):
+        drain_prefect_queue_services()

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -187,6 +187,28 @@ Two consequences worth remembering:
   releases — scopes are sorted largest-first, so which modules run concurrently can change on an
   upgrade. Tests must not depend on what else is or is not running.
 
+### One process, several Prefect servers
+
+A test process does not keep one Prefect server. The session-scoped `prefect_test_fixture` starts
+an ephemeral one for the whole session, and the `prefect` (module) and `prefect_class` (class)
+fixtures start a **container of their own** and re-point `PREFECT_API_URL` at it for that scope.
+Each orchestration client a test builds reads the setting when it is built, so it follows.
+
+Prefect's background queue services do not. `EventsWorker` and `APILogWorker` are process-wide
+`QueueService` singletons, memoized on `hash((cls, *args))`, and `EventsWorker.instance()` passes
+no API URL in that key; the websocket and orchestration clients it builds in `_lifespan` read
+`PREFECT_API_URL` once. Left alone it therefore stays bound to the first server of the process,
+and every event after that goes to a server the process has moved off — silently while that server
+is up, then as a wall of `Service 'EventsWorker' failed to process item` once it is torn down. The
+backlog is expensive too: a stale queue drains at about one event per 60s client request timeout,
+and `prefect_test_harness` ends the session in `drain_workers()`, which blocks with no timeout.
+
+`prefect` and `prefect_class` handle this through `prefect_api_target()` from
+`tests/helpers/prefect_services.py`, which drains the queue services on **both** sides of the
+change of server: on the way in while the old URL still resolves, so queued items reach the server
+they were meant for, and on the way out before the new container is stopped. Anything else that
+re-points `PREFECT_API_URL` must go through it rather than calling `temporary_settings` directly.
+
 Within a single module or class, however, pytest runs tests in definition order and
 `--dist loadscope` keeps the whole scope on one worker — so the sequential, stateful `test_stepNN`
 pattern used across `backend/tests/integration/` (and in component migration suites) is deliberate
@@ -269,6 +291,7 @@ Test data and fixture files:
 | `test_client.py` | HTTP test client wrapper |
 | `utils.py` | Container utilities |
 | `constants.py` | Port numbers, image names |
+| `prefect_services.py` | Rebinds Prefect's process-wide queue services when the test process changes Prefect server (`prefect_api_target`). See [One process, several Prefect servers](#one-process-several-prefect-servers). |
 | `file_repo.py` | Builds throwaway on-disk Git "remote" repos from `repos/` fixtures (`FileRepo`). The remotes accept pushes to their checked-out branch, so tests exercise push and write-back like a hosted remote would. |
 
 ### Test Data (`backend/tests/test_data/`)


### PR DESCRIPTION
# Why

A pytest process does not keep one Prefect server: the session-scoped `prefect_test_fixture`
starts an ephemeral one, and the `prefect` (module) and `prefect_class` (class) fixtures each
start a container of their own and re-point `PREFECT_API_URL` at it. Orchestration clients follow
the setting. Prefect's process-wide queue services do not — `EventsWorker.instance()` is memoized
on `hash((cls, *args))` with no API URL in the key, and the websocket and orchestration clients it
builds in `_lifespan` read `PREFECT_API_URL` once.

So from the second Prefect server onwards, every event was emitted at the server the process had
already moved off: silently while that server was still up, then as a wall of
`Service 'EventsWorker' failed to process item` once it had been torn down. Events the current
server's automations — and the tests that assert on them — are waiting for never arrived.

The backlog is not free either. A stale queue drains at roughly one event per 60s client request
timeout (`_handle` reaches the pinned orchestration client before the emit), and nothing bounds
the wait: `prefect_test_harness` ends the session in `drain_workers()`, which blocks with
`timeout=None`. A worker that finishes a shard holding undelivered events pays about a minute per
event in **session teardown**.

**Goal:** the queue services follow the Prefect server the fixtures point at.

**Non-goals:** this does *not* fix the separate 300s `setup_triggers` hang seen in
[run 33859229899](https://github.com/opsmill/infrahub/actions/runs/33859229899/job/100980614037),
which happened on a *fresh* container and is still open. It is a candidate mechanism for the
teardown-phase members of that flake family, not for that one.

## What changed

Behavioural changes:

- `prefect` and `prefect_class` now go through `prefect_api_target()`, which drains Prefect's
  queue services on **both** sides of a change of server — on the way in while the old URL still
  resolves, so queued items reach the server they were meant for, and on the way out before the
  new container is stopped.
- Events and API logs emitted by a test now reach the server that test's fixtures point at.

Implementation notes:

- New `backend/tests/helpers/prefect_services.py` holds `prefect_api_target()` and
  `drain_prefect_queue_services()`. Draining is what unpins a worker: `QueueService._stop`
  unregisters the instance synchronously, so the next event builds a client against the URL
  current at that point.
- The `drain_all()` block in `prefect_worker`'s teardown (`tests/helpers/test_worker.py`) becomes
  redundant — `prefect_class` tears down after it, while its container is still up — so it goes.
  One owner for the queue services instead of two.
- Documented in `dev/knowledge/backend/testing.md` under "One process, several Prefect servers",
  including the rule that anything re-pointing `PREFECT_API_URL` goes through
  `prefect_api_target()` rather than `temporary_settings` directly.

What stayed the same: no production code touched, no CI config, no schema. Test-only.

## How to review

Start with `backend/tests/helpers/prefect_services.py` — its module docstring carries the whole
argument. Then the two fixtures in `backend/tests/conftest.py` (net −18 lines).

The judgement call worth scrutiny is removing the `drain_all()` from `prefect_worker`'s teardown:
it is safe only because the `prefect_worker -> prefect_client -> prefect_class` dependency chain
puts `prefect_class`'s teardown after it.

## How to test

```bash
# Unit: the two pinning tests fail if either drain is removed from prefect_api_target
uv run pytest --no-cov backend/tests/unit/helpers/test_prefect_services.py

# Integration: three classes, three Prefect containers, one process
INFRAHUB_DB_TYPE=neo4j uv run pytest --no-cov --neo4j \
  backend/tests/integration/services/adapters/workflow/

# Module-scoped `prefect` path, across two modules
INFRAHUB_DB_TYPE=neo4j uv run pytest --no-cov --neo4j \
  backend/tests/integration/transform/ backend/tests/integration/diff/test_diff_freeze.py
```

Measured A/B on `integration/services/adapters/workflow/{test_setup,test_workflow_execution}.py`
(3 tests, 2 class-scoped containers, one process):

| | wall time | dropped events | outcome |
|---|---|---|---|
| drains removed | 357s | 11 | 3 passed, **1 teardown ERROR** (300s timeout in `drain_workers`) |
| this branch | 66s | 0 | 3 passed |

Also green locally: 118 tests across `tests/unit/helpers/` + `tests/unit/task_manager/`, 15/15 in
`integration/services/adapters/workflow/`, 7/7 on the module-scoped path.
`ruff check . --exclude python_sdk`, `ruff format --check`, mypy and `invoke docs.lint` clean.

## Impact & rollout

- **Backward compatibility:** test infrastructure only; no runtime behaviour changes.
- **Performance:** removes a per-event ~60s stall from session teardown on any worker that
  changed Prefect server; measured 357s → 66s on the two workflow-adapter modules.
- **Config/env changes:** none.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added — not applicable, test-only change with no user-visible effect
- [ ] External docs updated — not applicable
- [x] Internal .md docs updated (`dev/knowledge/backend/testing.md`)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

