### PR TITLE
fix: return ok for a successful branch merge when auto-delete is enabled (#10578)

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -418,8 +418,7 @@ class BranchMerge(Mutation):
                 # ignore_deleting=False so a branch that auto-delete has moved to DELETING is still returned
                 obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name, ignore_deleting=False)
             except BranchNotFoundError:
-                # delete_branch_after_merge removed the branch after the merge committed; the merge
-                # succeeded, so return the pre-merge branch with its deletion in progress.
+                # The merge succeeded and auto-delete has already removed the branch, so report deletion in progress rather than failing.
                 obj.status = BranchStatus.DELETING
             graphql_object = await obj.to_graphql_flat(fields=fields.get("object", {}))
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -410,10 +410,17 @@ class BranchMerge(Mutation):
             )
             task = {"id": workflow.id}
 
-        # Pull the latest information about the branch from the database directly
-        obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name)
-
         fields = extract_graphql_fields(info=info)
-        ok = True
 
-        return cls(object=await obj.to_graphql_flat(fields=fields.get("object", {})), ok=ok, task=task)
+        graphql_object = None
+        if "object" in fields:
+            try:
+                # ignore_deleting=False so a branch that auto-delete has moved to DELETING is still returned
+                obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name, ignore_deleting=False)
+            except BranchNotFoundError:
+                # delete_branch_after_merge removed the branch after the merge committed; the merge
+                # succeeded, so return the pre-merge branch with its deletion in progress.
+                obj.status = BranchStatus.DELETING
+            graphql_object = await obj.to_graphql_flat(fields=fields.get("object", {}))
+
+        return cls(object=graphql_object, ok=True, task=task)

--- a/backend/tests/functional/branch/test_branch_delete_after_merge.py
+++ b/backend/tests/functional/branch/test_branch_delete_after_merge.py
@@ -8,7 +8,9 @@ from infrahub_sdk.graphql import Mutation
 
 from infrahub import config
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
+from infrahub.exceptions import BranchNotFoundError
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workflows.catalogue import BRANCH_DELETE
 from tests.helpers.schema import CAR_SCHEMA, load_schema
@@ -115,3 +117,53 @@ class TestAutoDeleteBranchAfterMerge(TestInfrahubApp):
                 context=ANY,
                 parameters={"branch": branch.name, "proposed_change_id": pc.id},
             )
+
+    async def test_branch_merge_returns_ok_with_object_requested_when_auto_delete_enabled(
+        self,
+        initial_dataset: None,
+        client: InfrahubClient,
+        db: InfrahubDatabase,
+        delete_branch_after_merge_reset_config: None,
+    ) -> None:
+        config.SETTINGS.main.delete_branch_after_merge = True
+        branch = await client.branch.create(branch_name="auto_delete_returns_object")
+
+        tag = await client.create(kind="TestingTag", branch=branch.name, data={"name": {"value": "merge-marker"}})
+        await tag.save()
+
+        query = Mutation(
+            mutation="BranchMerge",
+            input_data={"data": {"name": branch.name}},
+            query={"ok": None, "object": {"status": None}},
+        )
+        result = await client.execute_graphql(query=query.render())
+
+        assert result["BranchMerge"]["ok"] is True
+        assert result["BranchMerge"]["object"]["status"] == "DELETING"
+
+        tags_on_default = await client.filters(
+            kind="TestingTag", name__value="merge-marker", branch=registry.default_branch
+        )
+        assert len(tags_on_default) == 1
+
+        with pytest.raises(BranchNotFoundError):
+            await Branch.get_by_name(db=db, name=branch.name, ignore_deleting=False)
+
+    async def test_branch_merge_returns_ok_without_object_when_auto_delete_enabled(
+        self,
+        initial_dataset: None,
+        client: InfrahubClient,
+        db: InfrahubDatabase,
+        delete_branch_after_merge_reset_config: None,
+    ) -> None:
+        config.SETTINGS.main.delete_branch_after_merge = True
+        branch = await client.branch.create(branch_name="auto_delete_no_object")
+
+        query = Mutation(
+            mutation="BranchMerge",
+            input_data={"data": {"name": branch.name}},
+            query={"ok": None},
+        )
+        result = await client.execute_graphql(query=query.render())
+
+        assert result["BranchMerge"]["ok"] is True

--- a/changelog/10578.fixed.md
+++ b/changelog/10578.fixed.md
@@ -1,0 +1,1 @@
+Fixed the branch merge mutation reporting a "branch not found" error for a merge that succeeded when automatic branch deletion after merge is enabled.


### PR DESCRIPTION
## Summary

`BranchMerge` returned `Branch: <name> not found.` (`BRANCH_NOT_FOUND`) for a merge that **fully succeeded** when `main.delete_branch_after_merge` is enabled and `wait_until_completion` is `true` (the default). Fixes #10578.

The mutation re-read the branch after the merge workflow to build its response. With auto-delete on, the merge's follow-ups submit `BRANCH_DELETE`, and `Branch.get_by_name` defaults to `ignore_deleting=True`, so a branch mid-delete reads as not found. The timing differs by tier: under the functional tier's inline execution the `BRANCH_DELETE` runs synchronously, so the re-read deterministically hits the deleted branch and fails every time; in a real Prefect deployment `BRANCH_DELETE` is submitted fire-and-forget (`run_deployment(timeout=0)`), so the re-read usually finds the branch still present as `MERGED` and the failure is an intermittent race. Either way the data change is live on the default branch and the branch is really deleted - only the response was wrong. This fix handles both paths.

The web UI is unaffected because it sends `wait_until_completion: false`. The SDK, `infrahubctl`, and any automation on the default are affected.

## Changes

- **Only re-read the branch when the caller requested `object`.** The old code queried unconditionally, so even a caller selecting just `ok` hit the error. `extract_graphql_fields` already tells us what was requested.
- **Tolerate the branch being gone when `object` is requested.** Read with `ignore_deleting=False` (returns the real object during the delete window); on `BranchNotFoundError` fall back to the pre-merge object with `status = DELETING`.
- `ok` is now always `true` for a successful merge.

### Why `DELETING` and not `MERGED`
With auto-delete off, a successful merge returns the branch as `MERGED` and it persists - callers can still query it. Returning `MERGED` in the auto-delete case would collapse those two different outcomes into one status, so a caller keeping the object and later querying the branch would get nothing with no signal why. `DELETING` correctly signals "last remnant before it is gone; do not expect to query it," while `ok: true` still carries success.

## Tests

`backend/tests/functional/branch/test_branch_delete_after_merge.py`, no mocks - the delete runs for real (in the functional tier `WorkflowLocalExecution.submit_workflow` runs it inline, so the failure is deterministic):

- `..._with_object_requested...` - asserts `ok: true`, `object.status == "DELETING"`, the data change landed on the default branch, and the branch is gone.
- `..._without_object...` - asserts `ok: true` when only `ok` is requested.

Both were confirmed red against the unmodified resolver (failing with the exact `BRANCH_NOT_FOUND`) and green after the fix. The 3 pre-existing tests in the file still pass.

> Note: the pre-existing `test_branch_auto_deleted_*` tests mock `submit_workflow`, which is exactly why they never caught this - the delete never ran. The new tests deliberately let it run.

## Out of scope

- Frontend toast #10577 is a separate defect.
- The analogous re-read pattern in `BranchRebase`/`BranchValidate`/`BranchCreate` is untouched - no auto-delete race applies there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
