### PR TITLE
test(backend): memoize a timed-out Prefect setup at expiry, not after

### DIFF
--- a/backend/tests/helpers/task_manager.py
+++ b/backend/tests/helpers/task_manager.py
@@ -29,6 +29,21 @@ the next test would start the setup over again. Worse, the abandoned coroutine
 stays pending on the session-scoped loop and runs on in between later tests,
 hanging tests that never touch Prefect at all.
 
+The setup runs as a task of its own so that giving up on it does not wait for it. Prefect
+answers a cancellation by writing a Crashed state to the server, shielded from the
+cancellation, and that write goes to the very server that just stopped answering: one
+request timeout per attempt, several attempts. Left inline, that bookkeeping ran on past
+the pytest timeout, the failure was never remembered, and the next test class paid the
+whole timeout again. So the failure is remembered and reported the moment the ceiling is
+hit, the task is cancelled, and after a short grace for the bookkeeping to finish it is
+left behind.
+
+The ceiling is an event-loop timer, so it cannot fire while the loop is blocked. Prefect's
+engine blocks it once per flow start: reading the server's default result storage is a
+synchronous HTTP call, with the client's own request timeout and retries. A server that
+wedges right there is ended by the pytest timeout alone, and that raises inside the setup
+task, whose result then carries the failure to the memo.
+
 A timed-out setup can leave a partially registered server behind. That is no worse
 than what the pytest timeout did, and the memo makes sure nothing builds on it.
 
@@ -38,6 +53,7 @@ themselves before yielding back, otherwise later tests will observe the corrupti
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import NoReturn
 
 from prefect.settings import get_current_settings
 
@@ -52,6 +68,12 @@ from tests.helpers.prefect_diagnostics import dump_prefect_test_server_diagnosti
 # the rest of the session.
 SETUP_TIMEOUT_SECONDS = 180.0
 
+# How long a timed-out setup may spend on Prefect's post-cancellation bookkeeping before it is
+# abandoned. Against a healthy but slow server the Crashed state is written in well under a second,
+# and the task ends cleanly; against a wedged one the write would take minutes, which is exactly
+# the wait this helper exists to avoid.
+CRASH_HANDLING_GRACE_SECONDS = 5.0
+
 
 def _current_prefect_api_url() -> str | None:
     return get_current_settings().api.url
@@ -63,11 +85,13 @@ class TaskManagerSetup:
         setup: Callable[[], Awaitable[None]] = setup_task_manager,
         server_key: Callable[[], str | None] = _current_prefect_api_url,
         timeout: float = SETUP_TIMEOUT_SECONDS,
+        crash_handling_grace: float = CRASH_HANDLING_GRACE_SECONDS,
         report_failure: Callable[[str], None] = dump_prefect_test_server_diagnostics,
     ) -> None:
         self._setup = setup
         self._server_key = server_key
         self._timeout = timeout
+        self._crash_handling_grace = crash_handling_grace
         self._report_failure = report_failure
         self._initialized: set[str | None] = set()
         self._failures: dict[str | None, BaseException] = {}
@@ -81,17 +105,63 @@ class TaskManagerSetup:
         if server in self._initialized:
             return
 
+        setup = asyncio.ensure_future(self._setup())
+        # run_once reads the outcome itself while it is still waiting; once it has moved on, this is
+        # what keeps asyncio from logging the outcome as never retrieved.
+        setup.add_done_callback(_collect_outcome)
         try:
-            async with asyncio.timeout(self._timeout):
-                await self._setup()
+            done, _ = await asyncio.wait({setup}, timeout=self._timeout)
+        except asyncio.CancelledError:
+            # Whoever cancelled this call is not waiting for the registration either.
+            setup.cancel()
+            raise
+
+        if not done:
+            await self._give_up(server=server, setup=setup)
+
+        try:
+            setup.result()
         # The pytest timeout raises Failed, which derives from BaseException, and that is
         # the failure worth remembering most.
         except BaseException as exc:
-            self._failures[server] = exc
-            self._report_failure(f"Prefect task manager setup failed for {server}: {exc!r}")
+            self._remember_failure(server=server, exc=exc)
             raise
 
         self._initialized.add(server)
