### PR TITLE
docs: mark NATS support as experimental

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -476,7 +476,14 @@ class BrokerSettings(BaseSettings):
         default=2, description="The maximum number of concurrent messages fetched by each worker", ge=1
     )
     virtualhost: str = Field(default="/", description="The virtual host to connect to")
-    driver: BrokerDriver = BrokerDriver.RabbitMQ
+    driver: BrokerDriver = Field(
+        default=BrokerDriver.RabbitMQ,
+        description=(
+            "Message bus implementation. RabbitMQ is the recommended and fully supported driver. "
+            "NATS JetStream is experimental and not feature-complete: some functionality does not currently "
+            "work, so it is not recommended for production."
+        ),
+    )
 
     @property
     def service_port(self) -> int:
@@ -493,7 +500,14 @@ class CacheSettings(BaseSettings):
         default=None, ge=1, le=65535, description="Specified if running on a non default port (6379)"
     )
     database: int = Field(default=0, ge=0, le=15, description="Id of the database to use")
-    driver: CacheDriver = CacheDriver.Redis
+    driver: CacheDriver = Field(
+        default=CacheDriver.Redis,
+        description=(
+            "Cache implementation. Redis is the recommended and fully supported driver. "
+            "NATS JetStream is experimental and not feature-complete: some functionality does not currently "
+            "work, so it is not recommended for production."
+        ),
+    )
     username: str = ""
     password: str = ""
     tls_enabled: bool = Field(default=False, description="Indicates if TLS is enabled for the connection")

--- a/docs/docs/overview/architecture.mdx
+++ b/docs/docs/overview/architecture.mdx
@@ -267,8 +267,8 @@ The message bus is the communication backbone between components in Infrahub. It
 - **Message persistence**: Ensures reliable delivery even during component failures
 - **Multiple messaging patterns**: Supports publish-subscribe, work queues, and request-reply patterns
 
-:::note
-Infrahub also supports NATS JetStream as an alternative message bus implementation, offering different performance characteristics and deployment models.
+:::warning Experimental
+Infrahub offers experimental support for NATS JetStream as an alternative message bus implementation. This integration is not feature-complete and some functionality does not currently work, so RabbitMQ remains the recommended option for production deployments.
 :::
 
 <ReferenceLink title="RabbitMQ Project" url="https://www.rabbitmq.com/" />
@@ -286,8 +286,8 @@ The cache system is built on **Redis** and serves multiple critical functions:
 - **Versatile data structures**: Supports complex operations beyond basic key-value storage
 - **Pub/sub capabilities**: Enables lightweight messaging for specific use cases
 
-:::note
-Infrahub also supports NATS JetStream as an alternative cache implementation.
+:::warning Experimental
+Infrahub offers experimental support for NATS JetStream as an alternative cache implementation. This integration is not feature-complete and some functionality does not currently work, so Redis remains the recommended option for production deployments.
 :::
 
 <ReferenceLink title="Redis Project" url="https://github.com/redis/redis" />

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -151,7 +151,7 @@ Configuration settings for the message bus.
 | `INFRAHUB_BROKER_MAXIMUM_MESSAGE_RETRIES` | The maximum number of retries that are attempted for failed messages | integer | 10 |
 | `INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES` | The maximum number of concurrent messages fetched by each worker | integer | 2 |
 | `INFRAHUB_BROKER_VIRTUALHOST` | The virtual host to connect to | string | / |
-| `INFRAHUB_BROKER_DRIVER` | None | string (rabbitmq, nats) | rabbitmq |
+| `INFRAHUB_BROKER_DRIVER` | Message bus implementation. RabbitMQ is the recommended and fully supported driver. NATS JetStream is experimental and not feature-complete: some functionality does not currently work, so it is not recommended for production. | string (rabbitmq, nats) | rabbitmq |
 
 ## Cache
 
@@ -160,7 +160,7 @@ Configuration settings for the message bus.
 | `INFRAHUB_CACHE_ADDRESS` | None | string | localhost |
 | `INFRAHUB_CACHE_PORT` | Specified if running on a non default port (6379) | None | None |
 | `INFRAHUB_CACHE_DATABASE` | Id of the database to use | integer | 0 |
-| `INFRAHUB_CACHE_DRIVER` | None | string (redis, nats) | redis |
+| `INFRAHUB_CACHE_DRIVER` | Cache implementation. Redis is the recommended and fully supported driver. NATS JetStream is experimental and not feature-complete: some functionality does not currently work, so it is not recommended for production. | string (redis, nats) | redis |
 | `INFRAHUB_CACHE_USERNAME` | None | string |  |
 | `INFRAHUB_CACHE_PASSWORD` | None | string |  |
 | `INFRAHUB_CACHE_TLS_ENABLED` | Indicates if TLS is enabled for the connection | boolean | False |


### PR DESCRIPTION
## Summary

The docs described NATS JetStream as a fully supported alternative to RabbitMQ (message bus) and Redis (cache). This is misleading: NATS support is experimental and not feature-complete, and some functionality does not currently work.

This PR reframes NATS as experimental across both the architecture overview and the configuration reference.

## Changes

- `docs/docs/overview/architecture.mdx`: converted the two `:::note` NATS blocks (message bus and cache) into `:::warning Experimental` admonitions and reworded them to state that NATS JetStream is experimental, not feature-complete, and not recommended for production.
- `backend/infrahub/config.py`: added descriptions to the `INFRAHUB_BROKER_DRIVER` and `INFRAHUB_CACHE_DRIVER` fields (previously undocumented) making clear that RabbitMQ and Redis are the recommended, fully supported drivers and that the NATS option is experimental.
- `docs/docs/reference/configuration.mdx`: regenerated from the updated field descriptions (generated file).

## Test plan

- Documentation and config-metadata change; no runtime behavior affected.
- `docs/docs/reference/configuration.mdx` regenerated via `invoke docs.generate-config`; only the two driver rows changed.