### PR TITLE
feat(changelog): enrich node changelogs delivered to webhooks with HFID and peer labels

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -15,7 +15,8 @@ from infrahub.core.branch.creator import BranchCreator
 from infrahub.core.branch.data_deleter import BranchDataDeleter
 from infrahub.core.branch.delete_coordinator import BranchDeleteOrchestrator
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
+from infrahub.core.changelog.builder import build_diff_changelog_collector
+from infrahub.core.changelog.diff import MigrationTracker
 from infrahub.core.constants import SYSTEM_USER_ID, DiffAction, MutationAction
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
@@ -331,10 +332,17 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
     )
     events: list[InfrahubEvent] = [rebase_event]
     changes: list[MergeChange] = []
-    changelog_collector = DiffChangelogCollector(
-        diff=default_branch_diff, branch=user_branch, db=db, migration_tracker=MigrationTracker(migrations=migrations)
-    )
-    for action, node_changelog in changelog_collector.collect_changelogs():
+    # The database session used for the rebase has already closed here, so open a fresh one for the
+    # changelog's own database reads.
+    async with database.start_session() as changelog_db:
+        changelog_collector = build_diff_changelog_collector(
+            diff=default_branch_diff,
+            db=changelog_db,
+            branch=user_branch,
+            migration_tracker=MigrationTracker(migrations=migrations),
+        )
+        collected_changelogs = await changelog_collector.collect_changelogs()
+    for action, node_changelog in collected_changelogs:
         mutation_action = MutationAction.from_diff_action(diff_action=action)
         meta = EventMeta.from_parent(parent=rebase_event, branch=user_branch)
         meta.origin = NodeMutationOrigin.REBASE

--- a/backend/infrahub/core/changelog/builder.py
+++ b/backend/infrahub/core/changelog/builder.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.manager import NodeManager
+
+from .diff import DiffChangelogCollector
+from .enrichment import node_label_loader
+from .models import RelationshipChangelogGetter
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.diff.model.path import EnrichedDiffRoot
+    from infrahub.database import InfrahubDatabase
+
+    from .diff import MigrationTracker
+
+
+def build_diff_changelog_collector(
+    diff: EnrichedDiffRoot, db: InfrahubDatabase, branch: Branch, migration_tracker: MigrationTracker | None = None
+) -> DiffChangelogCollector:
+    """Build a changelog collector whose label loader reads from the same database and branch."""
+    return DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+        migration_tracker=migration_tracker,
+    )
+
+
+def build_relationship_changelog_getter(db: InfrahubDatabase, branch: Branch) -> RelationshipChangelogGetter:
+    """Build a relationship changelog getter whose label loader reads from the same database and branch."""
+    return RelationshipChangelogGetter(
+        db=db, branch=branch, label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many)
+    )

--- a/backend/infrahub/core/changelog/diff.py
+++ b/backend/infrahub/core/changelog/diff.py
@@ -304,10 +304,7 @@ class DiffChangelogCollector:
         """Yield every relationship-peer holder across the changelogs (one-cardinality and each many-peer)."""
         for changelog in changelogs:
             for relationship in changelog.relationships.values():
-                if isinstance(relationship, RelationshipCardinalityOneChangelog):
-                    yield relationship
-                elif isinstance(relationship, RelationshipCardinalityManyChangelog):
-                    yield from relationship.peers
+                yield from relationship.peer_entries()
 
     def _needs_external_hfid(self, peer: RelationshipCardinalityOneChangelog | RelationshipPeerChangelog) -> bool:
         """True for a referenced peer whose HFID the changed-node load did not already resolve."""

--- a/backend/infrahub/core/changelog/diff.py
+++ b/backend/infrahub/core/changelog/diff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Sequence
 
@@ -19,6 +20,8 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from infrahub.core.branch import Branch
     from infrahub.core.diff.model.path import (
         EnrichedDiffAttribute,
@@ -30,6 +33,8 @@ if TYPE_CHECKING:
     from infrahub.core.models import SchemaUpdateMigrationInfo
     from infrahub.core.schema import MainSchemaTypes
     from infrahub.database import InfrahubDatabase
+
+    from .enrichment import NodeLabelLoader
 
 
 @dataclass
@@ -45,12 +50,15 @@ class DiffChangelogCollector:
         diff: EnrichedDiffRoot,
         branch: Branch,
         db: InfrahubDatabase,
+        label_loader: NodeLabelLoader,
         migration_tracker: MigrationTracker | None = None,
     ) -> None:
         self._diff = diff
         self._branch = branch
         self._db = db
+        self._label_loader = label_loader
         self._diff_nodes: dict[str, NodeInDiff]
+        self._node_hfids: dict[str, list[str] | None] = {}
         self.migration = migration_tracker or MigrationTracker()
 
     def _populate_diff_nodes(self) -> None:
@@ -70,8 +78,17 @@ class DiffChangelogCollector:
             rel_schema = schema.get_relationship(name=relationship_name)
             return rel_schema.peer
 
+    def _peer_hfid(self, peer_id: str) -> list[str] | None:
+        """Return a peer's HFID when it is among the changed nodes already loaded for this diff.
+
+        A changed relationship is symmetric, so a peer referenced here is normally a changed node
+        itself and its HFID comes for free from the batch; a peer outside the diff keeps None.
+        """
+        return self._node_hfids.get(peer_id)
+
     def _process_node(self, node: EnrichedDiffNode) -> NodeChangelog:
         node_changelog = NodeChangelog(node_id=node.uuid, node_kind=node.kind, display_label=node.label)
+        node_changelog.hfid = self._node_hfids.get(node.uuid)
         try:
             schema = self._db.schema.get(node_changelog.node_kind, branch=self._branch, duplicate=False)
         except SchemaNotFoundError:
@@ -80,10 +97,30 @@ class DiffChangelogCollector:
         for attribute in node.attributes:
             self._process_node_attribute(node=node_changelog, attribute=attribute, schema=schema)
 
+        if node_changelog.hfid is None and node.action == DiffAction.REMOVED:
+            # A removed node is gone when the batch load runs, but the diff still records its HFID;
+            # recover it so removed nodes report it like directly-deleted ones.
+            node_changelog.hfid = self._hfid_from_diff(node_changelog)
+
         for relationship in node.relationships:
             self._process_node_relationship(node=node_changelog, relationship=relationship)
 
         return node_changelog
+
+    @staticmethod
+    def _hfid_from_diff(node_changelog: NodeChangelog) -> list[str] | None:
+        """Recover a node's HFID from the human-friendly-id attribute the diff carries for it."""
+        attribute = node_changelog.attributes.get("human_friendly_id")
+        if attribute is None:
+            return None
+        raw = attribute.value if attribute.value is not None else attribute.value_previous
+        if not isinstance(raw, str):
+            return None
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, list) else None
 
     def _process_node_attribute(
         self, node: NodeChangelog, attribute: EnrichedDiffAttribute, schema: MainSchemaTypes | None
@@ -156,6 +193,9 @@ class DiffChangelogCollector:
                                 node_kind=node.node_kind,
                                 relationship_name=relationship.name,
                             )
+                            # The peer's display label is already carried by the diff, no load needed.
+                            changelog_rel.peer_display_label = entry.peer_label
+                            changelog_rel.peer_hfid = self._peer_hfid(peer_id=rel_prop.new_value)
                         if rel_prop.previous_value:
                             changelog_rel.peer_id_previous = rel_prop.previous_value
                             changelog_rel.peer_kind_previous = self.get_peer_kind(
@@ -201,6 +241,8 @@ class DiffChangelogCollector:
                 peer_kind=self.get_peer_kind(
                     peer_id=peer.peer_id, node_kind=node.node_kind, relationship_name=relationship.name
                 ),
+                peer_display_label=peer.peer_label,
+                peer_hfid=self._peer_hfid(peer_id=peer.peer_id),
                 peer_status=peer.action,
             )
             for peer_prop in peer.properties:
@@ -228,14 +270,58 @@ class DiffChangelogCollector:
 
         node.add_relationship(relationship_changelog=changelog_rel)
 
-    def collect_changelogs(self) -> Sequence[tuple[DiffAction, NodeChangelog]]:
+    async def collect_changelogs(self) -> Sequence[tuple[DiffAction, NodeChangelog]]:
+        """Build a changelog for every changed node in the diff, filled with each node's HFID.
+
+        Every changed node's HFID is resolved in a single batched load, since the diff itself does
+        not carry it.
+
+        Returns:
+            One (action, changelog) pair per changed node that has recorded changes.
+
+        """
         self._populate_diff_nodes()
-        changelogs = [
-            (node.action, self._process_node(node=node))
-            for node in self._diff.nodes
-            if node.action != DiffAction.UNCHANGED
+        changed_nodes = [node for node in self._diff.nodes if node.action != DiffAction.UNCHANGED]
+        # A node whose kind was dropped by a schema migration in the merge has no schema to resolve
+        # labels against; leave it out of the load so one such node cannot fail the whole batch.
+        labelable_ids = [
+            node.uuid for node in changed_nodes if self._db.schema.has(name=node.kind, branch=self._branch)
         ]
-        return [(action, node_changelog) for action, node_changelog in changelogs if node_changelog.has_changes]
+        self._node_hfids = await self._label_loader.load_hfids(labelable_ids)
+        changelogs = [(node.action, self._process_node(node=node)) for node in changed_nodes]
+        changelogs = [(action, node_changelog) for action, node_changelog in changelogs if node_changelog.has_changes]
+        await self._resolve_external_peer_hfids([node_changelog for _, node_changelog in changelogs])
+        return changelogs
+
+    def _peer_entries(
+        self, changelogs: list[NodeChangelog]
+    ) -> Iterator[RelationshipCardinalityOneChangelog | RelationshipPeerChangelog]:
+        """Yield every relationship-peer holder across the changelogs (one-cardinality and each many-peer)."""
+        for changelog in changelogs:
+            for relationship in changelog.relationships.values():
+                if isinstance(relationship, RelationshipCardinalityOneChangelog):
+                    yield relationship
+                elif isinstance(relationship, RelationshipCardinalityManyChangelog):
+                    yield from relationship.peers
+
+    def _needs_external_hfid(self, peer: RelationshipCardinalityOneChangelog | RelationshipPeerChangelog) -> bool:
+        """True for a referenced peer whose HFID the changed-node load did not already resolve."""
+        return peer.peer_hfid is None and peer.peer_id not in self._node_hfids
+
+    async def _resolve_external_peer_hfids(self, changelogs: list[NodeChangelog]) -> None:
+        """Fill the HFID of relationship peers that are referenced but not themselves changed nodes.
+
+        A changed relationship is usually symmetric, so most peers are changed nodes already loaded;
+        this resolves the rest so a peer's HFID does not depend on whether the peer also changed.
+        """
+        peers = list(self._peer_entries(changelogs))
+        external_ids = [peer.peer_id for peer in peers if peer.peer_id and self._needs_external_hfid(peer)]
+        if not external_ids:
+            return
+        peer_hfids = await self._label_loader.load_hfids(external_ids)
+        for peer in peers:
+            if peer.peer_hfid is None and peer.peer_id in peer_hfids:
+                peer.peer_hfid = peer_hfids[peer.peer_id]
 
 
 def _keep_branch_update(diff_property: EnrichedDiffProperty) -> bool:

--- a/backend/infrahub/core/changelog/diff.py
+++ b/backend/infrahub/core/changelog/diff.py
@@ -74,7 +74,12 @@ class DiffChangelogCollector:
         try:
             return self.get_node(node_id=peer_id).kind
         except KeyError:
-            schema = self._db.schema.get(node_kind, branch=self._branch, duplicate=False)
+            try:
+                schema = self._db.schema.get(node_kind, branch=self._branch, duplicate=False)
+            except SchemaNotFoundError:
+                # The node's kind was dropped by a schema migration, so an unchanged peer's kind
+                # cannot be resolved from the schema; degrade as the attribute path does.
+                return "n/a"
             rel_schema = schema.get_relationship(name=relationship_name)
             return rel_schema.peer
 

--- a/backend/infrahub/core/changelog/diff.py
+++ b/backend/infrahub/core/changelog/diff.py
@@ -293,8 +293,11 @@ class DiffChangelogCollector:
             node.uuid for node in changed_nodes if self._db.schema.has(name=node.kind, branch=self._branch)
         ]
         self._node_hfids = await self._label_loader.load_hfids(labelable_ids)
