### PR TITLE
ci: rebalance the component test shards on measured durations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,10 @@ jobs:
         run: "uv run ty check ."
       - name: "Linting: mypy"
         run: "uv run invoke backend.mypy"
+      # Collection only, so it belongs with the cheap checks rather than on the
+      # huge-runner shard it used to delay.
+      - name: "Validate component test shards"
+        run: "uv run invoke backend.validate-component-shards"
 
   markdown-lint:
     if: |
@@ -606,9 +610,6 @@ jobs:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
         run: "uv sync --all-groups"
-      - name: "Validate component test shards"
-        if: matrix.shard == 'other'
-        run: "uv run invoke backend.validate-component-shards"
       - name: "Component Tests (${{ matrix.shard }})"
         run: "uv run invoke backend.test-component --shard ${{ matrix.shard }}"
       - name: "Coveralls : Component Tests"

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -28,11 +28,14 @@ COMPONENT_TEST_DIRECTORY = f"{MAIN_DIRECTORY}/tests/component"
 # Directories listed here are run by their named shard; everything else falls into the
 # "other" catch-all shard, which ignores exactly the directories assigned below so new
 # test directories are picked up automatically. The partition is verified by
-# backend.validate-component-shards. Shard contents are sized from measured durations,
-# rebalance when they drift apart.
+# backend.validate-component-shards.
+#
+# Shard names are labels, not a taxonomy: contents are balanced from measured CI
+# durations so the jobs finish together, which is why suites unrelated to a shard's
+# name sit in it. The catch-all is the one that grows; rebalance when it pulls ahead.
 COMPONENT_TEST_SHARDS: dict[str, list[str]] = {
     "graphql": ["graphql"],
-    "core-diff": ["core/diff", "core/migrations", "core/changelog"],
+    "core-diff": ["core/diff", "core/migrations", "core/changelog", "merge_recompute_coalescing"],
     "core-schema": [
         "core/schema",
         "core/schema_manager",
@@ -44,6 +47,8 @@ COMPONENT_TEST_SHARDS: dict[str, list[str]] = {
         "core/node",
         "core/hierarchy",
         "core/graph",
+        "api",
+        "computed_attribute",
     ],
 }
 COMPONENT_TEST_CATCHALL_SHARD = "other"


### PR DESCRIPTION
# Why

`backend-tests-component (other)` is the critical path of every CI run: in run [34120772630](https://github.com/opsmill/infrahub/actions/runs/34120772630) it finished 11.6 minutes after every other job (55.2 min total). It is a catch-all shard that has grown to 23.6 min of test time while `core-schema` finishes in 11.6 min, so three of the four shard slots sit idle for the last third of the run.

Goal: make the four shard jobs finish together with no extra runners.

Non-goals: adding shards (more jobs add queue pressure when the fleet is saturated) or changing any test.

## What changed

- `api` and `computed_attribute` move from the catch-all into `core-schema`; `merge_recompute_coalescing` moves into `core-diff`. Projected test-step times from measured worker-seconds (three runs within 8% of each other): other 994s, graphql 998s, core-diff 983s, core-schema 981s, against 1418 / 998 / 842 / 698 today. Critical path 25.2 min → ~17 min.
- `Validate component test shards` (74s, collection only) moves off the catch-all shard into `python-lint`, which already runs on `backend/**` and `tasks/**` changes and feeds the huge-runner gate.
- Shard names stay as they were; the comment in `tasks/backend.py` now says they are labels balanced by measured duration, not a taxonomy.

No test code changes. Coveralls flag names are unchanged.

## How to test

- `uv run invoke backend.validate-component-shards` → 4004 tests, partition OK (graphql 931 / core-diff 531 / core-schema 1384 / other 1158).
- `uv run yamllint -s .` and `uv run invoke ci.validate-huge-runner-gate` pass.
- Watch the four `backend-tests-component` jobs on this PR finish within a couple of minutes of each other.

## Impact & rollout

- **Performance:** CI critical path about 8 minutes shorter per run; runner slots free earlier for queued jobs.
- **Deployment notes:** safe to merge; the forward merge to `develop` carries the same two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

