### PR TITLE
docs(faq): correct the backup and upgrade answers

### DIFF
--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -100,9 +100,9 @@ If you want to evaluate Infrahub against your own schema and dataset size, reach
 
 ### What does a high-availability Infrahub deployment look like?
 
-A production Infrahub deployment runs as a single clustered instance with component-level redundancy: database clustering with automatic leader election, cache failover, and mirrored message queues. This is the default topology we recommend for most organisations, and it is what the [Community vs Enterprise](../overview/community-vs-enterprise.mdx) page describes under the HA tiers.
+Infrahub Enterprise runs every component redundantly, so an individual component failure does not take the platform down. A highly available deployment uses a Neo4j cluster with automatic failover, Redis Sentinel for cache failover, a RabbitMQ cluster for the message bus, PostgreSQL replication for the task manager database, several API server and worker replicas, and redundant load balancers in front of the API layer. Kubernetes is the recommended topology for it, and the [Community vs Enterprise](../overview/community-vs-enterprise.mdx) page describes the HA tiers.
 
-Running a single logical instance means one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one target for monitoring and upgrades.
+A highly available deployment is still one logical instance: one schema, one resource allocation authority for IPs, prefixes, and identifiers, and one target for monitoring and upgrades. See [High availability](../deploy-manage/install-configure/production-deployment/high-availability.mdx) for the architecture and for Terraform and Helm deployment examples.
 
 ### Can I run multiple Infrahub instances?
 
@@ -121,7 +121,11 @@ No. A single Infrahub instance is designed as one clustered deployment in one re
 
 ### How do I back up and restore Infrahub?
 