-        changelogs = [(node.action, self._process_node(node=node)) for node in changed_nodes]
-        changelogs = [(action, node_changelog) for action, node_changelog in changelogs if node_changelog.has_changes]
+        changelogs = [
+            (node.action, node_changelog)
+            for node in changed_nodes
+            if (node_changelog := self._process_node(node=node)).has_changes
+        ]
         await self._resolve_external_peer_hfids([node_changelog for _, node_changelog in changelogs])
         return changelogs
 

--- a/backend/infrahub/core/changelog/enrichment.py
+++ b/backend/infrahub/core/changelog/enrichment.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+from opentelemetry import trace
+
+from infrahub import config
+from infrahub.log import get_logger
+from infrahub.utils import log_exception_guard
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.database import InfrahubDatabase
+
+log = get_logger()
+
+_ResultT = TypeVar("_ResultT")
+
+
+@dataclass(frozen=True)
+class NodeLabels:
+    """Human-readable identifiers of a node, added to changelog payloads for external consumers."""
+
+    display_label: str
+    """The node's display label."""
+
+    hfid: list[str] | None
+    """The node's human-friendly ID, or None when the node has none."""
+
+
+PLACEHOLDER_LABELS = NodeLabels(display_label="n/a", hfid=None)
+"""Fallback used when a referenced node cannot be resolved (for instance a peer deleted in a cascade)."""
+
+
+class NodeLoader(Protocol):
+    """Loads nodes by ID, letting the label reader read the graph without importing concrete implementations."""
+
+    async def __call__(self, *, db: InfrahubDatabase, ids: list[str], branch: Branch) -> dict[str, Node]: ...
+
+
+class NodeLabelReader(Protocol):
+    """Resolves the display label and human-friendly ID of nodes by ID."""
+
+    async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]: ...
+
+    async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]: ...
+
+
+class DbNodeLabelReader:
+    """Reads node labels from the graph through an injected node loader.
+
+    This is the only piece that touches the database, keeping the loading logic that surrounds it
+    testable without one.
+    """
+
+    def __init__(self, db: InfrahubDatabase, branch: Branch, node_loader: NodeLoader) -> None:
+        self._db = db
+        self._branch = branch
+        self._node_loader = node_loader
+
+    async def _load_nodes(self, node_ids: list[str]) -> dict[str, Node]:
+        """Load the nodes in query-size-limited pages so a large batch never issues one huge query."""
+        nodes: dict[str, Node] = {}
+        limit = config.SETTINGS.database.query_size_limit
+        for offset in range(0, len(node_ids), limit):
+            page = node_ids[offset : offset + limit]
+            nodes.update(await self._node_loader(db=self._db, ids=page, branch=self._branch))
+        return nodes
+
+    async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]:
+        nodes = await self._load_nodes(node_ids)
+        return {
+            node_id: NodeLabels(
+                display_label=await node.get_display_label(db=self._db),
+                hfid=await node.get_hfid(db=self._db),
+            )
+            for node_id, node in nodes.items()
+        }
+
+    async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]:
+        nodes = await self._load_nodes(node_ids)
+        return {node_id: await node.get_hfid(db=self._db) for node_id, node in nodes.items()}
+
+
+class NodeLabelLoader:
+    """Normalizes node IDs and resolves their changelog identifiers through an injected reader."""
+
+    def __init__(self, reader: NodeLabelReader) -> None:
+        self._reader = reader
+
+    async def load_labels(self, node_ids: Iterable[str]) -> dict[str, NodeLabels]:
+        """Return the display label and HFID of each node, holding only the ones that were found."""
+        return await self._resolve(node_ids, self._reader.load_labels)
+
+    async def load_hfids(self, node_ids: Iterable[str]) -> dict[str, list[str] | None]:
+        """Return only the HFID of each node, without resolving the display labels it does not need."""
+        return await self._resolve(node_ids, self._reader.load_hfids)
+
+    async def _resolve(
+        self, node_ids: Iterable[str], read: Callable[[list[str]], Awaitable[dict[str, _ResultT]]]
+    ) -> dict[str, _ResultT]:
+        """Normalize the IDs and read them, degrading to an empty mapping on failure.
+
+        Duplicate and empty IDs are ignored, and an empty request resolves without reading. Label
+        enrichment is cosmetic, so a read failure degrades rather than propagating: the operation
+        that asked for the labels has already committed and must not be failed or rolled back.
+        """
+        unique_ids = sorted({node_id for node_id in node_ids if node_id})
+        if not unique_ids:
+            return {}
+
+        with trace.get_tracer(__name__).start_as_current_span("changelog.load_node_labels") as span:
+            span.set_attribute("changelog.node_count", len(unique_ids))
+            # A schemaless peer or a transient read must not fail the committed operation.
+            with log_exception_guard(log, "Changelog label enrichment failed; changelog will omit labels"):
+                return await read(unique_ids)
+            return {}
+
+
+def node_label_loader(db: InfrahubDatabase, branch: Branch, node_loader: NodeLoader) -> NodeLabelLoader:
+    """Build a NodeLabelLoader that reads labels from the database through the given node loader."""
+    return NodeLabelLoader(reader=DbNodeLabelReader(db=db, branch=branch, node_loader=node_loader))

--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, PrivateAttr, computed_field, field_validator, model_validator
 
+from infrahub.core.changelog.enrichment import PLACEHOLDER_LABELS, NodeLabelLoader, NodeLabels
 from infrahub.core.constants import NULL_VALUE, DiffAction, RelationshipCardinality, RelationshipKind
 from infrahub.log import get_logger
 
@@ -120,6 +121,8 @@ class RelationshipCardinalityOneChangelog(BaseModel):
     peer_kind_previous: str | None = Field(default=None, description="The node kind of the previous peer")
     peer_id: str | None = Field(default=None, description="The current peer of this relationship")
     peer_kind: str | None = Field(default=None, description="The node kind of the current peer")
+    peer_display_label: str | None = Field(default=None, description="The display label of the current peer")
+    peer_hfid: list[str] | None = Field(default=None, description="The HFID of the current peer")
     properties: dict[str, PropertyChangelog] = Field(
         default_factory=dict, description="Changes to properties of this relationship if any were made"
     )
@@ -169,6 +172,8 @@ class RelationshipCardinalityOneChangelog(BaseModel):
 class RelationshipPeerChangelog(BaseModel):
     peer_id: str = Field(..., description="The ID of the peer")
     peer_kind: str = Field(..., description="The node kind of the peer")
+    peer_display_label: str | None = Field(default=None, description="The display label of the peer")
+    peer_hfid: list[str] | None = Field(default=None, description="The HFID of the peer")
     peer_status: DiffAction = Field(
         ..., description="Indicate how the relationship to this peer was changed in this update"
     )
@@ -232,6 +237,7 @@ class NodeChangelog(BaseModel):
     node_id: str
     node_kind: str
     display_label: str
