### PR TITLE
docs: add Demo OTN to the explore page

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -222,12 +222,16 @@ Redis
 Redoc
 refactored
 regex
+regenerator
+regenerators
 reimported
 repo
 requesters
 resizable
 Resizable
 reusability
+ROADM
+ROADMs
 rollout
 Schema
 schema_mapping

--- a/docs/docs/overview/explore.mdx
+++ b/docs/docs/overview/explore.mdx
@@ -81,6 +81,20 @@ Demo DC is an end-to-end reference implementation you can actually learn from. T
 
 <ReferenceLink title="Demo DC" url="$(base_url)demo-dc" openInNewTab />
 
+- **Demo OTN**
+
+Demo OTN is an optical transport reference implementation that models a European research core down to the fiber span and the wavelength. This demo includes:
+
+- Schema-driven optical modelling: conduits, fiber spans, optical multiplex sections, ROADMs, amplifiers, transponders, mux/demux, regenerators, the DWDM frequency grid and the CWDM wavelength plan
+- Provisioning from intent: Generators pick the route and the optical mode, allocate a grid position, and build the carriers, ports and client mappings behind a single service object
+- Link budget computed from the modelled plant: loss, OSNR, dispersion and latency over the ordered chain of spans and amplifiers, with Checks that fail a service that does not close
+- Impact analysis: name a fiber section and get the wavelengths, terabits, services and customers behind it, plus the conduits each span shares
+- Capacity planning that accounts for quantisation: free spectrum as blocks, and how many of the 96 anchors will actually take another carrier per mode
+- Diversity validation read off the conduits rather than the sections, so two services sharing a duct are not reported as diverse
+- Artifact-rendered network and ODU maps, generated per branch from the model
+
+<ReferenceLink title="Demo OTN" url="$(base_url)demo-otn" openInNewTab />
+
 - **Demo Service Catalog**
 
 The Service Catalog demo demonstrates how Infrahub can be used to manage and deploy services within an ISP environment. It walks through the process of creating a service catalog using Infrahub and Streamlit. From modeling services in the schema, codifying them in Generator, to making these capabilities accessible across the organization via a Streamlit app. This demo provides a comprehensive, end-to-end overview of the workflow.


### PR DESCRIPTION
# Why

The Explore Infrahub page lists the demos people can run to see Infrahub applied to a real domain, but the optical transport demo (`opsmill/infrahub-demo-otn`) was missing. Anyone arriving at the docs looking for an optical or transport use case had no way to find it.

Goal: readers of the Explore page can discover Demo OTN the same way they discover Demo DC, Demo Service Catalog and Demo SP.

Non-goals: no changes to the demo repository itself, and no changes to the other demo entries.

## What changed

- **Explore page** gets a `Demo OTN` entry, placed between Demo DC and Demo Service Catalog to keep the page's existing alphabetical order. It carries a one-line framing plus seven feature bullets (schema scope, provisioning from intent, link budget, impact analysis, capacity planning, diversity validation, the artifact-rendered maps) and a `ReferenceLink` to `$(base_url)demo-otn`.
- **Vale spelling exceptions** gain `ROADM`/`ROADMs` and `regenerator`/`regenerators`, the two optical terms in the new section that the dictionary rejected.

Content is taken from the demo repo's README, so the figures and claims match what the demo actually ships.

What stayed the same: no other page, component or config touched. The intro bullet list at the top of the page already links to the demos section generically, so it needed no edit.

## How to review

The link target is the one thing worth checking: the published site path is `demo-otn`, not `infrahub-demo-otn`. Confirmed live:

```bash
curl -o /dev/null -w '%{http_code}\n' -L https://docs.infrahub.app/demo-otn   # 200
```

Note the existing demo bullets use em dashes in their feature lists (`Schema-driven modelling — ...`) while this one uses colons. Happy to switch to em dashes if you would rather the punctuation match its neighbours exactly.

## How to test

```bash
markdownlint-cli2 'docs/docs/overview/explore.mdx'
vale docs/docs/overview/explore.mdx
```

Both clean: markdownlint 0 errors, Vale 0 errors / 0 warnings.

## Impact & rollout

- **Backward compatibility:** none needed, additive docs content.
- **Deployment notes:** safe to deploy. Targets `stable` because the docs site builds the `infrahub` submodule from `stable`, so the entry only appears on docs.infrahub.app once merged there.

## Checklist

- [x] External docs updated (if user-facing or ops-facing change)
- [x] I have reviewed AI generated content

No changelog fragment: this is docs-site content, not a product change, matching the precedent of #9531 (which added Demo SP to this same page) and #10233.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