+
+    async def _give_up(self, server: str | None, setup: asyncio.Future[None]) -> NoReturn:
+        """Remember and report the timeout before the cancellation reaches Prefect, then move on."""
+        timeout_error = TimeoutError(f"Prefect task manager setup did not finish within {self._timeout:.0f}s")
+        self._remember_failure(server=server, exc=timeout_error)
+
+        setup.cancel()
+        await asyncio.wait({setup}, timeout=self._crash_handling_grace)
+        ending = _ending_of(setup)
+        if ending is not None:
+            timeout_error.add_note(f"After the cancellation the setup ended with {ending!r}")
+
+        raise timeout_error
+
+    def _remember_failure(self, server: str | None, exc: BaseException) -> None:
+        self._failures[server] = exc
+        self._report_failure(f"Prefect task manager setup failed for {server}: {exc!r}")
+
+
+def _collect_outcome(setup: asyncio.Future[None]) -> None:
+    """Mark the setup's outcome as retrieved, so asyncio does not log an abandoned one at collection.
+
+    A setup that run_once gave up on, or was cancelled away from, has no other reader; its failure
+    was remembered and reported at that point.
+    """
+    if not setup.cancelled():
+        setup.exception()
+
+
+def _ending_of(setup: asyncio.Future[None]) -> BaseException | None:
+    """The exception a finished setup ended with, unless it is still running or simply cancelled."""
+    if not setup.done() or setup.cancelled():
+        return None
+    return setup.exception()
 
 
 _setup = TaskManagerSetup()

--- a/backend/tests/unit/helpers/test_task_manager.py
+++ b/backend/tests/unit/helpers/test_task_manager.py
@@ -1,4 +1,7 @@
 import asyncio
+import gc
+import logging
+import time
 
 import pytest
 
@@ -148,6 +151,151 @@ async def test_hanging_setup_gives_up_inside_the_coroutine() -> None:
         await once.run_once()
 
     assert setup.calls == 1
