### PR TITLE
ci: run the huge-runner jobs only on the top pull request of a stack

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -252,6 +252,10 @@
   description: "Run intensive CodSpeed benchmarks, usually excluded."
   color: "73FA20"
 
+- name: "ci/run-huge-runners"
+  description: "Run the huge-runner jobs on a pull request that would otherwise skip them"
+  color: "73FA20"
+
 - name: "cd/preview"
   description: "Deploy preview branch"
   color: "d77e96"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,14 @@ jobs:
   # ------------------------------------------ Huge-runner gate ------------------------------------------
   huge-runner-gate:
     name: Gate for huge-runner jobs
-    if: always() && !cancelled()
+    # Skipped below the top of a stack, which skips every huge-runner job: the top level covers the whole stack.
+    if: |
+      always() && !cancelled() &&
+      (
+        github.event.pull_request.stack == null ||
+        github.event.pull_request.stack.position == github.event.pull_request.stack.size ||
+        contains(github.event.pull_request.labels.*.name, 'ci/run-huge-runners')
+      )
     needs:
       - prepare-environment
       - files-changed
@@ -1278,10 +1285,11 @@ jobs:
       - prepare-environment
       - files-changed
       - huge-runner-gate
+    # For a stack, the branch the whole stack targets counts, not the level below.
     if: |
       !cancelled() &&
       needs.huge-runner-gate.result == 'success' &&
-      github.base_ref == 'stable' &&
+      (github.base_ref == 'stable' || github.event.pull_request.stack.base.ref == 'stable') &&
       needs.files-changed.outputs.e2e == 'true'
     runs-on:
       group: huge-runners

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -138,6 +138,26 @@ annotating, don't fix the bug in the same PR — keep the diff limited to the an
 the bug separately. The justification comment may record what you found (see
 [Exception Handling](backend/exceptions.md)), but the fix belongs in its own PR.
 
+## Stacked Pull Requests
+
+When a change ships as a
+[stack of pull requests](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests),
+CI runs the GitHub-hosted checks (lint, unit tests, generated-file validation) on every pull
+request of the stack, but the huge-runner jobs (component, integration, functional, docker and
+e2e tests, version upgrade, benchmarks) only on the top pull request. The top contains every
+commit of the stack, so one run there covers all levels.
+
+- **Mechanism:** the `huge-runner-gate` job in `.github/workflows/ci.yml`, which every
+  huge-runner job depends on, is skipped when the pull request is in a stack and not its top.
+  Skipped jobs count as passing for required status checks.
+- **Adding a level:** pushing a new pull request on top of a stack turns the previous top into an
+  intermediate pull request; its next CI run skips the huge-runner jobs.
+- **Override:** to run the huge-runner jobs on an intermediate pull request, add the
+  `ci/run-huge-runners` label, then push a commit: adding the label does not start a run, and
+  re-running an existing run does not see it.
+- **Scope:** only pull requests GitHub created as a stack carry stack metadata; a pull request
+  that merely targets another feature branch runs the huge-runner jobs.
+
 ## Critical Rules
 
 - Never force push to `stable` or `develop`


### PR DESCRIPTION
# Why

Stacked pull requests run CI on every level of the stack, and the huge-runner jobs (component, integration, functional, docker and e2e tests, version upgrade, benchmarks) are the expensive part. The top pull request of a stack contains every commit of the stack, so one run there covers all levels. This follows GitHub's [Optimizing CI for stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests).

Non-goals: the GitHub-hosted checks (lint, unit tests, generated-file validation) still run on every level of the stack.

## What changed

- `huge-runner-gate` is skipped when the pull request belongs to a stack and is not its top (`stack.position != stack.size`). Every huge-runner job requires the gate to have succeeded, so they skip with it. Pull requests outside a stack and push events carry no stack metadata and behave as before.
- New label `ci/run-huge-runners` overrides the skip for an intermediate pull request. Labels are read from the event payload, so add it and then push a commit; re-running an existing run does not see it.
- `E2E-testing-invoke-demo-start` also runs for a stack whose ultimate base is `stable`. The top of a stack targets the level below it rather than `stable`, so the previous `github.base_ref == 'stable'` check alone would never match it.
- `dev/guidelines/git-workflow.md` gains a "Stacked Pull Requests" section describing the behaviour and the override.

## How to review

`.github/workflows/ci.yml`: the `if` of `huge-runner-gate` and of `E2E-testing-invoke-demo-start`. The gate-wiring validator still passes: `always()` and `!cancelled()` stay top-level conjuncts and the stack condition is a single parenthesised disjunction.

## How to test

```bash
uv run yamllint -s .github/workflows/ci.yml .github/labels.yml
uv run invoke ci.validate-huge-runner-gate
actionlint .github/workflows/ci.yml
```

The gate only applies to pull requests whose merge ref includes this change, so it has to land on `stable` (and forward-merge to `develop`) before stacks benefit. The `ci/run-huge-runners` label is created by the labels workflow on push to `stable`.

## Impact & rollout

- **Deployment notes:** CI configuration only, safe to merge. Merging an intermediate pull request relies on the huge-runner coverage of the top-of-stack run on the combined code, which is the trade-off GitHub's guide describes.

## Checklist

- [x] Internal .md docs updated (internal knowledge and AI code tools knowledge)
- [x] I have reviewed AI generated content


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/opsmill/infrahub/pull/10611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