+    hfid: list[str] | None = None
 
     attributes: dict[str, AttributeChangelog] = Field(default_factory=dict)
     relationships: dict[str, RelationshipCardinalityOneChangelog | RelationshipCardinalityManyChangelog] = Field(
@@ -478,20 +484,43 @@ def peer_relationships(peer_schema: MainSchemaTypes, rel_schema: RelationshipSch
     return candidates
 
 
+def _labels_for(peer_id: str, labels: dict[str, NodeLabels]) -> NodeLabels:
+    """Return a peer's labels, or a placeholder when it could not be resolved (e.g. deleted)."""
+    return labels.get(peer_id, PLACEHOLDER_LABELS)
+
+
 class RelationshipChangelogGetter:
-    def __init__(self, db: InfrahubDatabase, branch: Branch) -> None:
+    """Builds the secondary node changelogs a relationship mutation implies.
+
+    A relationship change on the mutated node also changes the reciprocal relationship on each
+    peer, so one secondary changelog is emitted per affected peer. The mutated node's own
+    relationships and each secondary are filled with the peer's display label and HFID, resolved
+    for every referenced peer in a single batched load.
+    """
+
+    def __init__(self, db: InfrahubDatabase, branch: Branch, label_loader: NodeLabelLoader) -> None:
         self._db = db
         self._branch = branch
+        self._label_loader = label_loader
 
     async def get_changelogs(self, primary_changelog: NodeChangelog) -> list[NodeChangelog]:
-        """Return secondary changelogs based on this update.
+        """Enrich the mutated node's relationships in place and return the secondaries they imply.
 
-        These will typically include updates to relationships on other nodes.
+        Args:
+            primary_changelog: Changelog of the node that was directly mutated. Its relationships
+                are filled in place with each peer's display label and HFID.
+
+        Returns:
+            The secondary changelogs, one per affected peer.
+
         """
+        labels = await self._label_loader.load_labels(self._referenced_peer_ids(changelog=primary_changelog))
+        self._enrich_relationship_peers(changelog=primary_changelog, labels=labels)
+
         schema_branch = self._db.schema.get_schema_branch(name=self._branch.name)
         node_schema = schema_branch.get(name=primary_changelog.node_kind, duplicate=False)
-        secondaries: list[NodeChangelog] = []
 
+        secondaries: list[NodeChangelog] = []
         for relationship in primary_changelog.relationships.values():
             if isinstance(relationship, RelationshipCardinalityOneChangelog):
                 secondaries.extend(
@@ -500,6 +529,7 @@ class RelationshipChangelogGetter:
                         node_schema=node_schema,
                         primary_changelog=primary_changelog,
                         schema_branch=schema_branch,
+                        labels=labels,
                     )
                 )
             elif isinstance(relationship, RelationshipCardinalityManyChangelog):
@@ -509,10 +539,36 @@ class RelationshipChangelogGetter:
                         node_schema=node_schema,
                         primary_changelog=primary_changelog,
                         schema_branch=schema_branch,
+                        labels=labels,
                     )
                 )
-
         return secondaries
+
+    @staticmethod
+    def _referenced_peer_ids(changelog: NodeChangelog) -> list[str]:
+        """Collect the IDs of every peer referenced by this changelog's relationships."""
+        ids: list[str] = []
+        for relationship in changelog.relationships.values():
+            if isinstance(relationship, RelationshipCardinalityOneChangelog):
+                ids += [peer_id for peer_id in (relationship.peer_id, relationship.peer_id_previous) if peer_id]
+            elif isinstance(relationship, RelationshipCardinalityManyChangelog):
+                ids += [peer.peer_id for peer in relationship.peers if peer.peer_id]
+        return ids
+
+    @staticmethod
+    def _enrich_relationship_peers(changelog: NodeChangelog, labels: dict[str, NodeLabels]) -> None:
+        """Fill each current relationship peer of the mutated node with its display label and HFID."""
+        for relationship in changelog.relationships.values():
+            if isinstance(relationship, RelationshipCardinalityOneChangelog):
+                if relationship.peer_id:
+                    peer_labels = _labels_for(peer_id=relationship.peer_id, labels=labels)
+                    relationship.peer_display_label = peer_labels.display_label
+                    relationship.peer_hfid = peer_labels.hfid
+            elif isinstance(relationship, RelationshipCardinalityManyChangelog):
+                for peer in relationship.peers:
+                    peer_labels = _labels_for(peer_id=peer.peer_id, labels=labels)
+                    peer.peer_display_label = peer_labels.display_label
+                    peer.peer_hfid = peer_labels.hfid
 
     def _parse_cardinality_one_relationship(
         self,
@@ -520,6 +576,7 @@ class RelationshipChangelogGetter:
         node_schema: MainSchemaTypes,
         primary_changelog: NodeChangelog,
         schema_branch: SchemaBranch,
+        labels: dict[str, NodeLabels],
     ) -> list[NodeChangelog]:
         secondaries: list[NodeChangelog] = []
         rel_schema = node_schema.get_relationship(name=relationship.name)
@@ -527,50 +584,54 @@ class RelationshipChangelogGetter:
         if relationship.peer_status == DiffAction.ADDED:
             peer_schema = schema_branch.get(name=str(relationship.peer_kind), duplicate=False)
             secondaries.extend(
-                self._process_added_peers(
+                self._process_reciprocal_peers(
                     peer_id=str(relationship.peer_id),
                     peer_kind=str(relationship.peer_kind),
                     peer_schema=peer_schema,
                     rel_schema=rel_schema,
                     primary_changelog=primary_changelog,
+                    labels=labels,
+                    peer_status=DiffAction.ADDED,
                 )
             )
-
         elif relationship.peer_status == DiffAction.UPDATED:
             peer_schema = schema_branch.get(name=str(relationship.peer_kind), duplicate=False)
             secondaries.extend(
-                self._process_added_peers(
+                self._process_reciprocal_peers(
                     peer_id=str(relationship.peer_id),
                     peer_kind=str(relationship.peer_kind),
                     peer_schema=peer_schema,
                     rel_schema=rel_schema,
                     primary_changelog=primary_changelog,
+                    labels=labels,
+                    peer_status=DiffAction.ADDED,
                 )
             )
             previous_peer_schema = schema_branch.get(name=str(relationship.peer_kind_previous), duplicate=False)
             secondaries.extend(
-                self._process_removed_peers(
+                self._process_reciprocal_peers(
                     peer_schema=previous_peer_schema,
                     peer_id=str(relationship.peer_id_previous),
                     peer_kind=str(relationship.peer_kind_previous),
                     rel_schema=rel_schema,
                     primary_changelog=primary_changelog,
+                    labels=labels,
+                    peer_status=DiffAction.REMOVED,
                 )
             )
-
         elif relationship.peer_status == DiffAction.REMOVED:
             peer_schema = schema_branch.get(name=str(relationship.peer_kind_previous), duplicate=False)
-
             secondaries.extend(
-                self._process_removed_peers(
+                self._process_reciprocal_peers(
                     peer_id=str(relationship.peer_id_previous),
                     peer_kind=str(relationship.peer_kind_previous),
                     peer_schema=peer_schema,
                     rel_schema=rel_schema,
                     primary_changelog=primary_changelog,
+                    labels=labels,
+                    peer_status=DiffAction.REMOVED,
                 )
             )
-
         return secondaries
 
     def _parse_cardinality_many_relationship(
@@ -579,6 +640,7 @@ class RelationshipChangelogGetter:
         node_schema: MainSchemaTypes,
         primary_changelog: NodeChangelog,
         schema_branch: SchemaBranch,
+        labels: dict[str, NodeLabels],
     ) -> list[NodeChangelog]:
         secondaries: list[NodeChangelog] = []
         rel_schema = node_schema.get_relationship(name=relationship.name)
@@ -587,44 +649,53 @@ class RelationshipChangelogGetter:
             if peer.peer_status == DiffAction.ADDED:
                 peer_schema = schema_branch.get(name=peer.peer_kind, duplicate=False)
                 secondaries.extend(
-                    self._process_added_peers(
+                    self._process_reciprocal_peers(
                         peer_id=peer.peer_id,
                         peer_kind=peer.peer_kind,
                         peer_schema=peer_schema,
                         rel_schema=rel_schema,
                         primary_changelog=primary_changelog,
+                        labels=labels,
+                        peer_status=DiffAction.ADDED,
                     )
                 )
-
             elif peer.peer_status == DiffAction.REMOVED:
                 peer_schema = schema_branch.get(name=peer.peer_kind, duplicate=False)
                 secondaries.extend(
-                    self._process_removed_peers(
+                    self._process_reciprocal_peers(
                         peer_id=peer.peer_id,
                         peer_kind=peer.peer_kind,
                         peer_schema=peer_schema,
                         rel_schema=rel_schema,
                         primary_changelog=primary_changelog,
+                        labels=labels,
+                        peer_status=DiffAction.REMOVED,
                     )
                 )
-
         return secondaries
 
-    def _process_added_peers(
+    def _process_reciprocal_peers(
         self,
         peer_id: str,
         peer_kind: str,
         peer_schema: MainSchemaTypes,
         rel_schema: RelationshipSchema,
         primary_changelog: NodeChangelog,
+        labels: dict[str, NodeLabels],
+        peer_status: DiffAction,
     ) -> list[NodeChangelog]:
-        node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
+        """Build the secondary changelog a peer gets when its relationship to the primary changes."""
+        peer_labels = _labels_for(peer_id=peer_id, labels=labels)
+        node_changelog = NodeChangelog(
+            node_id=peer_id,
+            node_kind=peer_kind,
+            display_label=peer_labels.display_label,
+            hfid=peer_labels.hfid,
+        )
         for peer_relation in peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
             if peer_relation.cardinality == RelationshipCardinality.ONE:
-                node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
-                    name=peer_relation.name,
-                    peer_id=primary_changelog.node_id,
-                    peer_kind=primary_changelog.node_kind,
+                node_changelog.relationships[peer_relation.name] = self._reciprocal_one_relationship(
+                    name=peer_relation.name, primary_changelog=primary_changelog, peer_status=peer_status
                 )
             elif peer_relation.cardinality == RelationshipCardinality.MANY:
                 node_changelog.relationships[peer_relation.name] = RelationshipCardinalityManyChangelog(
@@ -633,39 +704,31 @@ class RelationshipChangelogGetter:
                         RelationshipPeerChangelog(
                             peer_id=primary_changelog.node_id,
                             peer_kind=primary_changelog.node_kind,
-                            peer_status=DiffAction.ADDED,
+                            peer_display_label=primary_changelog.display_label,
+                            peer_hfid=primary_changelog.hfid,
+                            peer_status=peer_status,
                         )
                     ],
                 )
 
         return [node_changelog] if node_changelog.relationships else []
 
-    def _process_removed_peers(
-        self,
-        peer_id: str,
-        peer_kind: str,
-        peer_schema: MainSchemaTypes,
-        rel_schema: RelationshipSchema,
-        primary_changelog: NodeChangelog,
-    ) -> list[NodeChangelog]:
-        node_changelog = NodeChangelog(node_id=peer_id, node_kind=peer_kind, display_label="n/a")
-        for peer_relation in peer_relationships(peer_schema=peer_schema, rel_schema=rel_schema):
-            if peer_relation.cardinality == RelationshipCardinality.ONE:
-                node_changelog.relationships[peer_relation.name] = RelationshipCardinalityOneChangelog(
-                    name=peer_relation.name,
-                    peer_id_previous=primary_changelog.node_id,
-                    peer_kind_previous=primary_changelog.node_kind,
-                )
-            elif peer_relation.cardinality == RelationshipCardinality.MANY:
-                node_changelog.relationships[peer_relation.name] = RelationshipCardinalityManyChangelog(
-                    name=peer_relation.name,
-                    peers=[
-                        RelationshipPeerChangelog(
-                            peer_id=primary_changelog.node_id,
-                            peer_kind=primary_changelog.node_kind,
-                            peer_status=DiffAction.REMOVED,
-                        )
-                    ],
-                )
-
-        return [node_changelog] if node_changelog.relationships else []
+    @staticmethod
+    def _reciprocal_one_relationship(
+        name: str, primary_changelog: NodeChangelog, peer_status: DiffAction
+    ) -> RelationshipCardinalityOneChangelog:
+        """Build the one-cardinality reciprocal, placing the primary as the current or removed peer."""
+        if peer_status == DiffAction.REMOVED:
+            # The primary is the removed (previous) peer, so no current-peer label.
+            return RelationshipCardinalityOneChangelog(
+                name=name,
+                peer_id_previous=primary_changelog.node_id,
+                peer_kind_previous=primary_changelog.node_kind,
+            )
+        return RelationshipCardinalityOneChangelog(
+            name=name,
+            peer_id=primary_changelog.node_id,
+            peer_kind=primary_changelog.node_kind,
+            peer_display_label=primary_changelog.display_label,
+            peer_hfid=primary_changelog.hfid,
+        )

--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, Sequence, cast
 from uuid import UUID
 
 from pydantic import BaseModel, Field, PrivateAttr, computed_field, field_validator, model_validator
@@ -132,6 +132,10 @@ class RelationshipCardinalityOneChangelog(BaseModel):
     def parent(self) -> ChangelogRelatedNode | None:
         return self._parent
 
+    def peer_entries(self) -> Sequence[RelationshipCardinalityOneChangelog | RelationshipPeerChangelog]:
+        """Return the peer-carrying entries this relationship holds."""
+        return [self]
+
     @computed_field
     def cardinality(self) -> str:
         return "one"
@@ -192,6 +196,10 @@ class RelationshipCardinalityManyChangelog(BaseModel):
     @computed_field
     def cardinality(self) -> str:
         return "many"
+
+    def peer_entries(self) -> Sequence[RelationshipCardinalityOneChangelog | RelationshipPeerChangelog]:
+        """Return the peer-carrying entries this relationship holds."""
+        return self.peers
 
     def add_new_peer(self, relationship: Relationship) -> None:
         properties: dict[str, PropertyChangelog] = {}

--- a/backend/infrahub/core/merge/orchestrator.py
+++ b/backend/infrahub/core/merge/orchestrator.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from infrahub import config, lock
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.changelog.diff import DiffChangelogCollector
+from infrahub.core.changelog.builder import build_diff_changelog_collector
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.registry import registry
 from infrahub.core.schema.update_coordinator import MigrationExecutor
@@ -113,8 +113,10 @@ class BranchMergeOrchestrator:
                 diff_branch_name=self.source_branch.name,
                 tracking_id=BranchTrackingId(name=self.source_branch.name),
             )
-            changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=self.source_branch, db=self.db)
-            node_events = changelog_collector.collect_changelogs()
+            changelog_collector = build_diff_changelog_collector(
+                diff=branch_diff, db=self.db, branch=self.source_branch
+            )
+            node_events = await changelog_collector.collect_changelogs()
 
             if await self.schema_analyzer.has_schema_changes():
                 self.log.info("Applying schema migrations after merge")

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1154,6 +1154,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
                 node_changelog.create_relationship(relationship=rel)
 
         node_changelog.display_label = await self.get_display_label(db=db)
+        node_changelog.hfid = await self.get_hfid(db=db)
         return node_changelog
 
     async def _update(
@@ -1197,6 +1198,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         )
 
         node_changelog.display_label = await self.get_display_label(db=db)
+        node_changelog.hfid = await self.get_hfid(db=db)
 
         if node_changelog.has_changes:
             await self._add_parent_to_changelog(
@@ -1252,6 +1254,7 @@ class Node(BaseNode, MetadataInterface, metaclass=BaseNodeMeta):
         node_changelog = NodeChangelog(
             node_id=self.get_id(), node_kind=self.get_kind(), display_label=await self.get_display_label(db=db)
         )
+        node_changelog.hfid = await self.get_hfid(db=db)
         # Go over the list of Attribute and update them one by one
         for name in self._attributes:
             attr: BaseAttribute = getattr(self, name)

--- a/backend/infrahub/events/generator.py
+++ b/backend/infrahub/events/generator.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, cast
 
 from infrahub.core.branch import Branch
-from infrahub.core.changelog.models import RelationshipChangelogGetter
+from infrahub.core.changelog.builder import build_relationship_changelog_getter
 from infrahub.core.constants import InfrahubKind, MutationAction
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
@@ -47,7 +47,7 @@ async def generate_node_mutation_events(
         fields=node.node_changelog.updated_fields,
         meta=meta,
     )
-    relationship_changelogs = RelationshipChangelogGetter(db=db, branch=branch)
+    relationship_changelogs = build_relationship_changelog_getter(db=db, branch=branch)
     node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=node.node_changelog)
 
     events: list[NodeMutatedEvent] = [main_event]

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -7,7 +7,8 @@ from graphene import Boolean, InputField, InputObjectType, List, Mutation, Strin
 from infrahub_sdk.utils import compare_lists
 
 from infrahub.core.account import GlobalPermission, ObjectPermission
-from infrahub.core.changelog.models import NodeChangelog, RelationshipChangelogGetter
+from infrahub.core.changelog.builder import build_relationship_changelog_getter
+from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import (
     InfrahubKind,
     MetadataOptions,
@@ -139,7 +140,7 @@ async def _emit_relationship_add_events(
         fields=[relationship_name],
         meta=EventMeta(branch=graphql_context.branch, context=event_context),
     )
-    relationship_changelogs = RelationshipChangelogGetter(db=graphql_context.db, branch=graphql_context.branch)
+    relationship_changelogs = build_relationship_changelog_getter(db=graphql_context.db, branch=graphql_context.branch)
     node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=node_changelog)
 
     events: list[NodeUpdatedEvent] = [main_event]
@@ -191,6 +192,7 @@ class RelationshipAdd(Mutation):
         node_changelog = NodeChangelog(
             node_id=source.get_id(), node_kind=source.get_kind(), display_label=display_label
         )
+        node_changelog.hfid = await source.get_hfid(db=graphql_context.db)
 
         existing_peers = await _collect_current_peers(info=info, data=data, source_node=source)
         _validate_cardinality_add(data=data, rel_schema=rel_schema, existing_peers=existing_peers)
@@ -276,6 +278,7 @@ class RelationshipRemove(Mutation):
         node_changelog = NodeChangelog(
             node_id=source.get_id(), node_kind=source.get_kind(), display_label=display_label
         )
+        node_changelog.hfid = await source.get_hfid(db=graphql_context.db)
 
         existing_peers = await _collect_current_peers(info=info, data=data, source_node=source)
         _validate_optional_remove(data=data, rel_schema=rel_schema, existing_peers=existing_peers)
@@ -373,7 +376,7 @@ class RelationshipRemove(Mutation):
                     meta=EventMeta(branch=graphql_context.branch, context=event_context),
                 )
 
-                relationship_changelogs = RelationshipChangelogGetter(
+                relationship_changelogs = build_relationship_changelog_getter(
                     db=graphql_context.db, branch=graphql_context.branch
                 )
                 node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=node_changelog)

--- a/backend/tests/adapters/http.py
+++ b/backend/tests/adapters/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -12,10 +13,19 @@ if TYPE_CHECKING:
     import httpx
 
 
+@dataclass(frozen=True)
+class RecordedPost:
+    url: str
+    data: Any | None = None
+    json: Any | None = None
+    headers: dict[str, Any] | None = None
+
+
 class MemoryHTTP(InfrahubHTTP):
     def __init__(self) -> None:
         self._get_response: dict[str, httpx.Response] = {}
         self._post_response: dict[str, httpx.Response | Exception] = {}
+        self.posts: list[RecordedPost] = []
 
     def verify_tls(self, verify: bool | None = None) -> bool | ssl.SSLContext:
         return False
@@ -35,6 +45,7 @@ class MemoryHTTP(InfrahubHTTP):
         headers: dict[str, Any] | None = None,
         verify: bool | None = None,
     ) -> httpx.Response:
+        self.posts.append(RecordedPost(url=url, data=data, json=json, headers=headers))
         registered = self._post_response[url]
         if isinstance(registered, Exception):
             raise registered

--- a/backend/tests/component/core/changelog/test_diff.py
+++ b/backend/tests/component/core/changelog/test_diff.py
@@ -5,6 +5,7 @@ import pytest
 
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.diff import DiffChangelogCollector
+from infrahub.core.changelog.enrichment import node_label_loader
 from infrahub.core.changelog.models import RelationshipCardinalityManyChangelog, RelationshipCardinalityOneChangelog
 from infrahub.core.constants import DiffAction
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -33,8 +34,13 @@ async def test_events_from_diff(
     await diff_merger.merge_graph(at=at)
     diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch1)
     diff = await diff_repository.get_one(diff_branch_name=branch1.name)
-    diff_events = DiffChangelogCollector(diff=diff, db=db, branch=branch1)
-    changelogs = diff_events.collect_changelogs()
+    diff_events = DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch1,
+        label_loader=node_label_loader(db=db, branch=branch1, node_loader=NodeManager.get_many),
+    )
+    changelogs = await diff_events.collect_changelogs()
     assert len(changelogs) == 2
 
 
@@ -98,8 +104,13 @@ async def test_merge_diff_changelogs(
     await diff_merger.merge_graph(at=at)
     diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch5)
     diff = await diff_repository.get_one(diff_branch_name=branch5.name)
-    diff_events = DiffChangelogCollector(diff=diff, db=db, branch=branch5)
-    events = diff_events.collect_changelogs()
+    diff_events = DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch5,
+        label_loader=node_label_loader(db=db, branch=branch5, node_loader=NodeManager.get_many),
+    )
+    events = await diff_events.collect_changelogs()
     assert len(events) == 5
     changelogs = [changelog[1] for changelog in events]
     p1_changelog = [node for node in changelogs if node.node_id == p1.id][0]
@@ -227,8 +238,13 @@ class TestConflict:
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
         await diff_merger.merge_graph(at=at)
         diff = await diff_repository.get_one(diff_branch_name=branch2.name)
-        diff_events = DiffChangelogCollector(diff=diff, db=db, branch=branch2)
-        events = diff_events.collect_changelogs()
+        diff_events = DiffChangelogCollector(
+            diff=diff,
+            db=db,
+            branch=branch2,
+            label_loader=node_label_loader(db=db, branch=branch2, node_loader=NodeManager.get_many),
+        )
+        events = await diff_events.collect_changelogs()
 
         match conflict_selection:
             case ConflictSelection.BASE_BRANCH:
@@ -285,8 +301,13 @@ class TestConflict:
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
         await diff_merger.merge_graph(at=at)
         diff = await diff_repository.get_one(diff_branch_name=branch2.name)
-        diff_events = DiffChangelogCollector(diff=diff, db=db, branch=branch2)
-        events = diff_events.collect_changelogs()
+        diff_events = DiffChangelogCollector(
+            diff=diff,
+            db=db,
+            branch=branch2,
+            label_loader=node_label_loader(db=db, branch=branch2, node_loader=NodeManager.get_many),
+        )
+        events = await diff_events.collect_changelogs()
         match conflict_selection:
             case ConflictSelection.BASE_BRANCH:
                 # When we want to keep the conflict in the base branch we don't expect to see any updates after the merge

--- a/backend/tests/component/core/changelog/test_enrichment.py
+++ b/backend/tests/component/core/changelog/test_enrichment.py
@@ -1,0 +1,417 @@
+"""Changelog enrichment: every node changelog carries its own and its relationship peers' labels.
+
+Node mutations and branch merge/rebase both feed the changelog that becomes a webhook payload.
+These tests run the real save / diff-collect paths against a live database and assert the
+human-friendly identifiers that land on the changelog.
+"""
+
+from typing import Any
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
+from infrahub.core.changelog.enrichment import NodeLabelLoader, NodeLabels, node_label_loader
+from infrahub.core.changelog.models import (
+    RelationshipCardinalityManyChangelog,
+    RelationshipCardinalityOneChangelog,
+    RelationshipChangelogGetter,
+)
+from infrahub.core.constants import RelationshipDeleteBehavior, SchemaPathType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.model.path import EnrichedDiffRoot
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.models import SchemaUpdateMigrationInfo
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+# A relationship only ZzzItem declares, so pointing it at a ZzzOwner leaves that owner unchanged.
+_ONE_DIRECTIONAL_SCHEMA: dict[str, Any] = {
+    "nodes": [
+        {
+            "name": "Owner",
+            "namespace": "Zzz",
+            "default_filter": "name__value",
+            "display_label": "name__value",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+        },
+        {
+            "name": "Item",
+            "namespace": "Zzz",
+            "default_filter": "name__value",
+            "display_label": "name__value",
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+            "relationships": [
+                {
+                    "name": "owner",
+                    "peer": "ZzzOwner",
+                    "cardinality": "one",
+                    "optional": True,
+                    "direction": "outbound",
+                    "identifier": "zzz_item_owner_oneway",
+                }
+            ],
+        },
+    ],
+}
+
+
+class _RaisingLabelReader:
+    """A NodeLabelReader that always fails, standing in for an unavailable label backend."""
+
+    async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]:
+        raise RuntimeError("label backend unavailable")
+
+    async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]:
+        raise RuntimeError("label backend unavailable")
+
+
+async def _create_person_and_dog(db: InfrahubDatabase, branch: Branch, schema: SchemaBranch) -> tuple[Node, Node]:
+    person = await Node.init(db=db, schema=schema.get(name="TestPerson"), branch=branch)
+    await person.new(db=db, name={"value": "Jack", "is_protected": True})
+    await person.save(db=db)
+
+    dog = await Node.init(db=db, schema=schema.get(name="TestDog"), branch=branch)
+    await dog.new(db=db, name={"value": "Rocky", "owner": person.id}, breed="Labrador", owner=person)
+    await dog.save(db=db)
+    return person, dog
+
+
+async def _merge_car_owned_by_person(
+    db: InfrahubDatabase, default_branch: Branch, branch_name: str
+) -> tuple[EnrichedDiffRoot, Branch, Node, Node]:
+    owner = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await owner.new(db=db, name="John", height=180)
+    await owner.save(db=db)
+
+    branch = await create_branch(db=db, branch_name=branch_name)
+    car = await Node.init(db=db, schema="TestCar", branch=branch)
+    await car.new(db=db, name="Volvo", nbr_seats=5, is_electric=False, owner={"id": owner.id})
+    await car.save(db=db)
+
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    await merger.merge_graph(at=Timestamp())
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(diff_branch_name=branch.name)
+    return diff, branch, owner, car
+
+
+async def test_mutation_enriches_the_mutated_nodes_own_relationships(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    animal_person_schema: SchemaBranch,
+) -> None:
+    person, dog = await _create_person_and_dog(db, default_branch, animal_person_schema)
+
+    # The mutated node carries its own materialized HFID.
+    assert dog.node_changelog.hfid == await dog.get_hfid(db=db)
+    assert dog.node_changelog.hfid
+
+    await RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    ).get_changelogs(primary_changelog=dog.node_changelog)
+
+    owner_rel = dog.node_changelog.relationships["owner"]
+    assert isinstance(owner_rel, RelationshipCardinalityOneChangelog)
+    assert owner_rel.peer_id == person.id
+    assert owner_rel.peer_display_label == await person.get_display_label(db=db)
+    assert owner_rel.peer_hfid == await person.get_hfid(db=db)
+
+
+async def test_mutation_enriches_secondary_peer_changelogs(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    animal_person_schema: SchemaBranch,
+) -> None:
+    person, dog = await _create_person_and_dog(db, default_branch, animal_person_schema)
+
+    secondaries = await RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    ).get_changelogs(primary_changelog=dog.node_changelog)
+    person_secondary = next(secondary for secondary in secondaries if secondary.node_id == person.id)
+
+    # The peer node's real label and HFID are resolved, not the placeholder.
+    assert person_secondary.display_label == await person.get_display_label(db=db)
+    assert person_secondary.display_label != "n/a"
+    assert person_secondary.hfid == await person.get_hfid(db=db)
+
+    # The reciprocal relationship points back to the mutated node with its label and HFID.
+    animals = person_secondary.relationships["animals"]
+    assert isinstance(animals, RelationshipCardinalityManyChangelog)
+    assert animals.peers[0].peer_id == dog.id
+    assert animals.peers[0].peer_display_label == dog.node_changelog.display_label
+    assert animals.peers[0].peer_hfid == dog.node_changelog.hfid
+
+
+async def test_mutation_changelog_survives_label_reader_failure(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    animal_person_schema: SchemaBranch,
+) -> None:
+    person, dog = await _create_person_and_dog(db, default_branch, animal_person_schema)
+
+    secondaries = await RelationshipChangelogGetter(
+        db=db, branch=default_branch, label_loader=NodeLabelLoader(reader=_RaisingLabelReader())
+    ).get_changelogs(primary_changelog=dog.node_changelog)
+
+    # The label read failed, so the secondaries carry placeholder labels rather than the failure
+    # propagating to the already-committed mutation.
+    person_secondary = next(secondary for secondary in secondaries if secondary.node_id == person.id)
+    assert person_secondary.display_label == "n/a"
+    assert person_secondary.hfid is None
+
+
+async def test_unresolvable_peer_falls_back_to_placeholder(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main: Node,
+    car_prius_main: Node,
+    person_john_main: Node,
+) -> None:
+    cars_relationship = (
+        registry.schema.get_schema_branch(name=default_branch.name)
+        .get(name="TestPerson", duplicate=False)
+        .get_relationship("cars")
+    )
+    original_on_delete = cars_relationship.on_delete
+    cars_relationship.on_delete = RelationshipDeleteBehavior.CASCADE
+
+    car_ids = {car_accord_main.id, car_prius_main.id}
+    try:
+        deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[person_john_main])
+        assert {node.id for node in deleted} == {person_john_main.id, *car_ids}
+
+        secondaries = await RelationshipChangelogGetter(
+            db=db,
+            branch=default_branch,
+            label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+        ).get_changelogs(primary_changelog=person_john_main.node_changelog)
+    finally:
+        cars_relationship.on_delete = original_on_delete
+    car_secondaries = [secondary for secondary in secondaries if secondary.node_id in car_ids]
+    assert len(car_secondaries) == len(car_ids)
+
+    # The cascaded peers are already gone when their labels are resolved.
+    assert all(secondary.display_label == "n/a" for secondary in car_secondaries)
+    assert all(secondary.hfid is None for secondary in car_secondaries)
+
+
+async def test_merge_enriches_node_hfid_and_peer_label(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
+    diff, branch, owner, car = await _merge_car_owned_by_person(db, default_branch, "merge_enrich")
+
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+    ).collect_changelogs()
+
+    car_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == car.id)
+    owner_rel = car_changelog.relationships["owner"]
+    assert isinstance(owner_rel, RelationshipCardinalityOneChangelog)
+
+    # The node's HFID is absent from the diff, so it is resolved with a load.
+    reloaded_car = await NodeManager.get_one(db=db, id=car.id, kind="TestCar", branch=branch)
+    assert car_changelog.hfid == await reloaded_car.get_hfid(db=db)
+    assert car_changelog.hfid
+
+    # The peer's display label is carried by the diff itself.
+    assert owner_rel.peer_id == owner.id
+    assert owner_rel.peer_display_label == await owner.get_display_label(db=db)
+    assert owner_rel.peer_display_label != "n/a"
+    # The peer's HFID comes from the batch: the owner is a changed node too on this merge.
+    assert owner_rel.peer_hfid == await owner.get_hfid(db=db)
+    assert owner_rel.peer_hfid
+
+
+async def test_merge_changelog_survives_label_reader_failure(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
+    diff, branch, _owner, car = await _merge_car_owned_by_person(db, default_branch, "merge_label_failure")
+
+    changelogs = await DiffChangelogCollector(
+        diff=diff, db=db, branch=branch, label_loader=NodeLabelLoader(reader=_RaisingLabelReader())
+    ).collect_changelogs()
+
+    # The collection completes despite the label read failing; the HFID just degrades to None.
+    car_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == car.id)
+    assert car_changelog.hfid is None
+    assert changelogs
+
+
+async def test_merge_changelog_reports_deleted_node_hfid(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
+    owner = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await owner.new(db=db, name="John", height=180)
+    await owner.save(db=db)
+    car = await Node.init(db=db, schema="TestCar", branch=default_branch)
+    await car.new(db=db, name="Volvo", nbr_seats=5, is_electric=False, owner={"id": owner.id})
+    await car.save(db=db)
+    expected_hfid = await car.get_hfid(db=db)
+    assert expected_hfid
+
+    branch = await create_branch(db=db, branch_name="merge_delete_hfid")
+    to_delete = await NodeManager.get_one(db=db, id=car.id, kind="TestCar", branch=branch)
+    await to_delete.delete(db=db)
+
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    await merger.merge_graph(at=Timestamp())
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(diff_branch_name=branch.name)
+
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+    ).collect_changelogs()
+
+    # The car is gone when the batch load runs, but its HFID is recovered from the diff.
+    car_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == car.id)
+    assert car_changelog.hfid == expected_hfid
+
+
+async def test_merge_fills_peer_hfid_for_a_peer_that_did_not_change(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    data_schema: None,
+) -> None:
+    registry.schema.register_schema(schema=SchemaRoot(**_ONE_DIRECTIONAL_SCHEMA), branch=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    owner = await Node.init(db=db, schema="ZzzOwner", branch=default_branch)
+    await owner.new(db=db, name="Alice")
+    await owner.save(db=db)
+    owner_hfid = await owner.get_hfid(db=db)
+
+    branch = await create_branch(db=db, branch_name="oneway_merge")
+    item = await Node.init(db=db, schema="ZzzItem", branch=branch)
+    await item.new(db=db, name="Gadget", owner={"id": owner.id})
+    await item.save(db=db)
+
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    await merger.merge_graph(at=Timestamp())
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(diff_branch_name=branch.name)
+
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+    ).collect_changelogs()
+
+    # The owner has no reciprocal relationship, so it is not a changed node, yet its HFID is still
+    # resolved for the item's changelog.
+    assert owner.id not in {changelog.node_id for _, changelog in changelogs}
+    item_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == item.id)
+    owner_rel = item_changelog.relationships["owner"]
+    assert isinstance(owner_rel, RelationshipCardinalityOneChangelog)
+    assert owner_rel.peer_id == owner.id
+    assert owner_rel.peer_hfid == owner_hfid
+
+
+async def test_merge_tolerates_kind_deleted_in_migration(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
+    diff, branch, owner, car = await _merge_car_owned_by_person(db, default_branch, "merge_kind_deleted")
+
+    owner_hfid = await owner.get_hfid(db=db)
+    # A schema migration in the merge drops the car's kind, so its schema no longer resolves on
+    # either branch. Snapshot the default schema to restore it once the assertions are done.
+    default_schema_snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    registry.schema.get_schema_branch(name=branch.name).delete(name="TestCar")
+    registry.schema.get_schema_branch(name=default_branch.name).delete(name="TestCar")
+    try:
+        changelogs = await DiffChangelogCollector(
+            diff=diff,
+            db=db,
+            branch=branch,
+            label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+        ).collect_changelogs()
+    finally:
+        registry.schema.set_schema_branch(name=default_branch.name, schema=default_schema_snapshot)
+
+    by_id = {changelog.node_id: changelog for _, changelog in changelogs}
+    # The node whose kind is gone still yields a changelog, only without its HFID.
+    assert by_id[car.id].hfid is None
+    # A node whose kind survives keeps its HFID: the load degrades per node, not per batch.
+    assert by_id[owner.id].hfid == owner_hfid
+
+
+async def test_rebase_remaps_renamed_attribute_in_changelog(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_simplified_proposed_change_schema: SchemaBranch,
+    car_person_schema: None,
+) -> None:
+    person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person.new(db=db, name="John", height=180)
+    await person.save(db=db)
+
+    branch = await create_branch(db=db, branch_name="rebase_rename")
+    person_on_branch = await NodeManager.get_one(db=db, id=person.id, kind="TestPerson", branch=branch)
+    person_on_branch.height.value = 190
+    await person_on_branch.save(db=db)
+
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(diff_branch_name=branch.name)
+
+    rename = SchemaUpdateMigrationInfo(
+        migration_name="attribute.name.update",
+        path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", property_name="height", field_name="stature"
+        ),
+    )
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        branch=branch,
+        db=db,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+        migration_tracker=MigrationTracker(migrations=[rename]),
+    ).collect_changelogs()
+
+    person_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == person.id)
+    # The rebase migration renamed the attribute; the changelog reports the new name.
+    assert "stature" in person_changelog.attributes
+    assert "height" not in person_changelog.attributes

