### PR TITLE
test(backend): wait for the display label before asserting the coalesced recompute

### DIFF
--- a/backend/tests/integration_docker/test_merge_recompute.py
+++ b/backend/tests/integration_docker/test_merge_recompute.py
@@ -135,11 +135,15 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         assert merged
         await _wait_until_merged(client=client, branch_name=branch.name)
 
+        # Each derived family is recomputed by its own flow: wait for every field the recompute changes.
         async def _both_recomputed() -> bool:
             refreshed_node1 = await client.get(kind=PROFILE_NODE_KIND, id=node1.id)
             refreshed_node2 = await client.get(kind=PROFILE_NODE_KIND, id=node2.id)
             return (
-                refreshed_node1.summary.value == "node1 on omega" and refreshed_node2.summary.value == "node2 on omega"
+                refreshed_node1.summary.value == "node1 on omega"
+                and refreshed_node2.summary.value == "node2 on omega"
+                and refreshed_node1.display_label == "node1 via omega"
+                and refreshed_node2.display_label == "node2 via omega"
             )
 
         await _wait_until(_both_recomputed)
@@ -183,9 +187,10 @@ class TestMergeRecompute(TestInfrahubDockerClient):
 
         await client.branch.rebase(branch_name=branch.name)
 
+        # Each derived family is recomputed by its own flow: wait for every field the recompute changes.
         async def _node_recomputed() -> bool:
             refreshed = await client.get(kind=PROFILE_NODE_KIND, id=node.id, branch=branch.name)
-            return refreshed.summary.value == "rnode on romega"
+            return refreshed.summary.value == "rnode on romega" and refreshed.display_label == "rnode via romega"
 
         await _wait_until(_node_recomputed)
 


### PR DESCRIPTION
## Summary

Removes a flake in `backend/tests/integration_docker/test_merge_recompute.py` where `test_rebase_recomputes_user_branch_only_reader` asserted the display label before the rebase recompute had written it. Seen on PR #10543 (run 34198947326, `backend-docker-integration (a)`):

```
assert final.display_label == "rnode via romega"
AssertionError: assert 'rnode via ralpha' == 'rnode via romega'
```

## Key Changes

- The two single-hop tests (`test_merge_recomputes_destination_only_reader`, `test_rebase_recomputes_user_branch_only_reader`) now wait for the display label as well as the computed attribute before asserting, matching every other test in the file.
- No product change. The coalesced merge/rebase recompute submits one process flow per derived family (computed attribute, display label, hfid) and they run concurrently on whichever worker picks them up, so polling only `summary` gave no guarantee about `display_label`.

## Evidence

Task-worker logs from the failing run:

| Time | Event |
|------|-------|
| 07:30:54.07 | `Process computed attribute for TestingProfileNode.summary` starts (task-worker-1) |
| 07:30:54.78 | test polls `summary` == new value, asserts `display_label`, fails |
| 07:30:55.39 | `Process display_labels for TestingProfileNode` starts (task-worker-2), completes shortly after |

The hfid assertion is left out of the predicate on purpose: the tests expect it unchanged by the peer rename, so it cannot race.

## Test Plan

- `uv run ruff format --check` and `uv run ruff check` on the file pass.
- CI `backend-docker-integration (a)` runs `TestMergeRecompute`; the two touched tests should pass and the rest of the class is unaffected.
- Test-only change, no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

