### PR TITLE
test(backend): exception-safe dependency overrides in the rebase tests

### DIFF
--- a/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
@@ -53,6 +53,7 @@ from tests.helpers.agnostic_edges import (
     relationship_vertex_uuid,
     to_times,
 )
+from tests.helpers.dependency_override import override_dependency
 from tests.helpers.schema.agnostic_retirement import (
     AGNOSTIC_RETIREMENT_SCHEMA,
     GADGET_KIND,
@@ -74,12 +75,13 @@ async def _rebase_branch(
         branch=default_branch,
         account=AccountSession(account_id=TEST_ACTOR_ID, auth_type=AuthType.NONE),
     )
+    # The rollback test raises through this block, so the doubles have to come off on an exception too.
     with (
-        dependency_provider.scope(build_database, lambda singleton=True: db),  # noqa: ARG005
+        override_dependency(build_database, lambda singleton=True: db, dependency_provider=dependency_provider),  # noqa: ARG005
         # Lambdas rather than the bare classes: fast_depends reads the callable's return annotation,
         # and a class used as the factory resolves to `None` and fails its validation.
-        dependency_provider.scope(build_workflow, lambda: WorkflowRecorder()),  # noqa: PLW0108
-        dependency_provider.scope(build_cache, lambda: MemoryCache()),  # noqa: PLW0108
+        override_dependency(build_workflow, lambda: WorkflowRecorder(), dependency_provider=dependency_provider),  # noqa: PLW0108
+        override_dependency(build_cache, lambda: MemoryCache(), dependency_provider=dependency_provider),  # noqa: PLW0108
     ):
         await rebase_branch(branch=branch.name, context=context, send_events=False)
     return await Branch.get_by_name(db=db, name=branch.name)

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -12,6 +12,7 @@ from infrahub.webhook.tasks import convert_node_to_webhook, webhook_process
 from infrahub.workers.dependencies import build_http_service
 from infrahub.workflows.constants import WorkflowTag
 from tests.adapters.http import MemoryHTTP
+from tests.helpers.dependency_override import override_dependency
 from tests.helpers.test_app import TestInfrahubApp
 
 from .conftest import BRANCH_CREATED_PAYLOAD, only_new_run, read_send_runs
@@ -116,7 +117,7 @@ class TestWebhookProcess(TestInfrahubApp):
             url="https://url.mock",
             response=httpx.Response(request=httpx.Request(method="GET", url="https://url.mock"), status_code=200),
         )
-        with dependency_provider.scope(build_http_service, lambda: http):
+        with override_dependency(build_http_service, lambda: http, dependency_provider=dependency_provider):
             before = {str(run.id) for run in await read_send_runs(flow_run_querier)}
             await webhook_process(
                 webhook_id=webhook1.id,
@@ -150,7 +151,7 @@ class TestWebhookProcess(TestInfrahubApp):
         )
 
         with (
-            dependency_provider.scope(build_http_service, lambda: http),
+            override_dependency(build_http_service, lambda: http, dependency_provider=dependency_provider),
             caplog.at_level(logging.INFO, logger="prefect.task_runs"),
             caplog.at_level(logging.INFO, logger="prefect.flow_runs"),
         ):
