### PR TITLE
fix: clear the mypy operator/return suppression on infrahub.message_bus.operations [INBOX-31]

### DIFF
--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Awaitable, Callable
+
 import ujson
 from prefect import Flow
 
@@ -8,7 +10,12 @@ from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
 
-COMMAND_MAP = {
+# Handlers are heterogeneous by design: each takes a specific InfrahubMessage subtype, and half are
+# wrapped as Prefect flows. The dispatch site only has the base type, so the parameters cannot be
+# pinned here — but the callable-and-awaits-to-None shape can be, and is.
+MessageHandler = Callable[..., Awaitable[None]]
+
+COMMAND_MAP: dict[str, MessageHandler] = {
     "git.file.get": git.file.get,
     "git.repository.connectivity": git.repository.connectivity,
     "refresh.git.fetch": git.repository.fetch,
@@ -31,6 +38,7 @@ async def execute_message(
         if skip_flow and isinstance(func, Flow):
             func = func.fn
         await func(message=message)
+        return None
     # Message-bus boundary: any handler failure must be routed to the reply/retry/dead-letter protocol, never crash the consumer
     except Exception as exc:  # noqa: BLE001
         if message.reply_requested:

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -10,9 +10,8 @@ from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
 
-# Handlers are heterogeneous by design: each takes a specific InfrahubMessage subtype, and half are
-# wrapped as Prefect flows. The dispatch site only has the base type, so the parameters cannot be
-# pinned here — but the callable-and-awaits-to-None shape can be, and is.
+# Each handler takes a distinct InfrahubMessage subtype while the dispatch site holds only the base
+# type, so the parameters cannot be pinned.
 MessageHandler = Callable[..., Awaitable[None]]
 
 COMMAND_MAP: dict[str, MessageHandler] = {

--- a/backend/tests/unit/message_bus/test_operations.py
+++ b/backend/tests/unit/message_bus/test_operations.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+from prefect import Flow, flow
+
+from infrahub import config
+from infrahub.message_bus import Meta, RPCErrorResponse
+from infrahub.message_bus.messages import SendEchoRequest
+from infrahub.message_bus.operations import COMMAND_MAP, execute_message
+from infrahub.message_bus.types import MessageTTL
+from tests.adapters.message_bus import BusRecorder
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from infrahub.message_bus import InfrahubMessage
+
+ECHO_ROUTING_KEY = "send.echo.request"
+SET_CHECK_STATUS = "infrahub.message_bus.operations.set_check_status"
+GET_LOGGER = "infrahub.message_bus.operations.get_logger"
+
+
+class HandlerError(Exception):
+    """Raised by the failing handler doubles to drive the dispatcher's error paths."""
+
+
+class RecordingBus(BusRecorder):
+    """Recording message bus that also keeps the replies and the delivery options of each publish."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.replies: list[tuple[InfrahubMessage, str]] = []
+        self.publish_options: list[tuple[MessageTTL | None, bool]] = []
+
+    async def publish(
+        self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
+    ) -> None:
+        self.publish_options.append((delay, is_retry))
+        await super().publish(message, routing_key=routing_key, delay=delay, is_retry=is_retry)
+
+    async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
+        self.replies.append((message, routing_key))
+
+
+class CheckStatusRecorder:
+    """Stand-in for set_check_status that keeps the conclusion reported for each message."""
+
+    def __init__(self) -> None:
+        self.conclusions: list[tuple[InfrahubMessage, str]] = []
+
+    async def __call__(self, message: InfrahubMessage, conclusion: str) -> None:
+        self.conclusions.append((message, conclusion))
+
+
+class LoggerRecorder:
+    """Stand-in for the dispatcher's logger that keeps the events reported at exception level."""
+
+    def __init__(self) -> None:
+        self.exceptions: list[str] = []
+
+    def exception(self, event: str, **kwargs: Any) -> None:
+        self.exceptions.append(event)
+
+
+@pytest.fixture
+def maximum_message_retries() -> Generator[int]:
+    """Pin the retry ceiling the dispatcher reads, restoring whatever the environment provided."""
+    original = config.SETTINGS.broker.maximum_message_retries
+    config.SETTINGS.broker.maximum_message_retries = 3
+    yield 3
+    config.SETTINGS.broker.maximum_message_retries = original
+
+
+async def test_plain_handler_is_awaited_and_message_is_acknowledged() -> None:
+    """A successful plain coroutine handler receives the decoded message and asks for no retry."""
+    received: list[InfrahubMessage] = []
+
+    async def handler(message: SendEchoRequest) -> None:
+        received.append(message)
+
+    bus = RecordingBus()
+    sent = SendEchoRequest(message="ping")
+
+    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
+        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+
+    assert len(received) == 1
+    handled = received[0]
+    assert isinstance(handled, SendEchoRequest)
+    assert handled.message == "ping"
+    assert delay is None
+    assert bus.messages == []
+
+
+async def test_flow_handler_is_unwrapped_when_flows_are_skipped() -> None:
+    """With skip_flow set, a Prefect flow handler is unwrapped to its function and that is awaited."""
+    received: list[InfrahubMessage] = []
+
+    @flow(name="unit-test-echo-handler")
+    async def handler(message: SendEchoRequest) -> None:
+        received.append(message)
+
+    assert isinstance(handler, Flow), "the scenario only covers the unwrap when the handler really is a flow"
+
+    bus = RecordingBus()
+    sent = SendEchoRequest(message="ping")
+
+    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
+        delay = await execute_message(
+            routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus, skip_flow=True
+        )
+
+    assert len(received) == 1
+    handled = received[0]
+    assert isinstance(handled, SendEchoRequest)
+    assert handled.message == "ping"
+    assert delay is None
+    assert bus.messages == []
+
+
+async def test_failure_with_reply_requested_returns_an_error_response() -> None:
+    """A handler failure on a message awaiting a reply is answered with an error and not retried."""
+
+    async def handler(message: SendEchoRequest) -> None:
+        raise HandlerError("handler exploded")
+
+    bus = RecordingBus()
+    sent = SendEchoRequest(message="ping", meta=Meta(reply_to="reply-queue", correlation_id="correlation-1"))
+
+    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
+        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+
+    assert len(bus.replies) == 1
+    response, routing_key = bus.replies[0]
+    assert routing_key == "reply-queue"
+    assert isinstance(response, RPCErrorResponse)
+    assert response.passed is False
+    assert response.errors == ["handler exploded"]
+    assert response.meta.correlation_id == "correlation-1"
+    assert delay is None
+    assert bus.messages == []
+
+
+async def test_failure_after_maximum_retries_is_logged_and_marked_failed(maximum_message_retries: int) -> None:
+    """A handler failure on an exhausted message is logged, marked failed and not retried again."""
+
+    async def handler(message: SendEchoRequest) -> None:
+        raise HandlerError("handler exploded")
+
+    bus = RecordingBus()
+    check_status = CheckStatusRecorder()
+    logger = LoggerRecorder()
+    sent = SendEchoRequest(message="ping", meta=Meta(retry_count=maximum_message_retries))
+
+    with (
+        patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}),
+        patch(SET_CHECK_STATUS, new=check_status),
+        patch(GET_LOGGER, new=lambda: logger),
+    ):
+        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+
+    assert logger.exceptions == ["Message failed after maximum number of retries"]
+    assert len(check_status.conclusions) == 1
+    failed_message, conclusion = check_status.conclusions[0]
+    assert failed_message.meta.retry_count == maximum_message_retries
+    assert conclusion == "failure"
+    assert delay is None
+    assert bus.messages == []
+
+
+async def test_failure_with_retries_remaining_is_requeued_with_a_delay(maximum_message_retries: int) -> None:
+    """A handler failure with retries left re-sends the message with a delay and returns that delay."""
+
+    async def handler(message: SendEchoRequest) -> None:
+        raise HandlerError("handler exploded")
+
+    bus = RecordingBus()
+    sent = SendEchoRequest(message="ping", meta=Meta(retry_count=maximum_message_retries - 2))
+
+    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
+        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+
+    assert len(bus.messages) == 1
+    assert bus.messages[0].meta.retry_count == maximum_message_retries - 1
+    assert bus.seen_routing_keys == [ECHO_ROUTING_KEY]
+    assert bus.publish_options == [(MessageTTL.FIVE, True)]
+    assert delay == MessageTTL.FIVE

--- a/backend/tests/unit/message_bus/test_operations.py
+++ b/backend/tests/unit/message_bus/test_operations.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from prefect import Flow, flow
+from prefect.context import FlowRunContext
 
 from infrahub import config
 from infrahub.message_bus import Meta, RPCErrorResponse
@@ -13,8 +14,6 @@ from infrahub.message_bus.types import MessageTTL
 from tests.adapters.message_bus import BusRecorder
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from infrahub.message_bus import InfrahubMessage
 
 ECHO_ROUTING_KEY = "send.echo.request"
@@ -37,14 +36,14 @@ class RecordingBus(BusRecorder):
         self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
     ) -> None:
         self.publish_options.append((delay, is_retry))
-        await super().publish(message, routing_key=routing_key, delay=delay, is_retry=is_retry)
+        await super().publish(message=message, routing_key=routing_key, delay=delay, is_retry=is_retry)
 
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
         self.replies.append((message, routing_key))
 
 
 class CheckStatusRecorder:
-    """Stand-in for set_check_status that keeps the conclusion reported for each message."""
+    """Check-status double that keeps the conclusion reported for each message."""
 
     def __init__(self) -> None:
         self.conclusions: list[tuple[InfrahubMessage, str]] = []
@@ -54,22 +53,21 @@ class CheckStatusRecorder:
 
 
 class LoggerRecorder:
-    """Stand-in for the dispatcher's logger that keeps the events reported at exception level."""
+    """Logger double that keeps each event reported at exception level along with its keywords."""
 
     def __init__(self) -> None:
-        self.exceptions: list[str] = []
+        self.exceptions: list[tuple[str, dict[str, Any]]] = []
 
     def exception(self, event: str, **kwargs: Any) -> None:
-        self.exceptions.append(event)
+        self.exceptions.append((event, kwargs))
 
 
 @pytest.fixture
-def maximum_message_retries() -> Generator[int]:
+def maximum_message_retries(monkeypatch: pytest.MonkeyPatch) -> int:
     """Pin the retry ceiling the dispatcher reads, restoring whatever the environment provided."""
-    original = config.SETTINGS.broker.maximum_message_retries
-    config.SETTINGS.broker.maximum_message_retries = 3
-    yield 3
-    config.SETTINGS.broker.maximum_message_retries = original
+    ceiling = 3
+    monkeypatch.setattr(config.SETTINGS.broker, "maximum_message_retries", ceiling)
+    return ceiling
 
 
 async def test_plain_handler_is_awaited_and_message_is_acknowledged(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,11 +92,14 @@ async def test_plain_handler_is_awaited_and_message_is_acknowledged(monkeypatch:
 
 
 async def test_flow_handler_is_unwrapped_when_flows_are_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With skip_flow set, a Prefect flow handler is unwrapped to its function and that is awaited."""
+    """With skip_flow set, a Prefect flow handler runs as a bare coroutine rather than as a flow run."""
     received: list[InfrahubMessage] = []
+    flow_run_contexts: list[FlowRunContext | None] = []
 
     @flow(name="unit-test-echo-handler")
     async def handler(message: SendEchoRequest) -> None:
+        # A flow invoked through the Prefect engine has a run context; the unwrapped function has none.
+        flow_run_contexts.append(FlowRunContext.get())
         received.append(message)
 
     assert isinstance(handler, Flow), "the scenario only covers the unwrap when the handler really is a flow"
@@ -109,6 +110,7 @@ async def test_flow_handler_is_unwrapped_when_flows_are_skipped(monkeypatch: pyt
     monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
     delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus, skip_flow=True)
 
+    assert flow_run_contexts == [None]
     assert len(received) == 1
     handled = received[0]
     assert isinstance(handled, SendEchoRequest)
@@ -158,7 +160,11 @@ async def test_failure_after_maximum_retries_is_logged_and_marked_failed(
     monkeypatch.setattr(f"{OPERATIONS_MODULE}.get_logger", lambda: logger)
     delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
 
-    assert logger.exceptions == ["Message failed after maximum number of retries"]
+    assert len(logger.exceptions) == 1
+    event, keywords = logger.exceptions[0]
+    assert event == "Message failed after maximum number of retries"
+    assert isinstance(keywords["error"], HandlerError)
+    assert str(keywords["error"]) == "handler exploded"
     assert len(check_status.conclusions) == 1
     failed_message, conclusion = check_status.conclusions[0]
     assert failed_message.meta.retry_count == maximum_message_retries

--- a/backend/tests/unit/message_bus/test_operations.py
+++ b/backend/tests/unit/message_bus/test_operations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
 
 import pytest
 from prefect import Flow, flow
@@ -19,8 +18,7 @@ if TYPE_CHECKING:
     from infrahub.message_bus import InfrahubMessage
 
 ECHO_ROUTING_KEY = "send.echo.request"
-SET_CHECK_STATUS = "infrahub.message_bus.operations.set_check_status"
-GET_LOGGER = "infrahub.message_bus.operations.get_logger"
+OPERATIONS_MODULE = "infrahub.message_bus.operations"
 
 
 class HandlerError(Exception):
@@ -74,7 +72,7 @@ def maximum_message_retries() -> Generator[int]:
     config.SETTINGS.broker.maximum_message_retries = original
 
 
-async def test_plain_handler_is_awaited_and_message_is_acknowledged() -> None:
+async def test_plain_handler_is_awaited_and_message_is_acknowledged(monkeypatch: pytest.MonkeyPatch) -> None:
     """A successful plain coroutine handler receives the decoded message and asks for no retry."""
     received: list[InfrahubMessage] = []
 
@@ -84,8 +82,8 @@ async def test_plain_handler_is_awaited_and_message_is_acknowledged() -> None:
     bus = RecordingBus()
     sent = SendEchoRequest(message="ping")
 
-    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
-        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+    monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
+    delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
 
     assert len(received) == 1
     handled = received[0]
@@ -95,7 +93,7 @@ async def test_plain_handler_is_awaited_and_message_is_acknowledged() -> None:
     assert bus.messages == []
 
 
-async def test_flow_handler_is_unwrapped_when_flows_are_skipped() -> None:
+async def test_flow_handler_is_unwrapped_when_flows_are_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
     """With skip_flow set, a Prefect flow handler is unwrapped to its function and that is awaited."""
     received: list[InfrahubMessage] = []
 
@@ -108,10 +106,8 @@ async def test_flow_handler_is_unwrapped_when_flows_are_skipped() -> None:
     bus = RecordingBus()
     sent = SendEchoRequest(message="ping")
 
-    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
-        delay = await execute_message(
-            routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus, skip_flow=True
-        )
+    monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
+    delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus, skip_flow=True)
 
     assert len(received) == 1
     handled = received[0]
@@ -121,7 +117,7 @@ async def test_flow_handler_is_unwrapped_when_flows_are_skipped() -> None:
     assert bus.messages == []
 
 
-async def test_failure_with_reply_requested_returns_an_error_response() -> None:
+async def test_failure_with_reply_requested_returns_an_error_response(monkeypatch: pytest.MonkeyPatch) -> None:
     """A handler failure on a message awaiting a reply is answered with an error and not retried."""
 
     async def handler(message: SendEchoRequest) -> None:
@@ -130,8 +126,8 @@ async def test_failure_with_reply_requested_returns_an_error_response() -> None:
     bus = RecordingBus()
     sent = SendEchoRequest(message="ping", meta=Meta(reply_to="reply-queue", correlation_id="correlation-1"))
 
-    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
-        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+    monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
+    delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
 
     assert len(bus.replies) == 1
     response, routing_key = bus.replies[0]
@@ -144,7 +140,9 @@ async def test_failure_with_reply_requested_returns_an_error_response() -> None:
     assert bus.messages == []
 
 
-async def test_failure_after_maximum_retries_is_logged_and_marked_failed(maximum_message_retries: int) -> None:
+async def test_failure_after_maximum_retries_is_logged_and_marked_failed(
+    monkeypatch: pytest.MonkeyPatch, maximum_message_retries: int
+) -> None:
     """A handler failure on an exhausted message is logged, marked failed and not retried again."""
 
     async def handler(message: SendEchoRequest) -> None:
@@ -155,12 +153,10 @@ async def test_failure_after_maximum_retries_is_logged_and_marked_failed(maximum
     logger = LoggerRecorder()
     sent = SendEchoRequest(message="ping", meta=Meta(retry_count=maximum_message_retries))
 
-    with (
-        patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}),
-        patch(SET_CHECK_STATUS, new=check_status),
-        patch(GET_LOGGER, new=lambda: logger),
-    ):
-        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+    monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
+    monkeypatch.setattr(f"{OPERATIONS_MODULE}.set_check_status", check_status)
+    monkeypatch.setattr(f"{OPERATIONS_MODULE}.get_logger", lambda: logger)
+    delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
 
     assert logger.exceptions == ["Message failed after maximum number of retries"]
     assert len(check_status.conclusions) == 1
@@ -171,7 +167,9 @@ async def test_failure_after_maximum_retries_is_logged_and_marked_failed(maximum
     assert bus.messages == []
 
 
-async def test_failure_with_retries_remaining_is_requeued_with_a_delay(maximum_message_retries: int) -> None:
+async def test_failure_with_retries_remaining_is_requeued_with_a_delay(
+    monkeypatch: pytest.MonkeyPatch, maximum_message_retries: int
+) -> None:
     """A handler failure with retries left re-sends the message with a delay and returns that delay."""
 
     async def handler(message: SendEchoRequest) -> None:
@@ -180,8 +178,8 @@ async def test_failure_with_retries_remaining_is_requeued_with_a_delay(maximum_m
     bus = RecordingBus()
     sent = SendEchoRequest(message="ping", meta=Meta(retry_count=maximum_message_retries - 2))
 
-    with patch.dict(COMMAND_MAP, {ECHO_ROUTING_KEY: handler}):
-        delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
+    monkeypatch.setitem(COMMAND_MAP, ECHO_ROUTING_KEY, handler)
+    delay = await execute_message(routing_key=ECHO_ROUTING_KEY, message_body=sent.body, message_bus=bus)
 
     assert len(bus.messages) == 1
     assert bus.messages[0].meta.retry_count == maximum_message_retries - 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,13 +431,6 @@ disable_error_code = [
     "return-value",
 ]
 
-[[tool.mypy.overrides]]
-module = "infrahub.message_bus.operations"
-disable_error_code = [
-    "operator",
-    "return",
-]
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"
@@ -1762,17 +1755,6 @@ include = ["backend/infrahub/message_bus/**"]
 # like this so that we can reactivate them one by one.                                           #
 ##################################################################################################
 unused-type-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
-
-[[tool.ty.overrides]]
-include = ["backend/infrahub/message_bus/operations/__init__.py"]
-
-[tool.ty.overrides.rules]
-##################################################################################################
-# COMMAND_MAP is a heterogeneous dispatch table: each handler takes a specific InfrahubMessage   #
-# subtype, but the dispatch site only has the base type. Scoped to this file so the rest of      #
-# message_bus/ stays enforced.                                                                    #
-##################################################################################################
-invalid-argument-type = "ignore"
 
 [[tool.ty.overrides]]
 include = ["backend/infrahub/artifacts/**"]


### PR DESCRIPTION
Clears the package-wide mypy override that disabled the `operator` and `return` error codes for
`infrahub.message_bus.operations`, and fixes the two errors it was hiding.

Jira: **INBOX-31**

## What was changed and why

The suppression was blanket — it applied to all 9 modules in the package, forever, though the errors
it hid were confined to one file. That package is the boundary where every message the worker
consumes is decoded, dispatched, and routed to the reply / retry / dead-letter protocol, so any
*future* `operator`/`return` fault there was being swallowed too.

**`backend/infrahub/message_bus/operations/__init__.py`**

- `COMMAND_MAP` was unannotated and heterogeneous — 4 entries are plain `async def` handlers, 4 are
  Prefect `@flow` objects — so mypy joined the value type to `object` and the dispatch call
  `await func(message=message)` was `"object" not callable`. It is now
  `COMMAND_MAP: dict[str, MessageHandler]` with `MessageHandler = Callable[..., Awaitable[None]]`.
- `execute_message` now returns `None` explicitly on its success path instead of falling off the end.
  That return is load-bearing: in `services/adapters/message_bus/nats.py` a truthy return means
  `message.nak(delay / 1000)` (re-queue) and a falsy one means `message.ack()`.

**`pyproject.toml`** — two blocks deleted, not one:

- the `[[tool.mypy.overrides]]` for the package (the ticket's target);
- the `[[tool.ty.overrides]]` scoped to the same file, which the new annotation makes redundant.
  Verified both ways so "removed" isn't confused with "was already dead": with the original code and
  that block deleted, `ty` reports **8 × `invalid-argument-type`** (one per handler); with the new
  typing it reports `All checks passed!`.

**No `# type: ignore` and no `cast` were added anywhere.** Net suppressions go down by two.

### On `Callable[..., Awaitable[None]]`

The `...` is deliberate, not a shrug. Handlers each take a *different* `InfrahubMessage` subtype
while the dispatch site holds only the base type, so parameters cannot be pinned without widening
every handler's own signature. A callback `Protocol` was tried and rejected: parameter
contravariance makes it emit 8 `dict-item` errors, one per handler.

The annotation still has teeth — injecting `"bad.not_callable": 42` and `"bad.sync_fn": len` into
the map produces two `Dict entry N has incompatible type` errors, so both a non-callable and a
callable-but-synchronous value are rejected. The shape mirrors
`MessageFunction = Callable[[InfrahubMessage], Awaitable[None]]`, already used in the same
subsystem's nats/rabbitmq adapters.

## Testing performed

`backend/tests/unit/message_bus/test_operations.py` is new. Nothing previously unit-tested
`execute_message` at all — `tests/adapters/message_bus.py` drives it for every message the backend
suite sends but discards the return value, so the retry decision was pinned only by an integration
test. The new file covers all five dispatch outcomes and asserts the **returned value** in each, not
just the side effect.

Two checks worth calling out:

- **The tests pass against the pre-change code as well.** That is the direct evidence that this
  change is behaviour-neutral — they characterize existing behaviour rather than guard a fix.
- **The flow-unwrap test was fixed after review found it didn't bite.** Deleting
  `if skip_flow and isinstance(func, Flow): func = func.fn` still passed, because Prefect's
  `Flow.__call__` runs the async function through the engine regardless — only the runtime changed
  (0.04s → 3.94s). It now records `FlowRunContext.get()` inside the handler and asserts it is `None`,
  which holds only when the bare coroutine ran. Confirmed: passes unmutated, fails with the unwrap
  removed.

Local gate, all green:

| Check | Result |
|---|---|
| `uv run mypy backend/infrahub/message_bus/operations` | `Success: no issues found in 9 source files` |
| `uv run ty check backend/infrahub/message_bus/operations` | `All checks passed!` |
| `uv run invoke backend.lint` (mypy repo-wide) | `Success: no issues found in 1686 source files` |
| `uv run invoke backend.test-unit` | `2656 passed` |
| `uv run pytest backend/tests/unit/message_bus` | `10 passed` |
| `ruff check` / `ruff format --check` / `ty check .` / `yamllint` / `uv lock --check` | clean |
| `backend.validate-generated` | no diff |
| frontend `biome ci` / `knip` / `betterer ci` | clean (unchanged by this PR) |

`test_mappings.py` passes unmodified. Its stale exclusion list (`event.node.mutated`,
`trigger.webhook.actions` — keys no longer in the map) is pre-existing and deliberately left alone.

No changelog fragment and no spec-kit design record: per `dev/guidelines/git-workflow.md`, a
trivial code-only change with no behaviour change ships as just the code diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013i34mfdwmNwDupcV621Eor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

