### PR TITLE
docs: address cubic review findings on stable test helpers

### DIFF
--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -37,7 +37,13 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# The raw job log keeps every terminal escape sequence, not only colour (SGR) codes. Strip general
+# CSI sequences (colour, cursor moves, erase-line/screen) and OSC sequences (window title) so none
+# survive into the test-extraction regexes.
+ANSI = re.compile(
+    r"\x1b\[[0-?]*[ -/]*[@-~]"  # CSI: ESC [ ... final-byte
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC: ESC ] ... (BEL | ST)
+)
 
 # The Actions list-runs API silently returns at most this many results per query.
 API_RESULT_CAP = 1000

--- a/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
@@ -75,7 +75,7 @@ async def _rebase_branch(
         branch=default_branch,
         account=AccountSession(account_id=TEST_ACTOR_ID, auth_type=AuthType.NONE),
     )
-    # The rollback test raises through this block, so the doubles have to come off on an exception too.
+    # The doubles must come off even when an exception propagates through this block.
     with (
         override_dependency(build_database, lambda singleton=True: db, dependency_provider=dependency_provider),  # noqa: ARG005
         # Lambdas rather than the bare classes: fast_depends reads the callable's return annotation,

--- a/backend/tests/helpers/prefect_services.py
+++ b/backend/tests/helpers/prefect_services.py
@@ -1,22 +1,12 @@
-"""Rebind Prefect's background queue services when the test process changes Prefect server.
+"""Drain Prefect's background queue services when the test process changes Prefect server.
 
-Prefect emits events and API logs through process-wide background services, ``EventsWorker`` and
-``APILogWorker``. ``EventsWorker.instance()`` is memoized on ``(client_type, client_options)``,
-and for a self-hosted server the options are empty, so the key carries no API URL. The worker it
-hands back built its websocket client and its orchestration client once, from whatever
-``PREFECT_API_URL`` was set the first time an event was emitted.
-
-A test process talks to more than one Prefect server: an ephemeral one for the whole session, plus
-a container that modules and classes opt into. Every orchestration client a test builds follows
-the current setting; the queue services do not. So from the second server onwards the events go to
-the previous one — silently, while that server is still up, and then as a wall of ``Service
-'EventsWorker' failed to process item`` once it has been torn down. Either way the events the
-current server's automations and the tests that assert on them are waiting for never arrive.
-
-Draining is what unpins them: ``_stop`` unregisters an instance synchronously, so the next event
-builds a new worker against the URL current at that point. Drain on both sides of a change of
-server — on the way in, while the old URL still resolves, so queued items reach the server they
-were meant for, and on the way out, before the new server is torn down.
+Prefect routes events and API logs through process-wide queue services that are created once and
+pin to the API URL in effect when they first start; a later change of URL does not rebind them. A
+test process that talks to more than one Prefect server would otherwise keep sending to the first.
+Draining unpins them, and it has to happen on both sides of a server change: on the way in, while
+the previous URL still resolves, so already-queued items reach the server they were meant for; and
+on the way out, before the new server is torn down. After a drain, the next event starts a fresh
+service against the current URL.
 """
 
 from __future__ import annotations

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -120,8 +120,8 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         stop.set()
         await lifecycle_task
 
-        # The Prefect queue services are unpinned by `prefect_class`, which tears down after this
-        # fixture and while its server is still up; see tests/helpers/prefect_services.py.
+        # No drain here — the queue services are unpinned at the server-change boundary, while the
+        # server is still up.
 
         # Clear local worker result storage cache
         _default_storages.clear()

--- a/backend/tests/helpers/workflow_override.py
+++ b/backend/tests/helpers/workflow_override.py
@@ -27,7 +27,7 @@ def override_workflow[WorkflowT: InfrahubWorkflow](
 
     Args:
         workflow: The adapter every workflow lookup should return inside the block.
-        dependency_provider: The provider the dependency injection resolves ``build_workflow`` through.
+        dependency_provider: The provider the dependency injection resolves the workflow lookup through.
 
     Yields:
         ``workflow`` itself.

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -190,9 +190,11 @@ Two consequences worth remembering:
 ### One process, several Prefect servers
 
 A test process does not keep one Prefect server. The session-scoped `prefect_test_fixture` starts
-an ephemeral one for the whole session, and the `prefect` (module) and `prefect_class` (class)
-fixtures start a **container of their own** and re-point `PREFECT_API_URL` at it for that scope.
-Each orchestration client a test builds reads the setting when it is built, so it follows.
+an ephemeral one for the whole session. The module-scoped `prefect` fixture reuses the
+session-scoped `prefect_container`, while the class-scoped `prefect_class` starts a container per
+class; both re-point `PREFECT_API_URL` at their server for the scope, so a test can end up on a
+different server than the one before it. Each orchestration client a test builds reads the setting
+when it is built, so it follows.
 
 Prefect's background queue services do not. `EventsWorker` and `APILogWorker` are process-wide
 `QueueService` singletons, memoized on `hash((cls, *args))`, and `EventsWorker.instance()` passes

--- a/docs/docs/overview/build-with-ai/setup.mdx
+++ b/docs/docs/overview/build-with-ai/setup.mdx
@@ -53,20 +53,12 @@ Keep the `infrahub-common` skill directory, wherever your installer placed it. I
 
 ## 3. Connect the MCP server
 
-Run the server with `uvx`, which fetches it on first use:
+The server runs as `uvx infrahub-mcp`, which `uvx` fetches on first use. Your assistant launches it from its MCP configuration rather than you starting it in a shell, so the two connection variables go in that configuration alongside the command:
 
-```bash
-uvx infrahub-mcp
-```
+- `INFRAHUB_ADDRESS` — your instance, for example `http://localhost:8000`
+- `INFRAHUB_API_TOKEN` — your API token
 
-Point it at your instance with two environment variables:
-
-```bash
-export INFRAHUB_ADDRESS="http://localhost:8000"
-export INFRAHUB_API_TOKEN="<your-token>"
-```
-
-Then register the server with your assistant. The configuration file and its location differ per client, so follow your client's MCP documentation for where the entry goes.
+The configuration file, its location, and how it carries environment variables differ per client, so follow your client's MCP documentation for where the entry goes.
 
 **Choose a transport.** Use stdio when the server runs on the same machine as your assistant, which is the local development case. Use streamable HTTP for a remote server, and for any of the per-user authentication modes below.
 


### PR DESCRIPTION
## Summary

Addresses the `cubic-dev-ai` review findings raised on the `stable → develop` sync PR #10555. The findings concern code already on `stable`, so the fixes land here and reach `develop` through the next sync. One commit per finding.

## Fixes

- **Docstrings and comments** — state the durable contract instead of naming identifiers, call sites, or file paths that rot. (7, 8, 9, 10)
- **Documentation accuracy** — correct how the Prefect test fixtures scope their containers, and describe the MCP server as launched by the assistant from its configuration rather than a shell command shown before its variables are set. (6, 11)
- **CI-flakiness collector** — strip all terminal escape sequences (not only colour codes) from raw job logs. (4)

  The escape-sequence matcher now covers any CSI or OSC sequence, where the previous `\x1b\[[0-9;]*m` matched SGR colour codes only. Sequences the old pattern left in the log — and which corrupted the extracted test name — are now removed. Each row shows the raw bytes in the downloaded log, what a human sees rendered in the terminal, and which regex removes them:

  | Kind | Raw bytes in the log | On screen | Old | New |
  | --- | --- | --- | --- | --- |
  | SGR colour | `test_create \x1b[32mPASSED\x1b[0m` | `test_create PASSED` (PASSED in green) | stripped | stripped |
  | CSI erase-line | `\x1b[2K\rPulling neo4j ...` | progress line redrawn in place | left in | stripped |
  | CSI cursor hide/show | `\x1b[?25lPulling images...\x1b[?25h` | `Pulling images...` with the cursor hidden | left in | stripped |
  | OSC window title | `\x1b]0;pytest infrahub\x07` | terminal tab titled `pytest infrahub` | left in | stripped |

  Only the first row (SGR colour) sits directly on a test line; the others come from image pulls and shell setup earlier in the job, and once left in the log they shifted the byte offsets the extractor keys off, so it read out zero tests.

Findings 1 (gate-validator tests, a documented won't-fix on #10488) and 3 (base-branch routing, moot for a forward-merge) need no change and were answered on the review threads. Finding 5 (a fallback fetch for a `gh` that does not know `--allow-escape-sequences`) is not implemented: the flag has shipped in `gh` since early 2025, older versions predate the minimum this tooling targets, and the extra branch only added a second code path to guard a `gh` no contributor is expected to run.

## Validation

`ruff`, `ty`, and `vale` pass on the changed files; the broadened escape-sequence regex is checked against CSI/OSC/SGR samples. Docstring, comment, and documentation changes plus a test-only tooling script — no production runtime behaviour affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1YejTRVwhwtYUqLTmYPWZ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