@@ -188,7 +189,7 @@ class TestWebhookProcess(TestInfrahubApp):
 
         with (
             pytest.raises(RuntimeError, match=r"^boom$"),
-            dependency_provider.scope(build_http_service, lambda: http),
+            override_dependency(build_http_service, lambda: http, dependency_provider=dependency_provider),
         ):
             await webhook_process(
                 webhook_id=webhook1.id,

--- a/backend/tests/helpers/dependency_override.py
+++ b/backend/tests/helpers/dependency_override.py
@@ -1,0 +1,39 @@
+"""Point a dependency-provider lookup at a test double and put the previous one back afterwards."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from typing import Any
+
+    from fast_depends import Provider
+
+
+@contextmanager
+def override_dependency(
+    original: Callable[..., Any], override: Callable[..., Any], dependency_provider: Provider
+) -> Iterator[None]:
+    """Resolve ``original`` through ``override`` for the duration of the block.
+
+    The previous state comes back in a ``finally``, whether the block ends normally or through an
+    exception: the override that was in place before is put back, and one that did not exist before
+    is removed. (fast_depends' own ``Provider.scope`` drops its override only on a normal exit.)
+
+    Args:
+        original: The dependant whose lookups should be redirected.
+        override: The callable every lookup of ``original`` should resolve through inside the block.
+        dependency_provider: The provider the dependency injection resolves ``original`` through.
+
+    """
+    previous_dependant = dependency_provider.overrides.get(original)
+    dependency_provider.override(original, override)
+    try:
+        yield
+    finally:
+        if previous_dependant is None:
+            dependency_provider.overrides.pop(original, None)
+        else:
+            dependency_provider.overrides[original] = previous_dependant

--- a/backend/tests/unit/helpers/test_dependency_override.py
+++ b/backend/tests/unit/helpers/test_dependency_override.py
@@ -1,0 +1,62 @@
+import pytest
+from fast_depends import Depends, Provider, inject
+
+from tests.helpers.dependency_override import override_dependency
+
+
+class Real:
+    pass
+
+
+class Double:
+    pass
+
+
+def build() -> object:
+    return Real()
+
+
+@pytest.fixture
+def provider() -> Provider:
+    return Provider()
+
+
+def resolved(provider: Provider) -> object:
+    def lookup(value: object = Depends(build)) -> object:
+        return value
+
+    return inject(lookup, dependency_provider=provider)()
+
+
+def test_override_is_removed_when_there_was_none_before(provider: Provider) -> None:
+    assert isinstance(resolved(provider), Real)
+
+    with override_dependency(build, lambda: Double(), dependency_provider=provider):  # noqa: PLW0108
+        assert isinstance(resolved(provider), Double)
+
+    assert build not in provider.overrides
+    assert isinstance(resolved(provider), Real)
+
+
+def test_nested_override_gives_the_outer_one_back(provider: Provider) -> None:
+    outer = Double()
+    inner = Double()
+
+    with override_dependency(build, lambda: outer, dependency_provider=provider):
+        with override_dependency(build, lambda: inner, dependency_provider=provider):
+            assert resolved(provider) is inner
+
+        assert resolved(provider) is outer
+
+    assert build not in provider.overrides
+
+
+def test_exception_inside_the_block_still_restores(provider: Provider) -> None:
+    with (
+        pytest.raises(RuntimeError, match=r"^boom$"),
+        override_dependency(build, lambda: Double(), dependency_provider=provider),  # noqa: PLW0108
+    ):
+        raise RuntimeError("boom")
+
+    assert build not in provider.overrides
+    assert isinstance(resolved(provider), Real)

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -494,9 +494,17 @@ with `dependency_provider.scope`: that context manager pops its override instead
 one it replaced, and neither it nor `config.OVERRIDE` is restored when the fixture is finalised
 through an exception, so the double leaks into whatever the next class builds.
 
-A `dependency_provider.scope(build_workflow, …)` that opens and closes around a single test, next
-to the other scoped dependencies, is fine as it is: it leaves `config.OVERRIDE.workflow` alone, so
-once it pops, lookups fall back to the adapter the class installed.
+A per-test swap of any dependant (`build_workflow`, `build_database`, `build_cache`, …) goes through
+`tests/helpers/dependency_override.py::override_dependency` when anything can raise inside the block —
+a `pytest.raises` around the call under test, or an assertion inside it. `dependency_provider.scope`
+pops its override on the statement after its `yield`, with no `finally`, so an exception thrown
+through it leaves the double installed for the rest of the xdist worker process. The next class on
+that worker whose app resolves `get_workflow()` before its own override is in place then starts with
+a `WorkflowRecorder` as its workflow and every one of its tests errors at `client` setup with
+`These tests are currently meant to run with a local worker`; which class that is depends on how
+xdist split the suite, so the failure moves between runs while the message stays the same. A
+`dependency_provider.scope` whose body cannot raise is still fine: it leaves `config.OVERRIDE.workflow`
+alone, so once it pops, lookups fall back to the adapter the class installed.
 
 The app built by `test_client` resolves its workflow once, during `lifespan`. pytest orders autouse
 fixtures by name, so `service` (and with it `test_client`) would otherwise run before


### PR DESCRIPTION
## Summary

`backend-tests-component (other)` has been failing on unrelated PRs and on `stable`/`develop` pushes since 2026-09-04 with a moving victim class and a constant message:

```
ERROR … - AssertionError: These tests are currently meant to run with a local worker
```

One test leaks a `WorkflowRecorder` factory into the dependency provider for the rest of its xdist worker. This PR adds an exception-safe replacement for `Provider.scope` and routes the agnostic-retirement rebase tests through it, so the leak stops at its source. A scan of every other `Provider.scope` in `backend/tests` found one more deterministic leak of the same shape, in the webhook process tests, which is fixed the same way; the rest are listed below.

## Why the failures happened

**The symptom.** The class-scoped `client` fixture in `tests/helpers/test_app.py` asserts that the app's workflow adapter is a `WorkflowLocalExecution`. In every failing job it found a `WorkflowRecorder` instead, and every test of that class errored at setup. Everything else in the job passed (`1332 passed, … 1 error`).

**The source.** `backend/tests/component/core/agnostic_retirement/test_on_rebase.py::TestAgnosticRetirementOnRebase::test_a_retirement_failure_rolls_back_the_whole_rebase` (landed 2026-09-04 in #10509) drives the real rebase flow inside three `dependency_provider.scope(...)` overrides — `build_database`, `build_workflow → lambda: WorkflowRecorder()`, `build_cache` — and deliberately lets `RetirementFailureError` propagate out of that block (`pytest.raises` wraps the call). `fast_depends.Provider.scope` is `override(); yield; overrides.pop()` with no `try/finally`, so an exception thrown through it skips the pop. All three overrides stay installed for the rest of the worker process. Reproduced in-venv:

```python
with pytest.raises(RuntimeError), provider.scope(build, lambda: Double()):
    raise RuntimeError("boom")
assert build in provider.overrides   # still there
```

**The victim.** The app built by `test_client` resolves its workflow once, in `lifespan`, through `get_workflow()` → the provider. The next class on that worker whose lifespan runs while no override of its own is in place gets a fresh `WorkflowRecorder` as `app.state.service.workflow`, and its `client` fixture fails. Which class that is depends on how xdist (`-n 2`) split the suite:

- Merge refs before #10536 (develop today, stable before 12:01 UTC on 2026-09-07): any `TestInfrahubApp` subclass requesting `client`, because autouse `service → test_client → lifespan` ran before `workflow_local` (pytest orders class autouse fixtures by name). Usually `core/test_get_kinds_lock.py::TestLockGenericPeerConcreteConstraint` (next in collection order after `core/agnostic_retirement/`). That class's `workflow_local` teardown then popped the leak, so exactly one class died per worker.
- Merge refs after #10536: `TestInfrahubApp.service` depends on `workflow_local`, so those classes are immune. The victims became the computed-attribute recorder classes (`test_scoped_recompute_python.py`, `test_merge_fanout_python.py`), whose `service` does not depend on their `workflow_recorder`. `override_workflow` restores the *previous* override on teardown — here the leaked one — so the leak now persists and every such class after it fails.

#10536 and the closed #10540 fixed fixture-teardown leaks; neither covers an exception thrown through `Provider.scope`.

**Evidence.**

- 13 of 13 `component (other)` failures since 2026-09-06 carry this signature (one of them also had an unrelated Prefect timeout on the other worker); 8 jobs passed. Examples: [stable push](https://github.com/opsmill/infrahub/actions/runs/34120772630/job/101742490075), [#10534](https://github.com/opsmill/infrahub/actions/runs/34120775207/job/101739588367), [#10535](https://github.com/opsmill/infrahub/actions/runs/34123847287/job/101749236867).
- Per-worker order reconstruction (`[gwN] [ xx%] OUTCOME nodeid` lines): in all 13 failing workers the raising test ran before the first ERROR; in the green run of #10536 it ran on gw0 while every recorder class ran on gw1. Over 8 failing vs 20 passing recorder-class runs, `test_on_rebase.py` precedes 100% of the failures and 0% of the passes, and no module between the leak and the victim touches the workflow override.
- Local reproduction, sequential (no xdist) so the order is fixed:

  ```
  INFRAHUB_DB_TYPE=neo4j uv run pytest -p no:randomly --neo4j \
    backend/tests/component/core/agnostic_retirement/test_on_rebase.py \
    backend/tests/component/computed_attribute/test_scoped_recompute_python.py
  ```

  Before this change: `4 passed, 3 errors` with the assertion above. After: `7 passed`.

Note for anyone doing this kind of triage: `pull_request` runs check out `refs/pull/N/merge`, so what ran is the PR head merged with the base at run time — head-SHA inclusion checks mislead here; the log's test list is the ground truth.

## Key Changes

- `tests/helpers/dependency_override.py::override_dependency` — exception-safe counterpart to `Provider.scope`: installs an override and, in a `finally`, restores the previous one (or removes it when there was none). Unit-tested for the plain, nested, and raising cases.
- `_rebase_branch` in `test_on_rebase.py` routes its three overrides through it, so the rollback test no longer leaks doubles into later classes.
- `functional/webhook/test_process.py` routes its three `build_http_service` overrides through it. `test_process_webhook_unexpected_error_crashes` had the same shape — `pytest.raises` outside the scope — and leaked a `MemoryHTTP` double that raises for the webhook target URL and `KeyError`s for any other. It stayed hidden because the neighbouring webhook tests open their own scope (which overwrote and popped it) and nothing else on those workers sends HTTP.
- `dev/knowledge/backend/testing.md` no longer blesses a per-test `dependency_provider.scope` unconditionally; it now says when the helper is required and describes this failure mode so the next occurrence is recognisable.

### Every other `Provider.scope` in `backend/tests` (AST scan of each `with` opening one; 53 remain after this PR)

| Exposure | Sites | Verdict |
|---|---|---|
| `pytest.raises` outside the scope | `test_on_rebase.py`, `webhook/test_process.py` | Deterministic leak on every run — fixed here |
| Assertions inside the scoped block | 10: `core/test_branch_rebase.py:380`, `git/test_git_rpc.py:159`, `graphql/mutations/test_proposed_change.py:601,660`, `message_bus/operations/git/test_file.py:24`, `message_bus/operations/requests/test_proposed_change.py:184,261`, `webhook/test_cancel_during_retry_wait.py:121`, `functional/pools/test_numberpool_lifecycle.py:86`, `integration/…/test_rabbitmq.py:431` | Leak only when that test already fails, turning one red test into a confusing cascade on its worker — left as-is, candidates for a follow-up |
| Single call inside the scope, assertions outside | 19 | Leak only on an unexpected error — left as-is |
| `pytest.raises` inside the scope | 4 | Safe |
| Fixture `with scope: yield` | 20 | Safe: pytest finalises a yield fixture with `next()`, never by throwing into it; the few with setup before the `yield` are mock wiring or the session DB bootstrap |

No changelog fragment: test-only change plus internal docs.

## Test Plan

- [x] `uv run ruff check` / `ruff format --check` on the changed files
- [x] `INFRAHUB_DB_TYPE=neo4j uv run pytest --neo4j backend/tests/functional/webhook/test_process.py` — 7 passed
- [x] `uv run mypy` on the changed files
- [x] `uv run pytest backend/tests/unit/helpers/test_dependency_override.py backend/tests/unit/helpers/test_workflow_override.py` — 6 passed
- [x] Sequential component reproduction above: 3 errors before, 7 passed after
- [x] `markdownlint-cli2 dev/knowledge/backend/testing.md`
- [ ] CI `backend-tests-component (other)` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
