### PR TITLE
fix(frontend): keep the Columns picker open when toggling a column

### DIFF
--- a/changelog/+ifc-3079-column-visibility.added.md
+++ b/changelog/+ifc-3079-column-visibility.added.md
@@ -1,7 +1,8 @@
 Choose which columns a list view shows. Every schema-driven table — the object list, relationship
 tabs, and the IPAM address and prefix lists — now has a **Columns** control. Wherever column headers
 offer a menu, that menu also carries a **Hide column** shortcut; relationship tabs have read-only
-headers, so there the Columns control is the way.
+headers, so there the Columns control is the way. The control stays open as you tick columns on and
+off, so setting up the view you want is a single visit.
 
 Your choice lives in the URL, so a reload keeps it and the link can be shared with a colleague who
 will see the same view. On the object list you can also reveal attributes the schema marks as

--- a/frontend/app/src/entities/nodes/columns/ui/columns-editor.tsx
+++ b/frontend/app/src/entities/nodes/columns/ui/columns-editor.tsx
@@ -85,6 +85,8 @@ export function ColumnsEditor({ schema, surface }: ColumnsEditorProps) {
           aria-label="Toggle columns"
           className="max-h-72"
           emptyMessage="No fields match"
+          // Columns are settings, not commands: the enclosing DialogTrigger would close on each one.
+          shouldCloseOnSelect={false}
         >
           {columnCandidates.map((columnCandidate) => {
             const { name, fieldSchema } = columnCandidate;

--- a/frontend/app/src/entities/nodes/columns/ui/columns-picker.test.tsx
+++ b/frontend/app/src/entities/nodes/columns/ui/columns-picker.test.tsx
@@ -35,6 +35,8 @@ const seedColumnsInUrl = ({ hidden, shown }: { hidden?: string; shown?: string }
   window.history.replaceState(null, "", `${window.location.pathname}?${search}`);
 };
 
+const getHiddenColumnsInUrl = () => new URLSearchParams(window.location.search).get("hide_columns");
+
 describe("ColumnsPicker", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", window.location.pathname);
@@ -96,5 +98,35 @@ describe("ColumnsPicker", () => {
     await expect
       .element(component.getByRole("button", { name: "Columns" }).getByText(/^\d+$/))
       .not.toBeInTheDocument();
+  });
+
+  // Here rather than in columns-editor.test.tsx: the only place the Popover and the editor compose.
+  test("keeps the popover open after a column is toggled", async () => {
+    // GIVEN
+    const component = await render(<ColumnsPicker schema={objectSchema} />);
+    await component.getByRole("button", { name: "Columns" }).click();
+
+    // WHEN
+    await component.getByRole("menuitem", { name: "Description" }).click();
+
+    // THEN
+    await expect.poll(getHiddenColumnsInUrl).toBe("description");
+    // aria-expanded, not menu visibility: the popover fades out, so the menu lingers in the DOM.
+    await expect
+      .element(component.getByRole("button", { name: /^Columns/ }))
+      .toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("hides several columns in one visit without reopening the popover", async () => {
+    // GIVEN
+    const component = await render(<ColumnsPicker schema={objectSchema} />);
+    await component.getByRole("button", { name: "Columns" }).click();
+
+    // WHEN
+    await component.getByRole("menuitem", { name: "Description" }).click();
+    await component.getByRole("menuitem", { name: "Status" }).click();
+
+    // THEN
+    await expect.poll(getHiddenColumnsInUrl).toBe("description,status");
   });
 });

--- a/tests/e2e/objects/test_object_columns.py
+++ b/tests/e2e/objects/test_object_columns.py
@@ -11,7 +11,9 @@ devices (the schema default order starts at atl1-core1).
 
 `exact=True` is load-bearing on every "Description" locator: InfraDevice also
 carries a `computed_description` attribute, whose "Computed Description" label
-substring-matches Playwright's default name matching.
+substring-matches Playwright's default name matching. It only works on a
+hidden column: a picker item for a column that is on screen appends an
+sr-only "visible" to its accessible name.
 """
 
 from __future__ import annotations
@@ -39,9 +41,11 @@ class TestObjectColumns:
         description_header = table.get_by_role("button", name="Description", exact=True)
         name_header = table.get_by_role("button", name="Name", exact=True)
         columns_button = admin_page.get_by_role("button", name=re.compile(r"^Columns"))
-        description_item = admin_page.get_by_role("menu", name="Toggle columns").get_by_role(
-            "menuitem", name="Description", exact=True
-        )
+        type_header = table.get_by_role("button", name="Type", exact=True)
+        columns_menu = admin_page.get_by_role("menu", name="Toggle columns")
+        description_item = columns_menu.get_by_role("menuitem", name="Description", exact=True)
+        # anchored, not exact: type is on screen, so the item reads "Type visible"
+        type_item = columns_menu.get_by_role("menuitem", name=re.compile(r"^Type\b"))
 
         # open a shared link that hides one column
         await admin_page.goto("/objects/InfraDevice?hide_columns=description")
@@ -64,5 +68,15 @@ class TestObjectColumns:
 
         # back to the default: no param left behind, column on screen again
         await expect(admin_page).not_to_have_url(re.compile(r"hide_columns"))
+        await expect(description_header).to_be_visible()
+        await expect(first_row_link).to_have_text("atl1-core1")
+
+        # the popover survived the toggle, so a second column needs no return trip to the toolbar
+        # (checked on the trigger: the menu lingers in the DOM for the fade-out either way)
+        await expect(columns_button).to_have_attribute("aria-expanded", "true")
+        await type_item.click()
+
+        await expect(admin_page).to_have_url(re.compile(r"hide_columns=type"))
+        await expect(type_header).not_to_be_visible()
         await expect(description_header).to_be_visible()
         await expect(first_row_link).to_have_text("atl1-core1")


### PR DESCRIPTION
## Problem

In the list view, the **Columns** popover dismissed itself every time a column was ticked or unticked, so adjusting several columns cost one trip to the toolbar each: open, click, closes, reopen, click.

Toggling a column is a *setting*, not a command — the popover should stay put while you set the view up.

## Cause

`PopoverTrigger` is react-aria's `DialogTrigger`, which supplies the embedded `Menu` with a `close` callback. `useMenuItem` fires it on every item activation.

## Fix

One prop on the `Menu` in `columns-editor.tsx`:

```tsx
shouldCloseOnSelect={false}
```

Chosen over `selectionMode="multiple"`, which only suppresses the *pointer* path — keyboard <kbd>Enter</kbd> would still dismiss. It also keeps the hand-rolled check indicator, the tooltip, and the last-column-disabled affordance exactly as they were; a `ListBox selectionMode="multiple"` would have been net-new to this codebase and would have lost them.

Scope is the Columns picker only. Genuine one-shot commands — **Hide column** in the table header menu — are a different `Menu` and still close on select.

## Tests

Two component tests in `columns-picker.test.tsx`, the only place the `Popover` and the editor are composed. **Both fail with the prop removed and pass with it** (verified by toggling it off and re-running).

They assert `aria-expanded` on the trigger rather than the menu's visibility: the popover fades out, so the menu lingers in the DOM and a visibility check passed either way.

The e2e test now drives the picker twice in a single visit — the second click only lands if the popover stayed open.

## Verification

| Check | Result |
|---|---|
| `biome ci .` | 1566 files, no errors |
| `pnpm knip` | exit 0 |
| `pnpm betterer ci` | 186 issues, unchanged |
| `pnpm test` | 197 files, 1374 tests, all passed |
| `ruff check` / `format --check` | clean |

The Playwright e2e needs the full stack plus `shard_sites_a` demo data, so it was not run locally — CI covers it.

## Notes for the reviewer

A review pass caught one real bug in the first draft of the e2e test, worth knowing about for future picker tests: a menu item for a column that is **currently on screen** renders an extra `sr-only` "visible" span, so its accessible name is `"Type visible"`, not `"Type"`. `exact=True` matches nothing there. The pre-existing `description_item` locator only works because description is hidden at that point in the test. The new locator is anchored instead, and the module docstring now records the trap.

Changelog: folded into the existing unreleased `+ifc-3079-column-visibility.added.md` rather than added as a separate fragment — a standalone entry would describe a fix to something users have never seen.

Refs [IFC-3178](https://opsmill.atlassian.net/browse/IFC-3178) (under epic [IFC-3079](https://opsmill.atlassian.net/browse/IFC-3079))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IFC-3178]: https://opsmill.atlassian.net/browse/IFC-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

