### PR TITLE
Merge stable into develop

### DIFF
--- a/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
+++ b/.agents/skills/analyzing-ci-flakiness/scripts/collect.py
@@ -37,7 +37,13 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# The raw job log keeps every terminal escape sequence, not only colour (SGR) codes. Strip general
+# CSI sequences (colour, cursor moves, erase-line/screen) and OSC sequences (window title) so none
+# survive into the test-extraction regexes.
+ANSI = re.compile(
+    r"\x1b\[[0-?]*[ -/]*[@-~]"  # CSI: ESC [ ... final-byte
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC: ESC ] ... (BEL | ST)
+)
 
 # The Actions list-runs API silently returns at most this many results per query.
 API_RESULT_CAP = 1000

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,22 +26,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # In order for Chromatic to correctly determine baseline commits, tot access the full Git history graph.
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
       - name: Install Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@4cc98810d00b34b8f9e89d454d64a8ac3d088340 # v18.7.1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: ./frontend/packages/ui

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip == 'false'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive
@@ -96,11 +96,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip == 'false'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
         if: steps.check.outputs.skip == 'false' && inputs.publish
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build and push by digest
         if: steps.check.outputs.skip == 'false'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: .
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload digest
         if: steps.check.outputs.skip == 'false' && inputs.publish
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -146,17 +146,17 @@ jobs:
       digest: ${{ steps.inspect.outputs.digest }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: ${{ inputs.artifact_prefix }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -192,10 +192,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to Harbor
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -236,13 +236,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.2
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
 
       - name: Login to Harbor
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -271,7 +271,7 @@ jobs:
       # protect. Every caller passes a version unique to its invocation, so the only
       # artifact this can replace is the same SBOM from a previous attempt.
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ inputs.version }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,9 @@ jobs:
 
   action-lint:
     if: needs.files-changed.outputs.github_workflows == 'true'
-    needs: ["files-changed"]
+    needs:
+      - files-changed
+      - prepare-environment
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
@@ -375,6 +377,23 @@ jobs:
         shell: bash
         env:
           SHELLCHECK_OPTS: --exclude=SC2086 --exclude=SC2046 --exclude=SC2004 --exclude=SC2129
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
+      # zizmor is a standalone static analyzer, so only the dev group is needed;
+      # building the project itself would make a cheap lint job slow.
+      - name: Install dependencies
+        run: "uv sync --only-group dev"
+      # Fails when a `uses:` reference is not pinned to a full commit SHA.
+      # See .github/zizmor.yml for the policy and the audits still to enable.
+      - name: "Linting: zizmor"
+        run: "uv run zizmor --no-progress --config .github/zizmor.yml .github/workflows/"
 
   infrahub-uv-check:
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
       observability_standalone: ${{ steps.changes.outputs.observability_standalone_all }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check for file changes
-        uses: dorny/paths-filter@v4.0.3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           token: ${{ github.token }}
@@ -82,16 +82,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -110,15 +110,15 @@ jobs:
       contents: read
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Set up Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -145,13 +145,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -188,13 +188,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -229,13 +229,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -269,13 +269,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -312,17 +312,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -350,11 +350,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: "Linting: markdownlint"
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: "docs/docs/**/*.md docs/docs/**/*.mdx"
 
@@ -365,7 +365,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check workflow files
@@ -394,18 +394,18 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
 
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -451,13 +451,13 @@ jobs:
         working-directory: ./python_testcontainers
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -494,16 +494,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -512,7 +512,7 @@ jobs:
         run: "uv run invoke backend.test-unit"
       - name: "Coveralls : Unit Tests"
         if: matrix.python-version == '3.14'
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -590,12 +590,12 @@ jobs:
       PYTEST_XDIST_WORKER_COUNT: 2
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -605,7 +605,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -613,7 +613,7 @@ jobs:
       - name: "Component Tests (${{ matrix.shard }})"
         run: "uv run invoke backend.test-component --shard ${{ matrix.shard }}"
       - name: "Coveralls : Component Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -649,12 +649,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -664,7 +664,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -675,7 +675,7 @@ jobs:
       - name: "Integration Tests (${{ matrix.shard }})"
         run: "uv run invoke backend.test-integration --shard ${{ matrix.shard }}"
       - name: "Coveralls : Integration Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -696,12 +696,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -711,7 +711,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -719,7 +719,7 @@ jobs:
       - name: "Functional Tests"
         run: "uv run invoke backend.test-functional"
       - name: "Coveralls : Functional Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -757,12 +757,12 @@ jobs:
       UV_VERSION: ${{ needs.prepare-environment.outputs.UV_VERSION }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install tini
@@ -783,7 +783,7 @@ jobs:
           echo INFRAHUB_TESTING_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
           echo INFRAHUB_TESTING_DOCKER_IMAGE="opsmill/infrahub" >> $GITHUB_ENV
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -858,16 +858,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -886,15 +886,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: frontend/package.json
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # https://github.com/microsoft/playwright/issues/41000
           node-version: 24.15.0
@@ -913,7 +913,7 @@ jobs:
         working-directory: ./frontend/packages/graph
         run: "pnpm test"
       - name: "Coveralls : Unit Tests"
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
@@ -932,16 +932,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -958,16 +958,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -985,16 +985,16 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Check out repository code
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1016,22 +1016,22 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1054,22 +1054,22 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1091,11 +1091,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: |
             --no-progress
@@ -1115,7 +1115,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
 
@@ -1141,7 +1141,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       # The official GitHub Action for Vale doesn't work, installing manually instead:
@@ -1182,16 +1182,16 @@ jobs:
       PYTEST_XDIST_WORKER_COUNT: 1
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1242,7 +1242,7 @@ jobs:
         run: exec tini -s -g -- uv run pytest -c tests/e2e/pytest.ini tests/e2e/tutorial
       - name: e2e-artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: E2E-testing-pytest-playwright-${{ matrix.shard }}
           path: |
@@ -1268,17 +1268,17 @@ jobs:
       group: huge-runners
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
 
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1358,12 +1358,12 @@ jobs:
       INFRAHUB_DB_TYPE: neo4j
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: Set up Python
         id: python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: "Setup git credentials"
@@ -1373,7 +1373,7 @@ jobs:
               git config --global credential.usehttppath true && \
               git config --global credential.helper '/usr/bin/env infrahub-git-credential'"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -1383,7 +1383,7 @@ jobs:
 
       - name: Run all benchmarks
         if: contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
@@ -1392,7 +1392,7 @@ jobs:
       - name: Run non-intensive benchmarks
         if: |
           !contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: instrumentation
@@ -1432,7 +1432,7 @@ jobs:
       #     running-workflow-name: report
       #     allowed-conclusions: success,skipped,cancelled,failure
 
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         continue-on-error: true
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,11 +1170,8 @@ jobs:
     runs-on:
       group: huge-runners
     timeout-minutes: 60
-    # ci.yml has no top-level permissions block; a job-level one restricts this job
-    # to exactly what is listed, so contents: read (checkout) must be explicit.
     permissions:
       contents: read
-      checks: write # Publish e2e results (junit check run)
     strategy:
       fail-fast: false
       matrix:
@@ -1251,15 +1248,6 @@ jobs:
           path: |
             test-results/
             playwright-junit.xml
-      - name: Publish e2e results
-        if: always() && github.event.pull_request.head.repo.fork == false
-        uses: mikepenz/action-junit-report@v6
-        with:
-          report_paths: playwright-junit.xml
-          check_name: "E2E pytest (${{ matrix.shard }})"
-          include_passed: false
-          detailed_summary: true
-          fail_on_failure: false # pytest already fails the job; only annotate
       # Leftover containers here mean the session-fixture teardown did not run.
       - name: Containers after tests
         if: always()

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -71,7 +71,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR head branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve.outputs.branch }}
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--permission-mode dontAsk"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install gh-aw extension
-        uses: github/gh-aw-actions/setup-cli@a95cb3861440650dd6b6e25f6488a4bc1c29cd74 # v0.68.3
+        uses: github/gh-aw-actions/setup-cli@a95cb3861440650dd6b6e25f6488a4bc1c29cd74 # v0.81.3
         with:
           version: v0.68.3

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: GitHub Releases to Discord
-        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682
+        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682 # v1.20.0
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"

--- a/.github/workflows/keyword-scan.yml
+++ b/.github/workflows/keyword-scan.yml
@@ -14,9 +14,9 @@ jobs:
        github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
       - name: "Setup Python environment"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v7.0.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v6
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'opsmill/infrahub'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           # Only manage PRs, not issues
           days-before-issue-stale: -1

--- a/.github/workflows/otel-export-trace.yml
+++ b/.github/workflows/otel-export-trace.yml
@@ -16,7 +16,7 @@ jobs:
       group: huge-runners
     steps:
       - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@v1
+        uses: inception-health/otel-export-trace-action@7eabc7de1f4753f0b45051b44bb0ba46d05a21ef # v1.8.0
         with:
           otlpEndpoint: ${{ secrets.TRACING_ENDPOINT }}
           otlpHeaders: ""

--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -47,7 +47,7 @@ jobs:
         id: short_ref
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/publish-preview-dev-docker-image.yml
+++ b/.github/workflows/publish-preview-dev-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
         id: short_ref
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,12 +43,12 @@ jobs:
 
       - name: "Set up Python"
         id: python
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
           # Full history + tags so hatch-vcs stamps the real tag version, not the fallback
@@ -56,7 +56,7 @@ jobs:
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install Dependencies

--- a/.github/workflows/push-bench-image.yml
+++ b/.github/workflows/push-bench-image.yml
@@ -21,13 +21,13 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         id: login
         with:
           registry: ${{ vars.HARBOR_HOST }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/opsmill/bench
@@ -44,7 +44,7 @@ jobs:
             org.opencontainers.image.source=opsmill/bench
 
       - name: Build and push by digest
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: utilities/benchmark
@@ -64,7 +64,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -76,17 +76,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: bench-digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.HARBOR_HOST }}
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/opsmill/bench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       latest_tag: ${{ steps.release.outputs.latest_tag }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
           # Full history + tags so hatch-vcs resolves the exact tag version from installed metadata
@@ -35,12 +35,12 @@ jobs:
 
       - name: "Set up Python"
         id: python
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Set docker image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           # if matrix.repo contains a slash, use it literally; otherwise look up the secret named by matrix.repo

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -35,9 +35,15 @@ jobs:
       matrix:
         # Either a literal path, or the name of a secret...
         repo:
+          - "opsmill/infrahub-ansible"
+          - "opsmill/infrahub-arista-avd"
           - "opsmill/infrahub-demo-dc"
+          - "opsmill/infrahub-demo-otn"
+          - "opsmill/infrahub-demo-service-catalog"
           - "opsmill/infrahub-demo-sp"
+          - "opsmill/infrahub-mcp"
           - "opsmill/infrahub-solution-ai-dc"
+          - "opsmill/nornir-infrahub"
           - "INFRAHUB_PACKER_REPOSITORY"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"

--- a/.github/workflows/schedule-publish-docker-image.yml
+++ b/.github/workflows/schedule-publish-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: develop
       - name: Set GIT ref
@@ -36,7 +36,7 @@ jobs:
         id: date
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}
@@ -72,7 +72,7 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - name: Checkout stable branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: stable
       - name: Set GIT ref