--- a/backend/tests/component/core/changelog/test_enrichment.py
+++ b/backend/tests/component/core/changelog/test_enrichment.py
@@ -425,7 +425,7 @@ async def test_merge_tolerates_kind_deleted_in_migration(
     assert by_id[owner.id].hfid == owner_hfid
 
 
-async def test_rebase_remaps_renamed_attribute_in_changelog(
+async def test_collector_applies_a_rename_migration_to_the_changelog(
     db: InfrahubDatabase,
     default_branch: Branch,
     register_simplified_proposed_change_schema: SchemaBranch,
@@ -446,6 +446,7 @@ async def test_rebase_remaps_renamed_attribute_in_changelog(
     diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
     diff = await diff_repository.get_one(diff_branch_name=branch.name)
 
+    # The migration a rebase would produce when an attribute is renamed on the destination branch.
     rename = SchemaUpdateMigrationInfo(
         migration_name="attribute.name.update",
         path=SchemaPath(
@@ -461,6 +462,6 @@ async def test_rebase_remaps_renamed_attribute_in_changelog(
     ).collect_changelogs()
 
     person_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == person.id)
-    # The rebase migration renamed the attribute; the changelog reports the new name.
+    # The rename migration remaps the attribute, so the changelog reports the new name.
     assert "stature" in person_changelog.attributes
     assert "height" not in person_changelog.attributes

--- a/backend/tests/component/core/changelog/test_enrichment.py
+++ b/backend/tests/component/core/changelog/test_enrichment.py
@@ -345,6 +345,55 @@ async def test_merge_fills_peer_hfid_for_a_peer_that_did_not_change(
     assert owner_rel.peer_hfid == owner_hfid
 
 
+async def test_merge_tolerates_dropped_kind_referencing_an_unchanged_peer(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    data_schema: None,
+) -> None:
+    registry.schema.register_schema(schema=SchemaRoot(**_ONE_DIRECTIONAL_SCHEMA), branch=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+    owner = await Node.init(db=db, schema="ZzzOwner", branch=default_branch)
+    await owner.new(db=db, name="Alice")
+    await owner.save(db=db)
+
+    branch = await create_branch(db=db, branch_name="oneway_drop")
+    item = await Node.init(db=db, schema="ZzzItem", branch=branch)
+    await item.new(db=db, name="Gadget", owner={"id": owner.id})
+    await item.save(db=db)
+
+    component_registry = get_component_registry()
+    coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+    merger = await component_registry.get_component(DiffMerger, db=db, branch=branch)
+    await coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+    await merger.merge_graph(at=Timestamp())
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+    diff = await diff_repository.get_one(diff_branch_name=branch.name)
+
+    # A schema migration drops the item's kind; its owner is unchanged and so absent from the diff.
+    default_schema_snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    registry.schema.get_schema_branch(name=branch.name).delete(name="ZzzItem")
+    registry.schema.get_schema_branch(name=default_branch.name).delete(name="ZzzItem")
+    try:
+        changelogs = await DiffChangelogCollector(
+            diff=diff,
+            db=db,
+            branch=branch,
+            label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+        ).collect_changelogs()
+    finally:
+        registry.schema.set_schema_branch(name=default_branch.name, schema=default_schema_snapshot)
+
+    item_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == item.id)
+    owner_rel = item_changelog.relationships["owner"]
+    assert isinstance(owner_rel, RelationshipCardinalityOneChangelog)
+    assert owner_rel.peer_id == owner.id
+    # The dropped kind cannot resolve the unchanged peer's kind, so it degrades instead of failing.
+    assert owner_rel.peer_kind == "n/a"
+
+
 async def test_merge_tolerates_kind_deleted_in_migration(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/backend/tests/component/core/changelog/test_enrichment.py
+++ b/backend/tests/component/core/changelog/test_enrichment.py
@@ -5,7 +5,10 @@ These tests run the real save / diff-collect paths against a live database and a
 human-friendly identifiers that land on the changelog.
 """
 
+from collections.abc import AsyncGenerator
 from typing import Any
+
+import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -106,6 +109,43 @@ async def _merge_car_owned_by_person(
     return diff, branch, owner, car
 
 
+@pytest.fixture
+async def cascade_delete_cars(default_branch: Branch, car_person_schema: SchemaBranch) -> AsyncGenerator[None, None]:
+    """Make the person-to-cars relationship cascade on delete for the test, then restore it."""
+    cars = (
+        registry.schema.get_schema_branch(name=default_branch.name)
+        .get(name="TestPerson", duplicate=False)
+        .get_relationship("cars")
+    )
+    original_on_delete = cars.on_delete
+    cars.on_delete = RelationshipDeleteBehavior.CASCADE
+    yield
+    cars.on_delete = original_on_delete
+
+
+@pytest.fixture
+async def one_directional_schema(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, data_schema: None
+) -> AsyncGenerator[None, None]:
+    """Register the one-directional schema on the default branch and restore the prior schema afterward."""
+    snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    registry.schema.register_schema(schema=SchemaRoot(**_ONE_DIRECTIONAL_SCHEMA), branch=default_branch.name)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+    yield
+    registry.schema.set_schema_branch(name=default_branch.name, schema=snapshot)
+    default_branch.update_schema_hash()
+    await default_branch.save(db=db)
+
+
+@pytest.fixture
+async def restore_default_schema(default_branch: Branch, car_person_schema: None) -> AsyncGenerator[None, None]:
+    """Restore the default branch schema after a test drops a kind from it in place."""
+    snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    yield
+    registry.schema.set_schema_branch(name=default_branch.name, schema=snapshot)
+
+
 async def test_mutation_enriches_the_mutated_nodes_own_relationships(
     db: InfrahubDatabase,
     default_branch: Branch,
@@ -178,30 +218,20 @@ async def test_mutation_changelog_survives_label_reader_failure(
 async def test_unresolvable_peer_falls_back_to_placeholder(
     db: InfrahubDatabase,
     default_branch: Branch,
+    cascade_delete_cars: None,
     car_accord_main: Node,
     car_prius_main: Node,
     person_john_main: Node,
 ) -> None:
-    cars_relationship = (
-        registry.schema.get_schema_branch(name=default_branch.name)
-        .get(name="TestPerson", duplicate=False)
-        .get_relationship("cars")
-    )
-    original_on_delete = cars_relationship.on_delete
-    cars_relationship.on_delete = RelationshipDeleteBehavior.CASCADE
-
     car_ids = {car_accord_main.id, car_prius_main.id}
-    try:
-        deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[person_john_main])
-        assert {node.id for node in deleted} == {person_john_main.id, *car_ids}
+    deleted = await NodeManager.delete(db=db, branch=default_branch, nodes=[person_john_main])
+    assert {node.id for node in deleted} == {person_john_main.id, *car_ids}
 
-        secondaries = await RelationshipChangelogGetter(
-            db=db,
-            branch=default_branch,
-            label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
-        ).get_changelogs(primary_changelog=person_john_main.node_changelog)
-    finally:
-        cars_relationship.on_delete = original_on_delete
+    secondaries = await RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    ).get_changelogs(primary_changelog=person_john_main.node_changelog)
     car_secondaries = [secondary for secondary in secondaries if secondary.node_id in car_ids]
     assert len(car_secondaries) == len(car_ids)
 
@@ -303,13 +333,8 @@ async def test_merge_changelog_reports_deleted_node_hfid(
 async def test_merge_fills_peer_hfid_for_a_peer_that_did_not_change(
     db: InfrahubDatabase,
     default_branch: Branch,
-    register_core_models_schema: SchemaBranch,
-    data_schema: None,
+    one_directional_schema: None,
 ) -> None:
-    registry.schema.register_schema(schema=SchemaRoot(**_ONE_DIRECTIONAL_SCHEMA), branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
-
     owner = await Node.init(db=db, schema="ZzzOwner", branch=default_branch)
     await owner.new(db=db, name="Alice")
     await owner.save(db=db)
@@ -348,13 +373,8 @@ async def test_merge_fills_peer_hfid_for_a_peer_that_did_not_change(
 async def test_merge_tolerates_dropped_kind_referencing_an_unchanged_peer(
     db: InfrahubDatabase,
     default_branch: Branch,
-    register_core_models_schema: SchemaBranch,
-    data_schema: None,
+    one_directional_schema: None,
 ) -> None:
-    registry.schema.register_schema(schema=SchemaRoot(**_ONE_DIRECTIONAL_SCHEMA), branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
-
     owner = await Node.init(db=db, schema="ZzzOwner", branch=default_branch)
     await owner.new(db=db, name="Alice")
     await owner.save(db=db)
@@ -373,18 +393,14 @@ async def test_merge_tolerates_dropped_kind_referencing_an_unchanged_peer(
     diff = await diff_repository.get_one(diff_branch_name=branch.name)
 
     # A schema migration drops the item's kind; its owner is unchanged and so absent from the diff.
-    default_schema_snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
     registry.schema.get_schema_branch(name=branch.name).delete(name="ZzzItem")
     registry.schema.get_schema_branch(name=default_branch.name).delete(name="ZzzItem")
-    try:
-        changelogs = await DiffChangelogCollector(
-            diff=diff,
-            db=db,
-            branch=branch,
-            label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
-        ).collect_changelogs()
-    finally:
-        registry.schema.set_schema_branch(name=default_branch.name, schema=default_schema_snapshot)
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+    ).collect_changelogs()
 
     item_changelog = next(changelog for _, changelog in changelogs if changelog.node_id == item.id)
     owner_rel = item_changelog.relationships["owner"]
@@ -398,25 +414,20 @@ async def test_merge_tolerates_kind_deleted_in_migration(
     db: InfrahubDatabase,
     default_branch: Branch,
     register_simplified_proposed_change_schema: SchemaBranch,
-    car_person_schema: None,
+    restore_default_schema: None,
 ) -> None:
     diff, branch, owner, car = await _merge_car_owned_by_person(db, default_branch, "merge_kind_deleted")
 
     owner_hfid = await owner.get_hfid(db=db)
-    # A schema migration in the merge drops the car's kind, so its schema no longer resolves on
-    # either branch. Snapshot the default schema to restore it once the assertions are done.
-    default_schema_snapshot = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    # A schema migration in the merge drops the car's kind, so its schema no longer resolves on either branch.
     registry.schema.get_schema_branch(name=branch.name).delete(name="TestCar")
     registry.schema.get_schema_branch(name=default_branch.name).delete(name="TestCar")
-    try:
-        changelogs = await DiffChangelogCollector(
-            diff=diff,
-            db=db,
-            branch=branch,
-            label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
-        ).collect_changelogs()
-    finally:
-        registry.schema.set_schema_branch(name=default_branch.name, schema=default_schema_snapshot)
+    changelogs = await DiffChangelogCollector(
+        diff=diff,
+        db=db,
+        branch=branch,
+        label_loader=node_label_loader(db=db, branch=branch, node_loader=NodeManager.get_many),
+    ).collect_changelogs()
 
     by_id = {changelog.node_id: changelog for _, changelog in changelogs}
     # The node whose kind is gone still yields a changelog, only without its HFID.

--- a/backend/tests/component/core/changelog/test_models.py
+++ b/backend/tests/component/core/changelog/test_models.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.changelog.enrichment import node_label_loader
 from infrahub.core.changelog.models import (
     AttributeChangelog,
     NodeChangelog,
@@ -39,6 +40,7 @@ async def test_node_changelog_creation(
         node_id=person1.id,
         node_kind="TestPerson",
         display_label="Jack",
+        hfid=["Jack"],
         attributes={
             "human_friendly_id": AttributeChangelog(
                 name="human_friendly_id",
@@ -111,6 +113,7 @@ async def test_node_changelog_creation(
         node_id=dog1.id,
         node_kind="TestDog",
         display_label="Rocky Labrador",
+        hfid=["Jack", "Rocky"],
         attributes={
             "human_friendly_id": AttributeChangelog(
                 name="human_friendly_id",
@@ -172,7 +175,11 @@ async def test_node_changelog_creation(
     )
     assert not dog1.node_changelog.parent
 
-    relationship_changelogs = RelationshipChangelogGetter(db=db, branch=default_branch)
+    relationship_changelogs = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     secondary_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=dog1.node_changelog)
     assert len(secondary_changelogs) == 1
 
@@ -186,6 +193,8 @@ async def test_node_changelog_creation(
             RelationshipPeerChangelog(
                 peer_id=dog1.id,
                 peer_kind=dog1.get_kind(),
+                peer_display_label="Rocky Labrador",
+                peer_hfid=["Jack", "Rocky"],
                 peer_status=DiffAction.ADDED,
                 properties={},
             )
@@ -209,6 +218,7 @@ async def test_node_changelog_creation_without_display_label(
         node_id=obj.id,
         node_kind=TestKind.TICKET,
         display_label=expected_display_label,
+        hfid=["Something broke", "None"],
         attributes={
             "human_friendly_id": AttributeChangelog(
                 name="human_friendly_id",
@@ -277,6 +287,7 @@ async def test_node_changelog_update_with_cardinality_one_relationship(
         node_id=dog1.id,
         node_kind="TestDog",
         display_label="Rocky Labrador",
+        hfid=["Jill", "Rocky"],
         attributes={
             "color": AttributeChangelog(
                 name="color", value="Brown", value_previous="#444444", properties={}, kind="Color"
@@ -309,7 +320,11 @@ async def test_node_changelog_update_with_cardinality_one_relationship(
     )
     assert not dog1_update.node_changelog.parent
 
-    relationship_changelogs = RelationshipChangelogGetter(db=db, branch=default_branch)
+    relationship_changelogs = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     secondary_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=dog1_update.node_changelog)
     assert len(secondary_changelogs) == 2
 
@@ -417,7 +432,11 @@ async def test_node_changelog_delete_with_cardinality_many_relationship(
     assert RelationshipPeerChangelog(peer_id=dog1.id, peer_kind="TestDog", peer_status=DiffAction.REMOVED) in animals
     assert RelationshipPeerChangelog(peer_id=dog2.id, peer_kind="TestDog", peer_status=DiffAction.REMOVED) in animals
 
-    relationship_changelogs = RelationshipChangelogGetter(db=db, branch=default_branch)
+    relationship_changelogs = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     secondary_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=person1_update.node_changelog)
 
     assert len(secondary_changelogs) == 2
@@ -500,7 +519,11 @@ async def test_secondary_changelog_names_the_hierarchy_children_relationship(
     await rack.new(db=db, name="rack-1", parent=site)
     await rack.save(db=db)
 
-    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    getter = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     attached = await getter.get_changelogs(primary_changelog=rack.node_changelog)
 
     assert [changelog.node_id for changelog in attached] == [site.id]
@@ -508,7 +531,15 @@ async def test_secondary_changelog_names_the_hierarchy_children_relationship(
     assert attached[0].relationships == {
         "children": RelationshipCardinalityManyChangelog(
             name="children",
-            peers=[RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.ADDED)],
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=rack.id,
+                    peer_kind="LocationRack",
+                    peer_display_label=rack.node_changelog.display_label,
+                    peer_hfid=rack.node_changelog.hfid,
+                    peer_status=DiffAction.ADDED,
+                )
+            ],
         )
     }
 
@@ -521,7 +552,13 @@ async def test_secondary_changelog_names_the_hierarchy_children_relationship(
         "children": RelationshipCardinalityManyChangelog(
             name="children",
             peers=[
-                RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.REMOVED)
+                RelationshipPeerChangelog(
+                    peer_id=rack.id,
+                    peer_kind="LocationRack",
+                    peer_display_label=to_delete.node_changelog.display_label,
+                    peer_hfid=to_delete.node_changelog.hfid,
+                    peer_status=DiffAction.REMOVED,
+                )
             ],
         )
     }
@@ -560,7 +597,11 @@ async def test_deleted_middle_node_reports_both_hierarchy_sides(
         ),
     }
 
-    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    getter = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     secondaries = await getter.get_changelogs(primary_changelog=to_delete.node_changelog)
 
     by_node = {changelog.node_id: changelog for changelog in secondaries}
@@ -570,14 +611,24 @@ async def test_deleted_middle_node_reports_both_hierarchy_sides(
             name="children",
             peers=[
                 RelationshipPeerChangelog(
-                    peer_id=mid.id, peer_kind=InfrahubKind.STANDARDGROUP, peer_status=DiffAction.REMOVED
+                    peer_id=mid.id,
+                    peer_kind=InfrahubKind.STANDARDGROUP,
+                    peer_display_label=to_delete.node_changelog.display_label,
+                    peer_hfid=to_delete.node_changelog.hfid,
+                    peer_status=DiffAction.REMOVED,
                 )
             ],
         )
     }
+    # The removed one-cardinality reciprocal carries the previous peer's id but no current-peer
+    # label, since the removal leaves no current peer for those fields to describe.
     assert by_node[leaf.id].relationships == {
         "parent": RelationshipCardinalityOneChangelog(
-            name="parent", peer_id_previous=mid.id, peer_kind_previous=InfrahubKind.STANDARDGROUP
+            name="parent",
+            peer_id_previous=mid.id,
+            peer_kind_previous=InfrahubKind.STANDARDGROUP,
+            peer_display_label=None,
+            peer_hfid=None,
         )
     }
 
@@ -606,7 +657,11 @@ async def test_secondary_changelog_hierarchy_move_reports_both_parents(
     await moved.parent.update(data=site_2, db=db)
     await moved.save(db=db)
 
-    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    getter = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     secondaries = await getter.get_changelogs(primary_changelog=moved.node_changelog)
 
     by_node = {changelog.node_id: changelog for changelog in secondaries}
@@ -615,14 +670,28 @@ async def test_secondary_changelog_hierarchy_move_reports_both_parents(
         "children": RelationshipCardinalityManyChangelog(
             name="children",
             peers=[
-                RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.REMOVED)
+                RelationshipPeerChangelog(
+                    peer_id=rack.id,
+                    peer_kind="LocationRack",
+                    peer_display_label=moved.node_changelog.display_label,
+                    peer_hfid=moved.node_changelog.hfid,
+                    peer_status=DiffAction.REMOVED,
+                )
             ],
         )
     }
     assert by_node[site_2.id].relationships == {
         "children": RelationshipCardinalityManyChangelog(
             name="children",
-            peers=[RelationshipPeerChangelog(peer_id=rack.id, peer_kind="LocationRack", peer_status=DiffAction.ADDED)],
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=rack.id,
+                    peer_kind="LocationRack",
+                    peer_display_label=moved.node_changelog.display_label,
+                    peer_hfid=moved.node_changelog.hfid,
+                    peer_status=DiffAction.ADDED,
+                )
+            ],
         )
     }
 
@@ -710,7 +779,11 @@ async def test_secondary_changelog_names_the_previous_peer_own_relationship(
     await moved.location.update(data=rack, db=db)
     await moved.save(db=db)
 
-    getter = RelationshipChangelogGetter(db=db, branch=default_branch)
+    getter = RelationshipChangelogGetter(
+        db=db,
+        branch=default_branch,
+        label_loader=node_label_loader(db=db, branch=default_branch, node_loader=NodeManager.get_many),
+    )
     by_node = {
         changelog.node_id: changelog
         for changelog in await getter.get_changelogs(primary_changelog=moved.node_changelog)
@@ -720,12 +793,28 @@ async def test_secondary_changelog_names_the_previous_peer_own_relationship(
     assert by_node[site.id].relationships == {
         "devices": RelationshipCardinalityManyChangelog(
             name="devices",
-            peers=[RelationshipPeerChangelog(peer_id=device.id, peer_kind="ZzzDevice", peer_status=DiffAction.REMOVED)],
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=device.id,
+                    peer_kind="ZzzDevice",
+                    peer_display_label=moved.node_changelog.display_label,
+                    peer_hfid=moved.node_changelog.hfid,
+                    peer_status=DiffAction.REMOVED,
+                )
+            ],
         )
     }
     assert by_node[rack.id].relationships == {
         "equipment": RelationshipCardinalityManyChangelog(
             name="equipment",
-            peers=[RelationshipPeerChangelog(peer_id=device.id, peer_kind="ZzzDevice", peer_status=DiffAction.ADDED)],
+            peers=[
+                RelationshipPeerChangelog(
+                    peer_id=device.id,
+                    peer_kind="ZzzDevice",
+                    peer_display_label=moved.node_changelog.display_label,
+                    peer_hfid=moved.node_changelog.hfid,
+                    peer_status=DiffAction.ADDED,
+                )
+            ],
         )
     }

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -175,6 +175,7 @@ class TestWebhookProcess(TestInfrahubApp):
         payload = http.posts[0].json
         assert payload is not None
         delivered = payload["data"]
+        assert delivered["display_label"] == "Jesko"
         assert delivered["hfid"] == ["Jesko"]
         owner = delivered["relationships"]["owner"]
         assert owner["peer_display_label"] == "John"

--- a/backend/tests/functional/webhook/test_process.py
+++ b/backend/tests/functional/webhook/test_process.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import httpx
 import pytest
 
+from infrahub.core.changelog.models import NodeChangelog, RelationshipCardinalityOneChangelog
 from infrahub.core.constants import InfrahubKind
 from infrahub.webhook.models import EventContext
 from infrahub.webhook.tasks import convert_node_to_webhook, webhook_process
@@ -130,6 +131,54 @@ class TestWebhookProcess(TestInfrahubApp):
 
         run = only_new_run(await read_send_runs(flow_run_querier), before)
         assert WorkflowTag.RELATED_NODE.render(identifier=webhook1.id) in run.tags
+
+    async def test_process_standard_webhook_preserves_enriched_changelog(
+        self,
+        db: InfrahubDatabase,
+        webhook1: Node,
+        webhook_deployment: None,
+        dependency_provider: Provider,
+    ) -> None:
+        changelog = NodeChangelog(
+            node_id="17d0a5e0-0000-0000-0000-000000000001",
+            node_kind="TestCar",
+            display_label="Jesko",
+            hfid=["Jesko"],
+        )
+        changelog.relationships["owner"] = RelationshipCardinalityOneChangelog(
+            name="owner",
+            peer_id="17d0a5e0-0000-0000-0000-000000000002",
+            peer_kind="TestPerson",
+            peer_display_label="John",
+            peer_hfid=["John"],
+        )
+        event_payload = {"data": changelog.model_dump(), "context": BRANCH_CREATED_PAYLOAD["context"]}
+
+        http = MemoryHTTP()
+        http.add_post_response(
+            url=WEBHOOK_TARGET_URL,
+            response=httpx.Response(request=httpx.Request(method="POST", url=WEBHOOK_TARGET_URL), status_code=200),
+        )
+        with dependency_provider.scope(build_http_service, lambda: http):
+            await webhook_process(
+                webhook_id=webhook1.id,
+                webhook_name="Webhook1",
+                webhook_kind=InfrahubKind.STANDARDWEBHOOK,
+                branch_name="main",
+                event_id="ce3b7013-4abb-4945-89de-1f56da4ff636",
+                event_type="infrahub.node.updated",
+                event_occured_at="2025-02-28T08:37:09.969Z",
+                event_payload=event_payload,
+            )
+
+        assert len(http.posts) == 1
+        payload = http.posts[0].json
+        assert payload is not None
+        delivered = payload["data"]
+        assert delivered["hfid"] == ["Jesko"]
+        owner = delivered["relationships"]["owner"]
+        assert owner["peer_display_label"] == "John"
+        assert owner["peer_hfid"] == ["John"]
 
     async def test_process_webhook_failure_is_classified(
         self,

--- a/backend/tests/unit/core/changelog/test_diff.py
+++ b/backend/tests/unit/core/changelog/test_diff.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub.core.changelog.diff import MigrationTracker
+from infrahub.core.changelog.models import NodeChangelog
+from infrahub.core.constants import DiffAction, SchemaPathType
+from infrahub.core.diff.model.path import EnrichedDiffAttribute
+from infrahub.core.models import SchemaUpdateMigrationInfo
+from infrahub.core.path import SchemaPath
+from infrahub.core.timestamp import Timestamp
+
+
+def _rename_migration(*, kind: str, old_name: str, new_name: str) -> SchemaUpdateMigrationInfo:
+    return SchemaUpdateMigrationInfo(
+        migration_name="attribute.name.update",
+        path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind=kind, property_name=old_name, field_name=new_name
+        ),
+    )
+
+
+@dataclass
+class AttributeNameCase:
+    name: str
+    migrations: list[SchemaUpdateMigrationInfo]
+    node_kind: str
+    attribute_name: str
+    expected_name: str
+
+
+ATTRIBUTE_NAME_CASES = [
+    AttributeNameCase(
+        name="renamed_attribute_resolves_to_new_name",
+        migrations=[_rename_migration(kind="TestPerson", old_name="height", new_name="stature")],
+        node_kind="TestPerson",
+        attribute_name="height",
+        expected_name="stature",
+    ),
+    AttributeNameCase(
+        name="unlisted_kind_keeps_original_name",
+        migrations=[_rename_migration(kind="TestPerson", old_name="height", new_name="stature")],
+        node_kind="TestCar",
+        attribute_name="height",
+        expected_name="height",
+    ),
+    AttributeNameCase(
+        name="unlisted_attribute_keeps_original_name",
+        migrations=[_rename_migration(kind="TestPerson", old_name="height", new_name="stature")],
+        node_kind="TestPerson",
+        attribute_name="name",
+        expected_name="name",
+    ),
+    AttributeNameCase(
+        name="non_rename_migration_is_ignored",
+        migrations=[
+            SchemaUpdateMigrationInfo(
+                migration_name="node.attribute.add",
+                path=SchemaPath(
+                    path_type=SchemaPathType.ATTRIBUTE,
+                    schema_kind="TestPerson",
+                    property_name="height",
+                    field_name="stature",
+                ),
+            )
+        ],
+        node_kind="TestPerson",
+        attribute_name="height",
+        expected_name="height",
+    ),
+    AttributeNameCase(
+        name="rename_without_new_name_keeps_original_name",
+        migrations=[
+            SchemaUpdateMigrationInfo(
+                migration_name="attribute.name.update",
+                path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", property_name="height"),
+            )
+        ],
+        node_kind="TestPerson",
+        attribute_name="height",
+        expected_name="height",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", ATTRIBUTE_NAME_CASES, ids=lambda case: case.name)
+def test_migration_tracker_resolves_attribute_name(case: AttributeNameCase) -> None:
+    tracker = MigrationTracker(migrations=case.migrations)
+    node = NodeChangelog(node_id="n1", node_kind=case.node_kind, display_label="label")
+    attribute = EnrichedDiffAttribute(name=case.attribute_name, changed_at=Timestamp(), action=DiffAction.UPDATED)
+
+    assert tracker.get_attribute_name(node=node, attribute=attribute) == case.expected_name
+
+
+def test_migration_tracker_without_migrations_keeps_original_name() -> None:
+    tracker = MigrationTracker()
+    node = NodeChangelog(node_id="n1", node_kind="TestPerson", display_label="label")
+    attribute = EnrichedDiffAttribute(name="height", changed_at=Timestamp(), action=DiffAction.UPDATED)
+
+    assert tracker.get_attribute_name(node=node, attribute=attribute) == "height"

--- a/backend/tests/unit/core/changelog/test_diff.py
+++ b/backend/tests/unit/core/changelog/test_diff.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
-from infrahub.core.changelog.diff import MigrationTracker
-from infrahub.core.changelog.models import NodeChangelog
+from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
+from infrahub.core.changelog.models import AttributeChangelog, NodeChangelog
 from infrahub.core.constants import DiffAction, SchemaPathType
 from infrahub.core.diff.model.path import EnrichedDiffAttribute
 from infrahub.core.models import SchemaUpdateMigrationInfo
@@ -92,6 +93,60 @@ def test_migration_tracker_resolves_attribute_name(case: AttributeNameCase) -> N
     attribute = EnrichedDiffAttribute(name=case.attribute_name, changed_at=Timestamp(), action=DiffAction.UPDATED)
 
     assert tracker.get_attribute_name(node=node, attribute=attribute) == case.expected_name
+
+
+def _hfid_attribute(*, value: Any = None, value_previous: Any = None) -> AttributeChangelog:
+    return AttributeChangelog(name="human_friendly_id", kind="Text", value=value, value_previous=value_previous)
+
+
+@dataclass
+class HfidFromDiffCase:
+    name: str
+    attribute: AttributeChangelog
+    expected: list[str] | None
+
+
+HFID_FROM_DIFF_CASES = [
+    HfidFromDiffCase(
+        name="json_list_value_is_parsed",
+        attribute=_hfid_attribute(value='["Volvo", "5"]'),
+        expected=["Volvo", "5"],
+    ),
+    HfidFromDiffCase(
+        name="previous_value_is_used_when_current_is_absent",
+        attribute=_hfid_attribute(value=None, value_previous='["Old"]'),
+        expected=["Old"],
+    ),
+    HfidFromDiffCase(
+        name="non_string_value_yields_none",
+        attribute=_hfid_attribute(value=["Volvo"]),
+        expected=None,
+    ),
+    HfidFromDiffCase(
+        name="invalid_json_yields_none",
+        attribute=_hfid_attribute(value="not-json"),
+        expected=None,
+    ),
+    HfidFromDiffCase(
+        name="json_that_is_not_a_list_yields_none",
+        attribute=_hfid_attribute(value='"Volvo"'),
+        expected=None,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", HFID_FROM_DIFF_CASES, ids=lambda case: case.name)
+def test_hfid_from_diff(case: HfidFromDiffCase) -> None:
+    node = NodeChangelog(node_id="n1", node_kind="TestCar", display_label="label")
+    node.add_attribute(attribute=case.attribute)
+
+    assert DiffChangelogCollector._hfid_from_diff(node) == case.expected
+
+
+def test_hfid_from_diff_without_attribute_yields_none() -> None:
+    node = NodeChangelog(node_id="n1", node_kind="TestCar", display_label="label")
+
+    assert DiffChangelogCollector._hfid_from_diff(node) is None
 
 
 def test_migration_tracker_without_migrations_keeps_original_name() -> None:

--- a/backend/tests/unit/core/changelog/test_enrichment.py
+++ b/backend/tests/unit/core/changelog/test_enrichment.py
@@ -4,18 +4,20 @@ from infrahub.core.changelog.enrichment import NodeLabelLoader, NodeLabels
 
 
 class RecordingReader:
-    """Test double for NodeLabelReader: returns preset labels and records the IDs it was asked for."""
+    """Test double for NodeLabelReader: returns preset labels and records each method's IDs separately."""
 
     def __init__(self, labels: dict[str, NodeLabels]) -> None:
         self._labels = labels
-        self.calls: list[list[str]] = []
+        self.label_calls: list[list[str]] = []
+        self.hfid_calls: list[list[str]] = []
 
     async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]:
-        self.calls.append(node_ids)
+        self.label_calls.append(node_ids)
         return {node_id: self._labels[node_id] for node_id in node_ids if node_id in self._labels}
 
     async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]:
-        return {node_id: labels.hfid for node_id, labels in (await self.load_labels(node_ids)).items()}
+        self.hfid_calls.append(node_ids)
+        return {node_id: self._labels[node_id].hfid for node_id in node_ids if node_id in self._labels}
 
 
 class FailingReader:
@@ -33,7 +35,7 @@ async def test_load_labels_deduplicates_sorts_and_drops_empty_ids() -> None:
 
     result = await NodeLabelLoader(reader=reader).load_labels(["b", "", "a", "a", "b"])
 
-    assert reader.calls == [["a", "b"]]
+    assert reader.label_calls == [["a", "b"]]
     assert result == {"a": NodeLabels("A", ["a"]), "b": NodeLabels("B", ["b"])}
 
 
@@ -43,7 +45,7 @@ async def test_load_labels_on_empty_input_never_reads() -> None:
     result = await NodeLabelLoader(reader=reader).load_labels(["", ""])
 
     assert result == {}
-    assert reader.calls == []
+    assert reader.label_calls == []
 
 
 async def test_load_labels_holds_only_the_nodes_the_reader_found() -> None:
@@ -60,6 +62,8 @@ async def test_load_hfids_projects_only_the_hfid() -> None:
     result = await NodeLabelLoader(reader=reader).load_hfids(["a", "b"])
 
     assert result == {"a": ["a", "x"], "b": None}
+    assert reader.hfid_calls == [["a", "b"]]
+    assert reader.label_calls == []
 
 
 async def test_load_labels_degrades_to_empty_when_the_reader_fails() -> None:

--- a/backend/tests/unit/core/changelog/test_enrichment.py
+++ b/backend/tests/unit/core/changelog/test_enrichment.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from infrahub.core.changelog.enrichment import NodeLabelLoader, NodeLabels
+
+
+class RecordingReader:
+    """Test double for NodeLabelReader: returns preset labels and records the IDs it was asked for."""
+
+    def __init__(self, labels: dict[str, NodeLabels]) -> None:
+        self._labels = labels
+        self.calls: list[list[str]] = []
+
+    async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]:
+        self.calls.append(node_ids)
+        return {node_id: self._labels[node_id] for node_id in node_ids if node_id in self._labels}
+
+    async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]:
+        return {node_id: labels.hfid for node_id, labels in (await self.load_labels(node_ids)).items()}
+
+
+class FailingReader:
+    """Test double for NodeLabelReader that always raises, standing in for a read failure."""
+
+    async def load_labels(self, node_ids: list[str]) -> dict[str, NodeLabels]:
+        raise RuntimeError("label backend unavailable")
+
+    async def load_hfids(self, node_ids: list[str]) -> dict[str, list[str] | None]:
+        raise RuntimeError("label backend unavailable")
+
+
+async def test_load_labels_deduplicates_sorts_and_drops_empty_ids() -> None:
+    reader = RecordingReader({"a": NodeLabels("A", ["a"]), "b": NodeLabels("B", ["b"])})
+
+    result = await NodeLabelLoader(reader=reader).load_labels(["b", "", "a", "a", "b"])
+
+    assert reader.calls == [["a", "b"]]
+    assert result == {"a": NodeLabels("A", ["a"]), "b": NodeLabels("B", ["b"])}
+
+
+async def test_load_labels_on_empty_input_never_reads() -> None:
+    reader = RecordingReader({"a": NodeLabels("A", ["a"])})
+
+    result = await NodeLabelLoader(reader=reader).load_labels(["", ""])
+
+    assert result == {}
+    assert reader.calls == []
+
+
+async def test_load_labels_holds_only_the_nodes_the_reader_found() -> None:
+    reader = RecordingReader({"a": NodeLabels("A", ["a"])})
+
+    result = await NodeLabelLoader(reader=reader).load_labels(["a", "missing"])
+
+    assert result == {"a": NodeLabels("A", ["a"])}
+
+
+async def test_load_hfids_projects_only_the_hfid() -> None:
+    reader = RecordingReader({"a": NodeLabels("A", ["a", "x"]), "b": NodeLabels("B", None)})
+
+    result = await NodeLabelLoader(reader=reader).load_hfids(["a", "b"])
+
+    assert result == {"a": ["a", "x"], "b": None}
+
+
+async def test_load_labels_degrades_to_empty_when_the_reader_fails() -> None:
+    result = await NodeLabelLoader(reader=FailingReader()).load_labels(["a", "b"])
+
+    assert result == {}
+
+
+async def test_load_hfids_degrades_to_empty_when_the_reader_fails() -> None:
+    result = await NodeLabelLoader(reader=FailingReader()).load_hfids(["a", "b"])
+
+    assert result == {}


### PR DESCRIPTION
## Summary

Enriches the node changelogs that become webhook payloads with each node's human-friendly ID (HFID) and its relationship peers' display labels and HFIDs, across the three flows that emit them: direct node mutations, branch merges, and branch rebases.

This PR targets `pmi-webhook-payload-enrichment` (a staging branch off `develop`) so the feature can be exercised before it merges into `develop`.

## What lands

- **Batched node-label loader** — resolves display labels and HFIDs in query-size pages through an injected reader; id normalization is unit-tested without a database, and a read failure degrades to an empty mapping rather than failing the committed operation that asked for it.
- **Node-mutation enrichment** — fills each mutated node's changelog and the secondary changelogs its relationship changes imply; a removed one-cardinality peer carries only its previous-peer identity.
- **Merge & rebase enrichment** — resolves each changed node's HFID (which the diff does not carry), recovers a removed node's HFID from the diff, resolves peers that did not themselves change, and leaves out a node whose kind a schema migration dropped so it cannot fail the whole collection; when such a node still references an unchanged peer, that peer's kind degrades to a placeholder rather than failing the collection.
- **Wiring** — a shared builder constructs each collector and getter with a label loader bound to the same database and branch, and the enriched changelog is emitted on mutation, merge and rebase.

## Testing

- Unit: id normalization and best-effort degradation, without a database.
- Component: mutation, merge, rebase, hierarchy, schemaless-kind tolerance, and reader-failure resilience against a live database.
- Functional: the enriched changelog reaches the delivered webhook payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
