### PR TITLE
fix: normalize IP attribute values on update (closes #10616)

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -449,6 +449,9 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         # Validate if the value is still correct, will raise a ValidationError if not
         self.validate(value=self.value, name=self.name, schema=self.schema)
+        # Every write path funnels through here, so this is where the stored form is made canonical
+        if self.value is not None:
+            self.value = self._normalize_value(self.value)
 
         # Check if the current value is still the default one
         if self.is_default:

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -455,10 +455,13 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin, MetadataInterface):
 
         # Check if the current value is still the default one
         if self.is_default:
+            default_value = self.schema.default_value
+            if default_value is not None:
+                default_value = self._normalize_value(default_value)
             if isinstance(self.value, Enum):
-                has_default_value = self.schema.default_value == self.value.value
+                has_default_value = default_value == self.value.value
             else:
-                has_default_value = self.schema.default_value == self.value
+                has_default_value = default_value == self.value
             if (self.schema.default_value is not None and not has_default_value) or (
                 self.schema.default_value is None and self.value is not None
             ):

--- a/backend/tests/component/core/test_attribute.py
+++ b/backend/tests/component/core/test_attribute.py
@@ -462,7 +462,7 @@ async def test_update_stores_normalized_value(
 
 
 async def test_save_keeps_is_default_when_schema_default_is_not_canonical(
-    db: InfrahubDatabase, default_branch: Branch, group_schema: None, data_schema: None
+    db: InfrahubDatabase, default_branch: Branch
 ) -> None:
     """A schema default written without its prefix length still counts as the default after the value is canonicalized."""
     node_schema = NodeSchema(

--- a/backend/tests/component/core/test_attribute.py
+++ b/backend/tests/component/core/test_attribute.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 from enum import Enum
 
 import pytest
@@ -369,6 +370,94 @@ async def test_ipnetwork_normalizes_value(
     attr = IPNetwork(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="192.0.2.0/24")
 
     assert attr._normalize_value(input_value) == normalized_value
+
+
+async def _read_stored_attribute_value(db: InfrahubDatabase, node_uuid: str, attr_name: str, branch_name: str) -> str:
+    """Return the raw value on the active AttributeValue vertex, bypassing the in-memory normalization on read."""
+    query = """
+    MATCH (n:Node {uuid: $node_uuid})-[:HAS_ATTRIBUTE]->(a:Attribute {name: $attr_name})
+    MATCH (a)-[hv:HAS_VALUE]->(av:AttributeValue)
+    WHERE hv.status = "active" AND hv.to IS NULL AND hv.branch = $branch_name
+    RETURN av.value AS value
+    """
+    results = await db.execute_query(
+        query=query, params={"node_uuid": node_uuid, "attr_name": attr_name, "branch_name": branch_name}
+    )
+    assert len(results) == 1
+    return results[0]["value"]
+
+
+@dataclass
+class UpdateNormalizationTestCase:
+    name: str
+    """Descriptive name for the test scenario (used as test ID)."""
+
+    attribute_name: str
+    """Attribute of TestAllAttributeTypes to exercise."""
+
+    initial_value: str
+    """Canonical value the node is created with."""
+
+    update_value: str
+    """Non-canonical value submitted through the update payload."""
+
+    expected_stored_value: str
+    """Canonical form that must end up on the AttributeValue vertex."""
+
+
+UPDATE_NORMALIZATION_TEST_CASES: list[UpdateNormalizationTestCase] = [
+    UpdateNormalizationTestCase(
+        name="iphost_bare_address_gets_prefix_length",
+        attribute_name="ipaddress",
+        initial_value="192.0.2.10/32",
+        update_value="192.0.2.20",
+        expected_stored_value="192.0.2.20/32",
+    ),
+    UpdateNormalizationTestCase(
+        name="ipnetwork_expanded_ipv6_is_compressed",
+        attribute_name="prefix",
+        initial_value="192.0.2.0/24",
+        update_value="2001:0DB8:0000:0000:0000:0000:0000:0000/32",
+        expected_stored_value="2001:db8::/32",
+    ),
+    UpdateNormalizationTestCase(
+        name="ipaddress_expanded_ipv6_is_compressed",
+        attribute_name="bare_address",
+        initial_value="192.0.2.10",
+        update_value="2001:0DB8:0000:0000:0000:0000:0000:0001",
+        expected_stored_value="2001:db8::1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in UPDATE_NORMALIZATION_TEST_CASES],
+)
+async def test_update_stores_normalized_value(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    all_attribute_types_schema: NodeSchema,
+    test_case: UpdateNormalizationTestCase,
+) -> None:
+    """An update payload must persist the same canonical form that creating the node with that value would."""
+    obj = await Node.init(db=db, schema="TestAllAttributeTypes")
+    await obj.new(db=db, name="obj1", **{test_case.attribute_name: test_case.initial_value})
+    await obj.save(db=db)
+
+    stored_after_create = await _read_stored_attribute_value(
+        db=db, node_uuid=obj.id, attr_name=test_case.attribute_name, branch_name=default_branch.name
+    )
+    assert stored_after_create == test_case.initial_value
+
+    reloaded = await NodeManager.get_one(id=obj.id, db=db, branch=default_branch)
+    await reloaded.from_graphql(db=db, data={test_case.attribute_name: {"value": test_case.update_value}})
+    await reloaded.save(db=db)
+
+    stored_after_update = await _read_stored_attribute_value(
+        db=db, node_uuid=obj.id, attr_name=test_case.attribute_name, branch_name=default_branch.name
+    )
+    assert stored_after_update == test_case.expected_stored_value
 
 
 async def test_validate_content_dropdown(

--- a/backend/tests/component/core/test_attribute.py
+++ b/backend/tests/component/core/test_attribute.py
@@ -6,6 +6,7 @@ import pytest
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
+from infrahub.core import registry
 from infrahub.core.attribute import (
     MAX_STRING_LENGTH,
     URL,
@@ -458,6 +459,38 @@ async def test_update_stores_normalized_value(
         db=db, node_uuid=obj.id, attr_name=test_case.attribute_name, branch_name=default_branch.name
     )
     assert stored_after_update == test_case.expected_stored_value
+
+
+async def test_save_keeps_is_default_when_schema_default_is_not_canonical(
+    db: InfrahubDatabase, default_branch: Branch, group_schema: None, data_schema: None
+) -> None:
+    """A schema default written without its prefix length still counts as the default after the value is canonicalized."""
+    node_schema = NodeSchema(
+        name="IpDefault",
+        namespace="Test",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", optional=True),
+            AttributeSchema(name="ipaddress", kind="IPHost", optional=True, default_value="10.0.0.1"),
+        ],
+    )
+    registry.schema.set(name=node_schema.kind, schema=node_schema, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+
+    obj = await Node.init(db=db, schema=node_schema.kind)
+    await obj.new(db=db, name="obj1")
+    await obj.save(db=db)
+
+    reloaded = await NodeManager.get_one(id=obj.id, db=db, branch=default_branch)
+    assert reloaded.ipaddress.value == "10.0.0.1/32"
+    assert reloaded.ipaddress.is_default is True
+    await reloaded.save(db=db)
+
+    reloaded_again = await NodeManager.get_one(id=obj.id, db=db, branch=default_branch)
+    assert reloaded_again.ipaddress.is_default is True
+    stored_value = await _read_stored_attribute_value(
+        db=db, node_uuid=obj.id, attr_name="ipaddress", branch_name=default_branch.name
+    )
+    assert stored_value == "10.0.0.1/32"
 
 
 async def test_validate_content_dropdown(

--- a/changelog/10616.fixed.md
+++ b/changelog/10616.fixed.md
@@ -1,0 +1,1 @@
+Fixed IPHost, IPNetwork and IPAddress attribute values not being normalized when updated, which broke value filters and the Schema Integrity check on proposed changes


### PR DESCRIPTION
# Why

Creating a node with an `IPHost`, `IPNetwork` or `IPAddress` attribute stores the canonical form, `192.0.2.20` becomes `192.0.2.20/32`. Updating the same attribute did not: `_normalize_value()` was called only in the attribute constructor, so an update mutation wrote the raw input into the graph. Every read path re-normalizes, so the API and the UI kept showing the canonical value and the bad row was invisible.

Two things broke because of it. `__value` filters compared against the raw string and stopped matching, and the Schema Integrity check on a proposed change failed with `Attribute-level 'kind' constraint violation`, also on nodes never touched in the branch, since the check runs over every node of the kind.

Goal: a value ends up in the graph in the same form whichever path wrote it.

Non-goal: rewriting rows that are already stored non-canonically. That needs a data migration (modelled on `m070_normalize_mac_address_values_to_colon`, three IP kinds, `GRAPH_VERSION` 78 to 79) and is left for a follow-up. Until then, affected nodes still have to be re-saved once.

Closes #10616

## What changed

- Update mutations on `IPHost`, `IPNetwork` and `IPAddress` attributes now store the canonical value, so `__value` filters match and the Schema Integrity check passes on proposed changes
- Re-submitting a bare address that is already stored with its prefix length is now a no-op instead of writing a new `AttributeValue` vertex and showing up in the branch diff

Implementation: three lines in `BaseAttribute._update()` (`backend/infrahub/core/attribute.py:452-454`), right after the existing `self.validate(...)`. That method is the single funnel every persistent write goes through, so it also covers the Jinja2 recompute, `bulk_write`, the computed-attribute mutation and the profile applier, which had the same gap. `validate()` has already run at that point and uses the same `ipaddress` parser as `_normalize_value()`, so normalization cannot raise there. It lands before the `to_db()` comparison, and `Node._update()` recomputes hfid and display label after attribute saves, so both derive from the canonical value.

Two corrections to the issue text: `MacAddress` is not affected in the graph (its `serialize_value()` already normalizes, and m070 migrated the stored values), and `from_graphql()` is not the only unnormalized write path. `MacAddress` does pick up one side effect: its in-memory `self.value` is now canonical on update as well, so hfid and uniqueness lock names computed in the same request see the stored form.

The `is_default` comparison in `_update()` now normalizes the schema default too, so an IP attribute whose schema declares `default_value: 10.0.0.1` keeps `is_default` after the stored value is canonicalized to `10.0.0.1/32`. Without that, any save of such a node cleared the flag.

No schema changes, no API contract changes, no migration.

## How to review

`backend/infrahub/core/attribute.py` is the whole fix. The test in `backend/tests/component/core/test_attribute.py::test_update_stores_normalized_value` asserts on the raw `av.value` read with Cypher, not on the API, because every read path re-normalizes and would hide a regression.

Alternatives considered: normalizing in `from_graphql()` only (leaves the other write paths open, and needs a guard because no validation has run yet), or overriding `serialize_value()` on the IP classes the way `MacAddress` does (fixes what is stored but leaves `self.value` raw in memory for the rest of the request, so hfid and uniqueness lock names would still see the bare form).

## How to test

```bash
uv run pytest backend/tests/component/core/test_attribute.py::test_update_stores_normalized_value -v
```

Three parametrized cases (`IPHost`, `IPNetwork`, `IPAddress`), all failing on `stable` with the raw input stored, all passing with the fix. Also run locally: `test_attribute.py`, `test_attribute_kind_update.py`, `test_node.py` (127 passed), `backend.test-unit` (2513 passed), `backend.lint` clean.

## Impact & rollout

- **Backward compatibility:** no breaking change. Existing non-canonical rows are not rewritten by this PR
- **Deployment notes:** safe to deploy

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/10616.fixed.md`)
- [ ] External docs updated (not user-facing beyond the changelog)
- [ ] Internal .md docs updated (not needed for this change)
- [x] I have reviewed AI generated content

<!-- AGENT_FIX_COMPLETE -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