@@ -86,7 +86,7 @@ jobs:
         id: date
       - name: Set docker image meta data
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: source-repo
 
       - name: Checkout target repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-docs
           token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}

--- a/.github/workflows/update-compose-file-and-chart.yml
+++ b/.github/workflows/update-compose-file-and-chart.yml
@@ -25,17 +25,17 @@ jobs:
     needs: prepare-environment
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: "Update Infrahub Image Version in docker-compose.yml file"
         run: "uv run invoke release.update-docker-compose --version '${{ inputs.version }}'"
       - name: Commit docker-compose.yml
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GH_INFRAHUB_BOT_TOKEN }}
           push-branch: ${{ github.ref_name }}
@@ -80,7 +80,7 @@ jobs:
           rebase: true
 
       - name: Checkout infrahub-helm
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-helm
           path: helm

--- a/.github/workflows/update-sdk-compatibility-docs.yml
+++ b/.github/workflows/update-sdk-compatibility-docs.yml
@@ -11,25 +11,25 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout SDK repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: opsmill/infrahub-sdk-python
           ref: stable
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
 
       - name: Install NodeJS
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "npm"
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           commit-message: "docs: update compatibility matrix"

--- a/.github/workflows/update-sdk-submodule.yml
+++ b/.github/workflows/update-sdk-submodule.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: "${{ matrix.branch-name }}"
           submodules: recursive
@@ -51,7 +51,7 @@ jobs:
           echo "BRANCH_EXISTS=$BRANCH_EXISTS" >> $GITHUB_ENV
 
       - name: Commit and push changes with github-actions-x/commit
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
           push-branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/uv-check.yml