+
+
+class LoopBlockingSetup(RecordingSetup):
+    """Stands in for Prefect's synchronous HTTP call at flow start, ended by the pytest timeout."""
+
+    def __init__(self, blocked_for: float, error: BaseException) -> None:
+        super().__init__()
+        self.blocked_for = blocked_for
+        self.error = error
+
+    async def __call__(self) -> None:
+        await super().__call__()
+        time.sleep(self.blocked_for)  # noqa: ASYNC251 - blocking the loop is the point of this double
+        raise self.error
+
+
+async def test_a_failure_raised_inside_a_setup_that_blocked_the_loop_past_the_ceiling_is_remembered() -> None:
+    """The ceiling is a loop timer and cannot fire while the loop is blocked.
+
+    The failure that ends the block is the one worth remembering, not a timeout dressed up after
+    the fact.
+    """
+    setup = LoopBlockingSetup(blocked_for=0.1, error=TimeoutFailure("Timeout >300.0s"))
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://blocked/api"), timeout=0.02)
+
+    with pytest.raises(TimeoutFailure, match=r"^Timeout >300\.0s$"):
+        await once.run_once()
+
+    with pytest.raises(
+        RuntimeError, match=r"^Prefect task manager setup already failed for http://blocked/api$"
+    ) as exc_info:
+        await once.run_once()
+
+    assert isinstance(exc_info.value.__cause__, TimeoutFailure)
+    assert setup.calls == 1
+
+
+class CrashHandlingSetup(RecordingSetup):
+    """Stands in for a Prefect flow whose cancellation is answered by a shielded state write.
+
+    The engine writes a Crashed state to the server the setup was talking to before it lets the
+    cancellation through. Against a wedged server that write itself hangs.
+    """
+
+    def __init__(self, crash_handling_seconds: float, ends_with: BaseException | None = None) -> None:
+        super().__init__()
+        self.crash_handling_seconds = crash_handling_seconds
+        self.ends_with = ends_with
+        """What the crash handling raises in place of the cancellation, when it fails on its own."""
+        self.crash_handling_started = asyncio.Event()
+        self.finished = asyncio.Event()
+
+    async def __call__(self) -> None:
+        await super().__call__()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.crash_handling_started.set()
+            try:
+                await asyncio.sleep(self.crash_handling_seconds)
+            finally:
+                self.finished.set()
+            if self.ends_with is not None:
+                raise self.ends_with from None
+            raise
+
+
+async def test_a_timed_out_setup_is_remembered_before_its_cancellation_is_handled() -> None:
+    """The memo cannot depend on the setup unwinding: against a wedged server that takes minutes."""
+    setup = CrashHandlingSetup(crash_handling_seconds=0.5)
+    report = RecordingReport()
+    once = TaskManagerSetup(
+        setup=setup,
+        server_key=MovingServer("http://wedged/api"),
+        timeout=0.05,
+        crash_handling_grace=0.05,
+        report_failure=report,
+    )
+
+    with pytest.raises(TimeoutError, match=r"^Prefect task manager setup did not finish within 0s$"):
+        await once.run_once()
+
+    assert setup.crash_handling_started.is_set()
+    assert not setup.finished.is_set(), "giving up must not wait for the crash handling"
+    assert report.reasons == [
+        "Prefect task manager setup failed for http://wedged/api: "
+        "TimeoutError('Prefect task manager setup did not finish within 0s')"
+    ]
+
+    with pytest.raises(
+        RuntimeError, match=r"^Prefect task manager setup already failed for http://wedged/api$"
+    ) as exc_info:
+        await once.run_once()
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    assert setup.calls == 1
+    assert len(report.reasons) == 1
+
+    await asyncio.wait_for(setup.finished.wait(), timeout=2)
+
+
+async def test_a_timed_out_setup_that_finishes_its_bookkeeping_is_not_left_behind() -> None:
+    setup = CrashHandlingSetup(crash_handling_seconds=0)
+    once = TaskManagerSetup(
+        setup=setup, server_key=MovingServer("http://slow/api"), timeout=0.05, crash_handling_grace=1
+    )
+
+    with pytest.raises(TimeoutError):
+        await once.run_once()
+
+    assert setup.finished.is_set()
+
+
+async def test_how_a_cancelled_setup_ended_is_kept_with_the_timeout() -> None:
+    """A crash write that fails on its own is a cause worth reading, not noise to hide behind the timeout."""
+    setup = CrashHandlingSetup(crash_handling_seconds=0, ends_with=RuntimeError("state write refused"))
+    once = TaskManagerSetup(
+        setup=setup, server_key=MovingServer("http://slow/api"), timeout=0.05, crash_handling_grace=1
+    )
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await once.run_once()
+
+    assert exc_info.value.__notes__ == [
+        "After the cancellation the setup ended with RuntimeError('state write refused')"
+    ]
+
+
+async def test_cancelling_the_caller_cancels_the_setup(caplog: pytest.LogCaptureFixture) -> None:
+    setup = CrashHandlingSetup(crash_handling_seconds=0, ends_with=RuntimeError("state write refused"))
+    once = TaskManagerSetup(setup=setup, server_key=MovingServer("http://server-a/api"), timeout=60)
+
+    with caplog.at_level(logging.ERROR, logger="asyncio"):
+        caller = asyncio.ensure_future(once.run_once())
+        await asyncio.sleep(0)
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+
+        await asyncio.wait_for(setup.finished.wait(), timeout=1)
+        # The setup task has no reader left; asyncio reports an unread outcome when it is collected.
+        del caller
+        gc.collect()
+
+    assert not [record for record in caplog.records if "never retrieved" in record.getMessage()]
 
 
 async def test_a_failed_setup_is_reported_once() -> None:

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -426,7 +426,10 @@ container is running — `component/api/conftest.py::workflow_local` and
 `setup_task_manager()`.** The raw call redoes every block, worker pool, deployment and builtin
 trigger against the current server with no timeout of its own; under CI load it hangs until
 pytest-timeout kills the whole class. The helper runs the registration once per server, bounded,
-and fails fast for that server afterwards.
+and fails fast for that server afterwards. It remembers a timed-out server the moment its ceiling is
+hit, before cancelling the registration: Prefect answers the cancellation with a shielded Crashed
+state write to the same server, which against a wedged one blocks for minutes, so the helper does
+not wait for it.
 
 **Never memoize server-side registration per process.** The registration goes to whichever server is
 current, so a process-wide "already done" flag lets the first server's setup satisfy fixtures pointing