-Database backup is a routine, automated operation, with native support for S3-compatible object storage. Compressed backups for large production deployments typically fall in the single-digit to tens of gigabytes range. See the [database backup and restore topic](../deploy-manage/maintain-upgrade/database-backup/overview) for step-by-step guidance and scheduling recommendations.
+Automate database backups alongside your files and artifacts, and store everything in S3-compatible cloud storage. A backup is a single archive containing the graph database and the task manager database. The backup tool writes a SHA256 checksum for every file and verifies them before a restore writes anything.
+
+Files and artifacts are stored in object storage rather than in the graph database, which references them by `storage_id`. Capture both at the same point, so a restore finds the content the graph expects. Compressed backups for large production deployments typically fall in the single-digit to tens of gigabytes range.
+
+See the [backup and restore guide](../deploy-manage/maintain-upgrade/database-backup/backup-and-restore) for the procedure, or [cluster backup and restore](../deploy-manage/maintain-upgrade/database-backup/cluster-backup-and-restore) for a Neo4j cluster. The [database backup topic](../deploy-manage/maintain-upgrade/database-backup/overview) covers how backup and restore work, and the [Infrahub Backup documentation](https://docs.infrahub.app/backup/) has the commands, the S3 settings, scheduling, and retention.
 
 ### What are realistic recovery targets for Infrahub?
 
@@ -131,9 +135,15 @@ In deployment patterns where data-plane agents enforce their last-known desired 
 
 ### How do I upgrade Infrahub?
 
-The `infrahub upgrade` command handles schema and database migrations. On Kubernetes, Helm runs the upgrade as a job during the release update and manages rolling pod updates. For VM-based deployments, documented procedures define the stop/upgrade/restart sequence with safety checks.
+Upgrading is a routine operation, not a major project. The schema is stored in Infrahub rather than in application code, so a new release does not require redesigning it or rebuilding the integrations that read it.
 
-We recommend a full database backup before every upgrade and validation in a staging environment that mirrors production topology. The [upgrade guide](../deploy-manage/maintain-upgrade/upgrade/overview) has the detailed steps.
+`infrahub upgrade` applies the database migrations and updates the core schema, the menu, the permissions, and the task manager configuration for the new version. Run `infrahub upgrade --check` first to report the pending migrations and the branches that need a rebase, without writing anything.
+
+Upgrades are supported from the previous minor version, so anything further behind moves one version at a time. A minor release can also include breaking changes that need work first, such as renaming a schema element or updating a GraphQL query. Check the release notes for each version in between.
+
+On Kubernetes, the Helm chart can run the upgrade as a pre-upgrade hook job, which you enable with `upgrade.enabled`. On Docker Compose, the sequence is stop the instance, fetch the new compose file, run the upgrade, and start again. Neither path is zero downtime, so plan a maintenance window. [Bare metal deployments](../deploy-manage/install-configure/install/enterprise.mdx) are supported, and we provide the upgrade procedure on request.
+
+We recommend a full database backup before every upgrade and validation in a staging environment that mirrors production topology. The [upgrade guide](../deploy-manage/maintain-upgrade/upgrade/overview) has the detailed steps for each edition and deployment method.
 
 ### What monitoring and observability does Infrahub provide?
 


### PR DESCRIPTION
## Summary

Corrects two answers on the FAQ page that state things the product does not do, and replaces the high-availability answer with the architecture it actually describes. Pattern: smaller update to one existing page.

Found while fact-checking an external FAQ draft that reuses these answers. The three claims below were checked against the code, the Helm chart, and the Infrahub Backup docs.

## Content changes

- **"How do I back up and restore Infrahub?"** — rewritten. Says what you can accomplish, what a backup contains, that files and artifacts are captured separately, and sends the commands, S3 settings, scheduling and retention to the Infrahub Backup docs.
- **"What does a high-availability Infrahub deployment look like?"** — rewritten. The old answer said "database clustering with automatic leader election, cache failover, and mirrored message queues", which names three of the six redundant components and none of them by name. It now lists what a highly available deployment runs, per `deploy-manage/install-configure/production-deployment/high-availability.mdx`, and links there for the architecture and the Terraform and Helm examples.
- **"How do I upgrade Infrahub?"** — rewritten. Corrects the Helm claim, replaces the VM-procedures claim, and adds the N-1 upgrade path and the release-notes check.

Everything else on the page is unchanged. Both headings keep their text, so the existing anchors still resolve.

## What needs reviewer attention

Both answers are new prose. Each opens on the operator's action, gives the mechanism in a sentence or two, and links out for the commands and settings. The flag names, the S3 settings and the `upgrade.enabled` value are on the linked pages rather than in the answers.

- **`docs/docs/faq/faq.mdx:124-128` — the backup answer.** The old text sent the reader to the backup topic "for step-by-step guidance and scheduling recommendations". A grep for `cron|schedul|retention|s3` over `deploy-manage/maintain-upgrade/database-backup/*.mdx` returns nothing, so scheduling, retention and the S3 settings now link to the Infrahub Backup docs. The S3 claim itself was correct and is kept: `create` takes `--s3-upload` and the bucket, prefix, endpoint and region settings, and `restore` reads an S3 URI (<https://docs.infrahub.app/backup/backup/create>).
- **`docs/docs/faq/faq.mdx:126` — files and artifacts.** Not in the backup archive (`deploy-manage/maintain-upgrade/database-backup/backup-and-restore.mdx:76`), and the graph references stored content by `storage_id` (`backup-and-restore.mdx:135`), so the two have to be captured together. The answer did not say this.
- **`docs/docs/faq/faq.mdx:138-140` — the upgrade answer.** The old text said "Helm runs the upgrade as a job during the release update and manages rolling pod updates", and that VM-based deployments have "documented procedures ... with safety checks".
  - The chart does ship a `post-install,pre-upgrade` hook job running `infrahub upgrade` (`opsmill/infrahub-helm`, `charts/infrahub/templates/infrahub-upgrade-job.yaml`), but `upgrade.enabled` defaults to `false` (`charts/infrahub/values.yaml:348`). The answer now says Helm can run it, and leaves the value to the guide.
  - No VM upgrade procedure is published. `deploy-manage/maintain-upgrade/upgrade/enterprise.mdx` covers Docker Compose and Helm, and `install/enterprise.mdx:301` tells bare-metal readers to contact OpsMill. The sentence now describes the Docker Compose sequence that is documented.
  - Added: upgrades run from the previous minor version only (`upgrade/overview.mdx`), and a minor release can include breaking changes needing schema or query work first (`release-notes/infrahub/release-1_10_0.mdx:219`). Previewing an upgrade without writing is `--check` (`backend/infrahub/cli/upgrade.py:77`).

## What didn't change

- The recovery-target answer, which checked out as it stands.
- Heading text, so `#how-do-i-back-up-and-restore-infrahub` and `#how-do-i-upgrade-infrahub` still resolve. No inbound link in `docs/docs` uses either anchor.

## Open issues for the reviewer / SME

- [ ] **The bare-metal upgrade runbook.** Product confirms it exists and is given to customers on request, and the answer says so. If it can be published, the upgrade guide is the place for it, and this answer can link there instead.

## Decided while writing this

- **S3 upload, scheduling and retention stay on the Infrahub Backup site.** Those options exist in the CLI and are documented there, not under `deploy-manage/maintain-upgrade/database-backup/`. Product's call is that the separate site is the right home, so this answer links across for them and keeps the in-repo pages for how backup and restore work.

## Out of scope (deferred)

- The Helm upgrade guides (`upgrade/enterprise.mdx`, `upgrade/community.mdx`) still show `helm upgrade` followed by a manual `kubectl exec ... infrahub upgrade` and `kubectl rollout restart`, with no mention of the chart's hook job. That is a separate correction to the upgrade pages, and it needs the chart owner to confirm which path is recommended.
- `faq.mdx:31` contains a forbidden word in a pre-existing heading. Untouched by this PR.

## Verification

- `cd docs && npm run build` succeeds. `onBrokenLinks` and `onBrokenAnchors` are both `throw`, so both new links resolve.
- `./docs/node_modules/.bin/markdownlint-cli2 'docs/docs/faq/faq.mdx'` reports 0 errors.
- Vale is not installed in this environment and did not run. `validate-documentation-style` in CI is the first Vale pass over this change.
- Manual word check over the changed file: the one match is pre-existing, at line 31.
- Prose walks in `dev/specs/docs/faq-corrections.checks.md` (uncommitted): the subject and verb of every new sentence, the non-technical verbs used, and the rewrites made in each pass, with the reason for each. Terminology checked against `deploy-manage/maintain-upgrade/` and `artifact-file-storage/`. Read through for naturalness after each revision.

---
Assisted-by: opsmill-docs-writing-infrahub-docs 0.4.0
Assisted-by: opsmill-dev-pr 0.2.0
