### PR TITLE
fix(testcontainers): record a timed measurement's context flat

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -102,14 +102,21 @@ class InfrahubPerformanceTest:
         self,
         definition: MeasurementDefinition,
         value: float | str,
-        **kwargs: dict[str, float],
+        context: dict[str, Any] | None = None,
+        **kwargs: str | float,
     ) -> None:
+        """Record a measurement.
+
+        Context dimensions can be passed either as keyword arguments or as a `context` mapping.
+        Either way they land flat on the recorded item, so every measurement of a definition
+        carries the same shape and the whole set compares as a single series.
+        """
         self.measurements.append(
             InfrahubMeasurementItem(
                 name=definition.name,
                 value=value,
                 unit=definition.unit,
-                context=kwargs or {},
+                context={**(context or {}), **kwargs},
             )
         )
 

--- a/python_testcontainers/tests/test_performance_payload.py
+++ b/python_testcontainers/tests/test_performance_payload.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 
 from infrahub_testcontainers.constants import PERFORMANCE_TEST_KIND, PERFORMANCE_TEST_VERSION
-from infrahub_testcontainers.measurements import BRANCH_MERGE_TIME
+from infrahub_testcontainers.measurements import BRANCH_MERGE_TIME, SCRIPT_EXECUTION_TIME
 from infrahub_testcontainers.models import ContextUnit
 from infrahub_testcontainers.performance_test import InfrahubPerformanceTest
 
@@ -22,3 +22,19 @@ def test_request_checksum_covers_the_payload_on_the_wire() -> None:
     assert (
         request["checksum"] == hashlib.sha256(json.dumps(request["data"], separators=(",", ":")).encode()).hexdigest()
     )
+
+
+def test_timed_and_direct_measurements_share_the_same_context_shape() -> None:
+    """Both recording paths must carry their dimensions flat, or the two cannot compare as one series."""
+    performance_test = InfrahubPerformanceTest(results_url="http://localhost")
+    performance_test.initialize(name="test_timed_and_direct_measurements_share_the_same_context_shape")
+
+    with performance_test.start_measurement(SCRIPT_EXECUTION_TIME, name="load", phase="read"):
+        pass
+    performance_test.add_measurement(SCRIPT_EXECUTION_TIME, value=100, name="load", phase="compute")
+
+    timed, direct = performance_test.measurements
+
+    assert timed.context == {"name": "load", "phase": "read"}
+    assert direct.context == {"name": "load", "phase": "compute"}
+    assert timed.context.keys() == direct.context.keys()


### PR DESCRIPTION
# Why

`InfrahubPerformanceTest` recorded the same measurement in two different shapes depending on how it was taken, so a phase timed with the `start_measurement` context manager could not be compared against one recorded directly with `add_measurement`.

`__exit__` hands the dimensions it collected to `add_measurement` as `context=`, but `add_measurement` only had `**kwargs` — so `context` was absorbed as if it were a dimension and then stored one level deeper:

```text
add_measurement   -> {'context': {'name': '2-percent-new-sites', 'phase': 'compute'}}
start_measurement -> {'context': {'context': {'name': '2-percent-new-sites', 'phase': 'read'}}}
```

Nothing raised — the results just silently landed nested. Present in `infrahub-testcontainers==1.11.1` and affecting every timed measurement in the performance suite (`test_branch_merge`, `test_node`, `test_ipam`, `test_branch_scale`, and others).

## What changed

- A timed measurement's dimensions now land flat, identically to a directly recorded one, so the two compare as a single series.
- `add_measurement` takes `context` explicitly and merges it with the keyword dimensions. Both call shapes are now correct, and passing `context=` by hand can no longer re-introduce the nesting.
- Corrected the `**kwargs: dict[str, float]` annotation to `str | float`, matching `start_measurement` and what callers actually pass.

What stayed the same: the payload envelope, the checksum, and the upload path are untouched.

## How to test

```bash
cd python_testcontainers
uv run pytest --rootdir=. -c pyproject.toml -q tests --ignore=tests/test_container_postgres_backup.py
```

7 passed, 2 skipped (the ignored test needs a Postgres container). The new regression test fails on the pre-fix code — verified by reverting `performance_test.py` alone:

```text
>       assert timed.context == {"name": "load", "phase": "read"}
E       AssertionError: assert {'context': {...ase': 'read'}} == {'name': 'loa...hase': 'read'}
```

## Impact & rollout

- **Backward compatibility:** the recorded shape of a timed measurement changes, which is the point of the fix. Anything that learned to read `context.context` for those measurements now reads the dimensions flat.
- **Config/env changes:** none.
- **Follow-up:** once a fixed version ships, performance tests that time a phase with `time.perf_counter()` to keep both phases comparable (e.g. `test_artifacts_backpressure.py`) can go back to `start_measurement`.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry — deliberately omitted (`ci/skip-changelog`): the measurement harness is internal performance tooling with no effect an Infrahub user could observe
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a, no doc references the measurement API
- [x] I have reviewed AI generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