### PR DESCRIPTION
## Summary

`backend-tests-functional` on #10547 ([job 101818495814](https://github.com/opsmill/infrahub/actions/runs/34145841529/job/101818495814)) lost a whole xdist worker to a Prefect test server that accepted connections and never answered: `203 passed, 34 errors`, every error on `gw2`, which passed nothing. That wedge is the known Prefect test-server flake family (8th occurrence, first in the functional suite; the server-side cause is still open), and it is not what this PR fixes.

What this PR fixes is that the guard built for exactly this case did not do its job. `setup_task_manager_once()` bounds one setup attempt to 180 s and memoizes the failure so every later class on that server fails fast. On `gw2` the guard fired on time, and the worker still burned the full 300 s pytest timeout on the first class and another 180 s on the second before anything was remembered.

## Why the guard did not memoize

The helper wrapped the setup inline in `asyncio.timeout(180)`. Expiry cancels the task, and the cancellation surfaces inside Prefect's flow engine, which answers it in `handle_crash` under `CancelScope(shield=True)` by writing a `Crashed` state to the server before letting the exception through. That write goes to the server that just stopped answering, with the client's 60 s request timeout and up to 5 retries. So the `except BaseException` that records the failure was never reached: pytest's SIGALRM landed first, in the event-loop driver frame, nothing was memoized, and the next class started the setup over.

Timeline from the job (all `gw2`): container up 17:06:28, `Setup triggers` starts 17:07:07, guard cancels the flow at 17:09:48 (`Crash detected`), SIGALRM at 17:11:19 (`Failed: Timeout >300.0s`, 15 tests), second class re-enters the setup at 17:11:27 and hits the guard at 17:14:27 (`TimeoutError` at the CSRF-token request, memoized), remaining 16 classes fail instantly with `Prefect task manager setup already failed`.

## Key Changes

- `tests/helpers/task_manager.py`: the setup runs as its own task under `asyncio.wait(timeout)`. On expiry the helper memoizes and calls the diagnostics report **first**, then cancels the task, waits `CRASH_HANDLING_GRACE_SECONDS = 5` for Prefect's shielded bookkeeping, and leaves the task behind (a done-callback collects its outcome so asyncio does not log it as never retrieved). Cancelling `run_once` itself cancels the setup task too.
- A failure raised *inside* the task still reaches the memo through the task's result. That matters because Prefect's async engine makes one synchronous HTTP call at every flow start (`update_for_flow(_sync=True)` → `read_server_default_result_storage`); a wedge there blocks the loop and every timer with it, and only SIGALRM ends it, now raised inside the setup task.
- `tests/unit/helpers/test_task_manager.py`: four new cases. The memo is armed while the crash handling is still running; a crash handling that finishes within the grace is not left behind; cancelling the caller cancels the setup; a failure raised after the loop was blocked past the ceiling is what gets remembered, not a substitute timeout.
- `dev/knowledge/backend/testing.md`: one sentence on the expiry-first memo.

No changelog fragment: test infrastructure and internal docs only.

## Validation

- `uv run pytest backend/tests/unit/helpers/` — 50 passed (12 in `test_task_manager.py`, 4 new).
- `INFRAHUB_USE_TEST_CONTAINERS=1 uv run pytest --neo4j backend/tests/component/api/test_40_schema.py::test_schema_load_blocked_on_merged_branch` — the real `setup_task_manager` flow through the new guard, passed in 46 s.
- Real-engine reproduction of the CI mechanism: `prefect_test_harness` behind a TCP proxy (on its own thread) that swallows every response once the flow body runs. Guard fired at 3 s, memo and report landed before `Crash detected`, the `set_state` POST was swallowed, `run_once` returned at 4.0 s (timeout 3 + grace 1), the second call failed in 0.000 s with the `TimeoutError` as cause, and `run_flow_async` stayed pending until the request timeout while the harness closed cleanly.
- `ruff check . --exclude python_sdk`, `ruff format --check`, `ty check .`, `mypy` on the changed files, `markdownlint-cli2` on the doc.

## Test Plan

- [x] Unit, component and real-engine checks above
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