+++ b/.github/workflows/uv-check.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: "Set up Python"
-        uses: "actions/setup-python@v7"
+        uses: "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: "Validate pyproject.toml and consistency with uv.lock"

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -54,15 +54,15 @@ jobs:
       UV_VERSION: ${{ needs.prepare-environment.outputs.UV_VERSION }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ needs.prepare-environment.outputs.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ needs.prepare-environment.outputs.UV_VERSION }}
       - name: Install dependencies

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,47 @@
+---
+# zizmor static analysis for GitHub Actions workflows (https://docs.zizmor.sh).
+# Run by the `action-lint` job in .github/workflows/ci.yml; zizmor itself is a
+# `dev` dependency in pyproject.toml, so the version is pinned by uv.lock.
+#
+# Scope: this config enforces ONE rule today -- every `uses:` reference must be
+# pinned to a full commit SHA. A tag is mutable, so whoever owns an action
+# repository can move `v4` onto new code that then runs with whatever secrets
+# the step is handed. Enforcing it here is what stops a tag ref from creeping
+# back in after the repo-wide pinning in #10470.
+#
+# The other audits are disabled rather than removed: each reports pre-existing
+# findings that deserve their own review, so they are listed below with the
+# count measured on 2026-09-08 and are meant to be enabled one at a time in
+# follow-up PRs -- not silently dropped.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Our own reusable workflows are meant to track a branch: SHA-pinning
+        # opsmill/infrahub-helm would freeze the helm publish pipeline at one
+        # commit, which is not the intent.
+        opsmill/*: any
+        # Everything else -- GitHub-owned actions included -- must be a SHA.
+        "*": hash-pin
+
+  # --- Pre-existing findings; enable one per follow-up PR. Counts: 2026-09-08.
+  template-injection:
+    disable: true      # 67 findings
+  excessive-permissions:
+    disable: true      # 60 findings
+  artipacked:
+    disable: true      # 51 findings
+  cache-poisoning:
+    disable: true      # 29 findings
+  self-repository:
+    disable: true      # 18 findings
+  adhoc-packages:
+    disable: true      # 12 findings
+  secrets-inherit:
+    disable: true      # 9 findings
+  dangerous-triggers:
+    disable: true      # 1 finding
+  overprovisioned-secrets:
+    disable: true      # 1 finding
+  use-trusted-publishing:
+    disable: true      # 1 finding

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -222,12 +222,16 @@ Redis
 Redoc
 refactored
 regex
+regenerator
+regenerators
 reimported
 repo
 requesters
 resizable
 Resizable
 reusability
+ROADM
+ROADMs
 rollout
 Schema
 schema_mapping

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -392,7 +392,6 @@ class QueryStat:
         return cls(**data)
 
 
-<<<<<<< HEAD
 class QueryInitKwargs(TypedDict, total=False):
     """Keyword arguments every query constructor accepts and forwards to its base."""
 
@@ -403,7 +402,8 @@ class QueryInitKwargs(TypedDict, total=False):
     order_by: list[str] | None
     branch_agnostic: bool
     user_id: str
-=======
+
+
 PAGINATION_LIMIT_PARAM = "query_limit"
 PAGINATION_OFFSET_PARAM = "query_offset"
 
@@ -414,7 +414,6 @@ class RenderedQuery:
 
     text: str
     params: dict[str, Any]
->>>>>>> origin/stable
 
 
 class Query:

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -392,6 +392,18 @@ class QueryStat:
         return cls(**data)
 
 
+PAGINATION_LIMIT_PARAM = "query_limit"
+PAGINATION_OFFSET_PARAM = "query_offset"
+
+
+@dataclass(frozen=True)
+class RenderedQuery:
+    """A query's text together with every parameter that text refers to."""
+
+    text: str
+    params: dict[str, Any]
+
+
 class Query:
     name: str = "base-query"
     type: QueryType
@@ -514,17 +526,11 @@ class Query:
         if with_clause:
             self.add_to_query(f"WITH {with_clause}")
 
-    def get_query(
-        self,
-        var: bool = False,
-        inline: bool = False,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> str:
-        # Make a local copy of the _query_lines
-        limit = limit or self.limit
-        offset = offset or self.offset
+    def render(self, limit: int | None = None, offset: int | None = None) -> RenderedQuery:
+        limit = self.limit if limit is None else limit
+        offset = self.offset if offset is None else offset
         tmp_query_lines = self.query_lines.copy()
+        params = dict(self.params)
 
         if self.insert_return:
             tmp_query_lines.append("RETURN " + ",".join(self.return_labels))
@@ -532,20 +538,34 @@ class Query:
         if self.order_by:
             tmp_query_lines.append("ORDER BY " + ",".join(self.order_by))
 
-        if offset and self.insert_limit:
-            tmp_query_lines.append(f"SKIP {offset}")
+        # Bound as parameters rather than literals, a zero offset included, so every page of a
+        # paginated query shares one text, and with it one cached plan. A zero limit is no bound,
+        # the same reading `execute()` gives it when choosing how to run.
+        if offset is not None and self.insert_limit:
+            params[PAGINATION_OFFSET_PARAM] = offset
+            tmp_query_lines.append(f"SKIP ${PAGINATION_OFFSET_PARAM}")
 
         if limit and self.insert_limit:
-            tmp_query_lines.append(f"LIMIT {limit}")
+            params[PAGINATION_LIMIT_PARAM] = limit
+            tmp_query_lines.append(f"LIMIT ${PAGINATION_LIMIT_PARAM}")
 
-        query_str = "\n".join(tmp_query_lines)
+        return RenderedQuery(text="\n".join(tmp_query_lines), params=params)
+
+    def get_query(
+        self,
+        var: bool = False,
+        inline: bool = False,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> str:
+        rendered = self.render(limit=limit, offset=offset)
 
         if var and not inline:
-            return "\n" + self.get_params_for_shell() + "\n\n" + query_str
+            return "\n" + self.get_params_for_shell(params=rendered.params) + "\n\n" + rendered.text
         if var and inline:
-            return self.insert_variables_in_query(query=query_str, variables=self.params)
+            return self.insert_variables_in_query(query=rendered.text, variables=rendered.params)
 
-        return query_str
+        return rendered.text
 
     def get_count_query(self, var: bool = False) -> str:
         tmp_query_lines = self.query_lines.copy()
@@ -584,28 +604,30 @@ class Query:
 
         return query
 
-    def get_params_for_shell(self) -> str:
+    def get_params_for_shell(self, params: dict[str, Any] | None = None) -> str:
+        params = self.params if params is None else params
         if config.SETTINGS.database.db_type.value == "memgraph":
-            return ujson.dumps(self.params)
+            return ujson.dumps(params)
 
-        return self._get_params_for_neo4j_shell()
+        return self._get_params_for_neo4j_shell(params=params)
 
-    def _get_params_for_neo4j_shell(self) -> str:
+    @staticmethod
+    def _get_params_for_neo4j_shell(params: dict[str, Any]) -> str:
         """Generate string to define some parameters in Neo4j browser interface.
 
         It's especially useful to later execute a query that includes some variables.
 
         The params string must be executed on its own window in Neo4j, before executing the query.
         """
-        params = []
+        rendered = []
 
-        for key, value in self.params.items():
+        for key, value in params.items():
             if isinstance(value, int | list):
-                params.append(f"{key}: {str(value)}")
+                rendered.append(f"{key}: {str(value)}")
             else:
-                params.append(f'{key}: "{value}"')
+                rendered.append(f'{key}: "{value}"')
 
-        return ":params { " + ", ".join(params) + " }"
+        return ":params { " + ", ".join(rendered) + " }"
 
     @trace.get_tracer(__name__).start_as_current_span("Query.execute")
     async def execute(self, db: InfrahubDatabase, timeout_seconds: float | None = None) -> Self:
@@ -615,13 +637,13 @@ class Query:
         if config.SETTINGS.miscellaneous.print_query_details:
             self.print(include_var=True)
 
-        query_str = self.get_query()
+        rendered = self.render()
 
         if self.type == QueryType.READ:
             if self.limit or self.offset:
                 results = await db.execute_query(
-                    query=query_str,
-                    params=self.params,
+                    query=rendered.text,
+                    params=rendered.params,
                     name=self.name,
                     context=self.get_context(),
                     type=self.type,
@@ -632,8 +654,8 @@ class Query:
 
         elif self.type == QueryType.WRITE:
             results, metadata = await db.execute_query_with_metadata(
-                query=query_str,
-                params=self.params,
+                query=rendered.text,
+                params=rendered.params,
                 name=self.name,
                 context=self.get_context(),
                 type=self.type,
@@ -645,7 +667,7 @@ class Query:
             raise ValueError(f"unknown value for {self.type}")
 
         if not results and self.raise_error_if_empty:
-            raise QueryError(query=query_str, params=self.params)
+            raise QueryError(query=rendered.text, params=rendered.params)
 
         clean_labels = cleanup_return_labels(self.return_labels)
         self.results = [QueryResult(data=result, labels=clean_labels) for result in results]
@@ -659,9 +681,10 @@ class Query:
         results: list[Record] = []
         remaining = True
         while remaining:
+            rendered = self.render(limit=query_limit, offset=offset)
             offset_results, metadata = await db.execute_query_with_metadata(
-                query=self.get_query(limit=query_limit, offset=offset),
-                params=self.params,
+                query=rendered.text,
+                params=rendered.params,
                 name=self.name,
                 context=self.get_context(),
                 type=self.type,

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -566,7 +566,8 @@ class NodeCreateAllQuery(NodeQuery):
         node = result.get("n")
 
         if node is None:
-            raise QueryError(query=self.get_query(), params=self.params)
+            rendered = self.render()
+            raise QueryError(query=rendered.text, params=rendered.params)
 
         return node["uuid"], node.element_id
 

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
-from infrahub_sdk.exceptions import ModuleImportError
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import CoreGeneratorInstance
 from infrahub_sdk.schema.repository import InfrahubGeneratorDefinitionConfig
@@ -103,7 +102,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         )
         await generator.run(identifier=generator_definition.name)
         generator_instance.status.value = GeneratorInstanceStatus.READY.value
-    except (ModuleImportError, Exception):
+    except Exception:
         generator_instance.status.value = GeneratorInstanceStatus.ERROR.value
         await generator_instance.update(do_full_update=True)
         raise
@@ -239,6 +238,7 @@ async def request_generator_definition_run(
         )
 
     tasks: list[Coroutine[Any, Any, Any]] = []
+    members: list[tuple[str, str]] = []
     for relationship in group.members.peers:
         member = relationship.peer
 
@@ -259,14 +259,31 @@ async def request_generator_definition_run(
             target_id=member.id,
             target_name=member.display_label,
         )
+        members.append((request_generator_run_model.target_id, request_generator_run_model.target_name))
         tasks.append(
             get_workflow().execute_workflow(
                 workflow=REQUEST_GENERATOR_RUN, context=context, parameters={"model": request_generator_run_model}
             )
         )
 
-    try:
-        await asyncio.gather(*tasks)
+    # Let every member run and report each outcome, rather than aborting on the first failure.
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    # A cancelled member is a BaseException, not an Exception, so propagate the cancellation
+    # instead of letting it slip past the failure filter below and count as a success.
+    for result in results:
+        if isinstance(result, asyncio.CancelledError):
+            raise result
+    failures = [
+        (target_id, target_name, result)
+        for (target_id, target_name), result in zip(members, results, strict=True)
+        if isinstance(result, Exception)
+    ]
+    if not failures:
         return Completed(message=f"Successfully run {len(tasks)} generators")
-    except Exception as exc:
-        return Failed(message="One or more generators failed", error=exc)
+
+    succeeded = len(results) - len(failures)
+    details = "; ".join(f"{target_name} ({target_id}): {error}" for target_id, target_name, error in failures)
+    return Failed(
+        message=f"{len(failures)} of {len(results)} generators failed, {succeeded} succeeded: {details}",
+        data=ExceptionGroup("generator run failures", [error for *_, error in failures]),
+    )

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -280,11 +280,6 @@ async def request_generator_definition_run(
     ]
     if not failures:
         return Completed(message=f"Successfully run {len(tasks)} generators")
-<<<<<<< HEAD
-    # Flow boundary: any generator failure must surface as a Failed state carrying the error, not a crashed flow run
-    except Exception as exc:  # noqa: BLE001
-        return Failed(message="One or more generators failed", error=exc)
-=======
 
     succeeded = len(results) - len(failures)
     details = "; ".join(f"{target_name} ({target_id}): {error}" for target_id, target_name, error in failures)
@@ -292,4 +287,3 @@ async def request_generator_definition_run(
         message=f"{len(failures)} of {len(results)} generators failed, {succeeded} succeeded: {details}",
         data=ExceptionGroup("generator run failures", [error for *_, error in failures]),
     )
->>>>>>> origin/stable

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -102,7 +102,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         )
         await generator.run(identifier=generator_definition.name)
         generator_instance.status.value = GeneratorInstanceStatus.READY.value
-    except Exception:
+    except Exception:  # noqa: BLE001
         generator_instance.status.value = GeneratorInstanceStatus.ERROR.value
         await generator_instance.update(do_full_update=True)
         raise

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -102,7 +102,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         )
         await generator.run(identifier=generator_definition.name)
         generator_instance.status.value = GeneratorInstanceStatus.READY.value
-    except Exception:  # noqa: BLE001
+    except Exception:
         generator_instance.status.value = GeneratorInstanceStatus.ERROR.value
         await generator_instance.update(do_full_update=True)
         raise

--- a/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
+++ b/backend/tests/component/core/agnostic_retirement/test_on_rebase.py
@@ -76,7 +76,7 @@ async def _rebase_branch(
         branch=default_branch,
         account=AccountSession(account_id=TEST_ACTOR_ID, auth_type=AuthType.NONE),
     )
-    # The rollback test raises through this block, so the doubles have to come off on an exception too.
+    # The doubles must come off even when an exception propagates through this block.
     with (
         override_dependency(build_database, lambda singleton=True: db, dependency_provider=dependency_provider),  # noqa: ARG005
         override_workflow(WorkflowRecorder(), dependency_provider=dependency_provider),

--- a/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
+++ b/backend/tests/component/proposed_change/test_generator_definition_run_member_failure.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub.auth.session import AccountSession
+from infrahub.auth.types import AuthType
+from infrahub.context import BranchContext, InfrahubContext
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.generators.models import (
+    ProposedChangeGeneratorDefinition,
+    RequestGeneratorDefinitionRun,
+    RequestGeneratorRun,
+)
+from infrahub.generators.tasks import request_generator_definition_run
+from infrahub.server import app
+from infrahub.workers.dependencies import build_client
+from infrahub.workflows.catalogue import REQUEST_GENERATOR_RUN
+from tests.adapters.workflow import WorkflowRecorder
+from tests.constants.kind import TAG as TAG_KIND
+from tests.helpers.dependency_override import override_dependency
+from tests.helpers.schema import load_schema
+from tests.helpers.schema.tag import TAG
+from tests.helpers.test_app import TestInfrahubAppBase
+from tests.helpers.workflow_override import override_workflow
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from fast_depends import Provider
+
+    from infrahub.context import EventContext
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+    from infrahub.workflows.constants import WorkflowPriority
+    from infrahub.workflows.models import WorkflowDefinition
+    from tests.helpers.test_client import InfrahubTestClient
+
+TAG_QUERY = f"""
+query GetGenTag($ids: [ID!]!) {{
+    {TAG_KIND}(ids: $ids) {{
+        edges {{ node {{ name {{ value }} }} }}
+    }}
+}}
+"""
+
+TAG_SCHEMA = SchemaRoot(nodes=[TAG])
+
+_HEALTHY_MEMBER = "member-alpha"
+_FAILING_MEMBER = "member-beta"
+
+_DEFINITION_ID = "definition_id"
+_REPOSITORY_ID = "repository_id"
+_GROUP_ID = "group_id"
+_QUERY_ID = "query_id"
+_HEALTHY_ID = "healthy_id"
+_FAILING_ID = "failing_id"
+
+
+def _member_failure_message(target_name: str) -> str:
+    return f"generator run failed for {target_name}"
+
+
+class WorkflowRecorderFailingMember(WorkflowRecorder):
+    """Records every workflow call and raises for the generator runs whose target is selected to fail or cancel.
+
+    Simulates individual target-group members' generator runs raising while the others succeed, without
+    running the real generator body. A selected member either raises an ordinary error or is cancelled.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failing_target_ids: set[str] = set()
+        self.cancelled_target_ids: set[str] = set()
+
+    def reset(self) -> None:
+        super().reset()
+        self.failing_target_ids = set()
+        self.cancelled_target_ids = set()
+
+    async def execute_workflow(
+        self,
+        workflow: WorkflowDefinition,
+        expected_return: type | None = None,
+        context: InfrahubContext | EventContext | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+        priority: WorkflowPriority | None = None,
+    ) -> Any:
+        result = await super().execute_workflow(
+            workflow=workflow,
+            expected_return=expected_return,
+            context=context,
+            parameters=parameters,
+            tags=tags,
+            priority=priority,
+        )
+        if workflow == REQUEST_GENERATOR_RUN:
+            model = (parameters or {})["model"]
+            if isinstance(model, RequestGeneratorRun):
+                if model.target_id in self.cancelled_target_ids:
+                    # asyncio.gather discards this instance's message, so none is set here.
+                    raise asyncio.CancelledError
+                if model.target_id in self.failing_target_ids:
+                    raise RuntimeError(_member_failure_message(model.target_name))
+        return result
+
+
+class TestGeneratorDefinitionRunReportsFailingMember(TestInfrahubAppBase):
+    """One member failing must be reported per-member, not collapsed into an opaque failure.
+
+    When a target-group member's generator run raises, the definition run's result must identify which
+    member failed, so a single misbehaving target is distinguishable from every target failing.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def workflow_recorder(
+        self,
+        prefect: Generator[str, None, None],
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[WorkflowRecorderFailingMember, None]:
+        recorder = WorkflowRecorderFailingMember()
+        with override_workflow(recorder, dependency_provider=dependency_provider):
+            yield recorder
+
+    @pytest.fixture(scope="class", autouse=True)
+    async def service(self, test_client: InfrahubTestClient) -> InfrahubServices:
+        return app.state.service
+
+    @pytest.fixture(scope="class")
+    async def client(
+        self,
+        test_client: InfrahubTestClient,
+        api_admin_token: str,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> AsyncGenerator[InfrahubClient, None]:
+        sdk_client = InfrahubClient(
+            config=Config(
+                api_token=api_admin_token,
+                requester=test_client.async_request,
+                sync_requester=test_client.sync_request,
+                schema_converge_timeout=5,
+            )
+        )
+        original_client = service._client
+        service._client = sdk_client
+        try:
+            with override_dependency(build_client, lambda: sdk_client, dependency_provider=dependency_provider):
+                yield sdk_client
+        finally:
+            service._client = original_client
+
+    @pytest.fixture(autouse=True)
+    def clear_recorder(self, workflow_recorder: WorkflowRecorderFailingMember) -> None:
+        workflow_recorder.reset()
+
+    def _context(self, account: CoreAccount, default_branch: Branch) -> InfrahubContext:
+        return InfrahubContext(
+            branch=BranchContext(name=default_branch.name),
+            account=AccountSession(account_id=account.id, auth_type=AuthType.API),
+        )
+
+    @pytest.fixture(scope="class")
+    async def dataset(self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient) -> dict[str, Any]:
+        await load_schema(db=db, schema=TAG_SCHEMA, update_db=True)
+
+        healthy = await Node.init(db=db, schema=TAG_KIND)
+        await healthy.new(db=db, name=_HEALTHY_MEMBER)
+        await healthy.save(db=db)
+        failing = await Node.init(db=db, schema=TAG_KIND)
+        await failing.new(db=db, name=_FAILING_MEMBER)
+        await failing.save(db=db)
+
+        repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
+        await repo.new(
+            db=db,
+            name="gen-member-repo",
+            location="https://github.com/test/gen-member.git",
+            commit="1234567890abcdef1234567890abcdef12345678",
+        )
+        await repo.save(db=db)
+
+        query = await Node.init(db=db, schema=InfrahubKind.GRAPHQLQUERY)
+        await query.new(db=db, name="GetGenTag", query=TAG_QUERY, models=[TAG_KIND])
+        await query.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+        await group.new(db=db, name="member-targets", members=[healthy, failing])
+        await group.save(db=db)
+
+        gendef = await Node.init(db=db, schema=InfrahubKind.GENERATORDEFINITION)
+        await gendef.new(
+            db=db,
+            name="tag-generator",
+            query=query,
+            repository=repo,
+            targets=group,
+            file_path="generators/tag.py",
+            class_name="TagGenerator",
+            parameters={"value": {"name": "name__value"}},
+        )
+        await gendef.save(db=db)
+
+        return {
+            _DEFINITION_ID: gendef.id,
+            _REPOSITORY_ID: repo.id,
+            _GROUP_ID: group.id,
+            _QUERY_ID: query.id,
+            _HEALTHY_ID: healthy.id,
+            _FAILING_ID: failing.id,
+        }
+
+    def _model(
+        self, dataset: dict[str, Any], branch: str, target_members: list[str] | None = None
+    ) -> RequestGeneratorDefinitionRun:
+        return RequestGeneratorDefinitionRun(
+            branch=branch,
+            target_members=target_members or [],
+            generator_definition=ProposedChangeGeneratorDefinition(
+                definition_id=dataset[_DEFINITION_ID],
+                definition_name="tag-generator",
+                class_name="TagGenerator",
+                file_path="generators/tag.py",
+                query_name="GetGenTag",
+                query_id=dataset[_QUERY_ID],
+                query_models=[TAG_KIND],
+                query_payload=TAG_QUERY,
+                repository_id=dataset[_REPOSITORY_ID],
+                parameters={"name": "name__value"},
+                group_id=dataset[_GROUP_ID],
+                convert_query_response=False,
+                execute_in_proposed_change=False,
+                execute_after_merge=True,
+            ),
+        )
+
+    async def test_failing_member_is_named_in_the_run_result(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.failing_target_ids = {dataset[_FAILING_ID]}
+
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Both members are dispatched, so the failure is one target's, not the definition's.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+        # The result names the one failed member and its error, reporting the healthy member as
+        # succeeded, rather than collapsing into an opaque failure.
+        assert state.is_failed()
+        assert state.message == (
+            "1 of 2 generators failed, 1 succeeded: "
+            f"member-beta ({dataset[_FAILING_ID]}): generator run failed for member-beta"
+        )
+
+        # The failure stays recoverable: the state re-raises the member's error inside an ExceptionGroup.
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await state.result(raise_on_failure=True)
+        assert [str(error) for error in exc_info.value.exceptions] == [_member_failure_message(_FAILING_MEMBER)]
+
+    async def test_a_cancelled_member_propagates_the_cancellation(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.cancelled_target_ids = {dataset[_FAILING_ID]}
+
+        # The cancellation propagates out of the definition run rather than being dropped by the
+        # failure filter and letting the run report success.
+        with pytest.raises(asyncio.CancelledError):
+            await request_generator_definition_run(
+                model=self._model(dataset, default_branch.name),
+                context=self._context(admin_account, default_branch),
+                return_state=True,
+            )
+
+        # Both members are dispatched, so the cancellation is one target's.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+    async def test_only_the_selected_members_are_run(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name, target_members=[dataset[_HEALTHY_ID]]),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Only the selected member runs; the other group member is skipped entirely.
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID]}
+        assert state.is_completed()
+        assert state.message == "Successfully run 1 generators"
+
+    async def test_every_failing_member_is_reported(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        workflow_recorder.failing_target_ids = {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        # Every failed member is named; member order in the group is not guaranteed, so compare the set.
+        assert state.is_failed()
+        prefix = "2 of 2 generators failed, 0 succeeded: "
+        assert state.message.startswith(prefix)
+        assert set(state.message.removeprefix(prefix).split("; ")) == {
+            f"{_HEALTHY_MEMBER} ({dataset[_HEALTHY_ID]}): {_member_failure_message(_HEALTHY_MEMBER)}",
+            f"{_FAILING_MEMBER} ({dataset[_FAILING_ID]}): {_member_failure_message(_FAILING_MEMBER)}",
+        }
+
+        # Every member's error is recoverable from the state as an ExceptionGroup.
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await state.result(raise_on_failure=True)
+        assert {str(error) for error in exc_info.value.exceptions} == {
+            _member_failure_message(_HEALTHY_MEMBER),
+            _member_failure_message(_FAILING_MEMBER),
+        }
+
+    async def test_all_members_succeeding_reports_completed(
+        self,
+        dataset: dict[str, Any],
+        default_branch: Branch,
+        admin_account: CoreAccount,
+        client: InfrahubClient,
+        workflow_recorder: WorkflowRecorderFailingMember,
+    ) -> None:
+        state = await request_generator_definition_run(
+            model=self._model(dataset, default_branch.name),
+            context=self._context(admin_account, default_branch),
+            return_state=True,
+        )
+
+        dispatched = {
+            call["parameters"]["model"].target_id
+            for call in workflow_recorder.get_execute_calls_for(REQUEST_GENERATOR_RUN)
+        }
+        assert dispatched == {dataset[_HEALTHY_ID], dataset[_FAILING_ID]}
+        assert state.is_completed()
+        assert state.message == "Successfully run 2 generators"

--- a/backend/tests/helpers/prefect_services.py
+++ b/backend/tests/helpers/prefect_services.py
@@ -1,22 +1,12 @@
-"""Rebind Prefect's background queue services when the test process changes Prefect server.
+"""Drain Prefect's background queue services when the test process changes Prefect server.
 
-Prefect emits events and API logs through process-wide background services, ``EventsWorker`` and
-``APILogWorker``. ``EventsWorker.instance()`` is memoized on ``(client_type, client_options)``,
-and for a self-hosted server the options are empty, so the key carries no API URL. The worker it
-hands back built its websocket client and its orchestration client once, from whatever
-``PREFECT_API_URL`` was set the first time an event was emitted.
-
-A test process talks to more than one Prefect server: an ephemeral one for the whole session, plus
-a container that modules and classes opt into. Every orchestration client a test builds follows
-the current setting; the queue services do not. So from the second server onwards the events go to
-the previous one — silently, while that server is still up, and then as a wall of ``Service
-'EventsWorker' failed to process item`` once it has been torn down. Either way the events the
-current server's automations and the tests that assert on them are waiting for never arrive.
-
-Draining is what unpins them: ``_stop`` unregisters an instance synchronously, so the next event
-builds a new worker against the URL current at that point. Drain on both sides of a change of
-server — on the way in, while the old URL still resolves, so queued items reach the server they
-were meant for, and on the way out, before the new server is torn down.
+Prefect routes events and API logs through process-wide queue services that are created once and
+pin to the API URL in effect when they first start; a later change of URL does not rebind them. A
+test process that talks to more than one Prefect server would otherwise keep sending to the first.
+Draining unpins them, and it has to happen on both sides of a server change: on the way in, while
+the previous URL still resolves, so already-queued items reach the server they were meant for; and
+on the way out, before the new server is torn down. After a drain, the next event starts a fresh
+service against the current URL.
 """
 
 from __future__ import annotations

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -120,8 +120,8 @@ class TestWorkerInfrahubAsync(TestInfrahubAppWithoutLocalWorkflow):
         stop.set()
         await lifecycle_task
 
-        # The Prefect queue services are unpinned by `prefect_class`, which tears down after this
-        # fixture and while its server is still up; see tests/helpers/prefect_services.py.
+        # No drain here — the queue services are unpinned at the server-change boundary, while the
+        # server is still up.
 
         # Clear local worker result storage cache
         _default_storages.clear()

--- a/backend/tests/helpers/workflow_override.py
+++ b/backend/tests/helpers/workflow_override.py
@@ -28,7 +28,7 @@ def override_workflow[WorkflowT: InfrahubWorkflow](
 
     Args:
         workflow: The adapter every workflow lookup should return inside the block.
-        dependency_provider: The provider the dependency injection resolves ``build_workflow`` through.
+        dependency_provider: The provider the dependency injection resolves the workflow lookup through.
 
     Yields:
         ``workflow`` itself.

--- a/backend/tests/integration_docker/test_merge_recompute.py
+++ b/backend/tests/integration_docker/test_merge_recompute.py
@@ -135,11 +135,15 @@ class TestMergeRecompute(TestInfrahubDockerClient):
         assert merged
         await _wait_until_merged(client=client, branch_name=branch.name)
 
+        # Each derived family is recomputed by its own flow: wait for every field the recompute changes.
         async def _both_recomputed() -> bool:
             refreshed_node1 = await client.get(kind=PROFILE_NODE_KIND, id=node1.id)
             refreshed_node2 = await client.get(kind=PROFILE_NODE_KIND, id=node2.id)
             return (
-                refreshed_node1.summary.value == "node1 on omega" and refreshed_node2.summary.value == "node2 on omega"
+                refreshed_node1.summary.value == "node1 on omega"
+                and refreshed_node2.summary.value == "node2 on omega"
+                and refreshed_node1.display_label == "node1 via omega"
+                and refreshed_node2.display_label == "node2 via omega"
             )
 
         await _wait_until(_both_recomputed)
@@ -183,9 +187,10 @@ class TestMergeRecompute(TestInfrahubDockerClient):
 
         await client.branch.rebase(branch_name=branch.name)
 
+        # Each derived family is recomputed by its own flow: wait for every field the recompute changes.
         async def _node_recomputed() -> bool:
             refreshed = await client.get(kind=PROFILE_NODE_KIND, id=node.id, branch=branch.name)
-            return refreshed.summary.value == "rnode on romega"
+            return refreshed.summary.value == "rnode on romega" and refreshed.display_label == "rnode via romega"
 
         await _wait_until(_node_recomputed)
 

--- a/backend/tests/unit/core/test_query.py
+++ b/backend/tests/unit/core/test_query.py
@@ -1,0 +1,90 @@
+import pytest
+
+from infrahub.core.query import Query, QueryType
+
+
+class PagedQuery(Query):
+    name = "paged-query"
+    type = QueryType.READ
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_to_query("MATCH (n:Node) WHERE n.uuid = $uuid")
+        self.params["uuid"] = "5ffa45d4"
+        self.return_labels = ["n"]
+
+
+class UnpagedQuery(PagedQuery):
+    insert_limit = False
+
+
+@pytest.fixture
+def paged_query() -> PagedQuery:
+    return PagedQuery()
+
+
+def test_render_binds_the_page_bounds_as_parameters(paged_query: PagedQuery) -> None:
+    rendered = paged_query.render(limit=2, offset=5)
+
+    assert rendered.text.endswith("SKIP $query_offset\nLIMIT $query_limit")
+    assert rendered.params == {"uuid": "5ffa45d4", "query_offset": 5, "query_limit": 2}
+
+
+def test_rendering_leaves_the_query_parameters_untouched(paged_query: PagedQuery) -> None:
+    paged_query.render(limit=2, offset=5)
+    paged_query.get_query(limit=2, offset=5)
+
+    assert paged_query.params == {"uuid": "5ffa45d4"}
+
+
+def test_every_page_of_a_query_shares_one_text(paged_query: PagedQuery) -> None:
+    first_page = paged_query.render(limit=100, offset=100)
+    second_page = paged_query.render(limit=100, offset=200)
+
+    assert first_page.text == second_page.text
+    assert first_page.params["query_offset"] == 100
+    assert second_page.params["query_offset"] == 200
+
+
+def test_first_page_shares_the_text_of_the_pages_after_it(paged_query: PagedQuery) -> None:
+    first_page = paged_query.render(limit=100, offset=0)
+    second_page = paged_query.render(limit=100, offset=100)
+
+    assert first_page.text == second_page.text
+    assert first_page.params["query_offset"] == 0
+
+
+def test_zero_limit_is_no_bound(paged_query: PagedQuery) -> None:
+    rendered = paged_query.render(limit=0, offset=2)
+
+    assert rendered.text.endswith("SKIP $query_offset")
+    assert "LIMIT" not in rendered.text
+    assert rendered.params == {"uuid": "5ffa45d4", "query_offset": 2}
+
+
+def test_unset_bounds_render_no_clauses(paged_query: PagedQuery) -> None:
+    rendered = paged_query.render()
+
+    assert "SKIP" not in rendered.text
+    assert "LIMIT" not in rendered.text
+    assert rendered.params == {"uuid": "5ffa45d4"}
+
+
+def test_query_rendering_its_own_bounds_gets_no_clauses_or_parameters() -> None:
+    rendered = UnpagedQuery().render(limit=2, offset=5)
+
+    assert "SKIP" not in rendered.text
+    assert "LIMIT" not in rendered.text
+    assert rendered.params == {"uuid": "5ffa45d4"}
+
+
+def test_inline_rendering_substitutes_the_bounds(paged_query: PagedQuery) -> None:
+    text = paged_query.get_query(var=True, inline=True, limit=2, offset=5)
+
+    assert text.endswith('WHERE n.uuid = "5ffa45d4"\nRETURN n\nSKIP 5\nLIMIT 2')
+
+
+def test_shell_rendering_lists_the_bounds_with_the_parameters(paged_query: PagedQuery) -> None:
+    text = paged_query.get_query(var=True, limit=2, offset=5)
+
+    assert text.startswith('\n:params { uuid: "5ffa45d4", query_offset: 5, query_limit: 2 }\n\n')

--- a/changelog/+paginated-queries-share-one-plan.fixed.md
+++ b/changelog/+paginated-queries-share-one-plan.fixed.md
@@ -1,0 +1,1 @@
+Fixed large listings slowing down as they page through results: Neo4j planned every page of a paginated database query from scratch because the page bounds were written into the query text, and all pages now share one cached plan.

--- a/changelog/10199.fixed.md
+++ b/changelog/10199.fixed.md
@@ -1,0 +1,1 @@
+Running a Generator definition whose targets include a failing member now reports which targets failed and how many succeeded, instead of collapsing into a single opaque failure.

--- a/dev/knowledge/backend/query-pattern.md
+++ b/dev/knowledge/backend/query-pattern.md
@@ -152,7 +152,7 @@ class MyQuery(Query):
 
 ### Pagination
 
-Pagination (`LIMIT`/`OFFSET`) is automatically appended based on constructor parameters. Pass `limit` and `offset` through to `super().__init__()` — a subclass that keeps its own copies leaves the base `self.limit`/`self.offset` at `None`, and `execute()` reads those to decide how to run: with both unset it takes the `query_with_size_limit()` path, which re-runs the query in `query_size_limit` chunks with offsets of its own. The subclass then pages twice, against itself.
+Pagination (`LIMIT`/`OFFSET`) is automatically appended based on constructor parameters, with the bounds bound as the `$query_limit` and `$query_offset` parameters rather than written into the text, so every page of a query shares one cached plan (`Query.render()` returns the text together with the parameters it needs, leaving `self.params` untouched); a query that keeps automatic pagination must not use those two parameter names for anything else. Pass `limit` and `offset` through to `super().__init__()` — a subclass that keeps its own copies leaves the base `self.limit`/`self.offset` at `None`, and `execute()` reads those to decide how to run: with both unset it takes the `query_with_size_limit()` path, which re-runs the query in `query_size_limit` chunks with offsets of its own. The subclass then pages twice, against itself.
 
 Automatic pagination is only correct over a total order: give the query an `ORDER BY` on a unique key (add `elementId(n)` as a tiebreaker when the sort property is not unique). Neo4j does not guarantee disjoint pages otherwise, so chunked reads can skip or repeat rows.
 

--- a/dev/knowledge/backend/testing.md
+++ b/dev/knowledge/backend/testing.md
@@ -190,9 +190,11 @@ Two consequences worth remembering:
 ### One process, several Prefect servers
 
 A test process does not keep one Prefect server. The session-scoped `prefect_test_fixture` starts
-an ephemeral one for the whole session, and the `prefect` (module) and `prefect_class` (class)
-fixtures start a **container of their own** and re-point `PREFECT_API_URL` at it for that scope.
-Each orchestration client a test builds reads the setting when it is built, so it follows.
+an ephemeral one for the whole session. The module-scoped `prefect` fixture reuses the
+session-scoped `prefect_container`, while the class-scoped `prefect_class` starts a container per
+class; both re-point `PREFECT_API_URL` at their server for the scope, so a test can end up on a
+different server than the one before it. Each orchestration client a test builds reads the setting
+when it is built, so it follows.
 
 Prefect's background queue services do not. `EventsWorker` and `APILogWorker` are process-wide
 `QueueService` singletons, memoized on `hash((cls, *args))`, and `EventsWorker.instance()` passes

--- a/docs/docs/computed-attributes/overview.mdx
+++ b/docs/docs/computed-attributes/overview.mdx
@@ -1,50 +1,89 @@
 ---
 title: Computed attributes
+description: What a computed attribute is, when to use it, and how Infrahub recalculates it as your data changes.
 ---
 
-The computed attributes feature enables the dynamic calculation of attribute values based on user-defined logic.
+A computed attribute is a read-only `Text` or `URL` value calculated from data already modeled in Infrahub. Use a computed attribute where that value should stay synchronized with the attributes and relationships it is built from, rather than being entered and maintained separately.
 
-Currently, Infrahub supports two main types of computed attributes:
+Define the calculation in the schema as a Jinja2 template, or reference a Python Transformation where the calculation needs cardinality-many relationships, nested relationships, or logic a template cannot express.
 
-* **Jinja2** – Lightweight, but limited in relationship handling.
-* **Python** – More flexible and powerful, but requires async execution.
+## When to use a computed attribute
+
+Computed attributes fit values that can be calculated from data you already model:
+
+- **Produce a name or identifier in the pattern another system requires.** Where a tool or a process reads a hostname, a circuit ID, an interface description, or a URL and expects a particular pattern, compute that string from the attributes and relationships holding the data it encodes — a device name from its site, role, and index, for example.
+- **Include data from a related object in a description.** An interface description can name the peer device, the circuit, and the role at the other end of the link. Connect the interface to a different peer, and Infrahub recalculates the description from the new relationship.
+- **Combine several modeled values into one string.** A circuit description can list its endpoints and their locations; a URL can combine an environment with an object identifier.
+- **Compute more than one string from the same data.** A node can carry several computed attributes — one name for network operations, another for asset or finance reporting — each calculated from the same attributes and relationships.
+
+Modeling site, role, platform, index, and status as separate attributes and relationships keeps each value available to query on its own, and lets you compute whatever combined string a person or a downstream system needs to read.
+
+## Choose the right derived value
+
+Infrahub provides several ways to represent an object using data from its attributes and relationships. Choose the mechanism based on how the value will be used.
+
+| You need | Use |
+|---|---|
+| A readable representation of an object in Infrahub lists, selectors, breadcrumbs, and diffs | [`display_label`](../schema/display_label.mdx) |
+| A stable, unique way to identify or reference an object across systems | [`human_friendly_id`](../schema/nodes-and-attributes.mdx#human-friendly-identifier-hfid) |
+| A Text or URL attribute calculated from modeled data that automation, integrations, or users need to query as an attribute | Computed attribute |
+
+Use a computed attribute when the generated value needs to exist as part of the object and be available to queries, automation, or integrations.
+
+`display_label` also uses a Jinja2 template, but it defines a single label for the whole node — not an attribute you can query — and only supports one level of direct, cardinality-one relationships. Use a computed attribute instead of `display_label` when you need to query the derived value, filter on it, or feed it to automation or integrations.
+
+<!-- vale Infrahub.branded-terms-case-swap = NO -->
+## Choose between Jinja2 and Python {#choosing-between-jinja2-and-python}
+<!-- vale Infrahub.branded-terms-case-swap = YES -->
+
+Use Jinja2 when the value can be calculated from attributes on the same object and direct cardinality-one relationships. Use a Python Transformation when the calculation needs more complex logic, cardinality-many relationships, or nested relationships.
+
+| | Jinja2 | Python Transformation |
+|---|---|---|
+| **Use when** | The value can be calculated from attributes and direct cardinality-one relationships | The calculation needs more complex logic, cardinality-many relationships, or nested relationships |
+| **Relationship support** | Direct relationships only; cardinality `many` is not supported | No equivalent relationship restriction |
+| **Mandatory attribute support** | Supported | Not supported; the attribute must be optional |
+| **Execution** | A change on the object itself is recalculated as part of the same update; a change on a related object is processed asynchronously. Recalculation is deferred if the template reads a not-yet-allocated pool-sourced attribute | Runs asynchronously on workers |
 
 ::::info Limitations
 
 Computed attributes have some inherent restrictions due to system constraints and performance considerations. Keep these in mind when designing your schema:
 
-* Only `URL` and `Text` attribute kinds are supported for computed attributes.
+- Only `URL` and `Text` attribute kinds are supported for computed attributes.
 
 ::::
 
-## Choosing between Jinja2 and Python
+## When Infrahub recalculates a value
 
-| Computed Attribute Kind | Mandatory Attribute Support | Relationship Constraints                                 | Complexity Handling                   |
-|-------------------------|-----------------------------|----------------------------------------------------------|---------------------------------------|
-| **Jinja2**              | ✅ Supported                | Cannot use `many` cardinality; only direct relationships | Best for straightforward operations   |
-| **Python**              | ❌ Not supported            | No restrictions                                          | Suitable for complex logic            |
+Infrahub recalculates a computed attribute when data used by its calculation changes. The inputs Infrahub tracks, and when the updated value becomes available, depend on whether the attribute uses Jinja2 or a Python Transformation.
+
+- **Jinja2** — Infrahub tracks the attributes and direct relationships referenced by the template. When one of those inputs changes, Infrahub recalculates the computed value. Changes to inputs on the same node are recalculated as part of the same update; changes to data on a related object are processed asynchronously. If the template references a pool-sourced attribute on the same node that has not been allocated yet, Infrahub defers that recalculation until the pool assigns a value. A template that references a path the schema does not have, or the attribute itself, is rejected when the schema loads.
+- **Python** — Infrahub uses the Transformation's GraphQL query to determine which data changes affect the computed value, tracking only the specific fields the query reads on each node kind, not every field. Infrahub recomputes the value directly whenever the object that owns it is created or updated. A change to a related object recomputes only the owners whose Transformation already read that object — not every object of that kind. When one of those tracked changes happens, Infrahub schedules the Transformation on a worker and updates the computed attribute once the task completes.
+
+When you change a Python Transformation, Infrahub recomputes the attributes that use it.
 
 ## Jinja2 computed attributes {#jinja-computed-attribute}
 
-Users can input a concise Jinja2 template directly within the schema definition. Any change to any field used to compute the value will automatically update it.
+Define a Jinja2 computed attribute directly on the attribute in your node schema.
 
-Use Jinja2 when the calculation logic is straightforward and concise.
+Use Jinja2 when the calculation is concise and depends only on attributes on the same object or direct cardinality-one relationships.
 
 ### Restrictions
 
 ::::warning
 
-* Jinja2 computed attributes **cannot** reference relationships with cardinality `many`.
-* Only **direct** relationships can be used (i.e., a relationship of a relationship is not accessible).
-* A computed attribute can only be inherited from one generic, as the order of operations would be unclear if the same computed attribute was defined on multiple generics.
+- Jinja2 computed attributes cannot reference relationships with cardinality `many`.
+- Only direct relationships are available; a relationship of a relationship cannot be referenced.
+- A computed attribute can be inherited from only one generic, because Infrahub cannot determine the evaluation order if multiple generics define the same computed attribute.
+- Infrahub evaluates computed attributes inside the API server, in a restricted execution context that only allows fully trusted filters — filters that make network calls or run regular expressions, for example, are blocked. See [Execution contexts in the SDK Templating Reference]($(base_url)python-sdk/reference/templating#execution-contexts) for the full list of allowed filters, and `security.restrict_untrusted_jinja2_filters` in the [configuration reference](../reference/configuration#security) to change this default.
 
 ::::
 
-### How to add a Jinja2 computed attribute
+### Add a Jinja2 computed attribute
 
-To create a Jinja2 computed attribute everything happens directly in the schema definition. Refer to this guide to find further information about [Schema Creation](../learn/tutorials/build-your-first-schema).
+Everything happens in the schema definition. See [Schema Creation](../learn/tutorials/build-your-first-schema) for how to build and load a schema.
 
-In the following example we will create a computed attribute `description` for our `NetworkDevice` node. The value will be dynamically generated by combining the device's role with the name of its associated site.
+This example calculates a `description` for a `NetworkDevice` from the device's role and the name of its related site.
 
 ```yaml
 ---
@@ -98,13 +137,11 @@ For more information, please consult the [SDK Templating Reference]($(base_url)p
 
 :::
 
-You can now load this schema into your Infrahub instance. For more details, refer to the [Schema Creation Guide](../learn/tutorials/build-your-first-schema).
+After loading the schema, Infrahub calculates the `description` attribute from the values referenced by the template.
 
-### How to test Jinja2 computed attributes locally
+### Test Jinja2 computed attributes locally
 
-When developing Jinja2 computed attributes, it can be difficult to get the filter syntax right, especially if you need to push the schema every time to test a change. Instead, you can test your Jinja2 computed attribute logic locally using Pytest and the `Jinja2Template` class from the Infrahub Python SDK.
-
-Example:
+Test Jinja2 calculation logic locally with Pytest and the `Jinja2Template` class from the Infrahub Python SDK before loading the updated schema. This validates formatting, filters, and edge cases independently of the schema-loading workflow.
 
 ```python
 import pytest
@@ -125,33 +162,36 @@ async def test_intf_index(intf_name, expected):
     assert rendered == expected
 ```
 
-This approach allows you to quickly iterate and validate your computed attribute logic without needing to push changes to the schema. Adjust the template and test cases as needed to cover different scenarios.
+Add test cases for the input formats and boundary conditions your template needs to support.
 
 ## Python computed attributes {#python-computed-attribute}
 
-Python computed attributes leverage Infrahub's [Python Transformation](../transformations/overview) feature. Users can define which Transformation to apply directly within the schema. The computation of the value is delegated to workers as asynchronous tasks, which may cause the value to take a few seconds to update.
+A Python computed attribute uses a [Python Transformation](../transformations/overview) to calculate the value. Reference the Transformation from the schema, then define the GraphQL query and Python logic in a linked repository.
 
-Python scripts do not have the limitations of Jinja2 computed attributes and can include more complex logic, including relationships with cardinality `many` and nested relationships.
+Use Python when the calculation needs cardinality-many relationships, nested relationships, or logic that cannot be expressed cleanly in Jinja2.
 
-Keep Python Transformations straightforward to avoid impacting system performance.
+Python computed attributes run asynchronously on Infrahub workers, so the updated value may not appear immediately after a dependent value changes.
 
 ### Restrictions
 
 ::::warning
 
-* Mandatory attributes **cannot** use Python computed attributes.
-* Complex scripts **may impact system performance**.
+- Python computed attributes cannot be mandatory.
+- Python computed attributes run as asynchronous Transformations. Consider the amount of data queried and the work performed by the Transformation when designing the calculation.
 
 ::::
 
-### How to add a Python computed attribute
+### Add a Python computed attribute
 
-Creating a Python computed attribute is a two-step process:
+Creating a Python computed attribute has five parts:
 
-1. Add the attribute to the schema.
-2. Prepare a Python Transformation to implement the logic.
+1. Add the computed attribute to the schema and reference the Transformation.
+2. Create the GraphQL query that provides the Transformation inputs.
+3. Create the Python Transformation that returns the computed string.
+4. Register the query and Transformation in `.infrahub.yml`.
+5. Commit the Transformation files to a Git repository connected to Infrahub.
 
-In the following example we will create a computed attribute `description` for our `InfraCircuit` node. The value will be a combination of all endpoints locations.
+This example calculates a `description` for an `InfraCircuit` from its endpoints and their locations.
 
 #### Add the attribute to the schema
 
@@ -215,7 +255,7 @@ nodes:
         kind: Attribute
 ```
 
-Once completed, you can load this schema into Infrahub.
+Load this schema into Infrahub.
 
 :::note
 
@@ -227,7 +267,7 @@ You can specify a Transformation that doesn't yet exist in Infrahub, and the att
 
 Please refer to the [Python Transformation guide](../learn/tutorials/transformations/build-a-python-transformation) for further details.
 
-1. First we prepare a GraphQL query that returns the data we need
+1. Create a GraphQL query that returns the data required by the Transformation.
 
 :::warning
 
@@ -271,7 +311,7 @@ query CircuitDescriptionQuery($id: ID!) {
 }
 ```
 
-2. Next, the Python script that implements the logic
+2. Create the Python Transformation and return the computed value as a string.
 
 ```python title="computed_circuit_description.py"
 from infrahub_sdk.transforms import InfrahubTransform
@@ -300,7 +340,7 @@ Make sure that the script returns a string!
 
 :::
 
-3. Tie everything together into `.infrahub.yml` file
+3. Register the query and Transformation in `.infrahub.yml`.
 
 ```yaml title=".infrahub.yml"
 ---
@@ -314,7 +354,7 @@ queries:
     file_path: computed_circuit_description.gql
 ```
 
-At this stage you should be able to test your Transformation using `infrahubctl`
+Test the Transformation with `infrahubctl` before loading it into Infrahub.
 
 :::note
 
@@ -326,12 +366,19 @@ To create a meaningful test, you may want to create: two sites, one circuit, and
 "site1::endpoint-a <- circuit1 -> site2::endpoint-b"
 ```
 
-4. Load the Transformation in Infrahub
+4. Commit the Transformation files to a Git repository and connect the repository to Infrahub.
 
-You need to commit these files to a Git repository and link the repository to Infrahub. Please refer to the [adding a repository to Infrahub](../git-integration/connect-repository) guide.
+See [adding a repository to Infrahub](../git-integration/connect-repository).
 
 :::success
 
 The circuit's description is now automatically computed (this process may take a few seconds). Any changes to related attributes (i.e., endpoint name) will trigger a reevaluation and update the value accordingly.
 
 :::
+
+## Related
+
+- [Display labels](../schema/display_label.mdx) — the readable representation of an object across the web interface and GraphQL
+- [Human-friendly identifier](../schema/nodes-and-attributes.mdx#human-friendly-identifier-hfid) — referencing an object uniquely across systems
+- [Transformations](../transformations/overview) — the Python Transformations a computed attribute can call
+- [Create and load schema](../schema/create-and-load) — loading a schema that defines a computed attribute

--- a/docs/docs/overview/build-with-ai/setup.mdx
+++ b/docs/docs/overview/build-with-ai/setup.mdx
@@ -53,20 +53,12 @@ Keep the `infrahub-common` skill directory, wherever your installer placed it. I
 
 ## 3. Connect the MCP server
 
-Run the server with `uvx`, which fetches it on first use:
+The server runs as `uvx infrahub-mcp`, which `uvx` fetches on first use. Your assistant launches it from its MCP configuration rather than you starting it in a shell, so the two connection variables go in that configuration alongside the command:
 
-```bash
-uvx infrahub-mcp
-```
+- `INFRAHUB_ADDRESS` — your instance, for example `http://localhost:8000`
+- `INFRAHUB_API_TOKEN` — your API token
 
-Point it at your instance with two environment variables:
-
-```bash
-export INFRAHUB_ADDRESS="http://localhost:8000"
-export INFRAHUB_API_TOKEN="<your-token>"
-```
-
-Then register the server with your assistant. The configuration file and its location differ per client, so follow your client's MCP documentation for where the entry goes.
+The configuration file, its location, and how it carries environment variables differ per client, so follow your client's MCP documentation for where the entry goes.
 
 **Choose a transport.** Use stdio when the server runs on the same machine as your assistant, which is the local development case. Use streamable HTTP for a remote server, and for any of the per-user authentication modes below.
 

--- a/docs/docs/overview/explore.mdx
+++ b/docs/docs/overview/explore.mdx
@@ -81,6 +81,20 @@ Demo DC is an end-to-end reference implementation you can actually learn from. T
 
 <ReferenceLink title="Demo DC" url="$(base_url)demo-dc" openInNewTab />
 
+- **Demo OTN**
+
+Demo OTN is an optical transport reference implementation that models a European research core down to the fiber span and the wavelength. This demo includes:
+
+- Schema-driven optical modelling: conduits, fiber spans, optical multiplex sections, ROADMs, amplifiers, transponders, mux/demux, regenerators, the DWDM frequency grid and the CWDM wavelength plan
+- Provisioning from intent: Generators pick the route and the optical mode, allocate a grid position, and build the carriers, ports and client mappings behind a single service object
+- Link budget computed from the modelled plant: loss, OSNR, dispersion and latency over the ordered chain of spans and amplifiers, with Checks that fail a service that does not close
+- Impact analysis: name a fiber section and get the wavelengths, terabits, services and customers behind it, plus the conduits each span shares
+- Capacity planning that accounts for quantisation: free spectrum as blocks, and how many of the 96 anchors will actually take another carrier per mode
+- Diversity validation read off the conduits rather than the sections, so two services sharing a duct are not reported as diverse
+- Artifact-rendered network and ODU maps, generated per branch from the model
+
+<ReferenceLink title="Demo OTN" url="$(base_url)demo-otn" openInNewTab />
+
 - **Demo Service Catalog**
 
 The Service Catalog demo demonstrates how Infrahub can be used to manage and deploy services within an ISP environment. It walks through the process of creating a service catalog using Infrahub and Streamlit. From modeling services in the schema, codifying them in Generator, to making these capabilities accessible across the organization via a Streamlit app. This demo provides a comprehensive, end-to-end overview of the workflow.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8282,9 +8282,9 @@
       "license": "MIT"
     },
     "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -12560,9 +12560,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.4",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
-      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "version": "17.13.7",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.7.tgz",
+      "integrity": "sha512-MF80Dm5Y2veNy8QWVx9Bj3ui4mo7+VPSPsR1M+oaHXV0Gx6zGX9a2F+OZG3Blby9tOlzU9Rs5FUimlEhbKtfnQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -20352,9 +20352,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
-      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.5.tgz",
+      "integrity": "sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7754,9 +7754,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7773,11 +7773,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -15943,9 +15943,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "prek>=0.3.0",
     "coverage==7.14.1",
     "pytest-playwright-asyncio>=0.8.0",
+    "zizmor>=1.30.0",
 ]
 
 # test-scale = [

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -102,14 +102,21 @@ class InfrahubPerformanceTest:
         self,
         definition: MeasurementDefinition,
         value: float | str,
-        **kwargs: dict[str, float],
+        context: dict[str, Any] | None = None,
+        **kwargs: str | float,
     ) -> None:
+        """Record a measurement.
+
+        Context dimensions can be passed either as keyword arguments or as a `context` mapping.
+        Either way they land flat on the recorded item, so every measurement of a definition
+        carries the same shape and the whole set compares as a single series.
+        """
         self.measurements.append(
             InfrahubMeasurementItem(
                 name=definition.name,
                 value=value,
                 unit=definition.unit,
-                context=kwargs or {},
+                context={**(context or {}), **kwargs},
             )
         )
 

--- a/python_testcontainers/tests/test_performance_payload.py
+++ b/python_testcontainers/tests/test_performance_payload.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 
 from infrahub_testcontainers.constants import PERFORMANCE_TEST_KIND, PERFORMANCE_TEST_VERSION
-from infrahub_testcontainers.measurements import BRANCH_MERGE_TIME
+from infrahub_testcontainers.measurements import BRANCH_MERGE_TIME, SCRIPT_EXECUTION_TIME
 from infrahub_testcontainers.models import ContextUnit
 from infrahub_testcontainers.performance_test import InfrahubPerformanceTest
 
@@ -22,3 +22,19 @@ def test_request_checksum_covers_the_payload_on_the_wire() -> None:
     assert (
         request["checksum"] == hashlib.sha256(json.dumps(request["data"], separators=(",", ":")).encode()).hexdigest()
     )
+
+
+def test_timed_and_direct_measurements_share_the_same_context_shape() -> None:
+    """Both recording paths must carry their dimensions flat, or the two cannot compare as one series."""
+    performance_test = InfrahubPerformanceTest(results_url="http://localhost")
+    performance_test.initialize(name="test_timed_and_direct_measurements_share_the_same_context_shape")
+
+    with performance_test.start_measurement(SCRIPT_EXECUTION_TIME, name="load", phase="read"):
+        pass
+    performance_test.add_measurement(SCRIPT_EXECUTION_TIME, value=100, name="load", phase="compute")
+
+    timed, direct = performance_test.measurements
+
+    assert timed.context == {"name": "load", "phase": "read"}
+    assert direct.context == {"name": "load", "phase": "compute"}
+    assert timed.context.keys() == direct.context.keys()

--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -118,9 +118,8 @@ def status(
 @task(optional=["database"])
 def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE) -> None:
     """Load the base schema for infrastructure."""
-    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=False)
+    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=True)
     load_infrastructure_menu(context=context, database=database, namespace=NAMESPACE)
-    restart_services(context=context, database=database, namespace=NAMESPACE)
 
 
 @task(optional=["database"])

--- a/uv.lock
+++ b/uv.lock
@@ -1577,6 +1577,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-ujson" },
     { name = "yamllint" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -1671,6 +1672,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-ujson" },
     { name = "yamllint" },
+    { name = "zizmor", specifier = ">=1.30.0" },
 ]
 
 [[package]]
@@ -4887,4 +4889,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/78/e32b0b913535def3e050cd0c4202aff11f10deb53e9844f42af37aa267e3/zizmor-1.30.0.tar.gz", hash = "sha256:9a17ac3bb043afbbd9d3c8b6f309fa5b319c6a32e3259fbaf050f6fcd3d0a9cd", size = 575489, upload-time = "2026-08-30T21:26:06.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/d2/a6eb24a670ce7466c0d6b2ca9e9673aa403f07786af7e5d7e593dace4e40/zizmor-1.30.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51c96204572b9f96b940806a371a9c57c8cff30cf93d3bd73c2febe483f942df", size = 9108421, upload-time = "2026-08-30T21:25:40.257Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3c/0b7fa1cf59784f743874a76db860a192bc319ff575f74277fa37e0a81d24/zizmor-1.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4193537785dd07177227e4695871ffae1d7fe3f6043c217498445e71b477bc1", size = 8716981, upload-time = "2026-08-30T21:25:43.173Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b6/019b9af74ae9c9472e4804801c61f18b5394392142b0c6c2b4651161d21a/zizmor-1.30.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:7569a58319fb270c14a64663a6565929035f26f6f6d13059314f796e988129eb", size = 8969733, upload-time = "2026-08-30T21:25:45.482Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2d/a2f8d3d78d56fdaa5da4fc71e86dfed50006a197ff30b2363e759a1c4b92/zizmor-1.30.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0e69a86290dff4c41b51c381a27029b5dc2b748c0510a9a333b18f862ea1bc68", size = 8601613, upload-time = "2026-08-30T21:25:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/79/ac655d04c89356b40a4f8166ede50ba207cfc0ea1410f99544e9d55a111b/zizmor-1.30.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9c08a7c34b33ed6f9a3a3d28fcf8c64e3e078c53c51bc9ce05c32ec3ba7feae9", size = 9441765, upload-time = "2026-08-30T21:25:50.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/52/c88a4a492b21e7f5891140a48d97fc92b389ddce899d80ce12d7a60e278b/zizmor-1.30.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:baa02978518248bf9f011e6ceca7b7c5efb5b893810cd4954e01785e1b68f959", size = 9000409, upload-time = "2026-08-30T21:25:53.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b9/649a07ff353d84362779bd747c945e5af23c54e94e4633751e3fa6b88099/zizmor-1.30.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0148b61f6315ad363ae748f838e8ed81e1cfb3ade6bbe480e7516e4fba630b82", size = 8570313, upload-time = "2026-08-30T21:25:55.926Z" },
+    { url = "https://files.pythonhosted.org/packages/97/84/ef925827d7d7d6baba31194bf9712d74df37a0e4ac361b8dbdbb2d4a9597/zizmor-1.30.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f15ed62ff34ad7875427384b03a2f72995d9ab8ddcb50dc141b25763de3aaa2", size = 9502173, upload-time = "2026-08-30T21:25:58.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f5/e5296d51f494de21f5da44b3d7bf270d1aae7fdf92b240e871cd2e975717/zizmor-1.30.0-py3-none-win32.whl", hash = "sha256:39f15155db3e4af9bb5cf125a236c67fd84ddd3174f60b4111b27c691b337e00", size = 7763311, upload-time = "2026-08-30T21:26:01.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b9/95d0cc6d169a43ad0c2a33c1395c0e5cde265880fa62e5d26a3b502a003c/zizmor-1.30.0-py3-none-win_amd64.whl", hash = "sha256:ca321b5b1cb85d08ac0c3c86275bfd5a6b5564c176437e3b41e10bd1e4463296", size = 8888408, upload-time = "2026-08-30T21:26:04.103Z" },
 ]


### PR DESCRIPTION
Supersedes #10582, which was blocked on merge conflicts.

Merges `stable` into `develop`. Three things conflicted, each resolved in its own commit on top of
the merge commit, so you can review them one at a time.

## What to review

**`fd27b46` — `backend/infrahub/generators/tasks.py`.** This is the only resolution with a decision
in it. `develop` had added a comment and a `# noqa: BLE001` to the `try` / `except Exception` block
at the end of `request_generator_definition_run`. `stable` deleted that block outright in #10538,
replacing it with per-member outcome reporting. I took `stable`'s version and dropped the comment,
since the block it described is gone. Worth a look if you think the comment was saying something
`stable`'s version does not already do.

**`888bdf6` — the `python_sdk` pointer.** `develop` was on `e912ca5`, `stable` on `32cb8aa`
(v1.23.2). Neither contains the other, so I pointed it at `ff01ea4`, the SDK's `infrahub-develop`
tip and the first upstream commit that has both. That advances `develop`'s SDK by 25 commits rather
than the 2 the merge strictly needed. Same approach as the last sync (`fdb00392b`), but say so if
you would rather cut a narrower SDK merge.

**`8adb632` — `backend/infrahub/core/query/__init__.py`.** Nothing to decide. Both sides added a new
top-level definition at the same spot, `QueryInitKwargs` on one side and the pagination parameter
names plus `RenderedQuery` on the other, so both are kept.

## What I checked

`stable`'s `render()` refactor auto-merged onto `develop`'s code, so I grepped the merged tree for
every caller of the symbols it changed (`get_query`, `get_params_for_shell`,
`_get_params_for_neo4j_shell`). No stale call sites and nothing overrides them. `frontend/` and
`schema/` are identical to `develop`. Generated files are not stale, `backend.validate-generated`,
`docs.validate` and both schema validations exit clean.
