### PR TITLE
fix(tasks): stop restarting the demo stack after loading the infrastructure schema

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -118,9 +118,8 @@ def status(
 @task(optional=["database"])
 def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE) -> None:
     """Load the base schema for infrastructure."""
-    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=False)
+    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=True)
     load_infrastructure_menu(context=context, database=database, namespace=NAMESPACE)
-    restart_services(context=context, database=database, namespace=NAMESPACE)
 
 
 @task(optional=["database"])


### PR DESCRIPTION
# Why

`E2E-testing-invoke-demo-start` fails intermittently in `demo.load-infra-data` with

```
['InfraBackBoneServiceUpsert'] The pool for service_identifier has not been provisioned yet. at service_identifier
```

Six occurrences since 2026-09-01 (three on 09-01, one on 09-07, two on 09-08 — on #10543 and #10553), none caused by the PR under test, and every completed failure of that job in the last six days.

`invoke demo.load-infra-schema` runs `infrahubctl schema load`, `infrahubctl menu load`, then restarts the server and both task-workers. The restart was a "temporary fix" from 2024-04 (f583fd8b2d); `dev.load-infra-schema` never had it, and schema/menu changes propagate through the schema-hash sync today.

The ids of schema-defined NumberPools are written asynchronously: schema load → `infrahub.schema.updated` event → Prefect `schema-updated` flow → `validate-schema-number-pools` → `update_schema_branch(update_db=True)` ("Persisting schema changes to the database on main", ~7 s) → "Updated schema hash for branch main after number pool synchronization". The restart lands 11–17 s after the schema load returns, i.e. inside that persist:

| event (offset from "6 schemas processed") | red, #10553 | red, #10543 | green, 2026-09-02 |
|---|---|---|---|
| `schema-updated` flow begins | +7.2 s | +7.4 s | +7.4 s |
| "Persisting schema changes" | +9.4 s | +10.0 s | +10.1 s |
| "Updated schema hash" | never | never | +17.4 s |
| worker `TerminationSignal` → `Crash detected! Execution was cancelled by the runtime environment` | +11.6 s | +12.2 s | +17.4 s (15 ms after the hash update) |

A crashed flow is never retried, so the server comes back with a schema whose `service_identifier` has no `number_pool_id`, and the first `InfraBackBoneService` create fails two minutes later.

Non-goal: the product-side gap (any worker restart during the `schema-updated` flow leaves schema-defined NumberPool attributes unusable until the next schema change) is not addressed here; it belongs in the synchronous schema-load path or a startup re-sync and deserves its own discussion.

## What changed

- `demo.load-infra-schema` no longer restarts the server and task-workers after loading the schema and menu.
- It passes `--wait 30` to `infrahubctl schema load`, so it returns once the schema hash has converged across workers — the same call `dev.load-infra-schema` makes.
- `invoke demo.restart` is untouched for anyone who wants an explicit restart.

## How to test

```bash
INFRAHUB_BUILD_NAME=flake14check INFRAHUB_SERVER_PORT=0 INFRAHUB_DB_BACKUP_PORT=0 VMAGENT_PORT=0 \
  uv run invoke demo.start demo.load-infra-schema demo.load-infra-data
docker logs flake14check-task-worker-1 2>&1 | grep -a "Persisting schema changes\|Updated schema hash\|Crash detected"
```

Expected: the data load completes through "Creating Backbone Links & Circuits", and the worker log shows "Updated schema hash for branch main after number pool synchronization" with no "Crash detected".

Local run against the 1.11.2 image with this change (2026-09-08 11:34–11:37 UTC): exit 0, data load completed through "Creating Backbone Links & Circuits". Worker log:

```
11:35:59.151 Setting InfraBackBoneService.service_identifier number_pool_id to 56cec18d-…
11:35:59.152 Persisting schema changes to the database on main
11:36:04.510 Updated schema hash for branch main after number pool synchronization
```

No "Crash detected" in either worker. CI's `E2E-testing-invoke-demo-start` on this PR exercises the same path.

## Impact & rollout

- Developer/demo tooling only; no product code, schema, or API change.
- No changelog fragment: `invoke demo.*` is repository tooling, not a user-visible product change.

## Checklist

- [ ] Tests added/updated — n/a, invoke task
- [x] Changelog entry — intentionally none (see above)
- [ ] External docs updated — n/a, docs only show the command line, which is unchanged
- [ ] Internal .md docs updated — n/a
- [x] I have reviewed AI generated content
